### PR TITLE
CNDB-15137 Tracks config options set in yaml, used by GuardrailsOptions.enforceDetault to set recommended values.

### DIFF
--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -60,6 +60,9 @@ public class Config
 {
     private static final Logger logger = LoggerFactory.getLogger(Config.class);
 
+    // Tracks the set of config keys set by the user.  See CNDB-15137
+    public final Set<String> userSetConfigKeys = new HashSet<>();
+
     public static Set<String> splitCommaDelimited(String src)
     {
         if (src == null)

--- a/src/java/org/apache/cassandra/config/YamlConfigurationLoader.java
+++ b/src/java/org/apache/cassandra/config/YamlConfigurationLoader.java
@@ -375,6 +375,11 @@ public class YamlConfigurationLoader implements ConfigurationLoader
                     if (value == null && get(object) != null && !allowsNull)
                         nullProperties.add(getName());
 
+                    // Record the property name if set from YAML
+                    if (object instanceof Config) {
+                        ((Config) object).userSetConfigKeys.add(getName());
+                    }
+
                     result.set(object, value);
                 }
 

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/datamodels/MultiNodeQueryTester.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/datamodels/MultiNodeQueryTester.java
@@ -36,6 +36,7 @@ import org.apache.cassandra.index.sai.cql.datamodels.DataModel;
 import org.apache.cassandra.index.sai.cql.datamodels.IndexQuerySupport;
 import org.apache.cassandra.utils.Shared;
 
+import static org.apache.cassandra.config.CassandraRelevantProperties.ENABLE_GUARDRAILS_FOR_ANONYMOUS_USER;
 import static org.apache.cassandra.distributed.api.Feature.GOSSIP;
 import static org.apache.cassandra.distributed.api.Feature.NETWORK;
 
@@ -65,6 +66,10 @@ abstract class MultiNodeQueryTester extends TestBaseImpl
     @BeforeClass
     public static void setupCluster() throws Exception
     {
+        // Disable guardrails for anonymous users (no client authentication) This allows the test to avoid
+        // being affected by guardrails for anonymous users.
+        ENABLE_GUARDRAILS_FOR_ANONYMOUS_USER.setBoolean(false);
+
         cluster = Cluster.build(3)
                          .withConfig(config -> config.with(NETWORK, GOSSIP)
                                                      .set("hinted_handoff_enabled", false))

--- a/test/unit/org/apache/cassandra/config/DatabaseDescriptorTest.java
+++ b/test/unit/org/apache/cassandra/config/DatabaseDescriptorTest.java
@@ -338,7 +338,7 @@ public class DatabaseDescriptorTest
             fail("Should have received a IllegalArgumentException batch_size_warn_threshold = -1");
         }
         catch (IllegalArgumentException ignored) { }
-        Assert.assertEquals(5120, DatabaseDescriptor.getBatchSizeWarnThreshold());
+        Assert.assertEquals(65536, DatabaseDescriptor.getBatchSizeWarnThreshold());
 
         try
         {

--- a/test/unit/org/apache/cassandra/config/DatabaseDescriptorTest.java
+++ b/test/unit/org/apache/cassandra/config/DatabaseDescriptorTest.java
@@ -346,7 +346,7 @@ public class DatabaseDescriptorTest
             fail("Should have received a ConfigurationException batch_size_warn_threshold = 2GiB");
         }
         catch (ConfigurationException ignored) { }
-        Assert.assertEquals(5120, DatabaseDescriptor.getBatchSizeWarnThreshold());
+        Assert.assertEquals(65536, DatabaseDescriptor.getBatchSizeWarnThreshold());
     }
 
     @Test


### PR DESCRIPTION
Fixes CNDB-15137

### What is the issue
The original port of STAR-543 incorrectly omitted the ability to enforce guardrail configuration defaults.

### What does this PR fix and why was it fixed
Restores the GuardrailsOptons.enforceDefault method that was omitted when STAR-543 was ported to CC 5.0. With this change, `YamlConfigurationLoader` tracks config options set in yaml, so that `GuardrailsOptions.enforceDetault` can determine when to set recommended values for on premise or CNDB uses.
