### PR TITLE
CNDB-15135: use EmptyFactory to avoid loading SAI per-sstable files if SAI_INDEX_READS_DISABLED is true (#1958)

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/IndexContext.java
+++ b/src/java/org/apache/cassandra/index/sai/IndexContext.java
@@ -96,6 +96,7 @@ import static org.apache.cassandra.config.CassandraRelevantProperties.SAI_MAX_ST
 import static org.apache.cassandra.config.CassandraRelevantProperties.SAI_MAX_VECTOR_TERM_SIZE;
 import static org.apache.cassandra.config.CassandraRelevantProperties.SAI_VALIDATE_MAX_TERM_SIZE_AT_COORDINATOR;
 import static org.apache.cassandra.utils.Clock.Global.nanoTime;
+import static org.apache.cassandra.config.CassandraRelevantProperties.SAI_INDEX_READS_DISABLED;
 
 /**
  * Manage metadata for each column index.
@@ -944,8 +945,15 @@ public class IndexContext
                 }
 
                 SSTableIndex index = new SSTableIndex(context, perIndexComponents);
-                long count = context.primaryKeyMapFactory().count();
-                logger.debug(logMessage("Successfully loaded index for SSTable {} with {} rows."), context.descriptor(), count);
+                if (SAI_INDEX_READS_DISABLED.getBoolean())
+                {
+                    logger.debug(logMessage("Skipped loading index for SSTable {} as it's disabled by {}"), context.descriptor(), SAI_INDEX_READS_DISABLED.getKey());
+                }
+                else
+                {
+                    long count = context.primaryKeyMapFactory().count();
+                    logger.debug(logMessage("Successfully loaded index for SSTable {} with {} rows."), context.descriptor(), count);
+                }
 
                 // Try to add new index to the set, if set already has such index, we'll simply release and move on.
                 // This covers situation when SSTable collection has the same SSTable multiple

--- a/src/java/org/apache/cassandra/index/sai/disk/PrimaryKeyMap.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/PrimaryKeyMap.java
@@ -124,4 +124,28 @@ public interface PrimaryKeyMap extends Closeable
     default void close() throws IOException
     {
     }
+
+    /**
+     * When SAI_INDEX_READS_DISABLED is true, this is used to avoid loading SAI files to reduce disk access and memory usage
+     */
+    class DummyThrowingFactory implements Factory
+    {
+        @Override
+        public PrimaryKeyMap newPerSSTablePrimaryKeyMap()
+        {
+            throw new UnsupportedOperationException("EmptyFactory doesn't support newPerSSTablePrimaryKeyMap()");
+        }
+
+        @Override
+        public long count()
+        {
+            throw new UnsupportedOperationException("EmptyFactory doesn't support count()");
+        }
+
+        @Override
+        public void close() throws IOException
+        {
+            // no-op
+        }
+    }
 }


### PR DESCRIPTION
### What is the issue
CNDB-15135

### What does this PR fix and why was it fixed
Avoid reading SAI per-sstable files if SAI_INDEX_READS_DISABLED is true
