### PR TITLE
CNDB-11455: Forbid ANN queries on non-regular columns

### DIFF
--- a/src/java/org/apache/cassandra/cql3/restrictions/StatementRestrictions.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/StatementRestrictions.java
@@ -87,6 +87,8 @@ public class StatementRestrictions
     public static final String BM25_ORDERING_REQUIRES_ANALYZED_INDEX_MESSAGE = "BM25 ordering on column %s requires an analyzed index";
     public static final String BM25_ORDERING_REQUIRES_REGULAR_COLUMN_MESSAGE = "BM25 ordering on %s column %s is not supported. " +
                                                                                "Only regular columns are supported.";
+    public static final String ANN_ORDERING_REQUIRES_REGULAR_COLUMN_MESSAGE = "ANN ordering on %s column %s is not supported. " +
+                                                                               "Only regular columns are supported.";
     public static final String NON_CLUSTER_ORDERING_REQUIRES_INDEX_MESSAGE =
     "Ordering on non-clustering column %s requires the column to be indexed with a non-analyzed index.";
     public static final String NON_CLUSTER_ORDERING_REQUIRES_ALL_RESTRICTED_NON_PARTITION_KEY_COLUMNS_INDEXED_MESSAGE =
@@ -737,6 +739,11 @@ public class StatementRestrictions
 
                 if (ordering.expression instanceof Ordering.Bm25 && !column.isRegular())
                     throw new InvalidRequestException(String.format(BM25_ORDERING_REQUIRES_REGULAR_COLUMN_MESSAGE,
+                                                                    column.kind.name().toLowerCase().replace("_", " "),
+                                                                    column.name));
+
+                if (ordering.expression instanceof Ordering.Ann && !column.isRegular())
+                    throw new InvalidRequestException(String.format(ANN_ORDERING_REQUIRES_REGULAR_COLUMN_MESSAGE,
                                                                     column.kind.name().toLowerCase().replace("_", " "),
                                                                     column.name));
 


### PR DESCRIPTION
### What is the issue

Vector clustering columns used in order by ANN clauses cause late, opaque failures in the query. It's unclear to clients why the query failed, and the query wastes work when completing the query is impossible. The failure presents as follows, where `embedding` is the vector-type clustering column referenced in the order by clause:


```
Uncaught exception on thread Thread[#361,ReadStage-10,5,main]
     java.lang.RuntimeException: java.lang.AssertionError: Only regular columns are supported, got embedding
     	at org.apache.cassandra.net.InboundSink.accept(InboundSink.java:113)
     	at org.apache.cassandra.net.InboundSink.accept(InboundSink.java:46)
     	at org.apache.cassandra.net.InboundMessageHandler$ProcessMessage.run(InboundMessageHandler.java:436)
     	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
     	at org.apache.cassandra.concurrent.AbstractLocalAwareExecutorService$FutureTask.run(AbstractLocalAwareExecutorService.java:165)
     	at org.apache.cassandra.concurrent.AbstractLocalAwareExecutorService$LocalSessionFutureTask.run(AbstractLocalAwareExecutorService.java:137)
     	at org.apache.cassandra.concurrent.SEPWorker.run(SEPWorker.java:119)
     	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
     	at java.base/java.lang.Thread.run(Thread.java:1570)
     Caused by: java.lang.AssertionError: Only regular columns are supported, got embedding
     	at org.apache.cassandra.index.sai.utils.PrimaryKeyWithSortKey.isIndexDataValid(PrimaryKeyWithSortKey.java:58)
     	at org.apache.cassandra.index.sai.plan.StorageAttachedIndexSearcher$ScoreOrderedResultRetriever.shouldInclude(StorageAttachedIndexSearcher.java:578)
     	at org.apache.cassandra.index.sai.plan.TopKProcessor.processPartition(TopKProcessor.java:346)
     	at org.apache.cassandra.index.sai.plan.TopKProcessor.filterInternal(TopKProcessor.java:230)
     	at org.apache.cassandra.index.sai.plan.TopKProcessor.filter(TopKProcessor.java:154)
     	at org.apache.cassandra.index.sai.plan.StorageAttachedIndexSearcher.search(StorageAttachedIndexSearcher.java:142)
     	at org.apache.cassandra.db.ReadCommand.searchStorage(ReadCommand.java:516)
     	at org.apache.cassandra.db.ReadCommand.executeLocally(ReadCommand.java:413)
     	at org.apache.cassandra.db.ReadCommandVerbHandler.doVerb(ReadCommandVerbHandler.java:74)
     	at org.apache.cassandra.net.InboundSink.lambda$new$0(InboundSink.java:79)
     	at org.apache.cassandra.net.InboundSink.accept(InboundSink.java:98)
     	... 8 common frames omitted
```

### What does this PR fix and why was it fixed
...

This is a similar issue to the one fixed for BM25 in CNDB-14348.  The PR adds reproduction tests and a fix to reject ANN queries on non-regular columns.
I did not add any tests about collections as that is a case that will be handled in another ticket - CNDB-13804. Currently, you can create an index on a collection that has vectors inside it. If you try to insert data into it, you get an error. 