### PR TITLE
CNDB-15002: Fix handling of grouped primary keys in ScoreOrderedResultRetriever (#1932)

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/format/Version.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/Version.java
@@ -67,7 +67,7 @@ public class Version implements Comparable<Version>
     // Start validating vector index component checksums, except for the TERMS_FILE because it's checksum is non-standard
     // and isn't easily validated when an sstable index has multiple segments within the TERMS_FILE.
     public static final Version EC = new Version("ec", V7OnDiskFormat.instance, (c, i, g) -> stargazerFileNameFormat(c, i, g, "ec"));
-    // total terms count serialization in index metadata
+    // total terms count serialization in index metadata, enables ANN_USE_SYNTHETIC_SCORE by default
     public static final Version ED = new Version("ed", V7OnDiskFormat.instance, (c, i, g) -> stargazerFileNameFormat(c, i, g, "ed"));
 
     // These are in reverse-chronological order so that the latest version is first. Version matching tests

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorTester.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorTester.java
@@ -174,7 +174,7 @@ public class VectorTester extends SAITester
     }
 
     /**
-     * {@link VectorTester} parameterized for {@link Version#CA}, {@link Version#DC}, and {@link Version#EB}.
+     * {@link VectorTester} parameterized for {@link Version#CA}, {@link Version#DC}, {@link Version#EC}, and {@link Version#ED}.
      */
     @Ignore
     @RunWith(Parameterized.class)
@@ -187,7 +187,7 @@ public class VectorTester extends SAITester
         public static Collection<Object[]> data()
         {
             // See Version file for explanation of changes associated with each version
-            return Stream.of(Version.CA, Version.DC, Version.EC).map(v -> new Object[]{ v }).collect(Collectors.toList());
+            return Stream.of(Version.CA, Version.DC, Version.EC, Version.ED).map(v -> new Object[]{ v }).collect(Collectors.toList());
         }
 
         @Before


### PR DESCRIPTION
### What is the issue
Fixes https://github.com/riptano/cndb/issues/15002

### What does this PR fix and why was it fixed
In the `ScoreOrderedResultRetriever`, we pull in up to `limit` Primary Keys. In the test case added, that includes two of the same primary keys because of an update. The bug then came from assuming that all of the `PrimaryKey` objects were interchangeable, so the `PrimaryKeyIterator` took the first one in the list, but that was invalid because when we use the PrimaryKey to get the score for the row, we need to use the score from the key that is actually valid.

The fix corrects this behavior by removing the ambiguity of which key to use.
