### PR TITLE
CNDB-15292: remove IRE expectation for compatible types, filter non-data files

### DIFF
--- a/src/java/org/apache/cassandra/io/sstable/SSTableHeaderFix.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableHeaderFix.java
@@ -315,7 +315,16 @@ public abstract class SSTableHeaderFix
     {
         Stream.of(path)
               .flatMap(SSTableHeaderFix::maybeExpandDirectory)
-              .filter(p -> Descriptor.fromFileWithComponent(new File(p)).right.type == SSTableFormat.Components.DATA.type)
+              .filter(p -> {
+                  try
+                  {
+                      return Descriptor.fromFileWithComponent(new File(p)).right.type == SSTableFormat.Components.DATA.type;
+                  }
+                  catch (IllegalArgumentException e) // ignore the '.keep' files
+                  {
+                      return false;
+                  }
+              })
               .map(Path::toString)
               .map((String file) -> Descriptor.fromFile(new File(file)))
               .forEach(descriptors::add);

--- a/test/unit/org/apache/cassandra/io/sstable/LegacySSTableTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/LegacySSTableTest.java
@@ -383,16 +383,7 @@ public class LegacySSTableTest
             {
                 alterTableAddColumn(legacyVersion, "val frozen<tuple<set<int>,set<text>>>");
                 alterTableAddColumn(legacyVersion, "val2 tuple<set<int>,set<text>>");
-                try
-                {
-                    alterTableAddColumn(legacyVersion, String.format("val3 frozen<legacy_%s_tuple_udt>", legacyVersion));
-                    throw new AssertionError(String.format("Against legacyVersion %s expected InvalidRequestException: Cannot re-add previously dropped column 'val3' of type frozen<legacy_da_tuple_udt>, incompatible with previous type frozen<tuple<frozen<tuple<text, text>>>>", legacyVersion));
-                }
-                catch (InvalidRequestException ex)
-                {
-                    // expected
-                    // InvalidRequestException: Cannot re-add previously dropped column 'val3' of type frozen<legacy_da_tuple_udt>, incompatible with previous type frozen<tuple<frozen<tuple<text, text>>>>
-                }
+                alterTableAddColumn(legacyVersion, String.format("val3 frozen<legacy_%s_tuple_udt>", legacyVersion));
                 // dropping non-frozen UDTs disabled, see AlterTableStatement.DropColumns.dropColumn(..)
                 //alterTableAddColumn(legacyVersion, String.format("val4 legacy_%s_tuple_udt", legacyVersion));
             }


### PR DESCRIPTION
### What is the issue

LegacySSTableTest.testVerifyOldDroppedTupleSSTables is throwing an AssertionError

### What does this PR fix and why was it fixed

LegacySSTableTest has an incorrect expectation of an IRE and SSTableHeaderFix needs to filter non-data files

