### PR TITLE
CNDB-15262: add needsReconciliation flag to fix IntersectFilteringQueryTest

### DIFF
--- a/src/java/org/apache/cassandra/cql3/restrictions/StatementRestrictions.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/StatementRestrictions.java
@@ -1156,8 +1156,8 @@ public class StatementRestrictions
 
         ANNOptions annOptions = selectOptions.parseANNOptions();
 
-        RowFilter rowFilter = RowFilter.builder(indexRegistry, indexHints)
-                                       .buildFromRestrictions(this, table, options, clientState, annOptions);
+        RowFilter.Builder filterBuilder = new RowFilter.Builder(needsReconciliation, indexRegistry, indexHints);
+        RowFilter rowFilter = filterBuilder.buildFromRestrictions(this, table, options, clientState, annOptions);
 
         if (hasAnnOptions && !rowFilter.hasANN())
             throw new InvalidRequestException(ANN_OPTIONS_WITHOUT_ORDER_BY_ANN);

--- a/src/java/org/apache/cassandra/db/filter/ClusteringIndexNamesFilter.java
+++ b/src/java/org/apache/cassandra/db/filter/ClusteringIndexNamesFilter.java
@@ -20,7 +20,6 @@ package org.apache.cassandra.db.filter;
 import java.io.IOException;
 import java.util.*;
 
-import org.apache.cassandra.cql3.Operator;
 import org.apache.cassandra.db.*;
 import org.apache.cassandra.db.partitions.*;
 import org.apache.cassandra.db.rows.*;


### PR DESCRIPTION
### What is the issue
IntersectFilteringQueryTest.shouldFailOnFilteringQuery and shouldWarnOnFilteringQuery are failing

### What does this PR fix and why was it fixed
needsReconciliation needs to be passed in order for a quorum level query to be used 
