### PR TITLE
CNDB-15155: Segregate SAI's query metrics per query type

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -567,6 +567,18 @@ public enum CassandraRelevantProperties
     CUSTOM_SAI_INDEX_COMPONENTS_DISCOVERY("cassandra.sai.custom_components_discovery_class"),
 
     /**
+     * Whether to enable SAI per-table metrics for different types of queries, such as filter queries, top-k queries,
+     * hybrid queries, single-partition queries, and range queries. These metrics are always counters.
+     */
+    SAI_QUERY_TYPE_PER_TABLE_METRICS_ENABLED("cassandra.sai.metrics.query_type.per_table.enabled", "true"),
+
+    /**
+     * Whether to enable SAI per-query metrics for different types of queries, such as filter queries, top-k queries,
+     * hybrid queries, single-partition queries, and range queries. These metrics are histograms and timers.
+     */
+    SAI_QUERY_TYPE_PER_QUERY_METRICS_ENABLED("cassandra.sai.metrics.query_type.per_query.enabled", "true"),
+
+    /**
      * If true, while creating or altering schema, NetworkTopologyStrategy won't check if the DC exists.
      * This is to remain compatible with older workflows that first change the replication before adding the nodes.
      * Otherwise, it will validate that the names match existing DCs before allowing replication change.

--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -576,7 +576,7 @@ public enum CassandraRelevantProperties
      * Whether to enable SAI per-query metrics for different types of queries, such as filter queries, top-k queries,
      * hybrid queries, single-partition queries, and range queries. These metrics are histograms and timers.
      */
-    SAI_QUERY_TYPE_PER_QUERY_METRICS_ENABLED("cassandra.sai.metrics.query_type.per_query.enabled", "true"),
+    SAI_QUERY_TYPE_PER_QUERY_METRICS_ENABLED("cassandra.sai.metrics.query_type.per_query.enabled", "false"),
 
     /**
      * If true, while creating or altering schema, NetworkTopologyStrategy won't check if the DC exists.

--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -567,16 +567,17 @@ public enum CassandraRelevantProperties
     CUSTOM_SAI_INDEX_COMPONENTS_DISCOVERY("cassandra.sai.custom_components_discovery_class"),
 
     /**
-     * Whether to enable SAI per-table metrics for different types of queries, such as filter queries, top-k queries,
-     * hybrid queries, single-partition queries, and range queries. These metrics are always counters.
+     * Whether to enable SAI per-table metrics for different kinds of query, such as filter-only queries, top-k-only
+     * queries, hybrid queries, single-partition queries, and multipartition queries. These metrics are always counters.
      */
-    SAI_QUERY_TYPE_PER_TABLE_METRICS_ENABLED("cassandra.sai.metrics.query_type.per_table.enabled", "true"),
+    SAI_QUERY_KIND_PER_TABLE_METRICS_ENABLED("cassandra.sai.metrics.query_kind.per_table.enabled", "true"),
 
     /**
-     * Whether to enable SAI per-query metrics for different types of queries, such as filter queries, top-k queries,
-     * hybrid queries, single-partition queries, and range queries. These metrics are histograms and timers.
+     * Whether to enable SAI per-query metrics for different kinds of query, such as filter-only queries, top-k-only
+     * queries, hybrid queries, single-partition queries, and multipartition queries. These metrics are histograms and
+     * timers.
      */
-    SAI_QUERY_TYPE_PER_QUERY_METRICS_ENABLED("cassandra.sai.metrics.query_type.per_query.enabled", "false"),
+    SAI_QUERY_KIND_PER_QUERY_METRICS_ENABLED("cassandra.sai.metrics.query_kind.per_query.enabled", "false"),
 
     /**
      * If true, while creating or altering schema, NetworkTopologyStrategy won't check if the DC exists.

--- a/src/java/org/apache/cassandra/db/MultiRangeReadCommand.java
+++ b/src/java/org/apache/cassandra/db/MultiRangeReadCommand.java
@@ -133,6 +133,15 @@ public class MultiRangeReadCommand extends ReadCommand
                                          command.indexQueryPlan());
     }
 
+    @Override
+    public boolean isSinglePartition()
+    {
+        if (dataRanges.size() != 1)
+            return false;
+
+        return dataRanges.get(0).isSinglePartition();
+    }
+
     /**
      * @return all token ranges to be queried
      */

--- a/src/java/org/apache/cassandra/db/MultiRangeReadCommand.java
+++ b/src/java/org/apache/cassandra/db/MultiRangeReadCommand.java
@@ -136,10 +136,7 @@ public class MultiRangeReadCommand extends ReadCommand
     @Override
     public boolean isSinglePartition()
     {
-        if (dataRanges.size() != 1)
-            return false;
-
-        return dataRanges.get(0).isSinglePartition();
+        return dataRanges.size() == 1 && dataRanges.get(0).isSinglePartition();
     }
 
     /**

--- a/src/java/org/apache/cassandra/db/PartitionRangeReadCommand.java
+++ b/src/java/org/apache/cassandra/db/PartitionRangeReadCommand.java
@@ -136,6 +136,12 @@ public class PartitionRangeReadCommand extends ReadCommand implements PartitionR
         return dataRange;
     }
 
+    @Override
+    public boolean isSinglePartition()
+    {
+        return dataRange.isSinglePartition();
+    }
+
     public ClusteringIndexFilter clusteringIndexFilter(DecoratedKey key)
     {
         return dataRange.clusteringIndexFilter(key);

--- a/src/java/org/apache/cassandra/db/ReadCommand.java
+++ b/src/java/org/apache/cassandra/db/ReadCommand.java
@@ -242,6 +242,14 @@ public abstract class ReadCommand extends AbstractReadQuery
         return indexQueryPlan;
     }
 
+    /**
+     * @return {@code true} if this command uses index-based filtering, {@code false} otherwise
+     */
+    public boolean usesIndexFiltering()
+    {
+        return indexQueryPlan != null && indexQueryPlan.usesIndexFiltering();
+    }
+
     @Override
     public boolean isTopK()
     {

--- a/src/java/org/apache/cassandra/db/ReadCommand.java
+++ b/src/java/org/apache/cassandra/db/ReadCommand.java
@@ -248,6 +248,11 @@ public abstract class ReadCommand extends AbstractReadQuery
         return indexQueryPlan != null && indexQueryPlan.isTopK();
     }
 
+    /**
+     * @return {@code true} if this command only queries a single partition, {@code false} otherwise.
+     */
+    public abstract boolean isSinglePartition();
+
     @VisibleForTesting
     public Index.Searcher indexSearcher()
     {

--- a/src/java/org/apache/cassandra/db/SinglePartitionReadCommand.java
+++ b/src/java/org/apache/cassandra/db/SinglePartitionReadCommand.java
@@ -386,6 +386,12 @@ public class SinglePartitionReadCommand extends ReadCommand implements SinglePar
                       lastReturned == null ? clusteringIndexFilter() : clusteringIndexFilter.forPaging(metadata().comparator, lastReturned, false));
     }
 
+    @Override
+    public boolean isSinglePartition()
+    {
+        return true;
+    }
+
     public PartitionIterator execute(ConsistencyLevel consistency, QueryState queryState, long queryStartNanoTime) throws RequestExecutionException
     {
         if (clusteringIndexFilter.isEmpty(metadata().comparator))

--- a/src/java/org/apache/cassandra/index/Index.java
+++ b/src/java/org/apache/cassandra/index/Index.java
@@ -231,7 +231,7 @@ public interface Index
     {
         return getBuildTaskSupport();
     }
-    
+
     /**
      * Returns the type of operations supported by the index in case its building has failed and it's needing recovery.
      *
@@ -1100,6 +1100,14 @@ public interface Index
         default boolean isTopK()
         {
             return false;
+        }
+
+        /**
+         * @return {@code true} if this plan uses index-based filtering, {@code false} otherwise
+         */
+        default boolean usesIndexFiltering()
+        {
+            return true;
         }
     }
 

--- a/src/java/org/apache/cassandra/index/sai/metrics/TableQueryMetrics.java
+++ b/src/java/org/apache/cassandra/index/sai/metrics/TableQueryMetrics.java
@@ -51,8 +51,9 @@ public class TableQueryMetrics
     public TableQueryMetrics(TableMetadata table)
     {
         addMetrics(table, "", cmd -> true);
-        addMetrics(table, "Filter", cmd -> !cmd.isTopK()); // queries that are filtering only
-        addMetrics(table, "TopK", ReadCommand::isTopK); // queries that are top-k only
+        addMetrics(table, "Filter", cmd -> !cmd.isTopK() && cmd.usesIndexFiltering()); // queries that are filtering only
+        addMetrics(table, "TopK", cmd -> cmd.isTopK() && !cmd.usesIndexFiltering()); // queries that are top-k only
+        addMetrics(table, "Hybrid", cmd -> cmd.isTopK() && cmd.usesIndexFiltering()); // queries that are both filtering and top-k
         addMetrics(table, "SinglePartition", ReadCommand::isSinglePartition); // single-partition queries
         addMetrics(table, "Range", cmd -> !cmd.isSinglePartition()); // range queries
     }

--- a/src/java/org/apache/cassandra/index/sai/metrics/TableQueryMetrics.java
+++ b/src/java/org/apache/cassandra/index/sai/metrics/TableQueryMetrics.java
@@ -17,66 +17,201 @@
  */
 package org.apache.cassandra.index.sai.metrics;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
 
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Timer;
+import org.apache.cassandra.db.ReadCommand;
 import org.apache.cassandra.index.sai.QueryContext;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.tracing.Tracing;
 
 import static org.apache.cassandra.metrics.CassandraMetricsRegistry.Metrics;
 
-public class TableQueryMetrics extends AbstractMetrics
+/**
+ * Table query metrics for different types of query. The metrics for each type of query are divided into two groups:
+ * <ul>
+ * <li>Per table counters ({@link PerTable}).</li>
+ * <li>Per query timers and histograms ({@link PerQuery}).</li>
+ * </ul>
+ */
+public class TableQueryMetrics
 {
-    public static final String TABLE_QUERY_METRIC_TYPE = "TableQueryMetrics";
+    /** Per table metrics for all types of queries (counters). */
+    private final List<PerTable> perTableMetrics = new ArrayList<>();
 
-    public final PerQueryMetrics perQueryMetrics;
-
-    public final Counter totalQueryTimeouts;
-    public final Counter totalPartitionReads;
-    public final Counter totalRowsFiltered;
-    public final Counter totalQueriesCompleted;
-
-    public final Counter sortThenFilterQueriesCompleted;
-    public final Counter filterThenSortQueriesCompleted;
+    /** Per query metrics for all types of queries (timers and histograms). */
+    private final List<PerQuery> perQueryMetrics = new ArrayList<>();
 
     public TableQueryMetrics(TableMetadata table)
     {
-        super(table.keyspace, table.name, TABLE_QUERY_METRIC_TYPE);
-
-        perQueryMetrics = new PerQueryMetrics(table);
-
-        totalPartitionReads = Metrics.counter(createMetricName("TotalPartitionReads"));
-        totalRowsFiltered = Metrics.counter(createMetricName("TotalRowsFiltered"));
-        totalQueriesCompleted = Metrics.counter(createMetricName("TotalQueriesCompleted"));
-        totalQueryTimeouts = Metrics.counter(createMetricName("TotalQueryTimeouts"));
-
-        sortThenFilterQueriesCompleted = Metrics.counter(createMetricName("SortThenFilterQueriesCompleted"));
-        filterThenSortQueriesCompleted = Metrics.counter(createMetricName("FilterThenSortQueriesCompleted"));
+        addMetrics(table, "", cmd -> true);
+        addMetrics(table, "Filter", cmd -> !cmd.isTopK()); // queries that are filtering only
+        addMetrics(table, "TopK", ReadCommand::isTopK); // queries that are top-k only
+        addMetrics(table, "SinglePartition", ReadCommand::isSinglePartition); // single-partition queries
+        addMetrics(table, "Range", cmd -> !cmd.isSinglePartition()); // range queries
     }
 
-    public void record(QueryContext queryContext)
+    private void addMetrics(TableMetadata table, String type, Predicate<ReadCommand> filter)
     {
-        if (queryContext.queryTimeouts() > 0)
-        {
-            assert queryContext.queryTimeouts() == 1;
-
-            totalQueryTimeouts.inc();
-        }
-
-        perQueryMetrics.record(queryContext);
+        perTableMetrics.add(new PerTable(table, type, filter));
+        perQueryMetrics.add(new PerQuery(table, type, filter));
     }
 
+    /**
+     * Records metrics for a single query.
+     *
+     * @param context the stats relevant to the execution of a single query
+     * @param command the query command
+     */
+    public void record(QueryContext context, ReadCommand command)
+    {
+        Snapshot snapshot = new Snapshot(context);
+        perTableMetrics.forEach(m -> m.record(snapshot, command));
+        perQueryMetrics.forEach(m -> m.record(snapshot, command));
+    }
+
+    /**
+     * Releases all the resources used by these metrics.
+     */
     public void release()
     {
-        super.release();
-        perQueryMetrics.release();
+        perTableMetrics.forEach(PerTable::release);
+        perQueryMetrics.forEach(PerQuery::release);
     }
 
-    public class PerQueryMetrics extends AbstractMetrics
+    private static String pluralize(long count, String root, String plural)
     {
+        return count == 1 ? String.format("1 %s", root) : String.format("%d %s%s", count, root, plural);
+    }
+
+    /**
+     * Family of metrics for a specific type of query.
+     */
+    public abstract static class AbstractQueryMetrics extends AbstractMetrics
+    {
+        private static final Pattern PATTERN = Pattern.compile("Query");
+
+        private final Predicate<ReadCommand> filter;
+
+        private AbstractQueryMetrics(String keyspace, String table, String scope, String type, Predicate<ReadCommand> filter)
+        {
+            super(keyspace, table, makeName(scope, type));
+            this.filter = filter;
+        }
+
+        protected final void record(Snapshot snapshot, ReadCommand command)
+        {
+            if (filter.test(command))
+                record(snapshot);
+        }
+
+        protected abstract void record(Snapshot snapshot);
+
+        public static String makeName(String scope, String type)
+        {
+            return PATTERN.matcher(scope).replaceFirst(type + "Query");
+        }
+    }
+
+    /**
+     * Per table metrics for a specific type of query. These metrics are always counters.
+     */
+    public static class PerTable extends AbstractQueryMetrics
+    {
+        public static final String METRIC_TYPE = "TableQueryMetrics";
+
+        public final Counter totalQueryTimeouts;
+        public final Counter totalPartitionReads;
+        public final Counter totalRowsFiltered;
+        public final Counter totalQueriesCompleted;
+
+        public final Counter sortThenFilterQueriesCompleted;
+        public final Counter filterThenSortQueriesCompleted;
+
+        /**
+         * @param table the table to measure metrics for
+         * @param type an identifier for the type of query which metrics are being recorded for
+         * @param filter a predicate that determines whether a given query should be recorded
+         */
+        public PerTable(TableMetadata table, String type, Predicate<ReadCommand> filter)
+        {
+            super(table.keyspace, table.name, METRIC_TYPE, type, filter);
+
+            totalPartitionReads = Metrics.counter(createMetricName("TotalPartitionReads"));
+            totalRowsFiltered = Metrics.counter(createMetricName("TotalRowsFiltered"));
+            totalQueriesCompleted = Metrics.counter(createMetricName("TotalQueriesCompleted"));
+            totalQueryTimeouts = Metrics.counter(createMetricName("TotalQueryTimeouts"));
+
+            sortThenFilterQueriesCompleted = Metrics.counter(createMetricName("SortThenFilterQueriesCompleted"));
+            filterThenSortQueriesCompleted = Metrics.counter(createMetricName("FilterThenSortQueriesCompleted"));
+        }
+
+        @Override
+        public void record(Snapshot snapshot)
+        {
+            if (snapshot.queryTimeouts > 0)
+            {
+                assert snapshot.queryTimeouts == 1;
+                totalQueryTimeouts.inc();
+            }
+
+            totalQueriesCompleted.inc();
+            totalPartitionReads.inc(snapshot.partitionsRead);
+            totalRowsFiltered.inc(snapshot.rowsFiltered);
+
+            if (snapshot.filterSortOrder == QueryContext.FilterSortOrder.SCAN_THEN_FILTER)
+                sortThenFilterQueriesCompleted.inc();
+            else if (snapshot.filterSortOrder == QueryContext.FilterSortOrder.SEARCH_THEN_ORDER)
+                filterThenSortQueriesCompleted.inc();
+
+            if (Tracing.isTracing())
+            {
+                final long queryLatencyMicros = TimeUnit.NANOSECONDS.toMicros(snapshot.totalQueryTimeNs);
+
+                if (snapshot.filterSortOrder == QueryContext.FilterSortOrder.SEARCH_THEN_ORDER)
+                {
+                    Tracing.trace("Index query accessed memtable indexes, {}, and {}, selected {} before ranking, " +
+                                  "post-filtered {} in {}, and took {} microseconds.",
+                                  pluralize(snapshot.sstablesHit, "SSTable index", "es"),
+                                  pluralize(snapshot.segmentsHit, "segment", "s"),
+                                  pluralize(snapshot.rowsPreFiltered, "row", "s"),
+                                  pluralize(snapshot.rowsFiltered, "row", "s"),
+                                  pluralize(snapshot.partitionsRead, "partition", "s"),
+                                  queryLatencyMicros);
+                }
+                else
+                {
+                    Tracing.trace("Index query accessed memtable indexes, {}, and {}, post-filtered {} in {}, " +
+                                  "and took {} microseconds.",
+                                  pluralize(snapshot.sstablesHit, "SSTable index", "es"),
+                                  pluralize(snapshot.segmentsHit, "segment", "s"),
+                                  pluralize(snapshot.rowsFiltered, "row", "s"),
+                                  pluralize(snapshot.partitionsRead, "partition", "s"),
+                                  queryLatencyMicros);
+                }
+            }
+        }
+
+        @Override
+        public void release()
+        {
+            super.release();
+        }
+    }
+
+    /**
+     * Per query metrics for a specific type of query. These metrics are always timers and histograms.
+     */
+    public static class PerQuery extends AbstractQueryMetrics
+    {
+        public static final String METRIC_TYPE = "PerQuery";
+
         public final Timer queryLatency;
 
         /**
@@ -111,9 +246,9 @@ public class TableQueryMetrics extends AbstractMetrics
          */
         public final Timer annGraphSearchLatency;
 
-        public PerQueryMetrics(TableMetadata table)
+        public PerQuery(TableMetadata table, String type, Predicate<ReadCommand> filter)
         {
-            super(table.keyspace, table.name, "PerQuery");
+            super(table.keyspace, table.name, METRIC_TYPE, type, filter);
 
             queryLatency = Metrics.timer(createMetricName("QueryLatency"));
 
@@ -121,7 +256,6 @@ public class TableQueryMetrics extends AbstractMetrics
             segmentsHit = Metrics.histogram(createMetricName("IndexSegmentsHit"), false);
 
             kdTreePostingsSkips = Metrics.histogram(createMetricName("KDTreePostingsSkips"), true);
-
             kdTreePostingsNumPostings = Metrics.histogram(createMetricName("KDTreePostingsNumPostings"), false);
             kdTreePostingsDecodes = Metrics.histogram(createMetricName("KDTreePostingsDecodes"), false);
 
@@ -137,92 +271,93 @@ public class TableQueryMetrics extends AbstractMetrics
             annGraphSearchLatency = Metrics.timer(createMetricName("ANNGraphSearchLatency"));
         }
 
-        private void recordStringIndexCacheMetrics(QueryContext events)
+        @Override
+        public void record(Snapshot snapshot)
         {
-            postingsSkips.update(events.triePostingsSkips());
-            postingsDecodes.update(events.triePostingsDecodes());
-        }
+            queryLatency.update(snapshot.totalQueryTimeNs, TimeUnit.NANOSECONDS);
+            sstablesHit.update(snapshot.sstablesHit);
+            segmentsHit.update(snapshot.segmentsHit);
+            partitionReads.update(snapshot.partitionsRead);
+            rowsFiltered.update(snapshot.rowsFiltered);
 
-        private void recordNumericIndexCacheMetrics(QueryContext events)
-        {
-            kdTreePostingsNumPostings.update(events.bkdPostingListsHit());
-
-            kdTreePostingsSkips.update(events.bkdPostingsSkips());
-            kdTreePostingsDecodes.update(events.bkdPostingsDecodes());
-        }
-
-        private void recordVectorIndexMetrics(QueryContext queryContext)
-        {
-            annGraphSearchLatency.update(queryContext.annGraphSearchLatency(), TimeUnit.NANOSECONDS);
-        }
-
-        public void record(QueryContext queryContext)
-        {
-            final long totalQueryTimeNs = queryContext.totalQueryTimeNs();
-            queryLatency.update(totalQueryTimeNs, TimeUnit.NANOSECONDS);
-            final long queryLatencyMicros = TimeUnit.NANOSECONDS.toMicros(totalQueryTimeNs);
-
-            final long ssTablesHit = queryContext.sstablesHit();
-            final long segmentsHit = queryContext.segmentsHit();
-            final long partitionsRead = queryContext.partitionsRead();
-            final long rowsFiltered = queryContext.rowsFiltered();
-            final long rowsPreFiltered = queryContext.rowsFiltered();
-
-            sstablesHit.update(ssTablesHit);
-            this.segmentsHit.update(segmentsHit);
-
-            partitionReads.update(partitionsRead);
-            totalPartitionReads.inc(partitionsRead);
-
-            this.rowsFiltered.update(rowsFiltered);
-            totalRowsFiltered.inc(rowsFiltered);
-
-            if (queryContext.filterSortOrder() == QueryContext.FilterSortOrder.SCAN_THEN_FILTER)
-                sortThenFilterQueriesCompleted.inc();
-            else if (queryContext.filterSortOrder() == QueryContext.FilterSortOrder.SEARCH_THEN_ORDER)
-                filterThenSortQueriesCompleted.inc();
-
-            if (Tracing.isTracing())
+            // Record string index cache metrics.
+            if (snapshot.trieSegmentsHit > 0)
             {
-                if (queryContext.filterSortOrder() == QueryContext.FilterSortOrder.SEARCH_THEN_ORDER)
-                {
-                    Tracing.trace("Index query accessed memtable indexes, {}, and {}, selected {} before ranking, post-filtered {} in {}, and took {} microseconds.",
-                                  pluralize(ssTablesHit, "SSTable index", "es"),
-                                  pluralize(segmentsHit, "segment", "s"),
-                                  pluralize(rowsPreFiltered, "row", "s"),
-                                  pluralize(rowsFiltered, "row", "s"),
-                                  pluralize(partitionsRead, "partition", "s"),
-                                  queryLatencyMicros);
-                }
-                else
-                {
-                    Tracing.trace("Index query accessed memtable indexes, {}, and {}, post-filtered {} in {}, and took {} microseconds.",
-                                  pluralize(ssTablesHit, "SSTable index", "es"),
-                                  pluralize(segmentsHit, "segment", "s"),
-                                  pluralize(rowsFiltered, "row", "s"),
-                                  pluralize(partitionsRead, "partition", "s"),
-                                  queryLatencyMicros);
-                }
+                postingsSkips.update(snapshot.triePostingsSkips);
+                postingsDecodes.update(snapshot.triePostingsDecodes);
             }
 
-            if (queryContext.trieSegmentsHit() > 0)
-                recordStringIndexCacheMetrics(queryContext);
-            if (queryContext.bkdSegmentsHit() > 0)
-                recordNumericIndexCacheMetrics(queryContext);
+            // Record numeric index cache metrics.
+            if (snapshot.bkdSegmentsHit > 0)
+            {
+                kdTreePostingsNumPostings.update(snapshot.bkdPostingListsHit);
+                kdTreePostingsSkips.update(snapshot.bkdPostingsSkips);
+                kdTreePostingsDecodes.update(snapshot.bkdPostingsDecodes);
+            }
+
+            // Record vector index metrics.
             // If ann brute forced the whole search, this is 0. We don't measure brute force latency. Maybe we should?
             // At the very least, we collect brute force comparison metrics, which should give a reasonable indicator
             // of work done.
-            if (queryContext.annGraphSearchLatency() > 0)
-                recordVectorIndexMetrics(queryContext);
+            if (snapshot.annGraphSearchLatency > 0)
+            {
+                annGraphSearchLatency.update(snapshot.annGraphSearchLatency, TimeUnit.NANOSECONDS);
+            }
 
-            shadowedKeysScannedHistogram.update(queryContext.getShadowedPrimaryKeyCount());
-
-            totalQueriesCompleted.inc();
+            shadowedKeysScannedHistogram.update(snapshot.shadowedPrimaryKeyCount);
         }
     }
 
-    private String pluralize(long count, String root, String plural)
+    /**
+     * A snapshot of all relevant metrics in a {@link QueryContext} at a specific point in time.
+     * This class memoizes the values of those metrics so that we can record them later in the
+     * {@link AbstractQueryMetrics#record(Snapshot)} method of as many {@link AbstractQueryMetrics}
+     * instances as needed, without calculating the same values once and again.
+     */
+    public static class Snapshot
     {
-        return count == 1 ? String.format("1 %s", root) : String.format("%d %s%s", count, root, plural);
+        private final long totalQueryTimeNs;
+        private final long sstablesHit;
+        private final long segmentsHit;
+        private final long partitionsRead;
+        private final long rowsFiltered;
+        private final long rowsPreFiltered;
+        private final long trieSegmentsHit;
+        private final long bkdPostingListsHit;
+        private final long bkdSegmentsHit;
+        private final long bkdPostingsSkips;
+        private final long bkdPostingsDecodes;
+        private final long triePostingsSkips;
+        private final long triePostingsDecodes;
+        private final long queryTimeouts;
+        private final long annGraphSearchLatency;
+        private final long shadowedPrimaryKeyCount;
+        private final QueryContext.FilterSortOrder filterSortOrder;
+
+        /**
+         * Creates a snapshot of all long-valued metrics from the given QueryContext.
+         *
+         * @param context the QueryContext to snapshot
+         */
+        public Snapshot(QueryContext context)
+        {
+            totalQueryTimeNs = context.totalQueryTimeNs();
+            sstablesHit = context.sstablesHit();
+            segmentsHit = context.segmentsHit();
+            partitionsRead = context.partitionsRead();
+            rowsFiltered = context.rowsFiltered();
+            rowsPreFiltered = context.rowsPreFiltered();
+            trieSegmentsHit = context.trieSegmentsHit();
+            bkdPostingListsHit = context.bkdPostingListsHit();
+            bkdSegmentsHit = context.bkdSegmentsHit();
+            bkdPostingsSkips = context.bkdPostingsSkips();
+            bkdPostingsDecodes = context.bkdPostingsDecodes();
+            triePostingsSkips = context.triePostingsSkips();
+            triePostingsDecodes = context.triePostingsDecodes();
+            queryTimeouts = context.queryTimeouts();
+            annGraphSearchLatency = context.annGraphSearchLatency();
+            shadowedPrimaryKeyCount = context.getShadowedPrimaryKeyCount();
+            filterSortOrder = context.filterSortOrder();
+        }
     }
 }

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -863,7 +863,8 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
     {
         closeUnusedIterators();
         closeQueryViews();
-        if (tableQueryMetrics != null) tableQueryMetrics.record(queryContext);
+        if (tableQueryMetrics != null)
+            tableQueryMetrics.record(queryContext, command);
     }
 
     /**

--- a/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexQueryPlan.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexQueryPlan.java
@@ -44,7 +44,6 @@ public class StorageAttachedIndexQueryPlan implements Index.QueryPlan
 {
     private final ColumnFamilyStore cfs;
     private final TableQueryMetrics queryMetrics;
-
     /**
      * postIndexFilter comprised by those expressions in the read command row filter that can't be handled by
      * {@link FilterTree#isSatisfiedBy(DecoratedKey, Unfiltered, Row)}. That includes expressions targeted
@@ -54,6 +53,7 @@ public class StorageAttachedIndexQueryPlan implements Index.QueryPlan
     private final Set<Index> indexes;
     private final IndexFeatureSet indexFeatureSet;
     private final Orderer orderer;
+    private final boolean usesIndexFiltering;
 
     private StorageAttachedIndexQueryPlan(ColumnFamilyStore cfs,
                                           TableQueryMetrics queryMetrics,
@@ -67,6 +67,7 @@ public class StorageAttachedIndexQueryPlan implements Index.QueryPlan
         this.indexes = indexes;
         this.indexFeatureSet = indexFeatureSet;
         this.orderer = Orderer.from(cfs.getIndexManager(), filter);
+        this.usesIndexFiltering = hasIndexFilters(filter, indexes);
     }
 
     @Nullable
@@ -251,5 +252,24 @@ public class StorageAttachedIndexQueryPlan implements Index.QueryPlan
     public boolean isTopK()
     {
         return orderer != null;
+    }
+
+    @Override
+    public boolean usesIndexFiltering()
+    {
+        return usesIndexFiltering;
+    }
+
+    public static boolean hasIndexFilters(RowFilter filter, Set<Index> indexes)
+    {
+        for (RowFilter.Expression e : filter.expressions())
+        {
+            for (Index index : indexes)
+            {
+                if (index.supportsExpression(e) && !Orderer.isFilterExpressionOrderer(e))
+                    return true;
+            }
+        }
+        return false;
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/SAITester.java
+++ b/test/unit/org/apache/cassandra/index/sai/SAITester.java
@@ -40,6 +40,7 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.management.AttributeNotFoundException;
+import javax.management.InstanceNotFoundException;
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
 
@@ -463,6 +464,11 @@ public class SAITester extends CQLTester
             throw new RuntimeException(e);
         }
         return metricValue;
+    }
+
+    protected void assertMetricDoesNotExist(ObjectName name)
+    {
+        Assertions.assertThatThrownBy(() -> getMetricValue(name)).hasRootCauseInstanceOf(InstanceNotFoundException.class);
     }
 
     protected void startCompaction() throws Throwable

--- a/test/unit/org/apache/cassandra/index/sai/cql/QueryTimeoutTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/QueryTimeoutTest.java
@@ -76,8 +76,8 @@ public class QueryTimeoutTest extends SAITester
         execute("SELECT * FROM %s WHERE v1 >= 0 AND v1 < 10000");
         execute("SELECT * FROM %s WHERE v2 = '0'");
 
-        queryCountName = objectNameNoIndex("TotalQueriesCompleted", CQLTester.KEYSPACE, currentTable(), TableQueryMetrics.TABLE_QUERY_METRIC_TYPE);
-        queryTimeoutsName = objectNameNoIndex("TotalQueryTimeouts", CQLTester.KEYSPACE, currentTable(), TableQueryMetrics.TABLE_QUERY_METRIC_TYPE);
+        queryCountName = objectNameNoIndex("TotalQueriesCompleted", CQLTester.KEYSPACE, currentTable(), TableQueryMetrics.PerTable.METRIC_TYPE);
+        queryTimeoutsName = objectNameNoIndex("TotalQueryTimeouts", CQLTester.KEYSPACE, currentTable(), TableQueryMetrics.PerTable.METRIC_TYPE);
     }
 
     @After

--- a/test/unit/org/apache/cassandra/index/sai/metrics/QueryMetricsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/metrics/QueryMetricsTest.java
@@ -38,6 +38,7 @@ import static org.apache.cassandra.index.sai.metrics.TableQueryMetrics.AbstractQ
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import org.apache.cassandra.index.sai.metrics.TableQueryMetrics.QueryKind;
 
 public class QueryMetricsTest extends AbstractMetricsTest
 {
@@ -46,18 +47,18 @@ public class QueryMetricsTest extends AbstractMetricsTest
     private static final String CREATE_INDEX_TEMPLATE = "CREATE CUSTOM INDEX IF NOT EXISTS %s ON %s.%s(%s) USING 'StorageAttachedIndex'";
 
     private static final String TABLE_QUERY_METRIC_TYPE = TableQueryMetrics.PerTable.METRIC_TYPE;
-    private static final String TABLE_FILTER_QUERY_METRIC_TYPE = makeName(TABLE_QUERY_METRIC_TYPE, "FilterOnly");
-    private static final String TABLE_TOPK_QUERY_METRIC_TYPE = makeName(TABLE_QUERY_METRIC_TYPE, "TopKOnly");
-    private static final String TABLE_HYBRID_QUERY_METRIC_TYPE = makeName(TABLE_QUERY_METRIC_TYPE, "Hybrid");
-    private static final String TABLE_SINGLE_PARTITION_QUERY_METRIC_TYPE = makeName(TABLE_QUERY_METRIC_TYPE, "SinglePartition");
-    private static final String TABLE_MULTI_PARTITION_QUERY_METRIC_TYPE = makeName(TABLE_QUERY_METRIC_TYPE, "MultiPartition");
+    private static final String TABLE_FILTER_QUERY_METRIC_TYPE = makeName(TABLE_QUERY_METRIC_TYPE, QueryKind.FILTER_ONLY);
+    private static final String TABLE_TOPK_QUERY_METRIC_TYPE = makeName(TABLE_QUERY_METRIC_TYPE, QueryKind.TOPK_ONLY);
+    private static final String TABLE_HYBRID_QUERY_METRIC_TYPE = makeName(TABLE_QUERY_METRIC_TYPE, QueryKind.HYBRID);
+    private static final String TABLE_SINGLE_PARTITION_QUERY_METRIC_TYPE = makeName(TABLE_QUERY_METRIC_TYPE, QueryKind.SINGLE_PARTITION);
+    private static final String TABLE_MULTI_PARTITION_QUERY_METRIC_TYPE = makeName(TABLE_QUERY_METRIC_TYPE, QueryKind.MULTI_PARTITION);
 
     private static final String PER_QUERY_METRIC_TYPE = TableQueryMetrics.PerQuery.METRIC_TYPE;
-    private static final String PER_FILTER_QUERY_METRIC_TYPE = makeName(PER_QUERY_METRIC_TYPE, "FilterOnly");
-    private static final String PER_TOPK_QUERY_METRIC_TYPE = makeName(PER_QUERY_METRIC_TYPE, "TopKOnly");
-    private static final String PER_HYBRID_QUERY_METRIC_TYPE = makeName(PER_QUERY_METRIC_TYPE, "Hybrid");
-    private static final String PER_SINGLE_PARTITION_QUERY_METRIC_TYPE = makeName(PER_QUERY_METRIC_TYPE, "SinglePartition");
-    private static final String PER_MULTI_PARTITION_QUERY_METRIC_TYPE = makeName(PER_QUERY_METRIC_TYPE, "MultiPartition");
+    private static final String PER_FILTER_QUERY_METRIC_TYPE = makeName(PER_QUERY_METRIC_TYPE, QueryKind.FILTER_ONLY);
+    private static final String PER_TOPK_QUERY_METRIC_TYPE = makeName(PER_QUERY_METRIC_TYPE, QueryKind.TOPK_ONLY);
+    private static final String PER_HYBRID_QUERY_METRIC_TYPE = makeName(PER_QUERY_METRIC_TYPE, QueryKind.HYBRID);
+    private static final String PER_SINGLE_PARTITION_QUERY_METRIC_TYPE = makeName(PER_QUERY_METRIC_TYPE, QueryKind.SINGLE_PARTITION);
+    private static final String PER_MULTI_PARTITION_QUERY_METRIC_TYPE = makeName(PER_QUERY_METRIC_TYPE, QueryKind.MULTI_PARTITION);
 
     private static final String GLOBAL_METRIC_TYPE = "ColumnQueryMetrics";
 

--- a/test/unit/org/apache/cassandra/index/sai/metrics/QueryMetricsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/metrics/QueryMetricsTest.java
@@ -536,6 +536,33 @@ public class QueryMetricsTest extends AbstractMetricsTest
         waitForEqualsIfExists(perTable, objectName(name, TABLE_SINGLE_PARTITION_QUERY_METRIC_TYPE), numRowsPerPartition);
         waitForEqualsIfExists(perTable, objectName(name, TABLE_MULTI_PARTITION_QUERY_METRIC_TYPE), numRows + numRows + numRows);
 
+        // Verify counters for timeouts.
+        name = "TotalQueryTimeouts";
+        waitForEquals(objectName(name, TABLE_QUERY_METRIC_TYPE), 0);
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_FILTER_QUERY_METRIC_TYPE), 0);
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_TOPK_QUERY_METRIC_TYPE), 0);
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_HYBRID_QUERY_METRIC_TYPE), 0);
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_SINGLE_PARTITION_QUERY_METRIC_TYPE), 0);
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_MULTI_PARTITION_QUERY_METRIC_TYPE), 0);
+
+        // Verify counters for sort-then-filter queries.
+        name = "SortThenFilterQueriesCompleted";
+        waitForEquals(objectName(name, TABLE_QUERY_METRIC_TYPE), 1);
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_FILTER_QUERY_METRIC_TYPE), 0);
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_TOPK_QUERY_METRIC_TYPE), 1); // was 4
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_HYBRID_QUERY_METRIC_TYPE), 0);
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_SINGLE_PARTITION_QUERY_METRIC_TYPE), 0);
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_MULTI_PARTITION_QUERY_METRIC_TYPE), 1);
+
+        // Verify counters for filter-then-sort queries.
+        name = "FilterThenSortQueriesCompleted";
+        waitForEquals(objectName(name, TABLE_QUERY_METRIC_TYPE), 1);
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_FILTER_QUERY_METRIC_TYPE), 0);
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_TOPK_QUERY_METRIC_TYPE), 0);
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_HYBRID_QUERY_METRIC_TYPE), 1);
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_SINGLE_PARTITION_QUERY_METRIC_TYPE), 0);
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_MULTI_PARTITION_QUERY_METRIC_TYPE), 1);
+
         // Verify histograms for partitions reads per query.
         name = "PartitionReads";
         waitForHistogramCountEquals(objectName(name, PER_QUERY_METRIC_TYPE), 4);


### PR DESCRIPTION


SAI's tracks query metrics providing info about latency, partition reads, filtered rows, etc. These metrics are for all the SAI queries for a certain table. When we see problems in queries, for example a high latency, questions that can usually come next are what query is producing this high latency? Are there vector queries? Are queries for a single partition? In that case, what is the latency of those queries? How many rows are they selecting? To answer those questions, I think it can be useful to track metrics for specific types of query.

The types of query depend on multiple characteristics, like being top-k, containing disjunctions, etc. We can make an overwhelming number of combinations of query characteristics conforming types of query. Storing so many metrics is probably not feasible, so we should choose the ones we consider more interesting. 

This PR only adds a few type of queries: filtering, top-k, single-partition and range queries. If we need new types in the future, this patch should make it easy to add separate metrics for them, possibly with an one-liner.

The general query metrics remain untouched, this PR only adds new ones.

Here is how the SAI metrics look like without this patch:
<img width="376" height="552" alt="metrics_old" src="https://github.com/user-attachments/assets/afc06ad6-676b-4f5b-b48e-d3bf33b98dc0" />
And this is with this patch:
<img width="337" height="593" alt="metrics_new" src="https://github.com/user-attachments/assets/3372d3f7-74ab-45e2-bf74-c49592694376" />
