### PR TITLE
CNDB-15038: set quoteValue to true to fix CqlBuilderTest

### DIFF
--- a/src/java/org/apache/cassandra/cql3/CqlBuilder.java
+++ b/src/java/org/apache/cassandra/cql3/CqlBuilder.java
@@ -290,7 +290,7 @@ public final class CqlBuilder
 
         public OptionsBuilder append(String name, Map<String, String> options)
         {
-            return options.isEmpty() ? this : append(name, () -> builder.append(options, false));
+            return options.isEmpty() ? this : append(name, () -> builder.append(options, true));
         }
 
         public OptionsBuilder append(String name, Set<String> options)


### PR DESCRIPTION
### What is the issue
After CNDB-15000, cql map values are no longer quoted

### What does this PR fix and why was it fixed
Restores quoting of cql map values
