### PR TITLE
CNDB-14997: Fix column selection on SAI-ordered queries

### DIFF
--- a/src/java/org/apache/cassandra/db/Columns.java
+++ b/src/java/org/apache/cassandra/db/Columns.java
@@ -589,7 +589,7 @@ public class Columns extends AbstractCollection<ColumnMetadata> implements Colle
          */
         public void serializeSubset(Collection<ColumnMetadata> columns, Columns superset, DataOutputPlus out) throws IOException
         {
-            /**
+            /*
              * We weight this towards small sets, and sets where the majority of items are present, since
              * we expect this to mostly be used for serializing result sets.
              *

--- a/src/java/org/apache/cassandra/index/sai/utils/InMemoryUnfilteredPartitionIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/InMemoryUnfilteredPartitionIterator.java
@@ -112,7 +112,7 @@ public class InMemoryUnfilteredPartitionIterator implements UnfilteredPartitionI
         @Override
         public RegularAndStaticColumns columns()
         {
-            return command.metadata().regularAndStaticColumns();
+            return partitionInfo.columns;
         }
 
         @Override

--- a/src/java/org/apache/cassandra/index/sai/utils/PartitionInfo.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/PartitionInfo.java
@@ -24,6 +24,7 @@ import javax.annotation.Nullable;
 
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.DeletionTime;
+import org.apache.cassandra.db.RegularAndStaticColumns;
 import org.apache.cassandra.db.rows.BaseRowIterator;
 import org.apache.cassandra.db.rows.EncodingStats;
 import org.apache.cassandra.db.rows.Row;
@@ -34,6 +35,7 @@ public class PartitionInfo
 {
     public final DecoratedKey key;
     public final Row staticRow;
+    public final RegularAndStaticColumns columns;
 
     // present if it's unfiltered partition iterator
     @Nullable
@@ -43,30 +45,36 @@ public class PartitionInfo
     @Nullable
     public final EncodingStats encodingStats;
 
-    public PartitionInfo(DecoratedKey key, Row staticRow)
+    private PartitionInfo(DecoratedKey key,
+                          Row staticRow,
+                          RegularAndStaticColumns columns,
+                          @Nullable DeletionTime partitionDeletion,
+                          @Nullable EncodingStats encodingStats)
     {
         this.key = key;
         this.staticRow = staticRow;
-        this.partitionDeletion = null;
-        this.encodingStats = null;
-    }
-
-    public PartitionInfo(DecoratedKey key, Row staticRow, DeletionTime partitionDeletion, EncodingStats encodingStats)
-    {
-        this.key = key;
-        this.staticRow = staticRow;
-
+        this.columns = columns;
         this.partitionDeletion = partitionDeletion;
         this.encodingStats = encodingStats;
     }
 
     public static <U extends Unfiltered, R extends BaseRowIterator<U>> PartitionInfo create(R baseRowIterator)
     {
-        return baseRowIterator instanceof UnfilteredRowIterator
-               ? new PartitionInfo(baseRowIterator.partitionKey(), baseRowIterator.staticRow(),
-                                   ((UnfilteredRowIterator) baseRowIterator).partitionLevelDeletion(),
-                                   ((UnfilteredRowIterator) baseRowIterator).stats())
-               : new PartitionInfo(baseRowIterator.partitionKey(), baseRowIterator.staticRow());
+        // only unfiltered row iterators have a partition deletion time and encoding stats
+        DeletionTime partitionDeletion = null;
+        EncodingStats encodingStats = null;
+        if (baseRowIterator instanceof UnfilteredRowIterator)
+        {
+            UnfilteredRowIterator unfilteredRowIterator = (UnfilteredRowIterator) baseRowIterator;
+            partitionDeletion = unfilteredRowIterator.partitionLevelDeletion();
+            encodingStats = unfilteredRowIterator.stats();
+        }
+
+        return new PartitionInfo(baseRowIterator.partitionKey(),
+                                 baseRowIterator.staticRow(),
+                                 baseRowIterator.columns(),
+                                 partitionDeletion,
+                                 encodingStats);
     }
 
     @Override
@@ -75,13 +83,16 @@ public class PartitionInfo
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         PartitionInfo that = (PartitionInfo) o;
-        return Objects.equals(key, that.key) && Objects.equals(staticRow, that.staticRow)
-               && Objects.equals(partitionDeletion, that.partitionDeletion) && Objects.equals(encodingStats, that.encodingStats);
+        return Objects.equals(key, that.key)
+               && Objects.equals(staticRow, that.staticRow)
+               && Objects.equals(columns, that.columns)
+               && Objects.equals(partitionDeletion, that.partitionDeletion)
+               && Objects.equals(encodingStats, that.encodingStats);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(key, staticRow, partitionDeletion, encodingStats);
+        return Objects.hash(key, staticRow, columns, partitionDeletion, encodingStats);
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/ColumnSelectionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/ColumnSelectionTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.cql;
+
+import org.junit.Test;
+
+public class ColumnSelectionTest extends VectorTester
+{
+    /**
+     * Tests that we can select any column in any table with SAI indexes. See CNDB-14997 for further details.
+     */
+    @Test
+    public void testColumnSelection() throws Throwable
+    {
+        createTable("CREATE TABLE %s (" +
+                    "k1 text, k2 text, " +
+                    "c1 text, c2 text, " +
+                    "s1 text static, s2 text static, " +
+                    "r1 text, r2 vector<float, 2>, " +
+                    "PRIMARY KEY((k1, k2), c1, c2))");
+        createIndex("CREATE CUSTOM INDEX ON %s(r1) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX ON %s(r2) USING 'StorageAttachedIndex'");
+
+        Object[] row = row("k1", "k2", "c1", "c2", "s1", "s2", "r1", vector(1, 2));
+        execute("INSERT INTO %s (k1, k2, c1, c2, s1, s2, r1, r2) VALUES (?, ?, ?, ?, ?, ?, ?, ?)", row);
+
+        beforeAndAfterFlush(() -> {
+
+            // filtering
+            assertRows(execute("SELECT * FROM %s WHERE r1='r1'"), row);
+            assertRows(execute("SELECT k1 FROM %s WHERE r1='r1'"), row(row[0]));
+            assertRows(execute("SELECT k2 FROM %s WHERE r1='r1'"), row(row[1]));
+            assertRows(execute("SELECT c1 FROM %s WHERE r1='r1'"), row(row[2]));
+            assertRows(execute("SELECT c2 FROM %s WHERE r1='r1'"), row(row[3]));
+            assertRows(execute("SELECT s1 FROM %s WHERE r1='r1'"), row(row[4]));
+            assertRows(execute("SELECT s2 FROM %s WHERE r1='r1'"), row(row[5]));
+            assertRows(execute("SELECT r1 FROM %s WHERE r1='r1'"), row(row[6]));
+            assertRows(execute("SELECT r2 FROM %s WHERE r1='r1'"), row(row[7]));
+            assertRows(execute("SELECT k1, c1, s1, r1 FROM %s WHERE r1='r1'"), row(row[0], row[2], row[4], row[6]));
+            assertRows(execute("SELECT k2, c2, s2, r2 FROM %s WHERE r1='r1'"), row(row[1], row[3], row[5], row[7]));
+
+            // generic ordering
+            assertRows(execute("SELECT * FROM %s ORDER BY r1 LIMIT 10"), row);
+            assertRows(execute("SELECT k1 FROM %s ORDER BY r1 LIMIT 10"), row(row[0]));
+            assertRows(execute("SELECT k2 FROM %s ORDER BY r1 LIMIT 10"), row(row[1]));
+            assertRows(execute("SELECT c1 FROM %s ORDER BY r1 LIMIT 10"), row(row[2]));
+            assertRows(execute("SELECT c2 FROM %s ORDER BY r1 LIMIT 10"), row(row[3]));
+            assertRows(execute("SELECT s1 FROM %s ORDER BY r1 LIMIT 10"), row(row[4]));
+            assertRows(execute("SELECT s2 FROM %s ORDER BY r1 LIMIT 10"), row(row[5]));
+            assertRows(execute("SELECT r1 FROM %s ORDER BY r1 LIMIT 10"), row(row[6]));
+            assertRows(execute("SELECT r2 FROM %s ORDER BY r1 LIMIT 10"), row(row[7]));
+            assertRows(execute("SELECT k1, c1, s1, r1 FROM %s ORDER BY r1 LIMIT 10"), row(row[0], row[2], row[4], row[6]));
+            assertRows(execute("SELECT k2, c2, s2, r2 FROM %s ORDER BY r1 LIMIT 10"), row(row[1], row[3], row[5], row[7]));
+
+            // ANN ordering
+            assertRows(execute("SELECT * FROM %s ORDER BY r2 ANN OF [1, 2] LIMIT 10"), row);
+            assertRows(execute("SELECT k1 FROM %s ORDER BY r2 ANN OF [1, 2] LIMIT 10"), row(row[0]));
+            assertRows(execute("SELECT k2 FROM %s ORDER BY r2 ANN OF [1, 2] LIMIT 10"), row(row[1]));
+            assertRows(execute("SELECT c1 FROM %s ORDER BY r2 ANN OF [1, 2] LIMIT 10"), row(row[2]));
+            assertRows(execute("SELECT c2 FROM %s ORDER BY r2 ANN OF [1, 2] LIMIT 10"), row(row[3]));
+            assertRows(execute("SELECT s1 FROM %s ORDER BY r2 ANN OF [1, 2] LIMIT 10"), row(row[4]));
+            assertRows(execute("SELECT s2 FROM %s ORDER BY r2 ANN OF [1, 2] LIMIT 10"), row(row[5]));
+            assertRows(execute("SELECT r1 FROM %s ORDER BY r2 ANN OF [1, 2] LIMIT 10"), row(row[6]));
+            assertRows(execute("SELECT r2 FROM %s ORDER BY r2 ANN OF [1, 2] LIMIT 10"), row(row[7]));
+            assertRows(execute("SELECT k1, c1, s1, r1 FROM %s ORDER BY r2 ANN OF [1, 2] LIMIT 10"), row(row[0], row[2], row[4], row[6]));
+            assertRows(execute("SELECT k2, c2, s2, r2 FROM %s ORDER BY r2 ANN OF [1, 2] LIMIT 10"), row(row[1], row[3], row[5], row[7]));
+        });
+    }
+}


### PR DESCRIPTION
When SAI's TopKProcessor created PK-sorted in-memory row iterators, it wasn't preserving the actual column information from the base row iterator. Instead, it was returning the columns of the base table, leading to incorrect column selection behavior.

The fix consists on copying the column selection of the original iterator into PartitionInfo, so the PK-sorted iterator can return that same column selection.