### PR TITLE
CNDB-14657: disable synthetic score for older versions in FeaturesVersionSupportTester

### DIFF
--- a/test/distributed/org/apache/cassandra/distributed/test/sai/features/FeaturesVersionSupportTester.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/features/FeaturesVersionSupportTester.java
@@ -61,7 +61,16 @@ public abstract class FeaturesVersionSupportTester extends TestBaseImpl
         
         FeaturesVersionSupportTester.version = version;
         cluster = init(Cluster.build(2)
-                              .withInstanceInitializer((cl, n) -> BB.install(cl, n, version))
+                              .withInstanceInitializer((cl, n) -> {
+                                  // Disable synthetic score to ensure compatibility between ED and older versions.
+                                  // ED enables it by default but older versions don't support it.
+                                  // Note: In 5.0, Ordering.useSyntheticScore() uses CassandraRelevantProperties
+                                  // which caches values at class loading time, so we must set this property before
+                                  // the classes are loaded. In the main branch, Ordering uses System.getProperty() directly,
+                                  // which is why this workaround isn't needed there.
+                                  System.setProperty("cassandra.sai.ann_use_synthetic_score", "false");
+                                  BB.install(cl, n, version);
+                              })
                               .withConfig(config -> config.with(GOSSIP).with(NETWORK))
                               .start(), 1);
         


### PR DESCRIPTION
### What is the issue

Synthetic scoring is not supported before ED

### What does this PR fix and why was it fixed

Disable synthetic scoring
