### PR TITLE
CNDB-8641: Add a metric to count all request errors

### DIFF
--- a/src/java/org/apache/cassandra/cql3/QueryEvents.java
+++ b/src/java/org/apache/cassandra/cql3/QueryEvents.java
@@ -35,6 +35,10 @@ import org.slf4j.LoggerFactory;
 import org.apache.cassandra.cql3.statements.AuthenticationStatement;
 import org.apache.cassandra.cql3.statements.BatchStatement;
 import org.apache.cassandra.exceptions.InvalidRequestException;
+import org.apache.cassandra.exceptions.RequestFailureException;
+import org.apache.cassandra.exceptions.RequestTimeoutException;
+import org.apache.cassandra.exceptions.UnavailableException;
+import org.apache.cassandra.exceptions.WriteTimeoutException;
 import org.apache.cassandra.metrics.ClientRequestsMetrics;
 import org.apache.cassandra.metrics.ClientRequestsMetricsProvider;
 import org.apache.cassandra.service.QueryState;
@@ -94,6 +98,12 @@ public class QueryEvents
             ClientRequestsMetrics metrics = ClientRequestsMetricsProvider.instance.metrics(((CQLStatement.SingleKeyspaceCqlStatement) statement).keyspace());
             if (cause instanceof InvalidRequestException)
                 metrics.allRequestsMetrics.invalid.mark();
+            else if (cause instanceof UnavailableException)
+                metrics.allRequestsMetrics.unavailables.mark();
+            else if (cause instanceof RequestTimeoutException)
+                metrics.allRequestsMetrics.timeouts.mark();
+            else if (cause instanceof RequestFailureException)
+                metrics.allRequestsMetrics.failures.mark();
             else
                 metrics.allRequestsMetrics.otherErrors.mark();
         }

--- a/src/java/org/apache/cassandra/metrics/AllRequestsMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/AllRequestsMetrics.java
@@ -1,0 +1,47 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.cassandra.metrics;
+
+
+import com.codahale.metrics.Meter;
+
+import static org.apache.cassandra.metrics.CassandraMetricsRegistry.Metrics;
+
+
+public class AllRequestsMetrics extends ClientRequestMetrics
+{
+    public final Meter invalid;
+    public final Meter otherErrors;
+
+    public AllRequestsMetrics(String scope, String prefix)
+    {
+        super(scope, prefix);
+        invalid = Metrics.meter(factory.createMetricName(namePrefix + "Invalid"));
+        otherErrors = Metrics.meter(factory.createMetricName(namePrefix + "OtherErrors"));
+    }
+
+    public void release()
+    {
+        super.release();
+        Metrics.remove(factory.createMetricName(namePrefix + "Invalid"));
+        Metrics.remove(factory.createMetricName(namePrefix + "OtherErrors"));
+    }
+}

--- a/src/java/org/apache/cassandra/metrics/AllRequestsMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/AllRequestsMetrics.java
@@ -38,6 +38,7 @@ public class AllRequestsMetrics extends ClientRequestMetrics
         otherErrors = Metrics.meter(factory.createMetricName(namePrefix + "OtherErrors"));
     }
 
+    @Override
     public void release()
     {
         super.release();

--- a/src/java/org/apache/cassandra/metrics/ClientRequestsMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/ClientRequestsMetrics.java
@@ -32,6 +32,7 @@ public class ClientRequestsMetrics
     public final CASClientWriteRequestMetrics casWriteMetrics;
     public final CASClientRequestMetrics casReadMetrics;
     public final ViewWriteMetrics viewWriteMetrics;
+    public final AllRequestsMetrics allRequestsMetrics;
     private final Map<ConsistencyLevel, ClientRequestMetrics> readMetricsMap;
     private final Map<ConsistencyLevel, ClientWriteRequestMetrics> writeMetricsMap;
 
@@ -52,6 +53,7 @@ public class ClientRequestsMetrics
         casWriteMetrics = new CASClientWriteRequestMetrics("CASWrite", namePrefix);
         casReadMetrics = new CASClientRequestMetrics("CASRead", namePrefix);
         viewWriteMetrics = new ViewWriteMetrics("ViewWrite", namePrefix);
+        allRequestsMetrics = new AllRequestsMetrics("All", namePrefix);
         readMetricsMap = new EnumMap<>(ConsistencyLevel.class);
         writeMetricsMap = new EnumMap<>(ConsistencyLevel.class);
         for (ConsistencyLevel level : ConsistencyLevel.values())

--- a/test/unit/org/apache/cassandra/metrics/ClientRequestsMetricsAllRequestsTest.java
+++ b/test/unit/org/apache/cassandra/metrics/ClientRequestsMetricsAllRequestsTest.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.metrics;
+
+import java.util.Collections;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.codahale.metrics.Meter;
+import com.datastax.driver.core.BoundStatement;
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.Session;
+import org.apache.cassandra.cql3.CQLStatement;
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.QueryEvents;
+import org.apache.cassandra.cql3.QueryOptions;
+import org.apache.cassandra.db.ConsistencyLevel;
+import org.apache.cassandra.exceptions.ReadFailureException;
+import org.apache.cassandra.exceptions.ReadTimeoutException;
+import org.apache.cassandra.exceptions.UnavailableException;
+import org.apache.cassandra.service.QueryState;
+
+import static org.junit.Assert.assertEquals;
+
+public class ClientRequestsMetricsAllRequestsTest extends CQLTester
+{
+    AllRequestsMetrics metrics = ClientRequestsMetricsProvider.instance.metrics(KEYSPACE).allRequestsMetrics;
+
+    @Before
+    public void setup()
+    {
+        createTable("CREATE TABLE %s (id INT PRIMARY KEY, v TEXT)");
+    }
+
+    @After
+    public void teardown()
+    {
+        dropTable("DROP TABLE %s");
+    }
+
+    @Test
+    public void testInvalidRequest()
+    {
+        long before = metrics.invalid.getCount();
+        try
+        {
+            executeNet("INSERT INTO %s (id, v) VALUES (1, ?)");
+        }
+        catch (Throwable t)
+        {
+            // expected
+        }
+        assertEquals(1, metrics.invalid.getCount() - before);
+    }
+
+    @Test
+    public void testInvalidPreparedRequest()
+    {
+        try(Session session = sessionNet())
+        {
+            PreparedStatement prepare1 = session.prepare(formatQuery("DELETE FROM %s WHERE id = ?"));
+            BoundStatement bind = prepare1.bind();
+            long before = metrics.invalid.getCount();
+            try
+            {
+                session.execute(bind);
+            }
+            catch (Throwable t)
+            {
+                // expected
+            }
+            assertEquals(1, metrics.invalid.getCount() - before);
+        }
+    }
+
+    @Test
+    public void testTimeoutRequest()
+    {
+        testNotifyQueryFailure(metrics.timeouts, new ReadTimeoutException(ConsistencyLevel.ONE));
+    }
+
+    @Test
+    public void testUnavailableRequest()
+    {
+        testNotifyQueryFailure(metrics.unavailables, UnavailableException.create(ConsistencyLevel.ONE, 1, 0));
+    }
+
+    @Test
+    public void testFailureRequest()
+    {
+        testNotifyQueryFailure(metrics.failures, new ReadFailureException(ConsistencyLevel.ONE, 0, 0, false, Collections.emptyMap()));
+    }
+
+    @Test
+    public void testOtherErrorRequest()
+    {
+        testNotifyQueryFailure(metrics.otherErrors, new RuntimeException());
+    }
+
+    public void testNotifyQueryFailure(Meter meter, Exception exception)
+    {
+        CQLStatement cqlStatement = parseStatement("CREATE TABLE %s (id INT PRIMARY KEY, v TEXT)");
+        long before = meter.getCount();
+
+        QueryEvents.instance.notifyQueryFailure(cqlStatement, cqlStatement.getRawCQLStatement(), QueryOptions.DEFAULT,
+                                                QueryState.forInternalCalls(), exception);
+
+        assertEquals(1, meter.getCount() - before);
+    }
+
+
+}


### PR DESCRIPTION
### What is the issue

https://github.com/riptano/cndb/issues/8641

PR in CNDB: https://github.com/riptano/cndb/pull/15306

### What does this PR fix and why was it fixed

This pull request introduces new metrics for tracking invalid and other error requests for CQL statements, and integrates these metrics into the query failure notification logic. The main changes are the addition of the `AllRequestsMetrics` class, updates to the `ClientRequestsMetrics` class to include these new metrics, and modifications to the query event notification methods to record errors using the new metrics.

Metrics added:
* org.apache.cassandra.metrics.ClientRequest.Timeouts.All
* org.apache.cassandra.metrics.ClientRequest.Unavailables.All
* org.apache.cassandra.metrics.ClientRequest.Failures.All
* org.apache.cassandra.metrics.ClientRequest.Invalid.All
* org.apache.cassandra.metrics.ClientRequest.OtherErrors.All

 Note: only requests for which a tenant can be identified are counted.
