### PR TITLE
CNDB-15156: Include actual number of cached rows above threshold in RFP warn (#1959)

### DIFF
--- a/src/java/org/apache/cassandra/service/reads/ReplicaFilteringProtection.java
+++ b/src/java/org/apache/cassandra/service/reads/ReplicaFilteringProtection.java
@@ -109,8 +109,8 @@ public class ReplicaFilteringProtection<E extends Endpoints<E>>
     private final int cachedRowsWarnThreshold;
     private final int cachedRowsFailThreshold;
 
-    /** Tracks whether or not we've already hit the warning threshold while evaluating a partition. */
-    private boolean hitWarningThreshold = false;
+    /** Tracks whether or not we've already hit the failure threshold while evaluating a partition. */
+    private boolean hitFailureThreshold = false;
 
     private int currentRowsCached = 0; // tracks the current number of cached rows
     private int maxRowsCached = 0; // tracks the high watermark for the number of cached rows
@@ -189,7 +189,22 @@ public class ReplicaFilteringProtection<E extends Endpoints<E>>
             public void close()
             {
                 // If we hit the failure threshold before consuming a single partition, record the current rows cached.
-                tableMetrics.rfpRowsCachedPerQuery.update(Math.max(currentRowsCached, maxRowsCached));
+                maxRowsCached = Math.max(currentRowsCached, maxRowsCached);
+                tableMetrics.rfpRowsCachedPerQuery.update(maxRowsCached);
+
+                // Check the cached rows warning threshold at the end of the query, so we can report the maximum number
+                // of cached rows we have had during the query.
+                if (!hitFailureThreshold && maxRowsCached > cachedRowsWarnThreshold)
+                {
+                    String message = String.format("Replica filtering protection has cached up to %d rows during query %s, " +
+                                                   "which is over the warning threshold of %d rows defined by " +
+                                                   "'cached_replica_rows_warn_threshold' in cassandra.yaml.",
+                                                   maxRowsCached, command.toCQLString(), cachedRowsWarnThreshold);
+
+                    ClientWarn.instance.warn(message);
+                    oneMinuteLogger.warn(message);
+                    Tracing.trace(message);
+                }
             }
 
             @Override
@@ -284,33 +299,25 @@ public class ReplicaFilteringProtection<E extends Endpoints<E>>
     {
         currentRowsCached++;
 
+        // Check the cached rows failure threshold every time the cached row count is incremented,
+        // so we can detect a violation and abort as soon as the threshold is crossed.
         if (currentRowsCached == cachedRowsFailThreshold + 1)
         {
-            String message = String.format("Replica filtering protection has cached over %d rows during query %s. " +
-                                           "(See 'cached_replica_rows_fail_threshold' in cassandra.yaml.)",
-                                           cachedRowsFailThreshold, command.toCQLString());
+            hitFailureThreshold = true;
+            String message = String.format("Replica filtering protection has cached %d rows during query %s, " +
+                                           "which is over the failure threshold of %d rows defined by " +
+                                           "'cached_replica_rows_fail_threshold' in cassandra.yaml.",
+                                           currentRowsCached, command.toCQLString(), cachedRowsFailThreshold);
 
             logger.error(message);
             Tracing.trace(message);
             throw new OverloadedException(message);
         }
-        else if (currentRowsCached == cachedRowsWarnThreshold + 1 && !hitWarningThreshold)
-        {
-            hitWarningThreshold = true;
-
-            String message = String.format("Replica filtering protection has cached over %d rows during query %s. " +
-                                           "(See 'cached_replica_rows_warn_threshold' in cassandra.yaml.)",
-                                           cachedRowsWarnThreshold, command.toCQLString());
-
-            ClientWarn.instance.warn(message);
-            oneMinuteLogger.warn(message);
-            Tracing.trace(message);
-        }
     }
 
     private void releaseCachedRows(int count)
     {
-        maxRowsCached = Math.max(maxRowsCached, currentRowsCached);
+        maxRowsCached = Math.max(currentRowsCached, maxRowsCached);
         currentRowsCached -= count;
     }
 


### PR DESCRIPTION
Include the number of rows cached by RFP when it exceeds either its warning or failure threshold. For this, the warning threshold check is moved to the end of the query, so we can report the maximum number of cached rows just once.

