### PR TITLE
CNDB-15022 Introduce additional guardrail profile for HCD

### DIFF
--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -2340,14 +2340,5 @@ drop_compact_storage_enabled: false
 #
 storage_compatibility_mode: NONE
 
-# Emulates DataStax Constellation database-as-a-service defaults.
-#
-# When enabled, some defaults are modified to match those used by DataStax Constellation (DataStax cloud data
-# platform). This includes (but is not limited to) stricter guardrails defaults.
-#
-# This can be used as an convenience to develop and test applications meant to run on DataStax Constellation.
-#
-# Warning: when enabled, the updated defaults reflect those of DataStax Constellation _at the time_ of the currently
-#                 used DSE release. This is a best-effort emulation of said defaults. Further, all nodes must use the same
-#                 config value.
-# emulate_dbaas_defaults: false
+# Changes defaults considered production safest for HCD users
+# hcd_guardrail_defaults: false

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -806,6 +806,7 @@ public class Config
     public volatile boolean log_out_of_token_range_requests = true;
     public volatile boolean reject_out_of_token_range_requests = false;
     public boolean emulate_dbaas_defaults = false;
+    public boolean hcd_guardrail_defaults = false;
 
     /**
      * The intial capacity for creating RangeTombstoneList.

--- a/src/java/org/apache/cassandra/config/DataStorageSpec.java
+++ b/src/java/org/apache/cassandra/config/DataStorageSpec.java
@@ -201,6 +201,14 @@ public abstract class DataStorageSpec
         }
 
         /**
+         * @return the amount of data storage in kibibytes
+         */
+        public long toKibibytes()
+        {
+            return unit().toKibibytes(quantity());
+        }
+
+        /**
          * @return the amount of data storage in bytes
          */
         public long toBytes()

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -1207,6 +1207,8 @@ public class DatabaseDescriptor
         try
         {
             guardrails = new GuardrailsOptions(conf);
+            guardrails.applyConfig();
+            guardrails.validate();
         }
         catch (IllegalArgumentException e)
         {
@@ -5571,6 +5573,17 @@ public class DatabaseDescriptor
     public static boolean isEmulateDbaasDefaults()
     {
         return conf.emulate_dbaas_defaults;
+    }
+
+    @VisibleForTesting
+    public static boolean setHcdGuardrailsDefaults(boolean hcd_guardrail_defaults)
+    {
+        return conf.hcd_guardrail_defaults = hcd_guardrail_defaults;
+    }
+
+    public static boolean isHcdGuardrailsDefaults()
+    {
+        return conf.hcd_guardrail_defaults;
     }
 
     public static PageSize getAggregationSubPageSize()

--- a/src/java/org/apache/cassandra/config/GuardrailsOptions.java
+++ b/src/java/org/apache/cassandra/config/GuardrailsOptions.java
@@ -38,6 +38,7 @@ import org.apache.cassandra.cql3.statements.schema.TableAttributes;
 import org.apache.cassandra.db.ConsistencyLevel;
 import org.apache.cassandra.db.guardrails.Guardrails;
 import org.apache.cassandra.db.guardrails.GuardrailsConfig;
+import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.schema.TableParams;
 import org.apache.cassandra.service.disk.usage.DiskUsageMonitor;
@@ -75,9 +76,15 @@ public class GuardrailsOptions implements GuardrailsConfig
     public GuardrailsOptions(Config config)
     {
         this.config = config;
+    }
 
-        enforceDefaults();
-
+    /**
+     * Validate that the value provided for each guardrail setting is valid.
+     *
+     * @throws ConfigurationException if any of the settings has an invalid setting.
+     */
+    public void validate()
+    {
         validateMaxIntThreshold(config.keyspaces_warn_threshold, config.keyspaces_fail_threshold, "keyspaces");
         validateMaxIntThreshold(config.tables_warn_threshold, config.tables_fail_threshold, "tables");
         validateMaxIntThreshold(config.columns_per_table_warn_threshold, config.columns_per_table_fail_threshold, "columns_per_table");
@@ -119,65 +126,71 @@ public class GuardrailsOptions implements GuardrailsConfig
     }
 
     /**
-     * If {@link DatabaseDescriptor#isEmulateDbaasDefaults()} is true, apply cloud defaults to guardrails settings that
-     * are not specified in yaml; otherwise, apply on-prem defaults to guardrails settings that are not specified in yaml;
+     * Apply guardrail defaults to settings not specified by yaml according
+     * to {@link DatabaseDescriptor#isEmulateDbaasDefaults()} or {@link DatabaseDescriptor#isHcdGuardrailsDefaults()}
      */
     @VisibleForTesting
-    public void enforceDefaults()
+    public void applyConfig()
     {
+
+        assert !(DatabaseDescriptor.isHcdGuardrailsDefaults() && DatabaseDescriptor.isEmulateDbaasDefaults())
+                : "Cannot set both hcd_guardrail_defaults and emulate_dbaas_defaults to true";
+
         // for read requests
-        enforceDefault("page_size_fail_threshold", (IntConsumer) (v -> config.page_size_fail_threshold = v), NO_LIMIT, 512);
+        enforceDefault("page_size_fail_threshold", (IntConsumer) (v -> config.page_size_fail_threshold = v), NO_LIMIT, 512, NO_LIMIT);
 
-        enforceDefault("in_select_cartesian_product_fail_threshold", (IntConsumer) (v -> config.in_select_cartesian_product_fail_threshold = v), NO_LIMIT, 25);
-        enforceDefault("partition_keys_in_select_fail_threshold", (IntConsumer) (v -> config.partition_keys_in_select_fail_threshold = v), NO_LIMIT, 20);
+        enforceDefault("in_select_cartesian_product_fail_threshold", (IntConsumer) (v -> config.in_select_cartesian_product_fail_threshold = v), NO_LIMIT, 25, 25);
+        enforceDefault("partition_keys_in_select_fail_threshold", (IntConsumer) (v -> config.partition_keys_in_select_fail_threshold = v), NO_LIMIT, 20, 20);
 
-        enforceDefault("tombstone_warn_threshold", (IntConsumer) (v -> config.tombstone_warn_threshold = v), 1000, 1000);
-        enforceDefault("tombstone_failure_threshold", (IntConsumer) (v -> config.tombstone_failure_threshold = v), 100000, 100000);
+        enforceDefault("tombstone_warn_threshold", (IntConsumer) (v -> config.tombstone_warn_threshold = v), 1000, 1000, 1000);
+        enforceDefault("tombstone_failure_threshold", (IntConsumer) (v -> config.tombstone_failure_threshold = v), 100000, 100000, 100000);
 
         // Default to no warning and failure at 4 times the maxTopK value
         int maxTopK = CassandraRelevantProperties.SAI_VECTOR_SEARCH_MAX_TOP_K.getInt();
-        enforceDefault("sai_ann_rerank_k_warn_threshold", (IntConsumer) (v -> config.sai_ann_rerank_k_warn_threshold = v), -1, -1);
-        enforceDefault("sai_ann_rerank_k_fail_threshold", (IntConsumer) (v -> config.sai_ann_rerank_k_fail_threshold = v), 4 * maxTopK, 4 * maxTopK);
+        enforceDefault("sai_ann_rerank_k_warn_threshold", (IntConsumer) (v -> config.sai_ann_rerank_k_warn_threshold = v), -1, -1, -1);
+        enforceDefault("sai_ann_rerank_k_fail_threshold", (IntConsumer) (v -> config.sai_ann_rerank_k_fail_threshold = v), 4 * maxTopK, 4 * maxTopK, 4 * maxTopK);
 
         // for write requests
-        enforceDefault("logged_batch_enabled", v -> config.logged_batch_enabled = v, true, true);
-        enforceDefault("batch_size_warn_threshold", v -> config.batch_size_warn_threshold = v, new DataStorageSpec.IntKibibytesBound("64KiB"), new DataStorageSpec.IntKibibytesBound("64KiB"));
-        enforceDefault("batch_size_fail_threshold", v -> config.batch_size_fail_threshold = v, new DataStorageSpec.IntKibibytesBound("640KiB"), new DataStorageSpec.IntKibibytesBound("640KiB"));
-        enforceDefault("unlogged_batch_across_partitions_warn_threshold", (IntConsumer) (v -> config.unlogged_batch_across_partitions_warn_threshold = v), 10, 10);
+        enforceDefault("logged_batch_enabled", v -> config.logged_batch_enabled = v, true, true, true);
+        enforceDefault("batch_size_warn_threshold", v -> config.batch_size_warn_threshold = v, new DataStorageSpec.IntKibibytesBound("64KiB"), new DataStorageSpec.IntKibibytesBound("64KiB"), new DataStorageSpec.IntKibibytesBound("64KiB"));
+        enforceDefault("batch_size_fail_threshold", v -> config.batch_size_fail_threshold = v, new DataStorageSpec.IntKibibytesBound("640KiB"), new DataStorageSpec.IntKibibytesBound("640KiB"), new DataStorageSpec.IntKibibytesBound("640KiB"));
+        enforceDefault("unlogged_batch_across_partitions_warn_threshold", (IntConsumer) (v -> config.unlogged_batch_across_partitions_warn_threshold = v), 10, 10, 10);
 
-        enforceDefault("drop_truncate_table_enabled", v -> config.drop_truncate_table_enabled = v, true, true);
+        enforceDefault("drop_truncate_table_enabled", v -> config.drop_truncate_table_enabled = v, true, true, true);
 
-        enforceDefault("user_timestamps_enabled", v -> config.user_timestamps_enabled = v, true, true);
+        enforceDefault("user_timestamps_enabled", v -> config.user_timestamps_enabled = v, true, true, true);
 
-        enforceDefault("column_value_size_fail_threshold", v -> config.column_value_size_fail_threshold = v, null, new DataStorageSpec.LongBytesBound(5 * 1024L, KIBIBYTES));
+        enforceDefault("column_value_size_fail_threshold", v -> config.column_value_size_fail_threshold = v, null, new DataStorageSpec.LongBytesBound(5 * 1024L, KIBIBYTES), null);
 
-        enforceDefault("read_before_write_list_operations_enabled", v -> config.read_before_write_list_operations_enabled = v, true, false);
+        enforceDefault("read_before_write_list_operations_enabled", v -> config.read_before_write_list_operations_enabled = v, true, false, true);
 
         // We use a LinkedHashSet just for the sake of preserving the ordering in error messages
         enforceDefault("write_consistency_levels_disallowed",
                        v -> config.write_consistency_levels_disallowed = ImmutableSet.copyOf(v),
                        Collections.<ConsistencyLevel>emptySet(),
-                       new LinkedHashSet<>(Arrays.asList(ConsistencyLevel.ANY, ConsistencyLevel.ONE, ConsistencyLevel.LOCAL_ONE)));
+                       new LinkedHashSet<>(Arrays.asList(ConsistencyLevel.ANY, ConsistencyLevel.ONE, ConsistencyLevel.LOCAL_ONE)),
+                       new LinkedHashSet<>(Arrays.asList(ConsistencyLevel.ANY)));
 
         // for schema
-        enforceDefault("counter_enabled", v -> config.counter_enabled = v, true, true);
+        enforceDefault("counter_enabled", v -> config.counter_enabled = v, true, true, true);
 
-        enforceDefault("fields_per_udt_fail_threshold", (IntConsumer) (v -> config.fields_per_udt_fail_threshold = v), -1, 10);
-        enforceDefault("collection_size_warn_threshold", v -> config.collection_size_warn_threshold = v, null, new DataStorageSpec.LongBytesBound(5 * 1024L, KIBIBYTES));
-        enforceDefault("items_per_collection_warn_threshold", v -> config.items_per_collection_warn_threshold = v, -1, 20);
+        enforceDefault("fields_per_udt_fail_threshold", (IntConsumer) (v -> config.fields_per_udt_fail_threshold = v), -1, 10, 100);
+        enforceDefault("collection_size_warn_threshold", v -> config.collection_size_warn_threshold = v, null, new DataStorageSpec.LongBytesBound(5 * 1024L, KIBIBYTES), new DataStorageSpec.LongBytesBound(10240L, KIBIBYTES));
+        enforceDefault("items_per_collection_warn_threshold", v -> config.items_per_collection_warn_threshold = v, -1, 20, 200);
 
-        enforceDefault("vector_dimensions_warn_threshold", v -> config.vector_dimensions_warn_threshold = v, -1, -1);
-        enforceDefault("vector_dimensions_fail_threshold", v -> config.vector_dimensions_fail_threshold = v, 8192, 8192);
+        enforceDefault("vector_dimensions_warn_threshold", v -> config.vector_dimensions_warn_threshold = v, -1, -1, -1);
+        enforceDefault("vector_dimensions_fail_threshold", v -> config.vector_dimensions_fail_threshold = v, 8192, 8192, 8192);
 
-        enforceDefault("columns_per_table_fail_threshold", v -> config.columns_per_table_fail_threshold = v, -1, 50);
-        enforceDefault("secondary_indexes_per_table_fail_threshold", v -> config.secondary_indexes_per_table_fail_threshold = v, NO_LIMIT, 1);
-        enforceDefault("sasi_indexes_per_table_fail_threshold", v -> config.sasi_indexes_per_table_fail_threshold = v, NO_LIMIT, 0);
-        enforceDefault("materialized_views_per_table_fail_threshold", v -> config.materialized_views_per_table_fail_threshold = v, NO_LIMIT, 2);
-        enforceDefault("tables_warn_threshold", v -> config.tables_warn_threshold = v, -1, 100);
-        enforceDefault("tables_fail_threshold", v -> config.tables_fail_threshold = v, -1, 200);
+        enforceDefault("columns_per_table_fail_threshold", v -> config.columns_per_table_fail_threshold = v, -1, 50, 200);
+        enforceDefault("secondary_indexes_per_table_fail_threshold", v -> config.secondary_indexes_per_table_fail_threshold = v, NO_LIMIT, 1, 0);
+        enforceDefault("sasi_indexes_per_table_fail_threshold", v -> config.sasi_indexes_per_table_fail_threshold = v, NO_LIMIT, 0, 0);
+        enforceDefault("materialized_views_per_table_fail_threshold", v -> config.materialized_views_per_table_fail_threshold = v, NO_LIMIT, 2, 0);
+        enforceDefault("tables_warn_threshold", v -> config.tables_warn_threshold = v, -1, 100, 100);
+        enforceDefault("tables_fail_threshold", v -> config.tables_fail_threshold = v, -1, 200, 200);
 
         enforceDefault("table_properties_disallowed",
                        v -> config.table_properties_disallowed = ImmutableSet.copyOf(v),
+                       Collections.<String>emptySet(),
                        Collections.<String>emptySet(),
                        Collections.<String>emptySet());
 
@@ -189,34 +202,35 @@ public class GuardrailsOptions implements GuardrailsConfig
                                                           .filter(p -> !p.equals(TableParams.Option.DEFAULT_TIME_TO_LIVE.toString()) &&
                                                                        !p.equals(TableParams.Option.COMMENT.toString()) &&
                                                                        !p.equals(TableParams.Option.EXTENSIONS.toString()))
-                                                          .collect(Collectors.toList())));
+                                                          .collect(Collectors.toList())),
+                       Collections.<String>emptySet());
 
         // for node status
-        enforceDefault("data_disk_usage_percentage_warn_threshold", v -> config.data_disk_usage_percentage_warn_threshold = v, NO_LIMIT, 70);
-        enforceDefault("data_disk_usage_percentage_fail_threshold", v -> config.data_disk_usage_percentage_fail_threshold = v, NO_LIMIT, 80);
-        enforceDefault("data_disk_usage_max_disk_size", v -> config.data_disk_usage_max_disk_size = v, null, (DataStorageSpec.LongBytesBound) null);
+        enforceDefault("data_disk_usage_percentage_warn_threshold", v -> config.data_disk_usage_percentage_warn_threshold = v, NO_LIMIT, 70, 70);
+        enforceDefault("data_disk_usage_percentage_fail_threshold", v -> config.data_disk_usage_percentage_fail_threshold = v, NO_LIMIT, 80, NO_LIMIT);
+        enforceDefault("data_disk_usage_max_disk_size", v -> config.data_disk_usage_max_disk_size = v, null, (DataStorageSpec.LongBytesBound) null, (DataStorageSpec.LongBytesBound) null);
 
-        enforceDefault("partition_size_warn_threshold", v -> config.partition_size_warn_threshold = v, new DataStorageSpec.LongBytesBound(100,MEBIBYTES), new DataStorageSpec.LongBytesBound(100, MEBIBYTES));
+        enforceDefault("partition_size_warn_threshold", v -> config.partition_size_warn_threshold = v, new DataStorageSpec.LongBytesBound(100,MEBIBYTES), new DataStorageSpec.LongBytesBound(100, MEBIBYTES), new DataStorageSpec.LongBytesBound(100, MEBIBYTES));
 
         // SAI Table Failure threshold (maye be overridden via system property)
         int overrideTableFailureThreshold = CassandraRelevantProperties.INDEX_GUARDRAILS_TABLE_FAILURE_THRESHOLD.getInt(UNSET);
         if (overrideTableFailureThreshold != UNSET)
             config.sai_indexes_per_table_fail_threshold = overrideTableFailureThreshold;
         else
-            enforceDefault("sai_indexes_per_table_fail_threshold", v -> config.sai_indexes_per_table_fail_threshold = v, DEFAULT_INDEXES_PER_TABLE_THRESHOLD, DEFAULT_INDEXES_PER_TABLE_THRESHOLD);
+            enforceDefault("sai_indexes_per_table_fail_threshold", v -> config.sai_indexes_per_table_fail_threshold = v, DEFAULT_INDEXES_PER_TABLE_THRESHOLD, DEFAULT_INDEXES_PER_TABLE_THRESHOLD, DEFAULT_INDEXES_PER_TABLE_THRESHOLD);
 
         // SAI Table Failure threshold (maye be overridden via system property)
         int overrideTotalFailureThreshold = CassandraRelevantProperties.INDEX_GUARDRAILS_TOTAL_FAILURE_THRESHOLD.getInt(UNSET);
         if (overrideTotalFailureThreshold != UNSET)
             config.sai_indexes_total_fail_threshold = overrideTotalFailureThreshold;
         else
-            enforceDefault("sai_indexes_total_fail_threshold", v -> config.sai_indexes_total_fail_threshold = v, DEFAULT_INDEXES_TOTAL_THRESHOLD, DEFAULT_INDEXES_TOTAL_THRESHOLD);
+            enforceDefault("sai_indexes_total_fail_threshold", v -> config.sai_indexes_total_fail_threshold = v, DEFAULT_INDEXES_TOTAL_THRESHOLD, DEFAULT_INDEXES_TOTAL_THRESHOLD, DEFAULT_INDEXES_TOTAL_THRESHOLD);
 
-        enforceDefault("offset_rows_warn_threshold", v -> config.offset_rows_warn_threshold = v, 10000, 10000);
-        enforceDefault("offset_rows_fail_threshold", v -> config.offset_rows_fail_threshold = v, 20000, 20000);
+        enforceDefault("offset_rows_warn_threshold", v -> config.offset_rows_warn_threshold = v, 10000, 10000, 10000);
+        enforceDefault("offset_rows_fail_threshold", v -> config.offset_rows_fail_threshold = v, 20000, 20000, 20000);
 
-        enforceDefault("query_filters_warn_threshold", v -> config.query_filters_warn_threshold = v, -1, -1);
-        enforceDefault("query_filters_fail_threshold", v -> config.query_filters_fail_threshold = v, -1, -1);
+        enforceDefault("query_filters_warn_threshold", v -> config.query_filters_warn_threshold = v, -1, -1, -1);
+        enforceDefault("query_filters_fail_threshold", v -> config.query_filters_fail_threshold = v, -1, -1, -1);
     }
 
     /**
@@ -225,32 +239,48 @@ public class GuardrailsOptions implements GuardrailsConfig
      *
      * @param configName current config value defined in yaml
      * @param optionSetter setter to updated given config
-     * @param onPremDefault default value for on-prem
+     * @param noProfileDefault default value for on-prem
      * @param dbaasDefault default value for constellation DB-as-a-service
+     * @param hcdDefault default value for HCD
      * @param <T>
      */
-    private <T> void enforceDefault(String configName, Consumer<T> optionSetter, T onPremDefault, T dbaasDefault)
+    private <T> void enforceDefault(String configName, Consumer<T> optionSetter, T noProfileDefault, T dbaasDefault, T hcdDefault)
     {
         if (config.userSetConfigKeys.contains(configName))
             return;
 
-        optionSetter.accept(DatabaseDescriptor.isEmulateDbaasDefaults() ? dbaasDefault : onPremDefault);
+        if (DatabaseDescriptor.isEmulateDbaasDefaults())
+            optionSetter.accept(dbaasDefault);
+        else if (DatabaseDescriptor.isHcdGuardrailsDefaults())
+            optionSetter.accept(hcdDefault);
+        else
+            optionSetter.accept(noProfileDefault);
     }
 
-    private void enforceDefault(String configName, IntConsumer optionSetter, int onPremDefault, int dbaasDefault)
+    private void enforceDefault(String configName, IntConsumer optionSetter, int noProfileDefault, int dbaasDefault, int hcdDefault)
     {
         if (config.userSetConfigKeys.contains(configName))
             return;
 
-        optionSetter.accept(DatabaseDescriptor.isEmulateDbaasDefaults() ? dbaasDefault : onPremDefault);
+        if (DatabaseDescriptor.isEmulateDbaasDefaults())
+            optionSetter.accept(dbaasDefault);
+        else if (DatabaseDescriptor.isHcdGuardrailsDefaults())
+            optionSetter.accept(hcdDefault);
+        else
+            optionSetter.accept(noProfileDefault);
     }
 
-    private void enforceDefault(String configName, Consumer<Boolean> optionSetter, boolean onPremDefault, boolean dbaasDefault)
+    private void enforceDefault(String configName, Consumer<Boolean> optionSetter, boolean noProfileDefault, boolean dbaasDefault, boolean hcdDefault)
     {
         if (config.userSetConfigKeys.contains(configName))
             return;
 
-        optionSetter.accept(DatabaseDescriptor.isEmulateDbaasDefaults() ? dbaasDefault : onPremDefault);
+        if (DatabaseDescriptor.isEmulateDbaasDefaults())
+            optionSetter.accept(dbaasDefault);
+        else if (DatabaseDescriptor.isHcdGuardrailsDefaults())
+            optionSetter.accept(hcdDefault);
+        else
+            optionSetter.accept(noProfileDefault);
     }
 
     @Override


### PR DESCRIPTION
There are now three profiles for guardrail defaults: none|dbaas|hcd

This redoes the work in 7940e9c
The defaults introduced previously (as new non-dbaas defaults) are now applied to the hcd profile.
--
HCD-179 Guardrail defaults for on-prem
Provide users defaults and feedback from startup checks/warnings sensible for production environments. Many users do not (and do not want to) understand the complexities of HCD/Cassandra, and such feedback helps them stay safely dumb. This is also expected to alleviate the impact on Support having to deal will silly abuses of the database. It is also avoids operators having to retrospectively police their developers creating the data models and client applications.

Set on-prem guardrail defaults to be (keeping in mind these can be changed by operators on-prem, so they are first and foremost important teachings to give):

columns_per_table_failure_threshold: 200
fields_per_udt_failure_threshold: 100
collection_size_warn_threshold_in_kb: 10240
items_per_collection_warn_threshold: 200
secondary_index_per_table_failure_threshold: 0
sasi_indexes_per_table_failure_threshold: 0
materialized_view_per_table_failure_threshold: 0
tables_warn_threshold: 100
tables_failure_threshold: 200
in_select_cartesian_product_failure_threshold: 25
partition_keys_in_select_failure_threshold: 20
disk_usage_percentage_warn_threshold: 70
write_consistency_levels_disallowed: ANY

Also add a startup warning when SimpleSnitch is used.

### What is the issue
Sets appropriate startup checks, and guardrail defaults under a new HCD profile.

### What does this PR fix and why was it fixed
Introduces a new yaml setting `hcd_guardrail_defaults` and a set of defaults when it's set true in GuardrailsConfig.  These defaults are applied when the yaml hasn't provided values.
Default settings have not otherwise changed if hcd_guardrail_defaults has not been set.
An assertion is thrown if both `hcd_guardrail_defaults` and `emulate_dbaas_defaults` is set true.

### CNDB testing

https://github.com/riptano/cndb/pull/14958 