### PR TITLE
CNDB-15058: track in-flight BF memory usage from trie index writer if early open is not enabled

### DIFF
--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -3484,6 +3484,13 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
         return Objects.requireNonNull(getIfExists(tableId)).metric;
     }
 
+    @Nullable
+    public static TableMetrics metricsForIfPresent(TableId tableId)
+    {
+        ColumnFamilyStore cfs = getIfExists(tableId);
+        return cfs == null ? null : cfs.metric;
+    }
+
     // Used by CNDB
     public long getMemtablesLiveSize()
     {

--- a/src/java/org/apache/cassandra/io/sstable/format/trieindex/TrieIndexSSTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/trieindex/TrieIndexSSTableWriter.java
@@ -29,12 +29,15 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.function.Consumer;
 
+import javax.annotation.Nullable;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.DeletionTime;
 import org.apache.cassandra.db.SerializationHeader;
@@ -66,6 +69,7 @@ import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileHandle;
 import org.apache.cassandra.io.util.SequentialWriter;
 import org.apache.cassandra.io.util.SequentialWriterOption;
+import org.apache.cassandra.metrics.TableMetrics;
 import org.apache.cassandra.schema.CompressionParams;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.schema.TableMetadataRef;
@@ -316,6 +320,9 @@ public class TrieIndexSSTableWriter extends SortedTableWriter
         private DataPosition riMark;
         private DataPosition piMark;
 
+        @Nullable
+        private final TableMetrics tableMetrics;
+
         IndexWriter(TableMetadata table)
         {
             CompressionParams params = table.params.compression;
@@ -341,10 +348,16 @@ public class TrieIndexSSTableWriter extends SortedTableWriter
 
             partitionIndex = new PartitionIndexBuilder(partitionIndexFile, partitionIndexFHBuilder, descriptor.version.getByteComparableVersion());
             bf = FilterFactory.getFilter(keyCount, table.params.bloomFilterFpChance);
+
             // register listeners to be alerted when the data files are flushed
             partitionIndexFile.setPostFlushListener(() -> partitionIndex.markPartitionIndexSynced(partitionIndexFile.getLastFlushOffset()));
             rowIndexFile.setPostFlushListener(() -> partitionIndex.markRowIndexSynced(rowIndexFile.getLastFlushOffset()));
             dataFile.setPostFlushListener(() -> partitionIndex.markDataSynced(dataFile.getLastFlushOffset()));
+
+            // when early open is disabled, partial written sstable's BF memory is not included in Tracker
+            tableMetrics = DatabaseDescriptor.getSSTablePreemptiveOpenIntervalInMB() <= 0 ? ColumnFamilyStore.metricsForIfPresent(table.id) : null;
+            if (tableMetrics != null && bf != null)
+                tableMetrics.inFlightBloomFilterOffHeapMemoryUsed.getAndAdd(bf.offHeapSize());
         }
 
         public long append(DecoratedKey key, RowIndexEntry indexEntry) throws IOException
@@ -481,6 +494,8 @@ public class TrieIndexSSTableWriter extends SortedTableWriter
         @Override
         protected Throwable doPostCleanup(Throwable accumulate)
         {
+            if (tableMetrics != null && bf != null)
+                tableMetrics.inFlightBloomFilterOffHeapMemoryUsed.getAndAdd(-bf.offHeapSize());
             return Throwables.close(accumulate, bf, partitionIndex, rowIndexFile, rowIndexFHBuilder, partitionIndexFile, partitionIndexFHBuilder);
         }
     }

--- a/src/java/org/apache/cassandra/metrics/TableMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/TableMetrics.java
@@ -31,6 +31,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.LongSupplier;
 import java.util.function.Predicate;
@@ -264,6 +265,8 @@ public class TableMetrics
     public final Gauge<Double> recentBloomFilterFalseRatio;
     /** Disk space used by bloom filter */
     public final Gauge<Long> bloomFilterDiskSpaceUsed;
+
+    public final AtomicLong inFlightBloomFilterOffHeapMemoryUsed = new AtomicLong(0);
     /** Off heap memory used by bloom filter */
     public final Gauge<Long> bloomFilterOffHeapMemoryUsed;
     /** Off heap memory used by index summary */
@@ -443,19 +446,19 @@ public class TableMetrics
     public static final Gauge<Long> globalBytesRepaired = Metrics.register(GLOBAL_FACTORY.createMetricName("BytesRepaired"),
                                                                            () -> totalNonSystemTablesSize(SSTableReader::isRepaired).left);
 
-    public static final Gauge<Long> globalBytesUnrepaired = 
+    public static final Gauge<Long> globalBytesUnrepaired =
         Metrics.register(GLOBAL_FACTORY.createMetricName("BytesUnrepaired"),
                          () -> totalNonSystemTablesSize(s -> !s.isRepaired() && !s.isPendingRepair()).left);
 
-    public static final Gauge<Long> globalBytesPendingRepair = 
+    public static final Gauge<Long> globalBytesPendingRepair =
         Metrics.register(GLOBAL_FACTORY.createMetricName("BytesPendingRepair"),
                          () -> totalNonSystemTablesSize(SSTableReader::isPendingRepair).left);
 
     public final Meter readRepairRequests;
     public final Meter shortReadProtectionRequests;
-    
+
     public final Meter replicaFilteringProtectionRequests;
-    
+
     /**
      * This histogram records the maximum number of rows {@link org.apache.cassandra.service.reads.ReplicaFilteringProtection}
      * caches at a point in time per query. With no replica divergence, this is equivalent to the maximum number of
@@ -570,20 +573,20 @@ public class TableMetrics
         samplers.put(SamplerType.CAS_CONTENTIONS, topCasPartitionContention);
         samplers.put(SamplerType.LOCAL_READ_TIME, topLocalReadQueryTime);
 
-        memtableColumnsCount = createTableGauge("MemtableColumnsCount", 
+        memtableColumnsCount = createTableGauge("MemtableColumnsCount",
                                                 () -> cfs.getTracker().getView().getCurrentMemtable().getOperations());
 
         // MemtableOnHeapSize naming deprecated in 4.0
-        memtableOnHeapDataSize = createTableGaugeWithDeprecation("MemtableOnHeapDataSize", "MemtableOnHeapSize", 
+        memtableOnHeapDataSize = createTableGaugeWithDeprecation("MemtableOnHeapDataSize", "MemtableOnHeapSize",
                                                                  () -> Memtable.getMemoryUsage(cfs.getTracker().getView().getCurrentMemtable()).ownsOnHeap,
                                                                  new GlobalTableGauge("MemtableOnHeapDataSize"));
 
         // MemtableOffHeapSize naming deprecated in 4.0
-        memtableOffHeapDataSize = createTableGaugeWithDeprecation("MemtableOffHeapDataSize", "MemtableOffHeapSize", 
+        memtableOffHeapDataSize = createTableGaugeWithDeprecation("MemtableOffHeapDataSize", "MemtableOffHeapSize",
                                                                   () -> Memtable.getMemoryUsage(cfs.getTracker().getView().getCurrentMemtable()).ownsOffHeap,
                                                                   new GlobalTableGauge("MemtableOnHeapDataSize"));
-        
-        memtableLiveDataSize = createTableGauge("MemtableLiveDataSize", 
+
+        memtableLiveDataSize = createTableGauge("MemtableLiveDataSize",
                                                 () -> cfs.getTracker().getView().getCurrentMemtable().getLiveDataSize());
 
         // AllMemtablesHeapSize naming deprecated in 4.0
@@ -665,7 +668,7 @@ public class TableMetrics
         };
 
         estimatedColumnCountHistogram = createTableGauge("EstimatedColumnCountHistogram", "EstimatedColumnCountHistogram",
-                                                         () -> combineHistograms(cfs.getSSTables(SSTableSet.CANONICAL), 
+                                                         () -> combineHistograms(cfs.getSSTables(SSTableSet.CANONICAL),
                                                                                  SSTableReader::getEstimatedCellPerPartitionCount), null);
 
         estimatedRowCount = createTableGauge("EstimatedRowCount", "EstimatedRowCount", new CachedGauge<>(1, TimeUnit.SECONDS)
@@ -702,7 +705,7 @@ public class TableMetrics
                 return sstableRows + memtableRows;
             }
         }, null);
-        
+
         sstablesPerReadHistogram = createTableHistogram("SSTablesPerReadHistogram", cfs.getKeyspaceMetrics().sstablesPerReadHistogram, true);
         sstablePartitionReadLatency = ExpMovingAverage.decayBy100();
         compressionRatio = createTableGauge("CompressionRatio", new Gauge<Double>()
@@ -991,7 +994,7 @@ public class TableMetrics
         {
             public Long getValue()
             {
-                long total = 0;
+                long total = inFlightBloomFilterOffHeapMemoryUsed.get();
                 for (SSTableReader sst : cfs.getSSTables(SSTableSet.LIVE))
                     total += sst.getBloomFilterOffHeapSize();
                 return total;

--- a/src/java/org/apache/cassandra/utils/FilterFactory.java
+++ b/src/java/org/apache/cassandra/utils/FilterFactory.java
@@ -17,6 +17,7 @@
  */
 package org.apache.cassandra.utils;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -72,6 +73,7 @@ public class FilterFactory
      * Asserts that the given probability can be satisfied using this
      * filter.
      */
+    @VisibleForTesting
     public static IFilter getFilter(long numElements, double maxFalsePosProbability)
     {
         return getFilter(numElements, maxFalsePosProbability, BloomFilter.memoryLimiter);

--- a/test/unit/org/apache/cassandra/db/compaction/CompactionControllerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CompactionControllerTest.java
@@ -23,7 +23,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.function.LongPredicate;
 
@@ -36,6 +38,8 @@ import org.junit.runner.RunWith;
 
 import org.apache.cassandra.SchemaLoader;
 import org.apache.cassandra.Util;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.metrics.TableMetrics;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.DecoratedKey;
@@ -50,6 +54,7 @@ import org.apache.cassandra.schema.KeyspaceParams;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.WrappedRunnable;
+import org.awaitility.Awaitility;
 import org.jboss.byteman.contrib.bmunit.BMRule;
 import org.jboss.byteman.contrib.bmunit.BMRules;
 import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
@@ -57,6 +62,7 @@ import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
 import static org.apache.cassandra.db.ColumnFamilyStore.FlushReason.UNIT_TESTS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNotNull;
 
@@ -200,6 +206,65 @@ public class CompactionControllerTest extends SchemaLoader
         expired = CompactionController.getFullyExpiredSSTables(cfs, compacting, x -> overlapping, gcBefore, true);
         assertNotNull(expired);
         assertEquals(1, expired.size());
+    }
+
+    @Test
+    @BMRule(name = "DelayCompaction",
+    targetClass = "CompactionTask$CompactionOperation",
+    targetMethod = "maybeStopOrUpdateState",
+    action = "java.lang.Thread.sleep(1000L);")
+    public void testInFlightBloomFilterMemory()
+    {
+        int earlyOpen = DatabaseDescriptor.getSSTablePreemptiveOpenIntervalInMB();
+        try
+        {
+            DatabaseDescriptor.setSSTablePreemptiveOpenIntervalInMB(0);
+
+            Keyspace keyspace = Keyspace.open(KEYSPACE);
+            ColumnFamilyStore cfs = keyspace.getColumnFamilyStore(CF1);
+            cfs.truncateBlocking();
+            cfs.disableAutoCompaction();
+
+            for (int s = 0; s < 3; ++s)
+            {
+                for (int k = 0; k < 5; k++)
+                    writeRows(cfs, Util.dk("k" + k), k, k + 1);
+                cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.UNIT_TESTS);
+            }
+
+            TableMetrics tableMetrics = ColumnFamilyStore.metricsForIfPresent(cfs.metadata.id);
+            long bloomFilterMemoryBeforeCompaction = tableMetrics.bloomFilterOffHeapMemoryUsed.getValue();
+            assertNotEquals(0, bloomFilterMemoryBeforeCompaction);
+            assertEquals(0, tableMetrics.inFlightBloomFilterOffHeapMemoryUsed.get());
+
+            // Submit a compaction where all tombstones are expired to make compactor read memtables.
+            Future<?> future = Executors.newCachedThreadPool().submit(() -> {
+                cfs.forceMajorCompaction();
+            });
+
+            Awaitility.await("In flight bloom filter is tracked")
+                      .pollInterval(1, TimeUnit.MILLISECONDS)
+                      .atMost(10, TimeUnit.SECONDS)
+                      .until(() ->
+                             {
+                                 // in-flight bf memory is included
+                                 return tableMetrics.inFlightBloomFilterOffHeapMemoryUsed.get() != 0 &&
+                                        bloomFilterMemoryBeforeCompaction < tableMetrics.bloomFilterOffHeapMemoryUsed.getValue() &&
+                                        // in-flight sstable is not part of tracker
+                                        3 == cfs.getLiveSSTables().size();
+                             });
+
+            // Compaction must have succeeded.
+            FBUtilities.waitOnFuture(future);
+            assertEquals(1, cfs.getLiveSSTables().size());
+
+            // In flight bloom filter is clear
+            assertEquals(0, tableMetrics.inFlightBloomFilterOffHeapMemoryUsed.get());
+        }
+        finally
+        {
+            DatabaseDescriptor.setSSTablePreemptiveOpenIntervalInMB(earlyOpen);
+        }
     }
 
     @Test


### PR DESCRIPTION
### What is the issue
cndb-15058: table metrics - bloom filter memory usage doesn't include partially written sstables' if early open is not enabled

### What does this PR fix and why was it fixed
Include in flight BF memory usage if early open is not enabled
