### PR TITLE
CNDB-15299 Suppress checkstyle on System.setProperty in FeaturesVersionSupportTester

### DIFF
--- a/test/distributed/org/apache/cassandra/distributed/test/sai/features/FeaturesVersionSupportTester.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/features/FeaturesVersionSupportTester.java
@@ -68,6 +68,7 @@ public abstract class FeaturesVersionSupportTester extends TestBaseImpl
                                   // which caches values at class loading time, so we must set this property before
                                   // the classes are loaded. In the main branch, Ordering uses System.getProperty() directly,
                                   // which is why this workaround isn't needed there.
+                                  // checkstyle: suppress below 'blockSystemPropertyUsage'
                                   System.setProperty("cassandra.sai.ann_use_synthetic_score", "false");
                                   BB.install(cl, n, version);
                               })


### PR DESCRIPTION
### What is the issue
Fixes CNDB-15299

### What does this PR fix and why was it fixed
Adds a comment to suppress checkstyle checks for System.getProperty() use that CNDB-14657 intentionally added.

