### PR TITLE
CNDB-15135: use EmptyFactory to avoid loading SAI per-sstable files if SAI_INDEX_READS_DISABLED is true

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/IndexContext.java
+++ b/src/java/org/apache/cassandra/index/sai/IndexContext.java
@@ -936,7 +936,7 @@ public class IndexContext
                 }
 
                 SSTableIndex index = new SSTableIndex(context, perIndexComponents);
-                if (CassandraRelevantProperties.SAI_INDEX_READS_DISABLED.getBoolean())
+                if (SAI_INDEX_READS_DISABLED.getBoolean())
                 {
                     logger.debug(logMessage("Skipped loading index for SSTable {} as it's disabled by {}"), context.descriptor(), SAI_INDEX_READS_DISABLED.getKey());
                 }

--- a/src/java/org/apache/cassandra/index/sai/IndexContext.java
+++ b/src/java/org/apache/cassandra/index/sai/IndexContext.java
@@ -38,6 +38,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.cql3.Operator;
 import org.apache.cassandra.cql3.statements.schema.IndexTarget;
 import org.apache.cassandra.db.ClusteringComparator;
@@ -934,8 +935,15 @@ public class IndexContext
                 }
 
                 SSTableIndex index = new SSTableIndex(context, perIndexComponents);
-                long count = context.primaryKeyMapFactory().count();
-                logger.debug(logMessage("Successfully loaded index for SSTable {} with {} rows."), context.descriptor(), count);
+                if (CassandraRelevantProperties.SAI_INDEX_READS_DISABLED.getBoolean())
+                {
+                    logger.debug(logMessage("Successfully loaded index for SSTable {}"), context.descriptor());
+                }
+                else
+                {
+                    long count = context.primaryKeyMapFactory().count();
+                    logger.debug(logMessage("Successfully loaded index for SSTable {} with {} rows."), context.descriptor(), count);
+                }
 
                 // Try to add new index to the set, if set already has such index, we'll simply release and move on.
                 // This covers situation when SSTable collection has the same SSTable multiple

--- a/src/java/org/apache/cassandra/index/sai/IndexContext.java
+++ b/src/java/org/apache/cassandra/index/sai/IndexContext.java
@@ -92,6 +92,7 @@ import org.apache.cassandra.utils.NoSpamLogger;
 import org.apache.cassandra.utils.Pair;
 import org.apache.cassandra.utils.concurrent.OpOrder;
 
+import static org.apache.cassandra.config.CassandraRelevantProperties.SAI_INDEX_READS_DISABLED;
 import static org.apache.cassandra.config.CassandraRelevantProperties.VALIDATE_MAX_TERM_SIZE_AT_COORDINATOR;
 
 /**
@@ -937,7 +938,7 @@ public class IndexContext
                 SSTableIndex index = new SSTableIndex(context, perIndexComponents);
                 if (CassandraRelevantProperties.SAI_INDEX_READS_DISABLED.getBoolean())
                 {
-                    logger.debug(logMessage("Successfully loaded index for SSTable {}"), context.descriptor());
+                    logger.debug(logMessage("Skipped loading index for SSTable {} as it's disabled by {}"), context.descriptor(), SAI_INDEX_READS_DISABLED.getKey());
                 }
                 else
                 {

--- a/src/java/org/apache/cassandra/index/sai/disk/PrimaryKeyMap.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/PrimaryKeyMap.java
@@ -124,4 +124,25 @@ public interface PrimaryKeyMap extends Closeable
     default void close() throws IOException
     {
     }
+
+    class EmptyFactory implements Factory
+    {
+        @Override
+        public PrimaryKeyMap newPerSSTablePrimaryKeyMap()
+        {
+            throw new UnsupportedOperationException("EmptyFactory doesn't support newPerSSTablePrimaryKeyMap()");
+        }
+
+        @Override
+        public long count()
+        {
+            throw new UnsupportedOperationException("EmptyFactory doesn't support count()");
+        }
+
+        @Override
+        public void close() throws IOException
+        {
+            // no-op
+        }
+    }
 }

--- a/src/java/org/apache/cassandra/index/sai/disk/PrimaryKeyMap.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/PrimaryKeyMap.java
@@ -125,7 +125,10 @@ public interface PrimaryKeyMap extends Closeable
     {
     }
 
-    class EmptyFactory implements Factory
+    /**
+     * When SAI_INDEX_READS_DISABLED is true, this is used to avoid loading SAI files to reduce disk access and memory usage
+     */
+    class DummyThrowingFactory implements Factory
     {
         @Override
         public PrimaryKeyMap newPerSSTablePrimaryKeyMap()


### PR DESCRIPTION

### What is the issue
#15135

### What does this PR fix and why was it fixed
Avoid reading SAI per-sstable files if SAI_INDEX_READS_DISABLED is true