### PR TITLE
CNDB-9697: notify JVMStabilityInspector when encountered corruption exception on compaction task (#1901)

### DIFF
--- a/src/java/org/apache/cassandra/io/FSDiskFullWriteError.java
+++ b/src/java/org/apache/cassandra/io/FSDiskFullWriteError.java
@@ -22,10 +22,19 @@ import java.io.IOException;
 
 public class FSDiskFullWriteError extends FSWriteError
 {
+    private final String keyspace;
+
     public FSDiskFullWriteError(String keyspace, long mutationSize)
     {
         super(new IOException(String.format("Insufficient disk space to write %d bytes into the %s keyspace",
                                             mutationSize,
                                             keyspace)));
+
+        this.keyspace = keyspace;
+    }
+
+    public String getKeyspace()
+    {
+        return keyspace;
     }
 }

--- a/src/java/org/apache/cassandra/io/FSNoDiskAvailableForWriteError.java
+++ b/src/java/org/apache/cassandra/io/FSNoDiskAvailableForWriteError.java
@@ -25,9 +25,18 @@ import java.io.IOException;
  */
 public class FSNoDiskAvailableForWriteError extends FSWriteError
 {
+    private final String keyspace;
+
     public FSNoDiskAvailableForWriteError(String keyspace)
     {
         super(new IOException(String.format("The data directories for the %s keyspace have been marked as unwritable",
                                             keyspace)));
+
+        this.keyspace = keyspace;
+    }
+
+    public String getKeyspace()
+    {
+        return keyspace;
     }
 }

--- a/src/java/org/apache/cassandra/io/compress/CompressedSequentialWriter.java
+++ b/src/java/org/apache/cassandra/io/compress/CompressedSequentialWriter.java
@@ -304,7 +304,7 @@ public class CompressedSequentialWriter extends SequentialWriter
             }
             catch (IOException e)
             {
-                throw new CorruptBlockException(getFile().toString(), chunkOffset, chunkSize, e);
+                throw new CorruptBlockException(getFile(), chunkOffset, chunkSize, e);
             }
 
             CRC32 checksum = new CRC32();
@@ -317,7 +317,7 @@ public class CompressedSequentialWriter extends SequentialWriter
             int storedChecksum = crcCheckBuffer.getInt();
             int computedChecksum = (int) checksum.getValue();
             if (storedChecksum != computedChecksum)
-                throw new CorruptBlockException(getFile().toString(), chunkOffset, chunkSize, storedChecksum, computedChecksum);
+                throw new CorruptBlockException(getFile(), chunkOffset, chunkSize, storedChecksum, computedChecksum);
         }
         catch (CorruptBlockException e)
         {
@@ -325,7 +325,7 @@ public class CompressedSequentialWriter extends SequentialWriter
         }
         catch (EOFException e)
         {
-            throw new CorruptSSTableException(new CorruptBlockException(getFile().toString(), chunkOffset, chunkSize), getFile());
+            throw new CorruptSSTableException(new CorruptBlockException(getFile(), chunkOffset, chunkSize), getFile());
         }
         catch (IOException e)
         {

--- a/src/java/org/apache/cassandra/io/compress/CorruptBlockException.java
+++ b/src/java/org/apache/cassandra/io/compress/CorruptBlockException.java
@@ -19,37 +19,47 @@ package org.apache.cassandra.io.compress;
 
 import java.io.IOException;
 
+import org.apache.cassandra.io.util.File;
+
 public class CorruptBlockException extends IOException
 {
-    public CorruptBlockException(String filePath, CompressionMetadata.Chunk chunk)
+    private final File file;
+
+    public CorruptBlockException(File file, CompressionMetadata.Chunk chunk)
     {
-        this(filePath, chunk, null);
+        this(file, chunk, null);
     }
 
-    public CorruptBlockException(String filePath, CompressionMetadata.Chunk chunk, Throwable cause)
+    public CorruptBlockException(File file, CompressionMetadata.Chunk chunk, Throwable cause)
     {
-        this(filePath, chunk.offset, chunk.length, cause);
+        this(file, chunk.offset, chunk.length, cause);
     }
 
-    public CorruptBlockException(String filePath, long offset, int length)
+    public CorruptBlockException(File file, long offset, int length)
     {
-        this(filePath, offset, length, null);
+        this(file, offset, length, null);
     }
 
-    public CorruptBlockException(String filePath, long offset, int length, Throwable cause)
+    public CorruptBlockException(File file, long offset, int length, Throwable cause)
     {
-        super(String.format("(%s): corruption detected, chunk at %d of length %d.", filePath, offset, length), cause);
+        super(String.format("(%s): corruption detected, chunk at %d of length %d.", file.toString(), offset, length), cause);
+        this.file = file;
     }
 
-    public CorruptBlockException(String filePath, CompressionMetadata.Chunk chunk, int storedChecksum, int calculatedChecksum)
+    public CorruptBlockException(File file, CompressionMetadata.Chunk chunk, int storedChecksum, int calculatedChecksum)
     {
-        this(filePath, chunk.offset, chunk.length, storedChecksum, calculatedChecksum);
+        this(file, chunk.offset, chunk.length, storedChecksum, calculatedChecksum);
     }
 
-    public CorruptBlockException(String filePath, long offset, int length, int storedChecksum, int calculatedChecksum)
+    public CorruptBlockException(File file, long offset, int length, int storedChecksum, int calculatedChecksum)
     {
         super(String.format("(%s): corruption detected, chunk at %d of length %d has mismatched checksums. Expected %d, but calculated %d",
-                            filePath, offset, length, storedChecksum, calculatedChecksum));
+                            file.toString(), offset, length, storedChecksum, calculatedChecksum));
+        this.file = file;
     }
 
+    public File getFile()
+    {
+        return file;
+    }
 }

--- a/src/java/org/apache/cassandra/io/compress/EncryptedSequentialWriter.java
+++ b/src/java/org/apache/cassandra/io/compress/EncryptedSequentialWriter.java
@@ -222,7 +222,7 @@ public class EncryptedSequentialWriter extends SequentialWriter
             encrypted.limit(CHUNK_SIZE);
 
             if (encrypted.getInt(CHUNK_SIZE - 4) != (int) checksum.getValue())
-                throw new CorruptBlockException(getFile().toString(), truncateChunk, CHUNK_SIZE);
+                throw new CorruptBlockException(getFile(), truncateChunk, CHUNK_SIZE);
 
             try
             {
@@ -234,7 +234,7 @@ public class EncryptedSequentialWriter extends SequentialWriter
             }
             catch (IOException e)
             {
-                throw new CorruptBlockException(getFile().toString(), truncateChunk, CHUNK_SIZE, e);
+                throw new CorruptBlockException(getFile(), truncateChunk, CHUNK_SIZE, e);
             }
         }
         catch (CorruptBlockException e)
@@ -243,7 +243,7 @@ public class EncryptedSequentialWriter extends SequentialWriter
         }
         catch (EOFException e)
         {
-            throw new CorruptSSTableException(new CorruptBlockException(getFile().toString(), truncateChunk, CHUNK_SIZE), getFile());
+            throw new CorruptSSTableException(new CorruptBlockException(getFile(), truncateChunk, CHUNK_SIZE), getFile());
         }
         catch (IOException e)
         {

--- a/src/java/org/apache/cassandra/io/sstable/CorruptSSTableException.java
+++ b/src/java/org/apache/cassandra/io/sstable/CorruptSSTableException.java
@@ -20,6 +20,7 @@ package org.apache.cassandra.io.sstable;
 import java.nio.file.Path;
 
 import org.apache.cassandra.io.util.File;
+import org.apache.cassandra.io.util.PathUtils;
 import org.apache.cassandra.utils.DseLegacy;
 
 public class CorruptSSTableException extends RuntimeException
@@ -34,7 +35,7 @@ public class CorruptSSTableException extends RuntimeException
 
     public CorruptSSTableException(Throwable cause, String path)
     {
-        this(cause, new File(path));
+        this(cause, new File(PathUtils.getPath(path)));
     }
 
     protected CorruptSSTableException(String msg, Throwable cause, File file)
@@ -48,5 +49,4 @@ public class CorruptSSTableException extends RuntimeException
     {
         this(cause, new File(path));
     }
-
 }

--- a/src/java/org/apache/cassandra/io/util/ChecksummedRebufferer.java
+++ b/src/java/org/apache/cassandra/io/util/ChecksummedRebufferer.java
@@ -49,7 +49,7 @@ class ChecksummedRebufferer extends BufferManagingRebufferer
         }
         catch (IOException e)
         {
-            throw new CorruptFileException(e, channel().filePath());
+            throw new CorruptFileException(e, channel().getFile());
         }
 
         return this;

--- a/src/java/org/apache/cassandra/io/util/CompressedChunkReader.java
+++ b/src/java/org/apache/cassandra/io/util/CompressedChunkReader.java
@@ -144,7 +144,7 @@ public abstract class CompressedChunkReader extends AbstractReaderFileProxy impl
         {
             compressed.limit(length);
             if (channel.read(compressed, chunkOffset) != length)
-                throw new CorruptBlockException(channel.filePath(), chunk);
+                throw new CorruptBlockException(channel.getFile(), chunk);
 
             if (shouldCheckCrc)
             {
@@ -155,7 +155,7 @@ public abstract class CompressedChunkReader extends AbstractReaderFileProxy impl
                 compressed.limit(length);
                 int storedChecksum = compressed.getInt();
                 if (storedChecksum != checksum)
-                    throw new CorruptBlockException(channel.filePath(), chunk, storedChecksum, checksum);
+                    throw new CorruptBlockException(channel.getFile(), chunk, storedChecksum, checksum);
             }
 
             compressed.position(0).limit(chunk.length);
@@ -200,7 +200,7 @@ public abstract class CompressedChunkReader extends AbstractReaderFileProxy impl
                 compressed.limit(length);
                 int storedChecksum = compressed.getInt();
                 if (storedChecksum != checksum)
-                    throw new CorruptBlockException(channel.filePath(), chunk, storedChecksum, checksum);
+                    throw new CorruptBlockException(channel.getFile(), chunk, storedChecksum, checksum);
             }
 
             compressed.position(0).limit(chunk.length);
@@ -307,7 +307,7 @@ public abstract class CompressedChunkReader extends AbstractReaderFileProxy impl
                         }
                         catch (IOException e)
                         {
-                            throw new CorruptBlockException(channel.filePath(), chunk, e);
+                            throw new CorruptBlockException(channel.getFile(), chunk, e);
                         }
                     }
                     finally
@@ -319,7 +319,7 @@ public abstract class CompressedChunkReader extends AbstractReaderFileProxy impl
                 {
                     uncompressed.position(0).limit(chunk.length);
                     if (channel.read(uncompressed, chunkOffset) != chunk.length)
-                        throw new CorruptBlockException(channel.filePath(), chunk);
+                        throw new CorruptBlockException(channel.getFile(), chunk);
                 }
                 uncompressed.flip();
             }
@@ -389,7 +389,7 @@ public abstract class CompressedChunkReader extends AbstractReaderFileProxy impl
                         compressedChunk.limit(compressedChunk.capacity());
                         int storedChecksum = compressedChunk.getInt();
                         if (storedChecksum != checksum)
-                            throw new CorruptBlockException(channel.filePath(), chunk, storedChecksum, checksum);
+                            throw new CorruptBlockException(channel.getFile(), chunk, storedChecksum, checksum);
                     }
 
                     compressedChunk.position(chunkOffsetInSegment).limit(chunkOffsetInSegment + chunk.length);
@@ -402,7 +402,7 @@ public abstract class CompressedChunkReader extends AbstractReaderFileProxy impl
                 }
                 catch (IOException e)
                 {
-                    throw new CorruptBlockException(channel.filePath(), chunk, e);
+                    throw new CorruptBlockException(channel.getFile(), chunk, e);
                 }
                 uncompressed.flip();
             }

--- a/src/java/org/apache/cassandra/io/util/CorruptFileException.java
+++ b/src/java/org/apache/cassandra/io/util/CorruptFileException.java
@@ -21,11 +21,16 @@ package org.apache.cassandra.io.util;
 @SuppressWarnings("serial")
 public class CorruptFileException extends RuntimeException
 {
-    public final String filePath;
+    public final File file;
 
-    public CorruptFileException(Exception cause, String filePath)
+    public CorruptFileException(Exception cause, File file)
     {
         super(cause);
-        this.filePath = filePath;
+        this.file = file;
+    }
+
+    public File getFile()
+    {
+        return file;
     }
 }

--- a/src/java/org/apache/cassandra/io/util/EncryptedChunkReader.java
+++ b/src/java/org/apache/cassandra/io/util/EncryptedChunkReader.java
@@ -106,7 +106,7 @@ public abstract class EncryptedChunkReader extends AbstractReaderFileProxy imple
             //Change the limit to include the checksum
             input.limit(start + CHUNK_SIZE);
             if (input.getInt() != checksum)
-                throw new CorruptBlockException(channel.filePath(), position, CHUNK_SIZE);
+                throw new CorruptBlockException(channel.getFile(), position, CHUNK_SIZE);
         }
 
         int length = input.getInt(start + CHUNK_SIZE - FOOTER_LENGTH);

--- a/src/java/org/apache/cassandra/repair/ValidationManager.java
+++ b/src/java/org/apache/cassandra/repair/ValidationManager.java
@@ -41,6 +41,7 @@ import org.apache.cassandra.metrics.TopPartitionTracker;
 import org.apache.cassandra.repair.state.ValidationState;
 import org.apache.cassandra.utils.Clock;
 import org.apache.cassandra.utils.FBUtilities;
+import org.apache.cassandra.utils.JVMStabilityInspector;
 import org.apache.cassandra.utils.MerkleTree;
 import org.apache.cassandra.utils.MerkleTrees;
 import org.apache.cassandra.utils.NonThrowingCloseable;
@@ -205,6 +206,7 @@ public class ValidationManager implements IValidationManager
                     // we need to inform the remote end of our failure, otherwise it will hang on repair forever
                     validator.fail(e);
                     logger.error("Validation failed.", e);
+                    JVMStabilityInspector.inspectThrowable(e);
                     throw e;
                 }
                 return this;

--- a/src/java/org/apache/cassandra/utils/JVMStabilityInspector.java
+++ b/src/java/org/apache/cassandra/utils/JVMStabilityInspector.java
@@ -111,6 +111,11 @@ public final class JVMStabilityInspector
         commitLogHandler = errorHandler;
     }
 
+    public static Consumer<Throwable> getDiskErrorHandler()
+    {
+        return diskHandler;
+    }
+
     /**
      * Certain Throwables and Exceptions represent "Die" conditions for the server.
      * This recursively checks the input Throwable's cause hierarchy until null.


### PR DESCRIPTION
### What is the issue
Corruption exception from compaction task didn't notify error handler.

Compaction aborted/failed metrics were not updated in some cases.

### What does this PR fix and why was it fixed
Trigger JVMStabilityInspector for corruption exception from compaction task and update aborted/failed metircs properly.

Trigger JVMStabilityInspector for error from repair validation.
