### PR TITLE
CNDB-15039: fix AbstractReadQueryToCQLStringTest

### DIFF
--- a/src/java/org/apache/cassandra/db/PartitionRangeReadCommand.java
+++ b/src/java/org/apache/cassandra/db/PartitionRangeReadCommand.java
@@ -478,17 +478,13 @@ public class PartitionRangeReadCommand extends ReadCommand implements PartitionR
         if (dataRange.isUnrestricted(metadata()) && rowFilter().isEmpty())
             return;
 
-        builder.append(" WHERE ");
-        // Put data range (token) conditions first, then row filter
-        if (!dataRange.isUnrestricted(metadata()))
+        // Pass the rowFilter to dataRange.toCQLString so it can handle 
+        // combining with clustering restrictions properly
+        String rangeString = dataRange.toCQLString(metadata(), rowFilter());
+        if (!rangeString.isEmpty())
         {
-            builder.append(dataRange.toCQLString(metadata(), RowFilter.none()));
-            if (!rowFilter().isEmpty())
-                builder.append(" AND ");
-        }
-        if (!rowFilter().isEmpty())
-        {
-            builder.append(rowFilter().toCQLString());
+            builder.append(" WHERE ");
+            builder.append(rangeString);
         }
     }
 

--- a/src/java/org/apache/cassandra/db/filter/RowFilter.java
+++ b/src/java/org/apache/cassandra/db/filter/RowFilter.java
@@ -1479,7 +1479,7 @@ public class RowFilter
             }
 
             return cql
-                   ? String.format("%s %s %s", column.name.toCQLString(), operator, type.toCQLString(value))
+                   ? String.format("%s %s %s", column.name.toCQLString(), operator, type.toCQLString(value, true))
                    : String.format("%s %s %s", column.name.toString(), operator, type.getString(value, true));
         }
 


### PR DESCRIPTION
### What is the issue
After CNDB-15000, cql string generation for read commands with clustering columns needs to be fixed, and value truncation is not working.

### What does this PR fix and why was it fixed
Refactor CQL string generation in PartitionRangeReadCommand and SinglePartitionReadCommand
to properly handle the interaction between row filters and clustering filters. This prevents
duplication of clustering column conditions when both regular filters and clustering
restrictions are present, particularly in queries using ALLOW FILTERING or secondary indexes
on clustering columns.
Fix value truncation in RowFilter CQL string generation.
