### PR TITLE
CND-14215: fix SSTablePartitionsTest.testDirectory

### DIFF
--- a/src/java/org/apache/cassandra/db/SerializationHeader.java
+++ b/src/java/org/apache/cassandra/db/SerializationHeader.java
@@ -339,7 +339,7 @@ public class SerializationHeader
             }
             catch (InvalidColumnTypeException e)
             {
-                AbstractType<?> fixed = allowImplicitlyFrozenTuples ? tryFix(type, columnName, isPrimaryKeyColumn, metadata.isCounter(), dropped, isForOfflineTool) : null;
+                AbstractType<?> fixed = (allowImplicitlyFrozenTuples || isForOfflineTool) ? tryFix(type, columnName, isPrimaryKeyColumn, metadata.isCounter(), dropped, isForOfflineTool) : null;
                 if (fixed == null)
                 {
                     // We don't know how to fix. We throw an error here because reading such table may result in corruption

--- a/src/java/org/apache/cassandra/io/sstable/format/StatsComponent.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/StatsComponent.java
@@ -77,12 +77,17 @@ public class StatsComponent
 
     public SerializationHeader serializationHeader(Descriptor descriptor, TableMetadata metadata)
     {
+        return serializationHeader(descriptor, metadata, false);
+    }
+
+    public SerializationHeader serializationHeader(Descriptor descriptor, TableMetadata metadata, boolean isOfflineTool)
+    {
         SerializationHeader.Component header = serializationHeader();
         if (header != null)
         {
             try
             {
-                return header.toHeader(descriptor, metadata);
+                return header.toHeader(descriptor.toString(), metadata, descriptor.version, isOfflineTool);
             }
             catch (UnknownColumnException ex)
             {

--- a/src/java/org/apache/cassandra/io/sstable/format/big/BigSSTableReaderLoadingBuilder.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/BigSSTableReaderLoadingBuilder.java
@@ -77,7 +77,7 @@ public class BigSSTableReaderLoadingBuilder extends SortedTableReaderLoadingBuil
                 builder.setKeyCache(new KeyCache(CacheService.instance.keyCache));
 
             StatsComponent statsComponent = StatsComponent.load(descriptor, MetadataType.STATS, MetadataType.HEADER, MetadataType.VALIDATION, MetadataType.COMPACTION);
-            builder.setSerializationHeader(statsComponent.serializationHeader(descriptor, builder.getTableMetadataRef().getLocal()));
+            builder.setSerializationHeader(statsComponent.serializationHeader(descriptor, builder.getTableMetadataRef().getLocal(), !online));
             checkArgument(!online || builder.getSerializationHeader() != null);
 
             builder.setStatsMetadata(statsComponent.statsMetadata());

--- a/src/java/org/apache/cassandra/io/sstable/format/bti/BtiTableReaderLoadingBuilder.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/bti/BtiTableReaderLoadingBuilder.java
@@ -94,7 +94,7 @@ public class BtiTableReaderLoadingBuilder extends SortedTableReaderLoadingBuilde
         try
         {
             StatsComponent statsComponent = StatsComponent.load(descriptor, MetadataType.STATS, MetadataType.VALIDATION, MetadataType.HEADER, MetadataType.COMPACTION);
-            builder.setSerializationHeader(statsComponent.serializationHeader(descriptor, builder.getTableMetadataRef().getLocal()));
+            builder.setSerializationHeader(statsComponent.serializationHeader(descriptor, builder.getTableMetadataRef().getLocal(), !online));
             checkArgument(!online || builder.getSerializationHeader() != null);
 
             builder.setStatsMetadata(statsComponent.statsMetadata());


### PR DESCRIPTION
### What is the issue

SSTablePartitionsTest.testDirectory fails with an AssertionError deserializing a header

### What does this PR fix and why was it fixed

`StatsComponent.serializeHeader` needed to know about offline tools to avoid the assertion.  However, the `legacy_ma_tuple` test SSTable has an invalid schema (non-frozen tuple with non-frozen collections) and after the validation added by CNDB-10090, this is correctly detected, which doesn't happen in OSS.  As a result, the test has also been modified so that unclean stderr can optionally be allowed.
