### PR TITLE
CNDB-15153: Improve logging of partition-restricted index queries

### DIFF
--- a/src/java/org/apache/cassandra/db/DataRange.java
+++ b/src/java/org/apache/cassandra/db/DataRange.java
@@ -252,6 +252,21 @@ public class DataRange
         return new DataRange(range, clusteringIndexFilter);
     }
 
+    /**
+     * Whether this range queries a single partition. That happens for partition queries using secondary indexes, which
+     * are internally mapped to range commands using a single-key data range.
+     *
+     * @return {@code true} if this range queries a single partition, {@code false} otherwise
+     */
+    public boolean isSinglePartition()
+    {
+        return keyRange.inclusiveLeft() &&
+               keyRange.inclusiveRight() &&
+               keyRange.left instanceof DecoratedKey &&
+               keyRange.right instanceof DecoratedKey &&
+               keyRange.left.equals(keyRange.right);
+    }
+
     public String toString(TableMetadata metadata)
     {
         return String.format("range=%s pfilter=%s", keyRange.getString(metadata.partitionKeyType), clusteringIndexFilter.toString(metadata));
@@ -265,17 +280,33 @@ public class DataRange
         CqlBuilder builder = new CqlBuilder();
 
         boolean needAnd = false;
-        if (!startKey().isMinimum())
+
+        if (isSinglePartition())
         {
-            appendClause(startKey(), builder, metadata, true, keyRange.isStartInclusive());
+            /*
+             * Single partition queries using an index are internally mapped to range commands where the start and end
+             * key are the same. If that is the case, we want to print the query as an equality on the partition key
+             * rather than a token range, as if it was a partition query, for better readability.
+             */
+            builder.append(ColumnMetadata.toCQLString(metadata.partitionKeyColumns()));
+            builder.append(" = ");
+            appendKeyString(builder, metadata.partitionKeyType, ((DecoratedKey) startKey()).getKey());
             needAnd = true;
         }
-        if (!stopKey().isMinimum())
+        else
         {
-            if (needAnd)
-                builder.append(" AND ");
-            appendClause(stopKey(), builder, metadata, false, keyRange.isEndInclusive());
-            needAnd = true;
+            if (!startKey().isMinimum())
+            {
+                appendClause(startKey(), builder, metadata, true, keyRange.isStartInclusive());
+                needAnd = true;
+            }
+            if (!stopKey().isMinimum())
+            {
+                if (needAnd)
+                    builder.append(" AND ");
+                appendClause(stopKey(), builder, metadata, false, keyRange.isEndInclusive());
+                needAnd = true;
+            }
         }
 
         String filterString = clusteringIndexFilter.toCQLString(metadata);

--- a/src/java/org/apache/cassandra/db/filter/ClusteringIndexNamesFilter.java
+++ b/src/java/org/apache/cassandra/db/filter/ClusteringIndexNamesFilter.java
@@ -167,12 +167,28 @@ public class ClusteringIndexNamesFilter extends AbstractClusteringIndexFilter
             return "";
 
         StringBuilder sb = new StringBuilder();
-        sb.append('(').append(ColumnMetadata.toCQLString(metadata.clusteringColumns())).append(')');
-        sb.append(clusterings.size() == 1 ? " = " : " IN (");
+
+        boolean multipleColumns = metadata.clusteringColumns().size() > 1;
+        boolean multipleClusterings = clusterings.size() > 1;
+
+        if (multipleColumns)
+            sb.append('(');
+        sb.append(ColumnMetadata.toCQLString(metadata.clusteringColumns()));
+        if (multipleColumns)
+            sb.append(')');
+        sb.append(multipleClusterings ? " IN (" : " = ");
         int i = 0;
         for (Clustering<?> clustering : clusterings)
-            sb.append(i++ == 0 ? "" : ", ").append('(').append(clustering.toCQLString(metadata)).append(')');
-        sb.append(clusterings.size() == 1 ? "" : ")");
+        {
+            sb.append(i++ == 0 ? "" : ", ");
+            if (multipleColumns)
+                sb.append('(');
+            sb.append(clustering.toCQLString(metadata));
+            if (multipleColumns)
+                sb.append(')');
+        }
+        if (multipleClusterings)
+            sb.append(')');
 
         appendOrderByToCQLString(metadata, sb);
         return sb.toString();

--- a/test/unit/org/apache/cassandra/db/PartitionRangeReadCommandCQLTest.java
+++ b/test/unit/org/apache/cassandra/db/PartitionRangeReadCommandCQLTest.java
@@ -17,6 +17,9 @@ package org.apache.cassandra.db;
 
 import org.junit.Test;
 
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.dht.IPartitioner;
 import org.assertj.core.api.Assertions;
 
 public class PartitionRangeReadCommandCQLTest extends ReadCommandCQLTester<PartitionRangeReadCommand>
@@ -28,19 +31,62 @@ public class PartitionRangeReadCommandCQLTest extends ReadCommandCQLTester<Parti
 
         assertToCQLString("SELECT * FROM %s", "SELECT * FROM %s");
 
-        assertToCQLString("SELECT * FROM %s WHERE c = 0 ALLOW FILTERING", "SELECT * FROM %s WHERE (c) = (0)");
-        assertToCQLString("SELECT * FROM %s WHERE (c) = (0) ALLOW FILTERING", "SELECT * FROM %s WHERE (c) = (0)");
+        assertToCQLString("SELECT * FROM %s WHERE c = 0 ALLOW FILTERING", "SELECT * FROM %s WHERE c = 0");
+        assertToCQLString("SELECT * FROM %s WHERE (c) = (0) ALLOW FILTERING", "SELECT * FROM %s WHERE c = 0");
         assertToCQLString("SELECT * FROM %s WHERE c > 0 ALLOW FILTERING", "SELECT * FROM %s WHERE c > 0");
         assertToCQLString("SELECT * FROM %s WHERE c < 0 ALLOW FILTERING", "SELECT * FROM %s WHERE c < 0");
         assertToCQLString("SELECT * FROM %s WHERE c >= 0 ALLOW FILTERING", "SELECT * FROM %s WHERE c >= 0");
         assertToCQLString("SELECT * FROM %s WHERE c <= 0 ALLOW FILTERING", "SELECT * FROM %s WHERE c <= 0");
 
         assertToCQLString("SELECT * FROM %s WHERE v = 1 ALLOW FILTERING", "SELECT * FROM %s WHERE v = 1");
-        assertToCQLString("SELECT * FROM %s WHERE c = 0 AND v = 1 ALLOW FILTERING", "SELECT * FROM %s WHERE v = 1 AND (c) = (0)");
+        assertToCQLString("SELECT * FROM %s WHERE c = 0 AND v = 1 ALLOW FILTERING", "SELECT * FROM %s WHERE v = 1 AND c = 0");
         assertToCQLString("SELECT * FROM %s WHERE c > 0 AND v = 1 ALLOW FILTERING", "SELECT * FROM %s WHERE v = 1 AND c > 0");
         assertToCQLString("SELECT * FROM %s WHERE c < 0 AND v = 1 ALLOW FILTERING", "SELECT * FROM %s WHERE v = 1 AND c < 0");
         assertToCQLString("SELECT * FROM %s WHERE c >= 0 AND v = 1 ALLOW FILTERING", "SELECT * FROM %s WHERE v = 1 AND c >= 0");
         assertToCQLString("SELECT * FROM %s WHERE c <= 0 AND v = 1 ALLOW FILTERING", "SELECT * FROM %s WHERE v = 1 AND c <= 0");
+
+        // test with token restrictions
+        IPartitioner partitioner = DatabaseDescriptor.getPartitioner();
+        String token = partitioner.getToken(Int32Type.instance.decompose(0)).toString();
+        assertToCQLString("SELECT * FROM %s WHERE token(k) > token(0)",
+                          "SELECT * FROM %s WHERE token(k) > " + token);
+        assertToCQLString("SELECT * FROM %s WHERE token(k) >= token(0)",
+                          "SELECT * FROM %s WHERE token(k) >= " + token);
+        assertToCQLString("SELECT * FROM %s WHERE token(k) >= token(0) AND token(k) <= token(0)",
+                          "SELECT * FROM %s WHERE token(k) >= " + token + " AND token(k) <= " + token);
+
+        // test with a secondary index (indexed queries are always mapped to range commands)
+        createIndex("CREATE INDEX ON %s(v)");
+        assertToCQLString("SELECT * FROM %s WHERE v = 0", "SELECT * FROM %s WHERE v = 0");
+        assertToCQLString("SELECT * FROM %s WHERE v = 0 AND k = 0", "SELECT * FROM %s WHERE v = 0 AND k = 0");
+        assertToCQLString("SELECT * FROM %s WHERE v = 0 AND k = 0 AND c = 0", "SELECT * FROM %s WHERE v = 0 AND k = 0 AND c = 0");
+        assertToCQLString("SELECT * FROM %s WHERE v = 0 AND k = 0 AND c > 0", "SELECT * FROM %s WHERE v = 0 AND k = 0 AND c > 0");
+        assertToCQLString("SELECT * FROM %s WHERE v = 0 AND k = 0 AND c < 0", "SELECT * FROM %s WHERE v = 0 AND k = 0 AND c < 0");
+        assertToCQLString("SELECT * FROM %s WHERE v = 0 AND k = 0 AND c >= 0", "SELECT * FROM %s WHERE v = 0 AND k = 0 AND c >= 0");
+        assertToCQLString("SELECT * FROM %s WHERE v = 0 AND k = 0 AND c <= 0", "SELECT * FROM %s WHERE v = 0 AND k = 0 AND c <= 0");
+        assertToCQLString("SELECT * FROM %s WHERE v = 0 AND k = 0 AND c IN (0)", "SELECT * FROM %s WHERE v = 0 AND k = 0 AND c = 0");
+        assertToCQLString("SELECT * FROM %s WHERE v = 0 AND k = 0 AND c IN (0, 1)", "SELECT * FROM %s WHERE v = 0 AND k = 0 AND c IN (0, 1)");
+        assertToCQLString("SELECT * FROM %s WHERE v = 0 AND token(k) > token(0)",
+                          "SELECT * FROM %s WHERE v = 0 AND token(k) > " + token);
+        assertToCQLString("SELECT * FROM %s WHERE v = 0 AND token(k) >= token(0)",
+                          "SELECT * FROM %s WHERE v = 0 AND token(k) >= " + token);
+        assertToCQLString("SELECT * FROM %s WHERE v = 0 AND token(k) >= token(0) AND token(k) <= token(0)",
+                          "SELECT * FROM %s WHERE v = 0 AND token(k) >= " + token + " AND token(k) <= " + token);
+
+        // test with index and multi-column clustering
+        createTable("CREATE TABLE %s (k int, c1 int, c2 int,v int, PRIMARY KEY (k, c1, c2))");
+        createIndex("CREATE INDEX ON %s(v)");
+        assertToCQLString("SELECT * FROM %s WHERE v = 0 AND k = 0", "SELECT * FROM %s WHERE v = 0 AND k = 0");
+        assertToCQLString("SELECT * FROM %s WHERE v = 0 AND k = 0 AND c1 = 1", "SELECT * FROM %s WHERE v = 0 AND k = 0 AND c1 = 1");
+        assertToCQLString("SELECT * FROM %s WHERE v = 0 AND k = 0 AND c1 > 1", "SELECT * FROM %s WHERE v = 0 AND k = 0 AND c1 > 1");
+        assertToCQLString("SELECT * FROM %s WHERE v = 0 AND k = 0 AND c1 < 1", "SELECT * FROM %s WHERE v = 0 AND k = 0 AND c1 < 1");
+        assertToCQLString("SELECT * FROM %s WHERE v = 0 AND k = 0 AND c1 >= 1", "SELECT * FROM %s WHERE v = 0 AND k = 0 AND c1 >= 1");
+        assertToCQLString("SELECT * FROM %s WHERE v = 0 AND k = 0 AND c1 <= 1", "SELECT * FROM %s WHERE v = 0 AND k = 0 AND c1 <= 1");
+        assertToCQLString("SELECT * FROM %s WHERE v = 0 AND k = 0 AND c1 = 1 AND c2 = 2", "SELECT * FROM %s WHERE v = 0 AND k = 0 AND (c1, c2) = (1, 2)");
+        assertToCQLString("SELECT * FROM %s WHERE v = 0 AND k = 0 AND c1 = 1 AND c2 > 2", "SELECT * FROM %s WHERE v = 0 AND k = 0 AND c1 = 1 AND c2 > 2");
+        assertToCQLString("SELECT * FROM %s WHERE v = 0 AND k = 0 AND c1 = 1 AND c2 < 2", "SELECT * FROM %s WHERE v = 0 AND k = 0 AND c1 = 1 AND c2 < 2");
+        assertToCQLString("SELECT * FROM %s WHERE v = 0 AND k = 0 AND c1 = 1 AND c2 >= 2", "SELECT * FROM %s WHERE v = 0 AND k = 0 AND c1 = 1 AND c2 >= 2");
+        assertToCQLString("SELECT * FROM %s WHERE v = 0 AND k = 0 AND c1 = 1 AND c2 <= 2", "SELECT * FROM %s WHERE v = 0 AND k = 0 AND c1 = 1 AND c2 <= 2");
     }
 
     @Override
@@ -51,4 +97,3 @@ public class PartitionRangeReadCommandCQLTest extends ReadCommandCQLTester<Parti
         return (PartitionRangeReadCommand) command;
     }
 }
-

--- a/test/unit/org/apache/cassandra/db/SinglePartitionReadCommandCQLTest.java
+++ b/test/unit/org/apache/cassandra/db/SinglePartitionReadCommandCQLTest.java
@@ -46,15 +46,15 @@ public class SinglePartitionReadCommandCQLTest extends ReadCommandCQLTester<Sing
 
         assertToCQLString("SELECT * FROM %s WHERE k = 0", "SELECT * FROM %s WHERE k = 0");
 
-        assertToCQLString("SELECT * FROM %s WHERE k = 0 AND c = 0", "SELECT * FROM %s WHERE k = 0 AND (c) = (0)");
-        assertToCQLString("SELECT * FROM %s WHERE k = 0 AND (c) = (0)", "SELECT * FROM %s WHERE k = 0 AND (c) = (0)");
+        assertToCQLString("SELECT * FROM %s WHERE k = 0 AND c = 0", "SELECT * FROM %s WHERE k = 0 AND c = 0");
+        assertToCQLString("SELECT * FROM %s WHERE k = 0 AND (c) = (0)", "SELECT * FROM %s WHERE k = 0 AND c = 0");
         assertToCQLString("SELECT * FROM %s WHERE k = 0 AND c > 0", "SELECT * FROM %s WHERE k = 0 AND c > 0");
         assertToCQLString("SELECT * FROM %s WHERE k = 0 AND c < 0", "SELECT * FROM %s WHERE k = 0 AND c < 0");
         assertToCQLString("SELECT * FROM %s WHERE k = 0 AND c >= 0", "SELECT * FROM %s WHERE k = 0 AND c >= 0");
         assertToCQLString("SELECT * FROM %s WHERE k = 0 AND c <= 0", "SELECT * FROM %s WHERE k = 0 AND c <= 0");
 
         assertToCQLString("SELECT * FROM %s WHERE k = 0 AND v = 1 ALLOW FILTERING", "SELECT * FROM %s WHERE k = 0 AND v = 1");
-        assertToCQLString("SELECT * FROM %s WHERE k = 0 AND c = 0 AND v = 1 ALLOW FILTERING", "SELECT * FROM %s WHERE k = 0 AND v = 1 AND (c) = (0)");
+        assertToCQLString("SELECT * FROM %s WHERE k = 0 AND c = 0 AND v = 1 ALLOW FILTERING", "SELECT * FROM %s WHERE k = 0 AND v = 1 AND c = 0");
         assertToCQLString("SELECT * FROM %s WHERE k = 0 AND c > 0 AND v = 1 ALLOW FILTERING", "SELECT * FROM %s WHERE k = 0 AND v = 1 AND c > 0");
         assertToCQLString("SELECT * FROM %s WHERE k = 0 AND c < 0 AND v = 1 ALLOW FILTERING", "SELECT * FROM %s WHERE k = 0 AND v = 1 AND c < 0");
         assertToCQLString("SELECT * FROM %s WHERE k = 0 AND c >= 0 AND v = 1 ALLOW FILTERING", "SELECT * FROM %s WHERE k = 0 AND v = 1 AND c >= 0");


### PR DESCRIPTION
Single partition queries using an index are internally mapped to range commands. Partition key restrictions are printed as token ranges. As a result a query like:
```
CREATE TABLE t (k int PRIMARY KEY, v int);
CREATE CUSTOM INDEX ON t(v) USING 'StorageAttachedIndex';
SELECT * FROM t WHERE v = 0 AND k = 0;
```
Will be logged as:
```
SELECT * FROM t WHERE v = 0 AND token(k) >= token(0) AND token(k) <= token(0)
```
While this format is kind of correct, it makes logs harder to read and makes one doubt for a second whether the query is a partition key. Note that this example is small, but it can look worse with multiple partition columns with long names and more index and clustering restrictions, as we have seen in production.

Also, the printed query is not strictly equivalent to the original query nor the underlying command because it will not discard token collisions.

This PR modifies the behaviour of `PartitionRangeReadCommand.toCQLString` to print the single-key ranges produced by secondary indexes as an equality on the primary key, rather than as a token range.
