### PR TITLE
CNDB-8641: Add metric  to ClientRequestMetrics to count InvalidRequestException

### DIFF
--- a/src/java/org/apache/cassandra/metrics/ClientRequestMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/ClientRequestMetrics.java
@@ -31,6 +31,7 @@ public class ClientRequestMetrics
     public final Meter timeouts;
     public final Meter unavailables;
     public final Meter failures;
+    public final Meter invalid;
 
     /**
      * this is the metric that measures the actual execution time of a certain request;
@@ -54,6 +55,7 @@ public class ClientRequestMetrics
         timeouts = Metrics.meter(factory.createMetricName(namePrefix + "Timeouts"));
         unavailables = Metrics.meter(factory.createMetricName(namePrefix + "Unavailables"));
         failures = Metrics.meter(factory.createMetricName(namePrefix + "Failures"));
+        invalid = Metrics.meter(factory.createMetricName(namePrefix + "Invalid"));
         executionTimeMetrics = new LatencyMetrics(factory, namePrefix);
         serviceTimeMetrics = new LatencyMetrics(factory, namePrefix + "ServiceTime");
     }
@@ -63,6 +65,7 @@ public class ClientRequestMetrics
         Metrics.remove(factory.createMetricName(namePrefix + "Timeouts"));
         Metrics.remove(factory.createMetricName(namePrefix + "Unavailables"));
         Metrics.remove(factory.createMetricName(namePrefix + "Failures"));
+        Metrics.remove(factory.createMetricName(namePrefix + "Invalid"));
         executionTimeMetrics.release();
         serviceTimeMetrics.release();
     }

--- a/src/java/org/apache/cassandra/service/StorageProxy.java
+++ b/src/java/org/apache/cassandra/service/StorageProxy.java
@@ -279,6 +279,14 @@ public class StorageProxy implements StorageProxyMBean
                 writeTracker.onError(e);
                 throw e;
             }
+            catch (InvalidRequestException e)
+            {
+                metrics.writeMetrics.invalid.mark();
+                metrics.writeMetricsForLevel(consistencyLevel).invalid.mark();
+                Tracing.trace("Invalid request: {}", e.getMessage());
+                writeTracker.onError(e);
+                throw e;
+            }
             finally
             {
                 long endTime = System.nanoTime();
@@ -592,6 +600,13 @@ public class StorageProxy implements StorageProxyMBean
         {
             metrics.casWriteMetrics.unavailables.mark();
             metrics.writeMetricsForLevel(consistencyForPaxos).unavailables.mark();
+            lwtTracker.onError(e);
+            throw e;
+        }
+        catch (InvalidRequestException e)
+        {
+            metrics.casWriteMetrics.invalid.mark();
+            metrics.writeMetricsForLevel(consistencyForPaxos).invalid.mark();
             lwtTracker.onError(e);
             throw e;
         }
@@ -1162,6 +1177,14 @@ public class StorageProxy implements StorageProxyMBean
             metrics.writeMetrics.unavailables.mark();
             metrics.writeMetricsForLevel(consistencyLevel).unavailables.mark();
             Tracing.trace("Overloaded");
+            writeTracker.onError(e);
+            throw e;
+        }
+        catch (InvalidRequestException e)
+        {
+            metrics.writeMetrics.invalid.mark();
+            metrics.writeMetricsForLevel(consistencyLevel).invalid.mark();
+            Tracing.trace("Invalid request: {}", e.getMessage());
             writeTracker.onError(e);
             throw e;
         }
@@ -2101,6 +2124,14 @@ public class StorageProxy implements StorageProxyMBean
             readTracker.onError(e);
             throw e;
         }
+        catch (InvalidRequestException e)
+        {
+            metrics.readMetrics.invalid.mark();
+            metrics.casReadMetrics.invalid.mark();
+            metrics.readMetricsForLevel(consistencyLevel).invalid.mark();
+            readTracker.onError(e);
+            throw e;
+        }
         finally
         {
             long endTime = System.nanoTime();
@@ -2155,6 +2186,13 @@ public class StorageProxy implements StorageProxyMBean
         {
             metrics.readMetrics.failures.mark();
             metrics.readMetricsForLevel(consistencyLevel).failures.mark();
+            readTracker.onError(e);
+            throw e;
+        }
+        catch (InvalidRequestException e)
+        {
+            metrics.readMetrics.invalid.mark();
+            metrics.readMetricsForLevel(consistencyLevel).invalid.mark();
             readTracker.onError(e);
             throw e;
         }

--- a/test/unit/org/apache/cassandra/metrics/ClientRequestsMetricsTest.java
+++ b/test/unit/org/apache/cassandra/metrics/ClientRequestsMetricsTest.java
@@ -240,6 +240,7 @@ public class ClientRequestsMetricsTest
         metrics.timeouts.mark();
         metrics.failures.mark();
         metrics.unavailables.mark();
+        metrics.invalid.mark();
         updateLatencyMetrics(metrics.executionTimeMetrics);
         updateLatencyMetrics(metrics.serviceTimeMetrics);
     }
@@ -297,6 +298,7 @@ public class ClientRequestsMetricsTest
         assertEquals(value, metrics.timeouts.getCount());
         assertEquals(value, metrics.failures.getCount());
         assertEquals(value, metrics.unavailables.getCount());
+        assertEquals(value, metrics.invalid.getCount());
         verifyLatencyMetrics(metrics.executionTimeMetrics, value);
         verifyLatencyMetrics(metrics.serviceTimeMetrics, value);
     }


### PR DESCRIPTION
### What is the issue

#8641

### What does this PR fix and why was it fixed

This PR introduces a new `invalid` meter to the `ClientRequestMetrics` class, update error handling in `StorageProxy` to record invalid requests, and enhance related unit tests.