### PR TITLE
CNDB-15401 enforce default guardrail value for page_weight used for paging in Bytes instead of page_size that is used for paging in Rows in CC5

### DIFF
--- a/src/java/org/apache/cassandra/config/GuardrailsOptions.java
+++ b/src/java/org/apache/cassandra/config/GuardrailsOptions.java
@@ -137,7 +137,7 @@ public class GuardrailsOptions implements GuardrailsConfig
                 : "Cannot set both hcd_guardrail_defaults and emulate_dbaas_defaults to true";
 
         // for read requests
-        enforceDefault("page_size_fail_threshold", (IntConsumer) (v -> config.page_size_fail_threshold = v), NO_LIMIT, 512, NO_LIMIT);
+        enforceDefault("page_weight_fail_threshold", v -> config.page_weight_fail_threshold = v, null, new DataStorageSpec.IntBytesBound("512KiB"), null);
 
         enforceDefault("in_select_cartesian_product_fail_threshold", (IntConsumer) (v -> config.in_select_cartesian_product_fail_threshold = v), NO_LIMIT, 25, 25);
         enforceDefault("partition_keys_in_select_fail_threshold", (IntConsumer) (v -> config.partition_keys_in_select_fail_threshold = v), NO_LIMIT, 20, 20);


### PR DESCRIPTION
### What is the issue
Fixed CNDB-15401 to enforce guardrail default for `pageWeight` (paging in Bytes) instead of `pageSize` (paging by Rows)

### What does this PR fix and why was it fixed
This is needed in CNDB, where the default page size in Rows is unlimited, and enforcing the `pageSize` (rows) default in CC5 causes CNDB containers not to be able to start.

