### PR TITLE
Port CNDB-15155 550263f to main-5.0

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -728,6 +728,20 @@ public enum CassandraRelevantProperties
     SAI_NUMERIC_VALUES_MONOTONIC_BLOCK_SIZE("dse.sai.numeric_values.monotonic_block_size", "16384"),
     /** Controls the number of rows read in a single batch when fetching rows for a partition key */
     SAI_PARTITION_ROW_BATCH_SIZE("cassandra.sai.partition_row_batch_size", "100"),
+
+    /**
+     * Whether to enable SAI per-query metrics for different kinds of query, such as filter-only queries, top-k-only
+     * queries, hybrid queries, single-partition queries, and multipartition queries. These metrics are histograms and
+     * timers.
+     */
+    SAI_QUERY_KIND_PER_QUERY_METRICS_ENABLED("cassandra.sai.metrics.query_kind.per_query.enabled", "false"),
+
+    /**
+     * Whether to enable SAI per-table metrics for different kinds of query, such as filter-only queries, top-k-only
+     * queries, hybrid queries, single-partition queries, and multipartition queries. These metrics are always counters.
+     */
+    SAI_QUERY_KIND_PER_TABLE_METRICS_ENABLED("cassandra.sai.metrics.query_kind.per_table.enabled", "true"),
+
     SAI_QUERY_OPT_LEVEL("cassandra.sai.query.optimization.level", "1"),
     SAI_REDUCE_TOPK_ACROSS_SSTABLES("cassandra.sai.reduce_topk_across_sstables", "true"),
     SAI_TEST_DISABLE_TIMEOUT("cassandra.sai.test.timeout_disabled", "false"),

--- a/src/java/org/apache/cassandra/db/MultiRangeReadCommand.java
+++ b/src/java/org/apache/cassandra/db/MultiRangeReadCommand.java
@@ -150,6 +150,12 @@ public class MultiRangeReadCommand extends ReadCommand
                : MultiRangeReadResponse.createDataResponse(iterator, this);
     }
 
+    @Override
+    public boolean isSinglePartition()
+    {
+        return dataRanges.size() == 1 && dataRanges.get(0).isSinglePartition();
+    }
+
     /**
      * @return all token ranges to be queried
      */

--- a/src/java/org/apache/cassandra/db/PartitionRangeReadCommand.java
+++ b/src/java/org/apache/cassandra/db/PartitionRangeReadCommand.java
@@ -188,6 +188,12 @@ public class PartitionRangeReadCommand extends ReadCommand implements PartitionR
                       false);
     }
 
+    @Override
+    public boolean isSinglePartition()
+    {
+        return dataRange.isSinglePartition();
+    }
+
     public ClusteringIndexFilter clusteringIndexFilter(DecoratedKey key)
     {
         return dataRange.clusteringIndexFilter(key);

--- a/src/java/org/apache/cassandra/db/ReadCommand.java
+++ b/src/java/org/apache/cassandra/db/ReadCommand.java
@@ -295,11 +295,24 @@ public abstract class ReadCommand extends AbstractReadQuery
         return indexQueryPlan;
     }
 
+    /**
+     * @return {@code true} if this command uses index-based filtering, {@code false} otherwise
+     */
+    public boolean usesIndexFiltering()
+    {
+        return indexQueryPlan != null && indexQueryPlan.usesIndexFiltering();
+    }
+
     @Override
     public boolean isTopK()
     {
         return indexQueryPlan != null && indexQueryPlan.isTopK();
     }
+
+    /**
+     * @return {@code true} if this command only queries a single partition, {@code false} otherwise.
+     */
+    public abstract boolean isSinglePartition();
 
     @VisibleForTesting
     public Index.Searcher indexSearcher()

--- a/src/java/org/apache/cassandra/db/SinglePartitionReadCommand.java
+++ b/src/java/org/apache/cassandra/db/SinglePartitionReadCommand.java
@@ -474,6 +474,12 @@ public class SinglePartitionReadCommand extends ReadCommand implements SinglePar
     }
 
     @Override
+    public boolean isSinglePartition()
+    {
+        return true;
+    }
+
+    @Override
     public PartitionIterator execute(ConsistencyLevel consistency, ClientState state, Dispatcher.RequestTime requestTime) throws RequestExecutionException
     {
         if (clusteringIndexFilter.isEmpty(metadata().comparator))

--- a/src/java/org/apache/cassandra/index/Index.java
+++ b/src/java/org/apache/cassandra/index/Index.java
@@ -1186,6 +1186,14 @@ public interface Index
         {
             return false;
         }
+
+        /**
+         * @return {@code true} if this plan uses index-based filtering, {@code false} otherwise
+         */
+        default boolean usesIndexFiltering()
+        {
+            return true;
+        }
     }
 
     /*

--- a/src/java/org/apache/cassandra/index/sai/QueryContext.java
+++ b/src/java/org/apache/cassandra/index/sai/QueryContext.java
@@ -66,6 +66,7 @@ public class QueryContext
     private float annRerankFloor = 0.0f; // only called from single-threaded setup code
 
     private final LongAdder shadowedPrimaryKeyCount = new LongAdder();
+    private final LongAdder postFilteringReadLatency = new LongAdder();
 
     // Determines the order of using indexes for filtering and sorting.
     // Null means the query execution order hasn't been decided yet.
@@ -144,6 +145,11 @@ public class QueryContext
     public void addAnnGraphSearchLatency(long val)
     {
         annGraphSearchLatency.add(val);
+    }
+
+    public void addPostFilteringReadLatency(long val)
+    {
+        postFilteringReadLatency.add(val);
     }
 
     public void setFilterSortOrder(FilterSortOrder filterSortOrder)
@@ -245,6 +251,11 @@ public class QueryContext
     {
         if (observedFloor < Float.POSITIVE_INFINITY)
             annRerankFloor = max(annRerankFloor, observedFloor);
+    }
+
+    public long getPostFilteringReadLatency()
+    {
+        return postFilteringReadLatency.longValue();
     }
 
     /**

--- a/src/java/org/apache/cassandra/tools/NodeProbe.java
+++ b/src/java/org/apache/cassandra/tools/NodeProbe.java
@@ -1934,10 +1934,10 @@ public class NodeProbe implements AutoCloseable
             case "SSTableIndexesHit":
             case "IndexSegmentsHit":
             case "RowsFiltered":
-                return TableQueryMetrics.PerQueryMetrics.PER_QUERY_METRICS_TYPE;
+                return TableQueryMetrics.PerQuery.METRIC_TYPE;
             case "PostFilteringReadLatency":
             case "TotalQueryTimeouts":
-                return TableQueryMetrics.TABLE_QUERY_METRIC_TYPE;
+                return TableQueryMetrics.PerTable.METRIC_TYPE;
             case "DiskUsedBytes":
                 return IndexGroupMetrics.INDEX_GROUP_METRICS_TYPE;
             case "TotalIndexCount":

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/TraceTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/TraceTest.java
@@ -37,7 +37,6 @@ import static org.apache.cassandra.distributed.api.Feature.GOSSIP;
 import static org.apache.cassandra.distributed.api.Feature.NETWORK;
 import static org.apache.cassandra.utils.TimeUUID.Generator.nextTimeUUID;
 import static org.awaitility.Awaitility.await;
-import static org.junit.Assert.assertEquals;
 
 public class TraceTest extends TestBaseImpl
 {
@@ -72,26 +71,20 @@ public class TraceTest extends TestBaseImpl
             UUID sessionId = nextTimeUUID().asUUID();
             cluster.coordinator(1).executeWithTracingWithResult(sessionId, "SELECT * from trace_ks.tbl WHERE v1 < " + MATCHED_ROWS, ConsistencyLevel.ONE);
 
+            // TODO We can improve the asserts for this when we have improved tracing and multi-node support
             await().atMost(5, TimeUnit.SECONDS).until(() -> {
                 List<TracingUtil.TraceEntry> traceEntries = TracingUtil.getTrace(cluster, sessionId, ConsistencyLevel.ONE);
                 return traceEntries.stream().map(traceEntry -> traceEntry.activity)
                                    .filter(activity -> activity.contains("post-filtered"))
                                    .mapToLong(this::fetchPartitionCount).sum() == MATCHED_ROWS;
             });
-            
-            //TODO We can improve the asserts for this when we have improved tracing and multi-node support
-            assertEquals(MATCHED_ROWS, TracingUtil.getTrace(cluster, sessionId, ConsistencyLevel.ONE)
-                                        .stream()
-                                        .map(traceEntry -> traceEntry.activity)
-                                        .filter(activity -> activity.contains("post-filtered"))
-                                        .mapToLong(this::fetchPartitionCount).sum());
         }
         finally
         {
             TracingUtil.setWaitForTracingEventTimeoutSecs(originalTraceTimeout);
         }
     }
-    
+
     private long fetchPartitionCount(String activity)
     {
         List<Long> values = new ArrayList<>();

--- a/test/unit/org/apache/cassandra/index/sai/SAITester.java
+++ b/test/unit/org/apache/cassandra/index/sai/SAITester.java
@@ -40,6 +40,7 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.management.AttributeNotFoundException;
+import javax.management.InstanceNotFoundException;
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
 
@@ -473,6 +474,11 @@ public class SAITester extends CQLTester
             throw new RuntimeException(e);
         }
         return metricValue;
+    }
+
+    protected void assertMetricDoesNotExist(ObjectName name)
+    {
+        Assertions.assertThatThrownBy(() -> getMetricValue(name)).hasRootCauseInstanceOf(InstanceNotFoundException.class);
     }
 
     protected void startCompaction() throws Throwable

--- a/test/unit/org/apache/cassandra/index/sai/cql/QueryTimeoutTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/QueryTimeoutTest.java
@@ -74,8 +74,8 @@ public class QueryTimeoutTest extends SAITester
         execute("SELECT * FROM %s WHERE v1 >= 0 AND v1 < 10000");
         execute("SELECT * FROM %s WHERE v2 = '0'");
 
-        queryCountName = objectNameNoIndex("TotalQueriesCompleted", CQLTester.KEYSPACE, currentTable(), TableQueryMetrics.TABLE_QUERY_METRIC_TYPE);
-        queryTimeoutsName = objectNameNoIndex("TotalQueryTimeouts", CQLTester.KEYSPACE, currentTable(), TableQueryMetrics.TABLE_QUERY_METRIC_TYPE);
+        queryCountName = objectNameNoIndex("TotalQueriesCompleted", CQLTester.KEYSPACE, currentTable(), TableQueryMetrics.PerTable.METRIC_TYPE);
+        queryTimeoutsName = objectNameNoIndex("TotalQueryTimeouts", CQLTester.KEYSPACE, currentTable(), TableQueryMetrics.PerTable.METRIC_TYPE);
     }
 
     @After

--- a/test/unit/org/apache/cassandra/index/sai/functional/GroupComponentsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/functional/GroupComponentsTest.java
@@ -124,7 +124,7 @@ public class GroupComponentsTest extends SAITester
         
         execute("SELECT * FROM %s WHERE value = 1");
         
-        long queriesCompleted = queryMetrics.totalQueriesCompleted.getCount();
+        long queriesCompleted = queryMetrics.perTableMetrics.get(TableQueryMetrics.QueryKind.ALL).totalQueriesCompleted.getCount();
         assertEquals("TableQueryMetrics should track completed queries", 1L, queriesCompleted);
         
         TableQueryMetrics queryMetrics2 = group.queryMetrics();

--- a/test/unit/org/apache/cassandra/index/sai/metrics/AbstractMetricsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/metrics/AbstractMetricsTest.java
@@ -44,8 +44,8 @@ public abstract class AbstractMetricsTest extends SAITester
 
     protected long getTableQueryMetrics(String keyspace, String table, String metricsName)
     {
-        return (long) getMetricValue(objectNameNoIndex(metricsName, keyspace, table, TableQueryMetrics.TABLE_QUERY_METRIC_TYPE));
-}
+        return (long) getMetricValue(objectNameNoIndex(metricsName, keyspace, table, TableQueryMetrics.PerTable.METRIC_TYPE));
+    }
 
     protected void waitForIndexCompaction(String keyspace, String table, String index)
     {

--- a/test/unit/org/apache/cassandra/index/sai/metrics/QueryMetricsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/metrics/QueryMetricsTest.java
@@ -22,15 +22,21 @@ import javax.management.InstanceNotFoundException;
 import javax.management.JMX;
 import javax.management.ObjectName;
 
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import com.datastax.driver.core.ResultSet;
+
+import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.cql3.UntypedResultSet;
+import org.apache.cassandra.db.ReadCommand;
+import org.apache.cassandra.index.sai.metrics.TableQueryMetrics.QueryKind;
 import org.apache.cassandra.index.sai.plan.QueryController;
 import org.apache.cassandra.metrics.CassandraMetricsRegistry;
 
-import static org.apache.cassandra.index.sai.metrics.TableQueryMetrics.TABLE_QUERY_METRIC_TYPE;
+import static org.apache.cassandra.index.sai.metrics.TableQueryMetrics.AbstractQueryMetrics.makeName;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -41,7 +47,20 @@ public class QueryMetricsTest extends AbstractMetricsTest
                                                         "{'class' : 'SizeTieredCompactionStrategy', 'enabled' : false }";
     private static final String CREATE_INDEX_TEMPLATE = "CREATE CUSTOM INDEX IF NOT EXISTS %s ON %s.%s(%s) USING 'StorageAttachedIndex'";
 
-    private static final String PER_QUERY_METRIC_TYPE = "PerQuery";
+    private static final String TABLE_QUERY_METRIC_TYPE = TableQueryMetrics.PerTable.METRIC_TYPE;
+    private static final String TABLE_FILTER_QUERY_METRIC_TYPE = makeName(TABLE_QUERY_METRIC_TYPE, QueryKind.FILTER_ONLY);
+    private static final String TABLE_TOPK_QUERY_METRIC_TYPE = makeName(TABLE_QUERY_METRIC_TYPE, QueryKind.TOPK_ONLY);
+    private static final String TABLE_HYBRID_QUERY_METRIC_TYPE = makeName(TABLE_QUERY_METRIC_TYPE, QueryKind.HYBRID);
+    private static final String TABLE_SINGLE_PARTITION_QUERY_METRIC_TYPE = makeName(TABLE_QUERY_METRIC_TYPE, QueryKind.SINGLE_PARTITION);
+    private static final String TABLE_MULTI_PARTITION_QUERY_METRIC_TYPE = makeName(TABLE_QUERY_METRIC_TYPE, QueryKind.MULTI_PARTITION);
+
+    private static final String PER_QUERY_METRIC_TYPE = TableQueryMetrics.PerQuery.METRIC_TYPE;
+    private static final String PER_FILTER_QUERY_METRIC_TYPE = makeName(PER_QUERY_METRIC_TYPE, QueryKind.FILTER_ONLY);
+    private static final String PER_TOPK_QUERY_METRIC_TYPE = makeName(PER_QUERY_METRIC_TYPE, QueryKind.TOPK_ONLY);
+    private static final String PER_HYBRID_QUERY_METRIC_TYPE = makeName(PER_QUERY_METRIC_TYPE, QueryKind.HYBRID);
+    private static final String PER_SINGLE_PARTITION_QUERY_METRIC_TYPE = makeName(PER_QUERY_METRIC_TYPE, QueryKind.SINGLE_PARTITION);
+    private static final String PER_MULTI_PARTITION_QUERY_METRIC_TYPE = makeName(PER_QUERY_METRIC_TYPE, QueryKind.MULTI_PARTITION);
+
     private static final String GLOBAL_METRIC_TYPE = "ColumnQueryMetrics";
 
     @Rule
@@ -68,9 +87,9 @@ public class QueryMetricsTest extends AbstractMetricsTest
         assertEquals(1, rows.all().size());
 
         assertEquals(1L, getTableQueryMetrics(keyspace1, table, "TotalQueriesCompleted"));
-        assertEquals(1L, getTableQueryMetrics(keyspace1, table, "PostFilteringReadLatency"));
+        assertEquals(1L, getPerQueryMetrics(keyspace1, table, "PostFilteringReadLatency"));
         assertEquals(0L, getTableQueryMetrics(keyspace2, table, "TotalQueriesCompleted"));
-        assertEquals(0L, getTableQueryMetrics(keyspace2, table, "PostFilteringReadLatency"));
+        assertEquals(0L, getPerQueryMetrics(keyspace2, table, "PostFilteringReadLatency"));
 
         execute("INSERT INTO " + keyspace2 + "." + table + " (id1, v1, v2) VALUES ('0', 0, '0')");
         execute("INSERT INTO " + keyspace2 + "." + table + " (id1, v1, v2) VALUES ('1', 1, '1')");
@@ -83,8 +102,8 @@ public class QueryMetricsTest extends AbstractMetricsTest
 
         assertEquals(2L, getTableQueryMetrics(keyspace1, table, "TotalQueriesCompleted"));
         assertEquals(1L, getTableQueryMetrics(keyspace2, table, "TotalQueriesCompleted"));
-        assertEquals(2L, getTableQueryMetrics(keyspace1, table, "PostFilteringReadLatency"));
-        assertEquals(1L, getTableQueryMetrics(keyspace2, table, "PostFilteringReadLatency"));
+        assertEquals(2L, getPerQueryMetrics(keyspace1, table, "PostFilteringReadLatency"));
+        assertEquals(1L, getPerQueryMetrics(keyspace2, table, "PostFilteringReadLatency"));
     }
 
     @Test
@@ -220,7 +239,7 @@ public class QueryMetricsTest extends AbstractMetricsTest
 
         waitForGreaterThanZero(objectNameNoIndex("QueryLatency", keyspace, table, PER_QUERY_METRIC_TYPE));
 
-        waitForEquals(objectNameNoIndex("TotalPartitionReads", keyspace, table, TableQueryMetrics.TABLE_QUERY_METRIC_TYPE), resultCounter);
+        waitForEquals(objectNameNoIndex("TotalPartitionReads", keyspace, table, TABLE_QUERY_METRIC_TYPE), resultCounter);
         waitForEquals(objectName("KDTreeIntersectionLatency", keyspace, table, index, GLOBAL_METRIC_TYPE), queryCounter);
     }
 
@@ -337,7 +356,7 @@ public class QueryMetricsTest extends AbstractMetricsTest
 
         waitForGreaterThanZero(objectNameNoIndex("QueryLatency", keyspace, table, PER_QUERY_METRIC_TYPE));
 
-        waitForEquals(objectNameNoIndex("TotalPartitionReads", keyspace, table, TableQueryMetrics.TABLE_QUERY_METRIC_TYPE), resultCounter);
+        waitForEquals(objectNameNoIndex("TotalPartitionReads", keyspace, table, TABLE_QUERY_METRIC_TYPE), resultCounter);
     }
 
     @Test
@@ -405,6 +424,186 @@ public class QueryMetricsTest extends AbstractMetricsTest
 
         waitForEquals(objectName("KDTreeIntersectionLatency", keyspace, table, index, GLOBAL_METRIC_TYPE), 1L);
         waitForEquals(objectName("KDTreeIntersectionEarlyExits", keyspace, table, index, GLOBAL_METRIC_TYPE), 2L);
+    }
+
+    /**
+     * Test the {@link ReadCommand} flags that are used to determine the kind of query (top-k only, filtering only,
+     * hybrid, single partition and multipartition) in metrics.
+     */
+    @Test
+    public void testQueryKindFlags()
+    {
+        createTable("CREATE TABLE %s (k int, c int, n int, s text, v vector<float, 2>, PRIMARY KEY(k, c))");
+
+        // test without indexes
+        assertQueryTypeFlags("SELECT * FROM %s", false, false);
+        assertQueryTypeFlags("SELECT * FROM %s WHERE n = 1 ALLOW FILTERING", false, false);
+
+        // test with legacy indexes
+        String idx = createIndex("CREATE INDEX ON %s(n)");
+        assertQueryTypeFlags("SELECT * FROM %s", false, false);
+        assertQueryTypeFlags("SELECT * FROM %s WHERE n = 1", false, true);
+        assertQueryTypeFlags("SELECT * FROM %s WHERE n = 1 AND s = 'a' ALLOW FILTERING", false, true);
+        assertQueryTypeFlags("SELECT * FROM %s WHERE n = 1 OR s = 'a' ALLOW FILTERING", false, false);
+
+        // test with SAI indexes
+        dropIndex("DROP INDEX %s." + idx);
+        createIndex("CREATE CUSTOM INDEX ON %s(n) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
+        assertQueryTypeFlags("SELECT * FROM %s", false, false);
+        assertQueryTypeFlags("SELECT * FROM %s WHERE n = 1", false, true);
+        assertQueryTypeFlags("SELECT * FROM %s WHERE n = 1 AND s = 'a' ALLOW FILTERING", false, true);
+        assertQueryTypeFlags("SELECT * FROM %s WHERE n = 1 OR s = 'a' ALLOW FILTERING", false, false);
+        assertQueryTypeFlags("SELECT * FROM %s ORDER BY v ANN OF [1, 1] LIMIT 10", true, false);
+        assertQueryTypeFlags("SELECT * FROM %s WHERE n=1 ORDER BY v ANN OF [1, 1] LIMIT 10", true, true);
+    }
+
+    private void assertQueryTypeFlags(String query, boolean expectedIsTopK, boolean expectedUsesIndexFiltering)
+    {
+        ReadCommand command = parseReadCommand(query);
+        Assert.assertEquals(expectedIsTopK, command.isTopK());
+        Assert.assertEquals(expectedUsesIndexFiltering, command.usesIndexFiltering());
+    }
+
+    /**
+     * Test that metrics are correctly separated for different types of queries.
+     */
+    @Test
+    public void testQueryKindMetrics()
+    {
+        testQueryKindMetrics(false, false);
+        testQueryKindMetrics(false, true);
+        testQueryKindMetrics(true, false);
+        testQueryKindMetrics(true, true);
+    }
+
+    private void testQueryKindMetrics(boolean perTable, boolean perQuery)
+    {
+        CassandraRelevantProperties.SAI_QUERY_KIND_PER_TABLE_METRICS_ENABLED.setBoolean(perTable);
+        CassandraRelevantProperties.SAI_QUERY_KIND_PER_QUERY_METRICS_ENABLED.setBoolean(perQuery);
+
+        // create table and indexes for vector and numeric
+        createTable("CREATE TABLE %s (k int, c int, n int, v vector<float, 2>, PRIMARY KEY(k, c))");
+        createIndex("CREATE CUSTOM INDEX ON %s(n) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
+
+        // insert some data
+        int numPartitions = 11;
+        int numRowsPerPartition = 13;
+        int numRows = numPartitions * numRowsPerPartition;
+        for (int k = 0; k < numPartitions; k++)
+            for (int c = 0; c < numRowsPerPartition; c++)
+                execute("INSERT INTO %s (k, c, n, v) VALUES (?, ?, 1, [1, 1])", k, c);
+
+        // filter query (goes to the general, filter and range query metrics)
+        UntypedResultSet rows = execute("SELECT k, c FROM %s WHERE n = 1");
+        assertEquals(numRows, rows.size());
+
+        // top-k query (goes to the general, top-k and range query metrics)
+        rows = execute("SELECT k, c FROM %s ORDER BY v ANN OF [1, 1] LIMIT 1000");
+        assertEquals(numRows, rows.size());
+
+        // partition query (goes to the general, filter single-partition query metrics)
+        rows = execute("SELECT k, c FROM %s WHERE k = 0 AND n = 1");
+        assertEquals(numRowsPerPartition, rows.size());
+
+        // hybrid query (goes to the general, hybrid and range query metrics)
+        rows = execute("SELECT k, c FROM %s WHERE n = 1 ORDER BY v ANN OF [1, 1] LIMIT 1000");
+        assertEquals(numRows, rows.size());
+
+        // Verify metrics for total queries completed.
+        String name = "TotalQueriesCompleted";
+        waitForEquals(objectName(name, TABLE_QUERY_METRIC_TYPE), 4);
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_FILTER_QUERY_METRIC_TYPE), 2);
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_TOPK_QUERY_METRIC_TYPE), 1);
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_HYBRID_QUERY_METRIC_TYPE), 1);
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_SINGLE_PARTITION_QUERY_METRIC_TYPE), 1);
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_MULTI_PARTITION_QUERY_METRIC_TYPE), 3);
+
+        // Verify counters for total partition reads. Note that the top-k query creates a partition per matching row,
+        // without grouping them by partition. That means a partition for every row.
+        name = "TotalPartitionReads";
+        waitForEquals(objectName(name, TABLE_QUERY_METRIC_TYPE), numPartitions + numRows + numRows + 1);
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_FILTER_QUERY_METRIC_TYPE), numPartitions + 1);
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_TOPK_QUERY_METRIC_TYPE), numRows);
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_HYBRID_QUERY_METRIC_TYPE), numRows);
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_SINGLE_PARTITION_QUERY_METRIC_TYPE), 1);
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_MULTI_PARTITION_QUERY_METRIC_TYPE), numPartitions + numRows + numRows);
+
+        // Verify counters for total rows filtered.
+        name = "TotalRowsFiltered";
+        waitForEquals(objectName(name, TABLE_QUERY_METRIC_TYPE), numRows + numRowsPerPartition + numRows + numRows);
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_FILTER_QUERY_METRIC_TYPE), numRows + numRowsPerPartition);
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_TOPK_QUERY_METRIC_TYPE), numRows);
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_HYBRID_QUERY_METRIC_TYPE), numRows);
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_SINGLE_PARTITION_QUERY_METRIC_TYPE), numRowsPerPartition);
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_MULTI_PARTITION_QUERY_METRIC_TYPE), numRows + numRows + numRows);
+
+        // Verify counters for timeouts.
+        name = "TotalQueryTimeouts";
+        waitForEquals(objectName(name, TABLE_QUERY_METRIC_TYPE), 0);
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_FILTER_QUERY_METRIC_TYPE), 0);
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_TOPK_QUERY_METRIC_TYPE), 0);
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_HYBRID_QUERY_METRIC_TYPE), 0);
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_SINGLE_PARTITION_QUERY_METRIC_TYPE), 0);
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_MULTI_PARTITION_QUERY_METRIC_TYPE), 0);
+
+        // Verify counters for sort-then-filter queries.
+        name = "SortThenFilterQueriesCompleted";
+        waitForEquals(objectName(name, TABLE_QUERY_METRIC_TYPE), 1);
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_FILTER_QUERY_METRIC_TYPE), 0);
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_TOPK_QUERY_METRIC_TYPE), 1); // was 4
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_HYBRID_QUERY_METRIC_TYPE), 0);
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_SINGLE_PARTITION_QUERY_METRIC_TYPE), 0);
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_MULTI_PARTITION_QUERY_METRIC_TYPE), 1);
+
+        // Verify counters for filter-then-sort queries.
+        name = "FilterThenSortQueriesCompleted";
+        waitForEquals(objectName(name, TABLE_QUERY_METRIC_TYPE), 1);
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_FILTER_QUERY_METRIC_TYPE), 0);
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_TOPK_QUERY_METRIC_TYPE), 0);
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_HYBRID_QUERY_METRIC_TYPE), 1);
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_SINGLE_PARTITION_QUERY_METRIC_TYPE), 0);
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_MULTI_PARTITION_QUERY_METRIC_TYPE), 1);
+
+        // Verify histograms for partitions reads per query.
+        name = "PartitionReads";
+        waitForHistogramCountEquals(objectName(name, PER_QUERY_METRIC_TYPE), 4);
+        waitForHistogramCountEqualsIfExists(perQuery, objectName(name, PER_FILTER_QUERY_METRIC_TYPE), 2);
+        waitForHistogramCountEqualsIfExists(perQuery, objectName(name, PER_TOPK_QUERY_METRIC_TYPE), 1);
+        waitForHistogramCountEqualsIfExists(perQuery, objectName(name, PER_HYBRID_QUERY_METRIC_TYPE), 1);
+        waitForHistogramCountEqualsIfExists(perQuery, objectName(name, PER_SINGLE_PARTITION_QUERY_METRIC_TYPE), 1);
+        waitForHistogramCountEqualsIfExists(perQuery, objectName(name, PER_MULTI_PARTITION_QUERY_METRIC_TYPE), 3);
+
+        // Verify histograms for rows filtered per query.
+        name = "RowsFiltered";
+        waitForHistogramCountEquals(objectName(name, PER_QUERY_METRIC_TYPE), 4);
+        waitForHistogramCountEqualsIfExists(perQuery, objectName(name, PER_FILTER_QUERY_METRIC_TYPE), 2);
+        waitForHistogramCountEqualsIfExists(perQuery, objectName(name, PER_TOPK_QUERY_METRIC_TYPE), 1);
+        waitForHistogramCountEqualsIfExists(perQuery, objectName(name, PER_HYBRID_QUERY_METRIC_TYPE), 1);
+        waitForHistogramCountEqualsIfExists(perQuery, objectName(name, PER_SINGLE_PARTITION_QUERY_METRIC_TYPE), 1);
+        waitForHistogramCountEqualsIfExists(perQuery, objectName(name, PER_MULTI_PARTITION_QUERY_METRIC_TYPE), 3);
+    }
+
+    private ObjectName objectName(String name, String type)
+    {
+        return objectNameNoIndex(name, KEYSPACE, currentTable(), type);
+    }
+
+    protected void waitForEqualsIfExists(boolean shouldExist, ObjectName name, long value)
+    {
+        if (shouldExist)
+            waitForEquals(name, value);
+        else
+            assertMetricDoesNotExist(name);
+    }
+
+    protected void waitForHistogramCountEqualsIfExists(boolean shouldExist, ObjectName name, long count)
+    {
+        if (shouldExist)
+            waitForHistogramCountEquals(name, count);
+        else
+            assertMetricDoesNotExist(name);
     }
 
     private long getPerQueryMetrics(String keyspace, String table, String metricsName)


### PR DESCRIPTION
### What is the issue
See https://github.com/datastax/cassandra/pull/1969

### What does this PR fix and why was it fixed
Port CNDB-15155 to main-5.0

A second checkpoint (prefixed `SQUASH`) commit is kept separate in the PR where upstream `cassandra-5.0` code needed to be re-implemented.  This was for CASSANDRA-18940
This will be squashed before rebase+merge.
