### PR TITLE
CNDB-15097: Mock with stubOnly and clear mocks between runs to save heap

### DIFF
--- a/test/unit/org/apache/cassandra/db/compaction/UnifiedCompactionStrategyTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/UnifiedCompactionStrategyTest.java
@@ -43,6 +43,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import org.junit.Assert;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -119,10 +120,16 @@ public class UnifiedCompactionStrategyTest extends BaseCompactionStrategyTest
         super.setUp();
     }
 
+    @After
+    public void tearDown()
+    {
+        Mockito.framework().clearInlineMocks();
+    }
+
     @Test
     public void testNoSSTables()
     {
-        Controller controller = Mockito.mock(Controller.class);
+        Controller controller = Mockito.mock(Controller.class, Mockito.withSettings().stubOnly());
         long minimalSizeBytes = 2 << 20;
         when(controller.getMinSstableSizeBytes()).thenReturn(minimalSizeBytes);
         when(controller.getScalingParameter(anyInt())).thenReturn(4);
@@ -205,7 +212,7 @@ public class UnifiedCompactionStrategyTest extends BaseCompactionStrategyTest
     {
         long minimalSizeBytes = m << 20;
 
-        Controller controller = Mockito.mock(Controller.class);
+        Controller controller = Mockito.mock(Controller.class, Mockito.withSettings().stubOnly());
         when(controller.getMinSstableSizeBytes()).thenReturn(minimalSizeBytes);
         when(controller.getNumShards(anyDouble())).thenReturn(1);
         when(controller.getBaseSstableSize(anyInt())).thenReturn((double) minimalSizeBytes);
@@ -325,7 +332,7 @@ public class UnifiedCompactionStrategyTest extends BaseCompactionStrategyTest
     {
         long minimalSizeBytes = m << 20;
 
-        Controller controller = Mockito.mock(Controller.class);
+        Controller controller = Mockito.mock(Controller.class, Mockito.withSettings().stubOnly());
         when(controller.getMinSstableSizeBytes()).thenReturn(minimalSizeBytes);
         when(controller.getNumShards(anyDouble())).thenReturn(16);
         when(controller.getBaseSstableSize(anyInt())).thenReturn((double) minimalSizeBytes);
@@ -412,7 +419,7 @@ public class UnifiedCompactionStrategyTest extends BaseCompactionStrategyTest
         final int m = 2; // minimal sorted run size in MB m
         long minimalSizeBytes = m << 20;
 
-        Controller controller = Mockito.mock(Controller.class);
+        Controller controller = Mockito.mock(Controller.class, Mockito.withSettings().stubOnly());
         when(controller.getMinSstableSizeBytes()).thenReturn(minimalSizeBytes);
         when(controller.getNumShards(anyDouble())).thenReturn(1);
         when(controller.getBaseSstableSize(anyInt())).thenReturn((double) minimalSizeBytes);
@@ -630,7 +637,7 @@ public class UnifiedCompactionStrategyTest extends BaseCompactionStrategyTest
         final int numShards = 1;
         final int levels = (int) Math.floor(Math.log(numSSTables) / Math.log(F)) + 1;
 
-        Controller controller = Mockito.mock(Controller.class);
+        Controller controller = Mockito.mock(Controller.class, Mockito.withSettings().stubOnly());
         when(controller.getMinSstableSizeBytes()).thenReturn(minSstableSizeBytes);
         when(controller.getScalingParameter(anyInt())).thenReturn(W);
         when(controller.getFanout(anyInt())).thenCallRealMethod();
@@ -655,7 +662,7 @@ public class UnifiedCompactionStrategyTest extends BaseCompactionStrategyTest
         when(controller.maxThroughput()).thenReturn(Double.MAX_VALUE);
         when(controller.getDataSetSizeBytes()).thenReturn(minSstableSizeBytes * numSSTables * numShards);
         when(controller.maxSSTablesToCompact()).thenReturn(maxSSTablesToCompact);
-        Random random = Mockito.mock(Random.class);
+        Random random = Mockito.mock(Random.class, Mockito.withSettings().stubOnly());
         when(random.nextInt(anyInt())).thenReturn(0);
         when(controller.random()).thenReturn(random);
 
@@ -791,7 +798,7 @@ public class UnifiedCompactionStrategyTest extends BaseCompactionStrategyTest
         final long minSstableSizeBytes = 2L << 20; // 2 MB
         final int numShards = 5;
 
-        Controller controller = Mockito.mock(Controller.class);
+        Controller controller = Mockito.mock(Controller.class, Mockito.withSettings().stubOnly());
         when(controller.getMinSstableSizeBytes()).thenReturn(minSstableSizeBytes);
         when(controller.getScalingParameter(anyInt())).thenReturn(W);
         when(controller.getFanout(anyInt())).thenCallRealMethod();
@@ -849,7 +856,7 @@ public class UnifiedCompactionStrategyTest extends BaseCompactionStrategyTest
 
     private CompactionProgress mockProgress(UnifiedCompactionStrategy strategy, TimeUUID id)
     {
-        CompactionProgress progress = Mockito.mock(CompactionProgress.class);
+        CompactionProgress progress = Mockito.mock(CompactionProgress.class, Mockito.withSettings().stubOnly());
         when(progress.durationInMillis()).thenReturn(1000L);
         when(progress.outputDiskSize()).thenReturn(1L);
         when(progress.operationId()).thenReturn(id);
@@ -1163,7 +1170,7 @@ public class UnifiedCompactionStrategyTest extends BaseCompactionStrategyTest
     {
         long minimalSizeBytes = m << 20;
 
-        Controller controller = Mockito.mock(Controller.class);
+        Controller controller = Mockito.mock(Controller.class, Mockito.withSettings().stubOnly());
         when(controller.getMinSstableSizeBytes()).thenReturn(minimalSizeBytes);
         when(controller.getScalingParameter(anyInt())).thenReturn(W);
         when(controller.getFanout(anyInt())).thenCallRealMethod();
@@ -1217,7 +1224,7 @@ public class UnifiedCompactionStrategyTest extends BaseCompactionStrategyTest
 
     private void assertCompactionTask(final int numShards, final int expectedNumOfTasks, boolean parallelizeOutputShards, Class expectedClass)
     {
-        Controller controller = Mockito.mock(Controller.class);
+        Controller controller = Mockito.mock(Controller.class, Mockito.withSettings().stubOnly());
         long minimalSizeBytes = 2 << 20;
         when(controller.getMinSstableSizeBytes()).thenReturn(minimalSizeBytes);
         when(controller.getScalingParameter(anyInt())).thenReturn(0);
@@ -1257,7 +1264,7 @@ public class UnifiedCompactionStrategyTest extends BaseCompactionStrategyTest
     @Test
     public void testGetNextCompactionAggregates()
     {
-        Controller controller = Mockito.mock(Controller.class);
+        Controller controller = Mockito.mock(Controller.class, Mockito.withSettings().stubOnly());
         long minimalSizeBytes = 2 << 20;
         when(controller.getMinSstableSizeBytes()).thenReturn(minimalSizeBytes);
         when(controller.getScalingParameter(anyInt())).thenReturn(0);
@@ -1278,14 +1285,14 @@ public class UnifiedCompactionStrategyTest extends BaseCompactionStrategyTest
 
         UnifiedCompactionStrategy strategy = new UnifiedCompactionStrategy(strategyFactory, controller);
 
-        CompactionPick compaction = Mockito.mock(CompactionPick.class);
+        CompactionPick compaction = Mockito.mock(CompactionPick.class, Mockito.withSettings().stubOnly());
         when(compaction.isEmpty()).thenReturn(false);
         when(compaction.hasExpiredOnly()).thenReturn(false);
         List<SSTableReader> nonExpiredSSTables = createSStables(realm.getPartitioner());
         when(compaction.sstables()).thenReturn(ImmutableSet.copyOf(nonExpiredSSTables));
         when(compaction.totalOverheadInBytes()).thenReturn(minimalSizeBytes);   // doesn't really matter
 
-        CompactionAggregate.UnifiedAggregate aggregate = Mockito.mock(CompactionAggregate.UnifiedAggregate.class);
+        CompactionAggregate.UnifiedAggregate aggregate = Mockito.mock(CompactionAggregate.UnifiedAggregate.class, Mockito.withSettings().stubOnly());
         when(aggregate.getSelected()).thenReturn(compaction);
 
         Collection<CompactionAggregate> compactionAggregates = strategy.getNextCompactionAggregates(ImmutableList.of(aggregate), 1000);
@@ -1387,7 +1394,7 @@ public class UnifiedCompactionStrategyTest extends BaseCompactionStrategyTest
 
     private void testDropExpiredFromBucket(int numShards, boolean parallelizeOutputShards) throws Exception
     {
-        Controller controller = Mockito.mock(Controller.class);
+        Controller controller = Mockito.mock(Controller.class, Mockito.withSettings().stubOnly());
         long minimalSizeBytes = 2 << 20;
         when(controller.getMaxLevelDensity(anyInt(), anyDouble())).thenCallRealMethod();
         when(controller.getMinSstableSizeBytes()).thenReturn(minimalSizeBytes);
@@ -1451,7 +1458,7 @@ public class UnifiedCompactionStrategyTest extends BaseCompactionStrategyTest
 
     private void testDropExpiredAndCompactNonExpired(boolean parallelizeOutputShards)
     {
-        Controller controller = Mockito.mock(Controller.class);
+        Controller controller = Mockito.mock(Controller.class, Mockito.withSettings().stubOnly());
         long minimalSizeBytes = 2 << 20;
         when(controller.getMaxLevelDensity(anyInt(), anyDouble())).thenCallRealMethod();
         when(controller.getMinSstableSizeBytes()).thenReturn(minimalSizeBytes);
@@ -1545,7 +1552,7 @@ public class UnifiedCompactionStrategyTest extends BaseCompactionStrategyTest
             when(sstable.onDiskLength()).thenReturn(onDiskLength);
         }
 
-        Controller controller = Mockito.mock(Controller.class);
+        Controller controller = Mockito.mock(Controller.class, Mockito.withSettings().stubOnly());
         long minimalSizeBytes = 2 << 20;
         when(controller.getMinSstableSizeBytes()).thenReturn(minimalSizeBytes);
         when(controller.getScalingParameter(anyInt())).thenReturn(0);
@@ -1611,7 +1618,7 @@ public class UnifiedCompactionStrategyTest extends BaseCompactionStrategyTest
     @Test
     public void testPending()
     {
-        Controller controller = Mockito.mock(Controller.class);
+        Controller controller = Mockito.mock(Controller.class, Mockito.withSettings().stubOnly());
         when(controller.getScalingParameter(anyInt())).thenReturn(-8); // F=10, T=2
         when(controller.getFanout(anyInt())).thenCallRealMethod();
         when(controller.getThreshold(anyInt())).thenCallRealMethod();
@@ -1736,7 +1743,7 @@ public class UnifiedCompactionStrategyTest extends BaseCompactionStrategyTest
         }
         dataTracker.addInitialSSTables(allSSTables);
 
-        Controller controller = Mockito.mock(Controller.class);
+        Controller controller = Mockito.mock(Controller.class, Mockito.withSettings().stubOnly());
         when(controller.getNumShards(anyDouble())).thenReturn(numShards);
         when(controller.parallelizeOutputShards()).thenReturn(true);
         when(controller.getOverheadSizeInBytes(any(), anyLong())).thenAnswer(inv -> (long) (inv.getArgument(1)) * 4 / 3);
@@ -1800,7 +1807,7 @@ public class UnifiedCompactionStrategyTest extends BaseCompactionStrategyTest
         allSSTables.addAll(mockNonOverlappingSSTables(15, 1, 200 << 20));
         allSSTables.addAll(mockNonOverlappingSSTables(25, 2, 400 << 20));
         dataTracker.addInitialSSTables(allSSTables);
-        Controller controller = Mockito.mock(Controller.class);
+        Controller controller = Mockito.mock(Controller.class, Mockito.withSettings().stubOnly());
         when(controller.getNumShards(anyDouble())).thenReturn(numShards);
         when(controller.parallelizeOutputShards()).thenReturn(false);
         UnifiedCompactionStrategy strategy = new UnifiedCompactionStrategy(strategyFactory, controller);
@@ -1837,7 +1844,7 @@ public class UnifiedCompactionStrategyTest extends BaseCompactionStrategyTest
         allSSTables.addAll(mockNonOverlappingSSTables(15, 1, 200 << 20));
         allSSTables.addAll(mockNonOverlappingSSTables(25, 2, 400 << 20));
         dataTracker.addInitialSSTables(allSSTables);
-        Controller controller = Mockito.mock(Controller.class);
+        Controller controller = Mockito.mock(Controller.class, Mockito.withSettings().stubOnly());
         when(controller.getNumShards(anyDouble())).thenReturn(numShards);
         when(controller.parallelizeOutputShards()).thenReturn(true);
 
@@ -1933,7 +1940,7 @@ public class UnifiedCompactionStrategyTest extends BaseCompactionStrategyTest
         allSSTables.addAll(mockNonOverlappingSSTables(30, 2, 400 << 20));
         dataTracker.addInitialSSTables(allSSTables);
 
-        Controller controller = Mockito.mock(Controller.class);
+        Controller controller = Mockito.mock(Controller.class, Mockito.withSettings().stubOnly());
         when(controller.getNumShards(anyDouble())).thenReturn(numShards);
         when(controller.parallelizeOutputShards()).thenReturn(parallelize);
         when(controller.maxConcurrentCompactions()).thenReturn(1000);
@@ -2121,7 +2128,7 @@ public class UnifiedCompactionStrategyTest extends BaseCompactionStrategyTest
             }
             allSSTables.addAll(list);
         }
-        Controller controller = Mockito.mock(Controller.class);
+        Controller controller = Mockito.mock(Controller.class, Mockito.withSettings().stubOnly());
         when(controller.getScalingParameter(anyInt())).thenReturn(fanout - 2); // F=T=fanout
         when(controller.getFanout(anyInt())).thenCallRealMethod();
         when(controller.getThreshold(anyInt())).thenCallRealMethod();
@@ -2133,7 +2140,7 @@ public class UnifiedCompactionStrategyTest extends BaseCompactionStrategyTest
         when(controller.overlapInclusionMethod()).thenReturn(overlapInclusionMethod);
         when(controller.parallelizeOutputShards()).thenReturn(true);
         when(controller.getOverheadSizeInBytes(any(), anyLong())).thenAnswer(inv -> (long) (inv.getArgument(1)) * 4 / 3);
-        Random randomMock = Mockito.mock(Random.class);
+        Random randomMock = Mockito.mock(Random.class, Mockito.withSettings().stubOnly());
         when(randomMock.nextInt(anyInt())).thenReturn(0);
         when(controller.random()).thenReturn(randomMock);
         UnifiedCompactionStrategy strategy = new UnifiedCompactionStrategy(strategyFactory, controller);
@@ -2194,7 +2201,7 @@ public class UnifiedCompactionStrategyTest extends BaseCompactionStrategyTest
     @Test
     public void testGetLevel()
     {
-        Controller controller = Mockito.mock(Controller.class);
+        Controller controller = Mockito.mock(Controller.class, Mockito.withSettings().stubOnly());
         UnifiedCompactionStrategy strategy = new UnifiedCompactionStrategy(strategyFactory, controller);
 
         UnifiedCompactionStrategy.Level level = strategy.getLevel(1, 0.25d, 0.5d);


### PR DESCRIPTION
### What is the issue
UnifiedCompactionStrategyTest.textMaximalSelection has been failing since CNDB-15020

### What does this PR fix and why was it fixed
This prevents excessive heap pressure by using Mockito's stubonly where possible, and clears mocks between tests