### PR TITLE
CNDB-15058: track in-flight BF memory usage from trie index writer if early open is not enabled (#1949)

### DIFF
--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -3826,6 +3826,13 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
         return Objects.requireNonNull(getIfExists(tableId)).metric;
     }
 
+    @Nullable
+    public static TableMetrics metricsForIfPresent(TableId tableId)
+    {
+        ColumnFamilyStore cfs = getIfExists(tableId);
+        return cfs == null ? null : cfs.metric;
+    }
+
     // Used by CNDB
     public long getMemtablesLiveSize()
     {

--- a/src/java/org/apache/cassandra/io/sstable/filter/BloomFilterMetrics.java
+++ b/src/java/org/apache/cassandra/io/sstable/filter/BloomFilterMetrics.java
@@ -66,6 +66,9 @@ public class BloomFilterMetrics<R extends SSTableReaderWithFilter> extends Abstr
      * Off heap memory used by bloom filter
      */
     public final GaugeProvider<Long> bloomFilterOffHeapMemoryUsed = newGaugeProvider("BloomFilterOffHeapMemoryUsed",
+                                                                                     // FIXME: CNDB-15213
+                                                                                     //   Seems to correspond to TableMetrics.bloomFilterOffHeapMemoryUsed.getLong() in main
+                                                                                     //   where we want TableMetrics.inFlightBloomFilterOffHeapMemoryUsed.get() as the initial value;
                                                                                      0L,
                                                                                      SSTableReaderWithFilter::getFilterOffHeapSize,
                                                                                      Long::sum);

--- a/src/java/org/apache/cassandra/io/sstable/filter/BloomFilterMetrics.java
+++ b/src/java/org/apache/cassandra/io/sstable/filter/BloomFilterMetrics.java
@@ -65,10 +65,7 @@ public class BloomFilterMetrics<R extends SSTableReaderWithFilter> extends Abstr
     /**
      * Off heap memory used by bloom filter
      */
-    public final GaugeProvider<Long> bloomFilterOffHeapMemoryUsed = newGaugeProvider("BloomFilterOffHeapMemoryUsed",
-                                                                                     // FIXME: CNDB-15213
-                                                                                     //   Seems to correspond to TableMetrics.bloomFilterOffHeapMemoryUsed.getLong() in main
-                                                                                     //   where we want TableMetrics.inFlightBloomFilterOffHeapMemoryUsed.get() as the initial value;
+    public final GaugeProvider<Long> bloomFilterOffHeapMemoryUsed = bloomFilterOffHeapMemoryUsedAwareCFSGaugeProvider("BloomFilterOffHeapMemoryUsed",
                                                                                      0L,
                                                                                      SSTableReaderWithFilter::getFilterOffHeapSize,
                                                                                      Long::sum);

--- a/src/java/org/apache/cassandra/utils/FilterFactory.java
+++ b/src/java/org/apache/cassandra/utils/FilterFactory.java
@@ -19,6 +19,7 @@ package org.apache.cassandra.utils;
 
 import java.io.IOException;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -76,6 +77,7 @@ public class FilterFactory
      * Asserts that the given probability can be satisfied using this
      * filter.
      */
+    @VisibleForTesting
     public static IFilter getFilter(long numElements, double maxFalsePosProbability)
     {
         return getFilter(numElements, maxFalsePosProbability, BloomFilter.memoryLimiter);


### PR DESCRIPTION
### What is the issue
cndb-15058: table metrics - bloom filter memory usage doesn't include partially written sstables' if early open is not enabled

### What does this PR fix and why was it fixed
Include in flight BF memory usage if early open is not enabled
