### PR TITLE
CNDB-15022 Introduce additional guardrail profile for HCD

### DIFF
--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -1487,17 +1487,8 @@ enable_transient_replication: false
 # 'ALTER ... DROP COMPACT STORAGE' is considered experimental and is not recommended for production use.
 enable_drop_compact_storage: false
 
-# Emulates DataStax Constellation database-as-a-service defaults.
-#
-# When enabled, some defaults are modified to match those used by DataStax Constellation (DataStax cloud data
-# platform). This includes (but is not limited to) stricter guardrails defaults.
-#
-# This can be used as an convenience to develop and test applications meant to run on DataStax Constellation.
-#
-# Warning: when enabled, the updated defaults reflect those of DataStax Constellation _at the time_ of the currently
-#                 used DSE release. This is a best-effort emulation of said defaults. Further, all nodes must use the same
-#                 config value.
-# emulate_dbaas_defaults: false
+# Changes defaults considered production safest for HCD users
+# hcd_guardrail_defaults: false
 
 # Guardrails settings.
 # guardrails:

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -576,6 +576,7 @@ public class Config
     public volatile int validation_preview_purge_head_start_in_sec = 60 * 60;
 
     public boolean emulate_dbaas_defaults = false;
+    public boolean hcd_guardrail_defaults = false;
 
     public GuardrailsConfig guardrails = new GuardrailsConfig();
 

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -3740,6 +3740,17 @@ public class DatabaseDescriptor
         return conf.emulate_dbaas_defaults;
     }
 
+    @VisibleForTesting
+    public static boolean setHcdGuardrailsDefaults(boolean hcd_guardrail_defaults)
+    {
+        return conf.hcd_guardrail_defaults = hcd_guardrail_defaults;
+    }
+
+    public static boolean isHcdGuardrailsDefaults()
+    {
+        return conf.hcd_guardrail_defaults;
+    }
+
     public static PageSize getAggregationSubPageSize()
     {
         return PageSize.inBytes(conf.aggregation_subpage_size_in_kb * 1024);

--- a/src/java/org/apache/cassandra/service/StartupChecks.java
+++ b/src/java/org/apache/cassandra/service/StartupChecks.java
@@ -42,7 +42,7 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -66,6 +66,7 @@ import org.apache.cassandra.io.sstable.format.SSTableFormat;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.io.util.PathUtils;
+import org.apache.cassandra.locator.SimpleSnitch;
 import org.apache.cassandra.nodes.Nodes;
 import org.apache.cassandra.schema.IndexMetadata;
 import org.apache.cassandra.schema.KeyspaceMetadata;
@@ -363,13 +364,19 @@ public class StartupChecks
             if (Murmur3Partitioner.instance != DatabaseDescriptor.getPartitioner())
                 logger.warn("Not using murmur3 partitioner ({}). {}", DatabaseDescriptor.getPartitioner().getClass().getName(), WARN_SUFFIX);
 
+            if (DatabaseDescriptor.getEndpointSnitch() instanceof SimpleSnitch)
+                logger.warn("SimpleSnitch is only for dev/test environments. {}", WARN_SUFFIX);
+
             if (DatabaseDescriptor.getNumTokens() > 16)
                 logger.warn("num_tokens {} too high. Values over 16 poorly impact repairs and node bootstrapping/decommissioning. {}",
                             DatabaseDescriptor.getNumTokens(), WARN_SUFFIX);
 
+            if(SSTableFormat.Type.BTI != SSTableFormat.Type.current())
+                logger.warn("Trie-based SSTables (bti) should always be the default (current is {}). {}", SSTableFormat.Type.current(), WARN_SUFFIX);
+
             // ServerTestUtils.prepare() enables transient replication, so we have to skip this when we're inside a unit test
             if(DatabaseDescriptor.isTransientReplicationEnabled() && null == System.getProperty("cassandra.testtag"))
-                throw new StartupException(StartupException.ERR_WRONG_CONFIG, "Transient Replication cannot not be used in HCD.");
+                throw new StartupException(StartupException.ERR_WRONG_CONFIG, "Transient Replication cannot be used in HCD.");
 
             if(DatabaseDescriptor.getEnableMaterializedViews())
                 logger.warn("Materialised Views should not be enabled. {}", WARN_SUFFIX);
@@ -392,8 +399,41 @@ public class StartupChecks
                 logger.warn("Guardrails value {} for batch_size_fail_threshold_in_kb is too high (>640). {}",
                         DatabaseDescriptor.getGuardrailsConfig().batch_size_fail_threshold_in_kb, WARN_SUFFIX);
 
-            if(SSTableFormat.Type.BTI != SSTableFormat.Type.current())
-                logger.warn("Trie-based SSTables (bti) should always be the default (current is {}). {}", SSTableFormat.Type.current(), WARN_SUFFIX);
+            if (DatabaseDescriptor.getGuardrailsConfig().columns_per_table_failure_threshold > 200)
+                logger.warn("Guardrails value {} for columns_per_table_failure_threshold is too high (>200). {}",
+                        DatabaseDescriptor.getGuardrailsConfig().columns_per_table_failure_threshold, WARN_SUFFIX);
+
+            if (DatabaseDescriptor.getGuardrailsConfig().fields_per_udt_failure_threshold > 100)
+                logger.warn("Guardrails value {} for fields_per_udt_failure_threshold is too high (>100). {}",
+                        DatabaseDescriptor.getGuardrailsConfig().fields_per_udt_failure_threshold, WARN_SUFFIX);
+
+            if (DatabaseDescriptor.getGuardrailsConfig().collection_size_warn_threshold_in_kb > 10480)
+                logger.warn("Guardrails value {} for collection_size_warn_threshold_in_kb is too high (>10480). {}",
+                        DatabaseDescriptor.getGuardrailsConfig().collection_size_warn_threshold_in_kb, WARN_SUFFIX);
+
+            if (DatabaseDescriptor.getGuardrailsConfig().items_per_collection_warn_threshold > 200)
+                logger.warn("Guardrails value {} for items_per_collection_warn_threshold is too high (>200). {}",
+                        DatabaseDescriptor.getGuardrailsConfig().items_per_collection_warn_threshold, WARN_SUFFIX);
+
+            if (DatabaseDescriptor.getGuardrailsConfig().tables_warn_threshold > 100)
+                logger.warn("Guardrails value {} for tables_warn_threshold is too high (>100). {}",
+                        DatabaseDescriptor.getGuardrailsConfig().tables_warn_threshold, WARN_SUFFIX);
+
+            if (DatabaseDescriptor.getGuardrailsConfig().tables_failure_threshold > 200)
+                logger.warn("Guardrails value {} for tables_failure_threshold is too high (>200). {}",
+                        DatabaseDescriptor.getGuardrailsConfig().tables_failure_threshold, WARN_SUFFIX);
+
+            if (DatabaseDescriptor.getGuardrailsConfig().in_select_cartesian_product_failure_threshold > 25)
+                logger.warn("Guardrails value {} for in_select_cartesian_product_failure_threshold is too high (>25). {}",
+                        DatabaseDescriptor.getGuardrailsConfig().in_select_cartesian_product_failure_threshold, WARN_SUFFIX);
+
+            if (DatabaseDescriptor.getGuardrailsConfig().partition_keys_in_select_failure_threshold > 20)
+                logger.warn("Guardrails value {} for partition_keys_in_select_failure_threshold is too high (>20). {}",
+                        DatabaseDescriptor.getGuardrailsConfig().partition_keys_in_select_failure_threshold, WARN_SUFFIX);
+
+            if (!DatabaseDescriptor.getGuardrailsConfig().write_consistency_levels_disallowed.contains("ANY"))
+                logger.warn("Guardrails value \"{}\" for write_consistency_levels_disallowed does not contain \"ANY\". {}",
+                        StringUtils.join(DatabaseDescriptor.getGuardrailsConfig().write_consistency_levels_disallowed, ','), WARN_SUFFIX);
         }
     };
 


### PR DESCRIPTION
There are now three profiles for guardrail defaults: none|dbaas|hcd

This redoes the work in 7940e9c
The defaults introduced previously (as new non-dbaas defaults) are now applied to the hcd profile. 

--

HCD-179 Guardrail defaults for on-prem
Provide users defaults and feedback from startup checks/warnings sensible for production environments. Many users do not (and do not want to) understand the complexities of HCD/Cassandra, and such feedback helps them stay safely dumb. This is also expected to alleviate the impact on Support having to deal will silly abuses of the database.  It is also avoids operators having to retrospectively police their developers creating the data models and client applications.

Set on-prem guardrail defaults to be (keeping in mind these can be changed by operators on-prem, so they are first and foremost important teachings to give):

  columns_per_table_failure_threshold: 200
  fields_per_udt_failure_threshold: 100
  collection_size_warn_threshold_in_kb: 10240
  items_per_collection_warn_threshold: 200
  secondary_index_per_table_failure_threshold: 0
  sasi_indexes_per_table_failure_threshold: 0
  materialized_view_per_table_failure_threshold: 0
  tables_warn_threshold: 100
  tables_failure_threshold: 200
  in_select_cartesian_product_failure_threshold: 25
  partition_keys_in_select_failure_threshold: 20
  disk_usage_percentage_warn_threshold: 70
  write_consistency_levels_disallowed: ANY

Also add a startup warning when SimpleSnitch is used.

### What is the issue
Sets appropriate startup checks, and guardrail defaults under a new HCD profile.

### What does this PR fix and why was it fixed
Introduces a new yaml setting `hcd_guardrail_defaults` and a set of defaults when it's set true in GuardrailsConfig.  These defaults are applied when the yaml hasn't provided values.
Default settings have not otherwise changed if hcd_guardrail_defaults has not been set.
An assertion is thrown if both `hcd_guardrail_defaults` and `emulate_dbaas_defaults` is set true.

### CNDB testing

https://github.com/riptano/cndb/pull/14958 