### PR TITLE
CNDB-9018: cache SSTable:CompactionMetadata in order to not read from storage multiple times (#1922)

### DIFF
--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableWriter.java
@@ -343,7 +343,7 @@ public abstract class SSTableWriter extends SSTable implements Transactional, SS
         observers.forEach(SSTableFlushObserver::onSSTableWriterSwitched);
     }
 
-    protected Map<MetadataType, MetadataComponent> finalizeMetadata()
+    protected final Map<MetadataType, MetadataComponent> finalizeMetadata()
     {
         return metadataCollector.finalizeMetadata(getPartitioner().getClass().getCanonicalName(),
                                                   metadata().params.bloomFilterFpChance,
@@ -353,11 +353,6 @@ public abstract class SSTableWriter extends SSTable implements Transactional, SS
                                                   header,
                                                   first.retainable().getKey(),
                                                   last.retainable().getKey());
-    }
-
-    protected StatsMetadata statsMetadata()
-    {
-        return (StatsMetadata) finalizeMetadata().get(MetadataType.STATS);
     }
 
     public void releaseMetadataOverhead()
@@ -415,7 +410,8 @@ public abstract class SSTableWriter extends SSTable implements Transactional, SS
             {
                 if (storageHandler != null)
                 {
-                    StatsMetadata stats = statsMetadata();
+                    Map<MetadataType, MetadataComponent> finalMetadata = finalizeMetadata();
+                    StatsMetadata stats = (StatsMetadata) finalMetadata.get(MetadataType.STATS);
                     finalReader = storageHandler.onOpeningWrittenSSTableFailure(SSTableReader.OpenReason.NORMAL,
                                                                                 descriptor,
                                                                                 components(),

--- a/src/java/org/apache/cassandra/io/sstable/format/big/BigSSTableReaderLoadingBuilder.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/BigSSTableReaderLoadingBuilder.java
@@ -19,6 +19,7 @@
 package org.apache.cassandra.io.sstable.format.big;
 
 import java.io.IOException;
+import java.util.Optional;
 import java.util.OptionalInt;
 
 import org.slf4j.Logger;
@@ -75,11 +76,12 @@ public class BigSSTableReaderLoadingBuilder extends SortedTableReaderLoadingBuil
             if (online && builder.getTableMetadataRef().getLocal().params.caching.cacheKeys())
                 builder.setKeyCache(new KeyCache(CacheService.instance.keyCache));
 
-            StatsComponent statsComponent = StatsComponent.load(descriptor, MetadataType.STATS, MetadataType.HEADER, MetadataType.VALIDATION);
+            StatsComponent statsComponent = StatsComponent.load(descriptor, MetadataType.STATS, MetadataType.HEADER, MetadataType.VALIDATION, MetadataType.COMPACTION);
             builder.setSerializationHeader(statsComponent.serializationHeader(descriptor, builder.getTableMetadataRef().getLocal()));
             checkArgument(!online || builder.getSerializationHeader() != null);
 
             builder.setStatsMetadata(statsComponent.statsMetadata());
+            builder.setCompactionMetadata(Optional.ofNullable(statsComponent.compactionMetadata()));
             if (descriptor.version.hasKeyRange() && statsComponent.statsMetadata() != null)
             {
                 builder.setFirst(tableMetadataRef.getLocal().partitioner.decorateKey(statsComponent.statsMetadata().firstKey));

--- a/src/java/org/apache/cassandra/io/sstable/format/big/BigTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/BigTableWriter.java
@@ -22,6 +22,7 @@ import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Consumer;
 
 import com.google.common.collect.ImmutableSet;
@@ -49,6 +50,10 @@ import org.apache.cassandra.io.sstable.indexsummary.IndexSummary;
 import org.apache.cassandra.io.sstable.indexsummary.IndexSummaryBuilder;
 import org.apache.cassandra.io.sstable.keycache.KeyCache;
 import org.apache.cassandra.io.sstable.keycache.KeyCacheSupport;
+import org.apache.cassandra.io.sstable.metadata.CompactionMetadata;
+import org.apache.cassandra.io.sstable.metadata.MetadataComponent;
+import org.apache.cassandra.io.sstable.metadata.MetadataType;
+import org.apache.cassandra.io.sstable.metadata.StatsMetadata;
 import org.apache.cassandra.io.util.DataPosition;
 import org.apache.cassandra.io.util.FileHandle;
 import org.apache.cassandra.io.util.FileUtils;
@@ -146,7 +151,9 @@ public class BigTableWriter extends SortedTableWriter<BigFormatPartitionWriter, 
         try
         {
 
-            builder.setStatsMetadata(statsMetadata());
+            Map<MetadataType, MetadataComponent> finalMetadata = finalizeMetadata();
+            builder.setStatsMetadata((StatsMetadata) finalMetadata.get(MetadataType.STATS));
+            builder.setCompactionMetadata(Optional.ofNullable((CompactionMetadata) finalMetadata.get(MetadataType.COMPACTION)));
 
             EstimatedHistogram partitionSizeHistogram = builder.getStatsMetadata().estimatedPartitionSize;
             if (boundary != null)

--- a/src/java/org/apache/cassandra/io/sstable/format/bti/BtiTableReaderLoadingBuilder.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/bti/BtiTableReaderLoadingBuilder.java
@@ -19,6 +19,7 @@
 package org.apache.cassandra.io.sstable.format.bti;
 
 import java.io.IOException;
+import java.util.Optional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -92,11 +93,12 @@ public class BtiTableReaderLoadingBuilder extends SortedTableReaderLoadingBuilde
     {
         try
         {
-            StatsComponent statsComponent = StatsComponent.load(descriptor, MetadataType.STATS, MetadataType.VALIDATION, MetadataType.HEADER);
+            StatsComponent statsComponent = StatsComponent.load(descriptor, MetadataType.STATS, MetadataType.VALIDATION, MetadataType.HEADER, MetadataType.COMPACTION);
             builder.setSerializationHeader(statsComponent.serializationHeader(descriptor, builder.getTableMetadataRef().getLocal()));
             checkArgument(!online || builder.getSerializationHeader() != null);
 
             builder.setStatsMetadata(statsComponent.statsMetadata());
+            builder.setCompactionMetadata(Optional.ofNullable(statsComponent.compactionMetadata()));
             ValidationMetadata validationMetadata = statsComponent.validationMetadata();
             validatePartitioner(builder.getTableMetadataRef().getLocal(), validationMetadata);
 

--- a/src/java/org/apache/cassandra/io/sstable/format/bti/BtiTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/bti/BtiTableWriter.java
@@ -19,6 +19,8 @@ package org.apache.cassandra.io.sstable.format.bti;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -44,6 +46,10 @@ import org.apache.cassandra.io.sstable.format.SSTableReader.OpenReason;
 import org.apache.cassandra.io.sstable.format.SSTableFormat;
 import org.apache.cassandra.io.sstable.format.SortedTableWriter;
 import org.apache.cassandra.io.sstable.format.bti.BtiFormat.Components;
+import org.apache.cassandra.io.sstable.metadata.CompactionMetadata;
+import org.apache.cassandra.io.sstable.metadata.MetadataComponent;
+import org.apache.cassandra.io.sstable.metadata.MetadataType;
+import org.apache.cassandra.io.sstable.metadata.StatsMetadata;
 import org.apache.cassandra.io.util.DataPosition;
 import org.apache.cassandra.io.util.FileHandle;
 import org.apache.cassandra.io.util.MmappedRegionsCache;
@@ -101,7 +107,9 @@ public class BtiTableWriter extends SortedTableWriter<BtiFormatPartitionWriter, 
 
         try
         {
-            builder.setStatsMetadata(statsMetadata());
+            Map<MetadataType, MetadataComponent> finalMetadata = finalizeMetadata();
+            builder.setStatsMetadata((StatsMetadata) finalMetadata.get(MetadataType.STATS));
+            builder.setCompactionMetadata(Optional.ofNullable((CompactionMetadata)finalMetadata.get(MetadataType.COMPACTION)));
 
             partitionIndex = partitionIndexSupplier.get();
             rowIndexFile = indexWriter.rowIndexFHBuilder.complete();

--- a/test/distributed/org/apache/cassandra/io/sstable/format/ForwardingSSTableReader.java
+++ b/test/distributed/org/apache/cassandra/io/sstable/format/ForwardingSSTableReader.java
@@ -23,6 +23,7 @@ import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.RateLimiter;
@@ -51,6 +52,7 @@ import org.apache.cassandra.io.sstable.IVerifier;
 import org.apache.cassandra.io.sstable.KeyIterator;
 import org.apache.cassandra.io.sstable.KeyReader;
 import org.apache.cassandra.io.sstable.SSTableReadsListener;
+import org.apache.cassandra.io.sstable.metadata.CompactionMetadata;
 import org.apache.cassandra.io.sstable.metadata.StatsMetadata;
 import org.apache.cassandra.io.util.ChannelProxy;
 import org.apache.cassandra.io.util.CheckedFunction;
@@ -526,6 +528,12 @@ public abstract class ForwardingSSTableReader extends SSTableReader
     public StatsMetadata getSSTableMetadata()
     {
         return delegate.getSSTableMetadata();
+    }
+
+    @Override
+    public Optional<CompactionMetadata> getCompactionMetadata() throws IOException
+    {
+        return delegate.getCompactionMetadataUnsafe();
     }
 
     @Override

--- a/test/unit/org/apache/cassandra/db/lifecycle/LogTransactionTest.java
+++ b/test/unit/org/apache/cassandra/db/lifecycle/LogTransactionTest.java
@@ -1392,6 +1392,7 @@ public class LogTransactionTest extends AbstractTransactionalTest
                                                                          .setFilter(FilterFactory.AlwaysPresent)
                                                                          .setMaxDataAge(1L)
                                                                          .setStatsMetadata(metadata)
+                                                                         .setCompactionMetadata(null)
                                                                          .setOpenReason(SSTableReader.OpenReason.NORMAL)
                                                                          .setSerializationHeader(header)
                                                                          .setFirst(key)

--- a/test/unit/org/apache/cassandra/io/sstable/SSTableReaderTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/SSTableReaderTest.java
@@ -18,6 +18,7 @@
 package org.apache.cassandra.io.sstable;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.attribute.FileTime;
@@ -29,6 +30,7 @@ import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
@@ -93,6 +95,7 @@ import org.apache.cassandra.io.sstable.format.bti.BtiFormat;
 import org.apache.cassandra.io.sstable.indexsummary.IndexSummarySupport;
 import org.apache.cassandra.io.sstable.keycache.KeyCache;
 import org.apache.cassandra.io.sstable.keycache.KeyCacheSupport;
+import org.apache.cassandra.io.sstable.metadata.CompactionMetadata;
 import org.apache.cassandra.io.sstable.metadata.MetadataComponent;
 import org.apache.cassandra.io.sstable.metadata.MetadataType;
 import org.apache.cassandra.io.sstable.metadata.ValidationMetadata;
@@ -122,6 +125,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
@@ -1505,7 +1509,7 @@ public class SSTableReaderTest
     }
 
     @Test
-    public void testGetApproximateKeyCount() throws InterruptedException
+    public void testGetApproximateKeyCount() throws Exception
     {
         ColumnFamilyStore store = discardSSTables(KEYSPACE1, CF_STANDARD);
         getNewSSTable(store);
@@ -1516,6 +1520,31 @@ public class SSTableReaderTest
 
             TimeUnit.MILLISECONDS.sleep(1000); //Giving enough time to clear files.
             List<SSTableReader> sstables = new ArrayList<>(viewFragment1.sstables);
+            assertEquals(50, SSTableReader.getApproximateKeyCount(sstables));
+
+            Field compactionMetadataField = ReflectionUtils.getField(SSTable.class, "compactionMetadata");
+            for (SSTableReader sstable : sstables)
+                compactionMetadataField.set(sstable, null);
+
+            // simulate the case in which CompactionMetadata is not loaded yet
+            for (SSTableReader sstable : sstables)
+                assertNull(compactionMetadataField.get(sstable));
+
+            assertEquals(50, SSTableReader.getApproximateKeyCount(sstables));
+
+            // verify that CompactionMetadata has been loaded from storage
+            for (SSTableReader sstable : sstables)
+            {
+                Optional<CompactionMetadata> compactionMetadata = (Optional<CompactionMetadata>) compactionMetadataField.get(sstable);
+                assertNotNull(compactionMetadata);
+                assertTrue(compactionMetadata.isPresent());
+            }
+
+            // simulate the case in which CompactionMetadata is not present
+            for (SSTableReader sstable : sstables)
+                compactionMetadataField.set(sstable, Optional.empty());
+
+            // in this case the cardinality is not available, so we fallback to the index summary
             assertEquals(50, SSTableReader.getApproximateKeyCount(sstables));
         }
     }


### PR DESCRIPTION
### What is the issue
Every time you call getApproximateKeyCount Cassandra reads from storage and deserialize CompactionMetadata, and in order to do it it also reads CompressionMetadata in case of Compression.

```
  at org.apache.cassandra.io.util.PathUtils.newFileChannel(PathUtils.java:113)
        at org.apache.cassandra.io.util.PathUtils.newReadChannel(PathUtils.java:91)
        at org.apache.cassandra.io.util.File.newReadChannel(File.java:597)
        at org.apache.cassandra.io.util.FileInputStreamPlus.<init>(FileInputStreamPlus.java:39)
        at org.apache.cassandra.io.util.File.newInputStream(File.java:634)
        at org.apache.cassandra.io.compress.CompressionMetadata.<init>(CompressionMetadata.java:170)
        at org.apache.cassandra.io.compress.CompressionMetadata.read(CompressionMetadata.java:138)
        at org.apache.cassandra.io.compress.CompressionMetadata.read(CompressionMetadata.java:130)
        at org.apache.cassandra.io.compress.CompressionMetadata.read(CompressionMetadata.java:115)
        at org.apache.cassandra.io.sstable.metadata.MetadataSerializer.getEncryptor(MetadataSerializer.java:345)
        at org.apache.cassandra.io.sstable.metadata.MetadataSerializer.deserialize(MetadataSerializer.java:216)
        at org.apache.cassandra.io.sstable.metadata.MetadataSerializer.deserialize(MetadataSerializer.java:162)
        at org.apache.cassandra.io.sstable.metadata.MetadataSerializer.deserialize(MetadataSerializer.java:170)
        at org.apache.cassandra.io.sstable.format.SSTableReader.getApproximateKeyCount(SSTableReader.java:347)
```

### What does this PR fix and why was it fixed
CompactionMetadata is immutable, we can cache it instead of reading and deserializing from storage every time-

---------
