### PR TITLE
CNDB-15141: add LogTransaction#validate API to perform validation before txn prepare

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -220,6 +220,15 @@ public enum CassandraRelevantProperties
     UCS_COMPACTION_INCLUDE_NON_DATA_FILES_SIZE("unified_compaction.include_non_data_files_size", "true"),
 
     /**
+     * Whether to enable compaction validation to detect potential data loss and abort compaction
+     */
+    COMPACTION_VALIDATION_ENABLED("cassandra.compaction_validation_enabled", "true"),
+    /**
+     * Whether to execute compaction validation in dry-run mode to log error without aborting compaction
+     */
+    COMPACTION_VALIDATION_DRY_RUN("cassandra.compaction_validation_dry_run", "true"),
+
+    /**
      * The factory for handler of the storage of sstables
      */
     REMOTE_STORAGE_HANDLER_FACTORY("cassandra.remote_storage_handler_factory"),

--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -220,13 +220,11 @@ public enum CassandraRelevantProperties
     UCS_COMPACTION_INCLUDE_NON_DATA_FILES_SIZE("unified_compaction.include_non_data_files_size", "true"),
 
     /**
-     * Whether to enable compaction validation to detect potential data loss and abort compaction
+     * Compaction validation mode to determine whether to skip validation or warn on data loss or abort on data loss;
+     *
+     * Available options: NONE, WARN, ABORT. Default is NONE
      */
-    COMPACTION_VALIDATION_ENABLED("cassandra.compaction_validation_enabled", "true"),
-    /**
-     * Whether to execute compaction validation in dry-run mode to log error without aborting compaction
-     */
-    COMPACTION_VALIDATION_DRY_RUN("cassandra.compaction_validation_dry_run", "true"),
+    COMPACTION_VALIDATION_MODE("cassandra.compaction_validation_mode", "NONE"),
 
     /**
      * The factory for handler of the storage of sstables

--- a/src/java/org/apache/cassandra/db/compaction/validation/CompactionValidationMetrics.java
+++ b/src/java/org/apache/cassandra/db/compaction/validation/CompactionValidationMetrics.java
@@ -11,8 +11,8 @@ public class CompactionValidationMetrics extends MicrometerMetrics
     public static final CompactionValidationMetrics INSTANCE = new CompactionValidationMetrics();
 
     public Counter validationCount;
-    public Counter validationWithoutMissingKeys;
-    public Counter missingKeys;
+    public Counter validationWithoutAbsentKeys;
+    public Counter absentKeys;
     public Counter potentialDataLosses;
 
     public CompactionValidationMetrics()
@@ -30,8 +30,8 @@ public class CompactionValidationMetrics extends MicrometerMetrics
     private void initializeMetrics()
     {
         this.validationCount = registryWithTags().left.counter("compaction_validation_total", registryWithTags().right);
-        this.validationWithoutMissingKeys = registryWithTags().left.counter("compaction_validation_without_missing_key_total", registryWithTags().right);
-        this.missingKeys = registryWithTags().left.counter("compaction_validation_missing_keys_total", registryWithTags().right);
+        this.validationWithoutAbsentKeys = registryWithTags().left.counter("compaction_validation_without_absent_keys_total", registryWithTags().right);
+        this.absentKeys = registryWithTags().left.counter("compaction_validation_absent_keys_count_from_output_total", registryWithTags().right);
         this.potentialDataLosses = registryWithTags().left.counter("compaction_validation_potential_data_loss_total", registryWithTags().right);
     }
 
@@ -45,13 +45,13 @@ public class CompactionValidationMetrics extends MicrometerMetrics
         potentialDataLosses.increment();
     }
 
-    public void incrementValidationWithoutMissingKeys()
+    public void incrementValidationWithoutAbsentKeys()
     {
-        validationWithoutMissingKeys.increment();
+        validationWithoutAbsentKeys.increment();
     }
 
-    public void incrementMissingKeys(int keys)
+    public void incrementAbsentKeys(int keys)
     {
-        missingKeys.increment(keys);
+        absentKeys.increment(keys);
     }
 }

--- a/src/java/org/apache/cassandra/db/compaction/validation/CompactionValidationMetrics.java
+++ b/src/java/org/apache/cassandra/db/compaction/validation/CompactionValidationMetrics.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.cassandra.db.compaction.validation;
 
 import io.micrometer.core.instrument.Counter;

--- a/src/java/org/apache/cassandra/db/compaction/validation/CompactionValidationMetrics.java
+++ b/src/java/org/apache/cassandra/db/compaction/validation/CompactionValidationMetrics.java
@@ -1,0 +1,57 @@
+package org.apache.cassandra.db.compaction.validation;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import org.apache.cassandra.metrics.MicrometerMetrics;
+
+/// Metrics for tracking compaction validation operations and results.
+public class CompactionValidationMetrics extends MicrometerMetrics
+{
+    public static final CompactionValidationMetrics INSTANCE = new CompactionValidationMetrics();
+
+    public Counter validationCount;
+    public Counter validationWithoutMissingKeys;
+    public Counter missingKeys;
+    public Counter potentialDataLosses;
+
+    public CompactionValidationMetrics()
+    {
+        initializeMetrics();
+    }
+
+    @Override
+    public synchronized void register(MeterRegistry newRegistry, Tags newTags)
+    {
+        super.register(newRegistry, newTags);
+        initializeMetrics();
+    }
+
+    private void initializeMetrics()
+    {
+        this.validationCount = registryWithTags().left.counter("compaction_validation_total", registryWithTags().right);
+        this.validationWithoutMissingKeys = registryWithTags().left.counter("compaction_validation_without_missing_key_total", registryWithTags().right);
+        this.missingKeys = registryWithTags().left.counter("compaction_validation_missing_keys_total", registryWithTags().right);
+        this.potentialDataLosses = registryWithTags().left.counter("compaction_validation_potential_data_loss_total", registryWithTags().right);
+    }
+
+    public void incrementValidation()
+    {
+        validationCount.increment();
+    }
+
+    public void incrementPotentialDataLosses()
+    {
+        potentialDataLosses.increment();
+    }
+
+    public void incrementValidationWithoutMissingKeys()
+    {
+        validationWithoutMissingKeys.increment();
+    }
+
+    public void incrementMissingKeys(int keys)
+    {
+        missingKeys.increment(keys);
+    }
+}

--- a/src/java/org/apache/cassandra/db/compaction/validation/CompactionValidationTask.java
+++ b/src/java/org/apache/cassandra/db/compaction/validation/CompactionValidationTask.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.cassandra.db.compaction.validation;
 
 import java.util.ArrayList;

--- a/src/java/org/apache/cassandra/db/lifecycle/AbstractLogTransaction.java
+++ b/src/java/org/apache/cassandra/db/lifecycle/AbstractLogTransaction.java
@@ -28,6 +28,7 @@ import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.utils.concurrent.Transactional;
 
 import static org.apache.cassandra.db.compaction.OperationType.COMPACTION;
+import static org.apache.cassandra.db.compaction.OperationType.GARBAGE_COLLECT;
 
 /**
  * A class that tracks sstable files involved in a transaction across sstables:
@@ -51,8 +52,8 @@ public abstract class AbstractLogTransaction extends Transactional.AbstractTrans
      */
     public void validate(Set<SSTableReader> obsolete, Set<SSTableReader> update)
     {
-        // Only validate compaction tasks
-        if (opType() != COMPACTION)
+        // Only validate compaction tasks and GC tasks
+        if (opType() != COMPACTION && opType() != GARBAGE_COLLECT)
             return;
 
         if (!CassandraRelevantProperties.COMPACTION_VALIDATION_ENABLED.getBoolean())

--- a/src/java/org/apache/cassandra/db/lifecycle/AbstractLogTransaction.java
+++ b/src/java/org/apache/cassandra/db/lifecycle/AbstractLogTransaction.java
@@ -18,9 +18,9 @@
 package org.apache.cassandra.db.lifecycle;
 
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
-import org.apache.cassandra.db.compaction.OperationType;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.utils.concurrent.Transactional;
 
@@ -37,6 +37,16 @@ public abstract class AbstractLogTransaction extends Transactional.AbstractTrans
                                           List<Obsoletion> obsoletions,
                                           Tracker tracker,
                                           Throwable accumulate);
+
+    /**
+     * Perform optional validation on current transaction's input sstables and output sstables
+     *
+     * @param obsolete sstables to obsolete
+     * @param update sstables to update to system
+     */
+    public void validate(Set<SSTableReader> obsolete, Set<SSTableReader> update)
+    {
+    }
 
     public static class Obsoletion
     {

--- a/src/java/org/apache/cassandra/db/lifecycle/AbstractLogTransaction.java
+++ b/src/java/org/apache/cassandra/db/lifecycle/AbstractLogTransaction.java
@@ -52,8 +52,8 @@ public abstract class AbstractLogTransaction extends Transactional.AbstractTrans
      */
     public void validate(Set<SSTableReader> obsolete, Set<SSTableReader> update)
     {
-        // Only validate compaction tasks and GC tasks
-        if (opType() != COMPACTION && opType() != GARBAGE_COLLECT)
+        // Only validate compaction tasks.
+        if (opType() != COMPACTION)
             return;
 
         if (!CassandraRelevantProperties.COMPACTION_VALIDATION_ENABLED.getBoolean())

--- a/src/java/org/apache/cassandra/db/lifecycle/AbstractLogTransaction.java
+++ b/src/java/org/apache/cassandra/db/lifecycle/AbstractLogTransaction.java
@@ -22,7 +22,6 @@ import java.util.Set;
 import java.util.UUID;
 
 import org.apache.cassandra.config.CassandraRelevantProperties;
-import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.compaction.validation.CompactionValidationMetrics;
 import org.apache.cassandra.db.compaction.validation.CompactionValidationTask;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
@@ -61,10 +60,6 @@ public abstract class AbstractLogTransaction extends Transactional.AbstractTrans
 
         // Nothing to verify if no obsolete SSTables
         if (obsolete.isEmpty())
-            return;
-
-        // Early-open modifies obsolete SSTables' start keys, making validation unreliable
-        if (DatabaseDescriptor.getSSTablePreemptiveOpenIntervalInMB() > 0)
             return;
 
         CompactionValidationTask task = new CompactionValidationTask(id(), obsolete, update, CompactionValidationMetrics.INSTANCE);

--- a/src/java/org/apache/cassandra/db/lifecycle/AbstractLogTransaction.java
+++ b/src/java/org/apache/cassandra/db/lifecycle/AbstractLogTransaction.java
@@ -56,9 +56,6 @@ public abstract class AbstractLogTransaction extends Transactional.AbstractTrans
         if (opType() != COMPACTION)
             return;
 
-        if (!CassandraRelevantProperties.COMPACTION_VALIDATION_ENABLED.getBoolean())
-            return;
-
         // Nothing to verify if no obsolete SSTables
         if (obsolete.isEmpty())
             return;

--- a/src/java/org/apache/cassandra/db/lifecycle/LifecycleTransaction.java
+++ b/src/java/org/apache/cassandra/db/lifecycle/LifecycleTransaction.java
@@ -221,6 +221,7 @@ public class LifecycleTransaction extends Transactional.AbstractTransactional im
 
         // This needs to be called after checkpoint and having prepared the obsoletions because it will upload the deletion
         // marks in CNDB
+        log.validate(logged.obsolete, logged.update);
         log.prepareToCommit();
     }
 

--- a/src/java/org/apache/cassandra/db/lifecycle/LifecycleTransaction.java
+++ b/src/java/org/apache/cassandra/db/lifecycle/LifecycleTransaction.java
@@ -219,9 +219,12 @@ public class LifecycleTransaction extends Transactional.AbstractTransactional im
         // since those that are not original are early readers that share the same desc with the finals
         maybeFail(prepareForObsoletion(filterIn(logged.obsolete, originals), log, obsoletions = new ArrayList<>(), tracker, null));
 
+        // Use original sstables instead of logged.obsolete which may change their starting position due to early-open
+        Set<SSTableReader> obsolete = Sets.newHashSet(filterIn(originals, logged.obsolete));
+        log.validate(obsolete, logged.update);
+
         // This needs to be called after checkpoint and having prepared the obsoletions because it will upload the deletion
         // marks in CNDB
-        log.validate(logged.obsolete, logged.update);
         log.prepareToCommit();
     }
 

--- a/test/unit/org/apache/cassandra/db/compaction/validation/CompactionValidationTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/validation/CompactionValidationTest.java
@@ -55,7 +55,6 @@ public class CompactionValidationTest extends CQLTester
         CQLTester.setUpClass();
 
         DatabaseDescriptor.createAllDirectories();
-        DatabaseDescriptor.setSSTablePreemptiveOpenIntervalInMB(-1);
 
         requireNetwork();
     }

--- a/test/unit/org/apache/cassandra/db/compaction/validation/CompactionValidationTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/validation/CompactionValidationTest.java
@@ -43,7 +43,7 @@ public class CompactionValidationTest extends CQLTester
         cfs.forceMajorCompaction();
 
         assertThat(cfs.getLiveSSTables()).hasSize(1);
-        assertSuccessfulValidationWithoutMissingKeys(initial);
+        assertSuccessfulValidationWithoutAbsentKeys(initial);
     }
 
     @Test
@@ -62,7 +62,7 @@ public class CompactionValidationTest extends CQLTester
         cfs.forceMajorCompaction();
 
         assertThat(cfs.getLiveSSTables()).hasSize(1);
-        assertSuccessfulValidationWithoutMissingKeys(initial);
+        assertSuccessfulValidationWithoutAbsentKeys(initial);
     }
 
     @Test
@@ -86,7 +86,7 @@ public class CompactionValidationTest extends CQLTester
         cfs.forceMajorCompaction();
         assertThat(cfs.getLiveSSTables()).hasSize(1);
 
-        assertSuccessfulValidationWithMissingKeys(initial, 2); // key 0 and key 1 are removed
+        assertSuccessfulValidationWithAbsentKeys(initial, 2); // key 0 and key 1 are removed
     }
 
     @Test
@@ -114,7 +114,7 @@ public class CompactionValidationTest extends CQLTester
         cfs.forceMajorCompaction();
         assertThat(cfs.getLiveSSTables()).isEmpty();
 
-        assertSuccessfulValidationWithMissingKeys(initial, 2); // key 1 are removed
+        assertSuccessfulValidationWithAbsentKeys(initial, 2); // key 1 are removed
     }
 
     @Test
@@ -138,7 +138,7 @@ public class CompactionValidationTest extends CQLTester
         cfs.forceMajorCompaction();
         assertThat(cfs.getLiveSSTables()).hasSize(1);
 
-        assertSuccessfulValidationWithMissingKeys(initial, 2); // key 0 and key 1 are removed
+        assertSuccessfulValidationWithAbsentKeys(initial, 2); // key 0 and key 1 are removed
     }
 
     @Test
@@ -162,7 +162,7 @@ public class CompactionValidationTest extends CQLTester
         cfs.forceMajorCompaction();
         assertThat(cfs.getLiveSSTables()).hasSize(1);
 
-        assertSuccessfulValidationWithMissingKeys(initial, 2); // key 0 and key 1 are removed
+        assertSuccessfulValidationWithAbsentKeys(initial, 2); // key 0 and key 1 are removed
     }
 
     @Test
@@ -182,7 +182,7 @@ public class CompactionValidationTest extends CQLTester
         cfs.forceMajorCompaction();
 
         assertThat(cfs.getLiveSSTables()).hasSize(1);
-        assertSuccessfulValidationWithoutMissingKeys(initial);
+        assertSuccessfulValidationWithoutAbsentKeys(initial);
     }
 
     @Test
@@ -204,7 +204,7 @@ public class CompactionValidationTest extends CQLTester
         cfs.forceMajorCompaction();
 
         assertThat(cfs.getLiveSSTables()).hasSize(1);
-        assertSuccessfulValidationWithMissingKeys(initial, 2); // 2 boundary keys from 1st sstable are missing
+        assertSuccessfulValidationWithAbsentKeys(initial, 2); // 2 boundary keys from 1st sstable are absent
     }
 
     @Test
@@ -228,7 +228,7 @@ public class CompactionValidationTest extends CQLTester
 
         // all sstables are removed
         assertThat(cfs.getLiveSSTables()).hasSize(0);
-        assertSuccessfulValidationWithMissingKeys(initial, 2);
+        assertSuccessfulValidationWithAbsentKeys(initial, 2);
     }
 
     private void populateSSTable(int startPartition, int endPartition, int ck1PerPartition, int ck2PerClustering) throws Throwable
@@ -297,12 +297,12 @@ public class CompactionValidationTest extends CQLTester
         flush();
     }
 
-    private void assertSuccessfulValidationWithMissingKeys(Stats initialStats, int missingKeys)
+    private void assertSuccessfulValidationWithAbsentKeys(Stats initialStats, int absentKeys)
     {
-        initialStats.assertStats(1, 0, missingKeys, 0);
+        initialStats.assertStats(1, 0, absentKeys, 0);
     }
 
-    private void assertSuccessfulValidationWithoutMissingKeys(Stats initialStats)
+    private void assertSuccessfulValidationWithoutAbsentKeys(Stats initialStats)
     {
         initialStats.assertStats(1, 1, 0, 0);
     }
@@ -310,15 +310,15 @@ public class CompactionValidationTest extends CQLTester
     private static class Stats
     {
         private final int validations;
-        private final int validationsWithoutMissingKeys;
-        private final int missingKeys;
+        private final int validationsWithoutAbsentKeys;
+        private final int absentKeys;
         private final int potentialDataLosses;
 
-        private Stats(int validations, int validationsWithoutMissingKeys, int missingKeys, int potentialDataLosses)
+        private Stats(int validations, int validationsWithoutAbsentKeys, int absentKeys, int potentialDataLosses)
         {
             this.validations = validations;
-            this.validationsWithoutMissingKeys = validationsWithoutMissingKeys;
-            this.missingKeys = missingKeys;
+            this.validationsWithoutAbsentKeys = validationsWithoutAbsentKeys;
+            this.absentKeys = absentKeys;
             this.potentialDataLosses = potentialDataLosses;
         }
 
@@ -326,17 +326,17 @@ public class CompactionValidationTest extends CQLTester
         {
             CompactionValidationMetrics metrics = CompactionValidationMetrics.INSTANCE;
             return new Stats((int) metrics.validationCount.count(),
-                    (int) metrics.validationWithoutMissingKeys.count(),
-                    (int) metrics.missingKeys.count(),
+                    (int) metrics.validationWithoutAbsentKeys.count(),
+                    (int) metrics.absentKeys.count(),
                     (int) metrics.potentialDataLosses.count());
         }
 
-        public void assertStats(int validationDiff, int validationsWithoutMissingKeysDiff, int missingKeysDiff, int potentialDataLossesDiff)
+        public void assertStats(int validationDiff, int validationsWithoutAbsentKeysDiff, int absentKeysDiff, int potentialDataLossesDiff)
         {
             Stats current = Stats.fetch();
             assertEquals(this.validations + validationDiff, current.validations);
-            assertEquals(this.validationsWithoutMissingKeys + validationsWithoutMissingKeysDiff, current.validationsWithoutMissingKeys);
-            assertEquals(this.missingKeys + missingKeysDiff, current.missingKeys);
+            assertEquals(this.validationsWithoutAbsentKeys + validationsWithoutAbsentKeysDiff, current.validationsWithoutAbsentKeys);
+            assertEquals(this.absentKeys + absentKeysDiff, current.absentKeys);
             assertEquals(this.potentialDataLosses + potentialDataLossesDiff, current.potentialDataLosses);
         }
     }

--- a/test/unit/org/apache/cassandra/db/compaction/validation/CompactionValidationTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/validation/CompactionValidationTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.cassandra.db.compaction.validation;
 
 import org.junit.BeforeClass;

--- a/test/unit/org/apache/cassandra/db/compaction/validation/CompactionValidationTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/validation/CompactionValidationTest.java
@@ -1,0 +1,343 @@
+package org.apache.cassandra.db.compaction.validation;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.utils.FBUtilities;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+
+public class CompactionValidationTest extends CQLTester
+{
+    private static final String CREATE_TABLE_TEMPLATE = "CREATE TABLE %s (pk int, ck1 int, ck2 int, v1 int, v2 int, primary key(pk, ck1, ck2))";
+
+    @BeforeClass
+    public static void setupClass()
+    {
+        CQLTester.setUpClass();
+
+        DatabaseDescriptor.createAllDirectories();
+        DatabaseDescriptor.setSSTablePreemptiveOpenIntervalInMB(-1);
+
+        requireNetwork();
+    }
+
+    @Test
+    public void testValidation() throws Throwable
+    {
+        createTable(CREATE_TABLE_TEMPLATE);
+
+        populateSSTable(1, 10, 5, 5);
+        populateSSTable(13, 20, 5, 5);
+        populateSSTable(23, 30, 5, 5);
+
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        assertThat(cfs.getLiveSSTables()).hasSize(3);
+
+        Stats initial = Stats.fetch();
+
+        cfs.forceMajorCompaction();
+
+        assertThat(cfs.getLiveSSTables()).hasSize(1);
+        assertSuccessfulValidationWithoutMissingKeys(initial);
+    }
+
+    @Test
+    public void testValidationWithRowTombstone() throws Throwable
+    {
+        createTable(CREATE_TABLE_TEMPLATE);
+
+        populateSSTable(1, 1, 5, 5);
+        populateRowDeletionSSTable(1, 1, 5, 5);
+
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        assertThat(cfs.getLiveSSTables()).hasSize(2);
+
+        Stats initial = Stats.fetch();
+
+        cfs.forceMajorCompaction();
+
+        assertThat(cfs.getLiveSSTables()).hasSize(1);
+        assertSuccessfulValidationWithoutMissingKeys(initial);
+    }
+
+    @Test
+    public void testValidationWithExpiredRowTombstone() throws Throwable
+    {
+        createTable(CREATE_TABLE_TEMPLATE + " WITH gc_grace_seconds = 1");
+
+        populateSSTable(0, 0, 4, 4);
+        populateSSTable(1, 1, 4, 4);
+        populateSSTable(2, 2, 4, 4);
+        populateRowDeletionSSTable(0, 1, 4, 4); // delete all rows in key 0 and key 1
+
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        assertThat(cfs.getLiveSSTables()).hasSize(4);
+
+        // sleep 3 seconds to pass gc_grace_seconds
+        FBUtilities.sleepQuietly(3000);
+
+        Stats initial = Stats.fetch();
+
+        cfs.forceMajorCompaction();
+        assertThat(cfs.getLiveSSTables()).hasSize(1);
+
+        assertSuccessfulValidationWithMissingKeys(initial, 2); // key 0 and key 1 are removed
+    }
+
+    @Test
+    public void testValidationWithExpiredRowTombstoneWithStatic() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck1 int, ck2 int, v1 int, v2 int, st int static, primary key(pk, ck1, ck2)) WITH gc_grace_seconds = 1");
+
+        populateSSTable(1, 1, 5, 5);
+        populateSSTable(2, 2, 5, 5);
+        execute("INSERT INTO %s (pk, st) VALUES (?, ?)", 2, 2);
+        flush();
+
+        populateRowDeletionSSTable(1, 1, 5, 5); // delete key 1 rows
+        populatePartitionDeletionSSTable(2, 2); // delete key 2 rows and static rows
+        flush();
+
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        assertThat(cfs.getLiveSSTables()).hasSize(5);
+
+        // sleep 3 seconds to pass gc_grace_seconds
+        FBUtilities.sleepQuietly(3000);
+
+        Stats initial = Stats.fetch();
+
+        cfs.forceMajorCompaction();
+        assertThat(cfs.getLiveSSTables()).isEmpty();
+
+        assertSuccessfulValidationWithMissingKeys(initial, 2); // key 1 are removed
+    }
+
+    @Test
+    public void testValidationWithExpiredPartitionTombstone() throws Throwable
+    {
+        createTable(CREATE_TABLE_TEMPLATE + " WITH gc_grace_seconds = 1");
+
+        populateSSTable(0, 0, 5, 5);
+        populateSSTable(1, 1, 5, 5);
+        populateSSTable(2, 2, 5, 5);
+        populatePartitionDeletionSSTable(0, 1);
+
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        assertThat(cfs.getLiveSSTables()).hasSize(4);
+
+        // sleep 3 seconds to pass gc_grace_seconds
+        FBUtilities.sleepQuietly(3000);
+
+        Stats initial = Stats.fetch();
+
+        cfs.forceMajorCompaction();
+        assertThat(cfs.getLiveSSTables()).hasSize(1);
+
+        assertSuccessfulValidationWithMissingKeys(initial, 2); // key 0 and key 1 are removed
+    }
+
+    @Test
+    public void testValidationWithExpiredRangeTombstone() throws Throwable
+    {
+        createTable(CREATE_TABLE_TEMPLATE + " WITH gc_grace_seconds = 1");
+
+        populateSSTable(0, 0, 5, 5);
+        populateSSTable(1, 1, 5, 5);
+        populateSSTable(2, 2, 5, 5);
+        populateRangeDeletionSSTable(0, 1, 5); // populate 5 range deletion for key 0 and 1
+
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        assertThat(cfs.getLiveSSTables()).hasSize(4);
+
+        // sleep 3 seconds to pass gc_grace_seconds
+        FBUtilities.sleepQuietly(3000);
+
+        Stats initial = Stats.fetch();
+
+        cfs.forceMajorCompaction();
+        assertThat(cfs.getLiveSSTables()).hasSize(1);
+
+        assertSuccessfulValidationWithMissingKeys(initial, 2); // key 0 and key 1 are removed
+    }
+
+    @Test
+    public void testValidationWithTTLRowTombstone() throws Throwable
+    {
+        createTable(CREATE_TABLE_TEMPLATE + " WITH default_time_to_live = 1");
+
+        populateSSTable(1, 1, 5, 5);
+        populateSSTable(2, 2, 5, 5);
+        populateSSTableWithTTL(3, 3, 4, 4, 100);
+
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        assertThat(cfs.getLiveSSTables()).hasSize(3);
+
+        Stats initial = Stats.fetch();
+
+        cfs.forceMajorCompaction();
+
+        assertThat(cfs.getLiveSSTables()).hasSize(1);
+        assertSuccessfulValidationWithoutMissingKeys(initial);
+    }
+
+    @Test
+    public void testValidationWithExpiredTTLRowTombstone() throws Throwable
+    {
+        createTable(CREATE_TABLE_TEMPLATE + " WITH default_time_to_live = 1 and gc_grace_seconds = 1");
+
+        populateSSTable(1, 3, 5, 5);
+        populateSSTableWithTTL(4, 4, 5, 5, 1000); // ttl of 1000 is not expiring
+
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        assertThat(cfs.getLiveSSTables()).hasSize(2);
+
+        // sleep 4 seconds to pass ttl and gc_grace_seconds
+        FBUtilities.sleepQuietly(4000);
+
+        Stats initial = Stats.fetch();
+
+        cfs.forceMajorCompaction();
+
+        assertThat(cfs.getLiveSSTables()).hasSize(1);
+        assertSuccessfulValidationWithMissingKeys(initial, 2); // 2 boundary keys from 1st sstable are missing
+    }
+
+    @Test
+    public void testValidationWithoutOutputSSTable() throws Throwable
+    {
+        createTable(CREATE_TABLE_TEMPLATE + " WITH gc_grace_seconds = 1");
+
+        populateSSTable(1, 1, 5, 5);
+        populateSSTable(2, 2, 5, 5);
+        populateRowDeletionSSTable(1, 2, 5, 5);
+
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        assertThat(cfs.getLiveSSTables()).hasSize(3);
+
+        // sleep 3 seconds to pass gc_grace_seconds
+        FBUtilities.sleepQuietly(3_000);
+
+        Stats initial = Stats.fetch();
+
+        cfs.forceMajorCompaction();
+
+        // all sstables are removed
+        assertThat(cfs.getLiveSSTables()).hasSize(0);
+        assertSuccessfulValidationWithMissingKeys(initial, 2);
+    }
+
+    private void populateSSTable(int startPartition, int endPartition, int ck1PerPartition, int ck2PerClustering) throws Throwable
+    {
+        for (int partition = startPartition; partition <= endPartition; partition++)
+        {
+            for (int ck1 = 0; ck1 < ck1PerPartition; ck1++)
+            {
+                for (int ck2 = 0; ck2 < ck2PerClustering; ck2++)
+                {
+                    execute("INSERT INTO %s (pk, ck1, ck2, v1, v2) VALUES (?, ?, ?, ?, ?)", partition, ck1, ck2, 0, 0);
+                }
+            }
+        }
+        flush();
+    }
+
+    private void populateSSTableWithTTL(int startPartition, int endPartition, int ck1PerPartition, int ck2PerClustering, int ttl) throws Throwable
+    {
+        for (int partition = startPartition; partition <= endPartition; partition++)
+        {
+            for (int ck1 = 0; ck1 < ck1PerPartition; ck1++)
+            {
+                for (int ck2 = 0; ck2 < ck2PerClustering; ck2++)
+                {
+                    execute("INSERT INTO %s (pk, ck1, ck2, v1, v2) VALUES (?, ?, ?, ?, ?) USING TTL ?", partition, ck1, ck2, 0, 0, ttl);
+                }
+            }
+        }
+        flush();
+    }
+
+    private void populateRowDeletionSSTable(int startKey, int endKey, int ck1PerPartition, int ck2PerClustering) throws Throwable
+    {
+        for (int partition = startKey; partition <= endKey; partition++)
+        {
+            for (int ck1 = 0; ck1 < ck1PerPartition; ck1++)
+            {
+                for (int ck2 = 0; ck2 < ck2PerClustering; ck2++)
+                {
+                    execute("DELETE FROM %s where pk = ? and ck1 = ? and ck2 = ?", partition, ck1, ck2);
+                }
+            }
+        }
+        flush();
+    }
+
+    private void populatePartitionDeletionSSTable(int startKey, int endKey) throws Throwable
+    {
+        for (int partition = startKey; partition <= endKey; partition++)
+        {
+            execute("DELETE FROM %s where pk = ?", partition);
+        }
+        flush();
+    }
+
+    private void populateRangeDeletionSSTable(int startKey, int endKey, int ck1PerPartition) throws Throwable
+    {
+        for (int partition = startKey; partition <= endKey; partition++)
+        {
+            for (int ck1 = 0; ck1 < ck1PerPartition; ck1++)
+            {
+                execute("DELETE FROM %s where pk = ? and ck1 = ?", partition, ck1);
+            }
+        }
+        flush();
+    }
+
+    private void assertSuccessfulValidationWithMissingKeys(Stats initialStats, int missingKeys)
+    {
+        initialStats.assertStats(1, 0, missingKeys, 0);
+    }
+
+    private void assertSuccessfulValidationWithoutMissingKeys(Stats initialStats)
+    {
+        initialStats.assertStats(1, 1, 0, 0);
+    }
+
+    private static class Stats
+    {
+        private final int validations;
+        private final int validationsWithoutMissingKeys;
+        private final int missingKeys;
+        private final int potentialDataLosses;
+
+        private Stats(int validations, int validationsWithoutMissingKeys, int missingKeys, int potentialDataLosses)
+        {
+            this.validations = validations;
+            this.validationsWithoutMissingKeys = validationsWithoutMissingKeys;
+            this.missingKeys = missingKeys;
+            this.potentialDataLosses = potentialDataLosses;
+        }
+
+        public static Stats fetch()
+        {
+            CompactionValidationMetrics metrics = CompactionValidationMetrics.INSTANCE;
+            return new Stats((int) metrics.validationCount.count(),
+                    (int) metrics.validationWithoutMissingKeys.count(),
+                    (int) metrics.missingKeys.count(),
+                    (int) metrics.potentialDataLosses.count());
+        }
+
+        public void assertStats(int validationDiff, int validationsWithoutMissingKeysDiff, int missingKeysDiff, int potentialDataLossesDiff)
+        {
+            Stats current = Stats.fetch();
+            assertEquals(this.validations + validationDiff, current.validations);
+            assertEquals(this.validationsWithoutMissingKeys + validationsWithoutMissingKeysDiff, current.validationsWithoutMissingKeys);
+            assertEquals(this.missingKeys + missingKeysDiff, current.missingKeys);
+            assertEquals(this.potentialDataLosses + potentialDataLossesDiff, current.potentialDataLosses);
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/db/compaction/validation/CompactionValidationTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/validation/CompactionValidationTest.java
@@ -62,7 +62,8 @@ public class CompactionValidationTest extends CQLTester
     @Before
     public void setup()
     {
-        CassandraRelevantProperties.COMPACTION_VALIDATION_DRY_RUN.reset();
+        CassandraRelevantProperties.COMPACTION_VALIDATION_MODE.reset();
+        CassandraRelevantProperties.COMPACTION_VALIDATION_MODE.setString("WARN");
     }
 
     @After
@@ -277,9 +278,9 @@ public class CompactionValidationTest extends CQLTester
     }
 
     @Test
-    public void testAbortOnDataLossWithNonDryRun() throws Throwable
+    public void testAbortOnDataLoss() throws Throwable
     {
-        CassandraRelevantProperties.COMPACTION_VALIDATION_DRY_RUN.setBoolean(false);
+        CassandraRelevantProperties.COMPACTION_VALIDATION_MODE.setString("ABORT");
         Injections.inject(SIMULATE_NOT_FULLY_EXPIRED);
 
         createTable(CREATE_TABLE_TEMPLATE + " WITH gc_grace_seconds = 1");


### PR DESCRIPTION
### What is the issue
https://github.com/riptano/cndb/issues/15141

### What does this PR fix and why was it fixed
Added compaction task verification before transaction commit to validate if all source sstables' min/max keys are present in output sstables or expired if missing from output sstables.

This is mainly to detect data loss caused by compaction strategy skipping some subranges of source sstables HCD-130.

It works as following:
1. Extract all boundary keys (min/max) from source sstable
2. Check if boundary keys exist in output sstables
  a If all present, validation passes
  b. If any keys are missing, continue validation
3. For missing keys, read partition data from source sstables
4. Apply tombstone purging by using `gc_grace_seconds=0`
5. Check purged content
  a If there is no live data, validation passes. Keys are properly obsoleted
  b If there is live data, validation fails and throws to abort compaction if it's not dry run.


Configs:
* `cassandra.compaction_validation_mode=NONE`, available options: NONE/WARN/ABORT