### PR TITLE
CNDB-15478: CNDB-15393: fix ShardManager#coveringRange to decrement left instead of incrementing right (#2003)

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/ShardManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/ShardManager.java
@@ -113,8 +113,8 @@ public interface ShardManager
 
     static Range<Token> coveringRange(PartitionPosition first, PartitionPosition last)
     {
-        // To include the token of last, the range's upper bound must be increased.
-        return new Range<>(first.getToken(), last.getToken().nextValidToken());
+        // To include the token of left, the range's lower bound must be decreased.
+        return new Range<>(first.getToken().isMinimum() ? first.getToken() : first.getToken().prevValidToken(), last.getToken());
     }
 
 

--- a/src/java/org/apache/cassandra/dht/ByteOrderedPartitioner.java
+++ b/src/java/org/apache/cassandra/dht/ByteOrderedPartitioner.java
@@ -141,6 +141,13 @@ public class ByteOrderedPartitioner implements IPartitioner
             throw new UnsupportedOperationException(String.format("Token type %s does not support token allocation.",
                                                                   getClass().getSimpleName()));
         }
+
+        @Override
+        public Token prevValidToken()
+        {
+            throw new UnsupportedOperationException(String.format("Token type %s does not support token allocation.",
+                                                                  getClass().getSimpleName()));
+        }
     }
 
     public BytesToken getToken(ByteBuffer key)

--- a/src/java/org/apache/cassandra/dht/ComparableObjectToken.java
+++ b/src/java/org/apache/cassandra/dht/ComparableObjectToken.java
@@ -80,4 +80,11 @@ abstract class ComparableObjectToken<C extends Comparable<C>> extends Token
         throw new UnsupportedOperationException(String.format("Token type %s does not support token allocation.",
                                                               getClass().getSimpleName()));
     }
+
+    @Override
+    public Token prevValidToken()
+    {
+        throw new UnsupportedOperationException(String.format("Token type %s does not support token allocation.",
+                                                              getClass().getSimpleName()));
+    }
 }

--- a/src/java/org/apache/cassandra/dht/Murmur3Partitioner.java
+++ b/src/java/org/apache/cassandra/dht/Murmur3Partitioner.java
@@ -234,6 +234,12 @@ public class Murmur3Partitioner implements IPartitioner
             return keyForToken(new LongToken(token));
         }
 
+        @Override
+        public Token prevValidToken()
+        {
+            return new LongToken(token - 1);    // wraparound to MAXIMUM if token is MINIMUM
+        }
+
         /**
          * Reverses murmur3 to find a possible 16 byte key that generates a given token
          */

--- a/src/java/org/apache/cassandra/dht/RandomPartitioner.java
+++ b/src/java/org/apache/cassandra/dht/RandomPartitioner.java
@@ -278,6 +278,30 @@ public class RandomPartitioner implements IPartitioner
             return new BigIntegerToken(next);
         }
 
+        @Override
+        public Token prevValidToken()
+        {
+            BigInteger prev;
+            if (token.compareTo(ZERO) == 0)
+            {
+                // For ZERO token, return MINIMUM as adjustment
+                // 1. Range semantics: Most range functions expect minimum as an upper bound, not maximum as a lowerbound
+                // 2. Wraparound risks: Functions designed for non-wraparound ranges might not handle maximum on the lower side correctly
+                // Note: this means MAXIMUM.nextValidToken().prevValidToken() != MAXIMUM
+                prev = MINIMUM.token;
+            }
+            else if (this.isMinimum())
+            {
+                // For MINIMUM, wrap around to MAXIMUM.
+                prev = MAXIMUM;
+            }
+            else
+            {
+                prev = token.subtract(BigInteger.ONE);
+            }
+            return new BigIntegerToken(prev);
+        }
+
         public double size(Token next)
         {
             BigIntegerToken n = (BigIntegerToken) next;

--- a/src/java/org/apache/cassandra/dht/Token.java
+++ b/src/java/org/apache/cassandra/dht/Token.java
@@ -186,6 +186,18 @@ public abstract class Token implements RingPosition<Token>, Serializable
      */
     abstract public Token nextValidToken();
 
+    /**
+     * Returns the previous possible token in the token space, one that compares
+     * smaller than this and such that there is no other token that sits
+     * between this token and it in the token order.
+     *
+     * This is not possible for all token types, esp. for comparison-based
+     * tokens such as the LocalPartioner used for classic secondary indexes.
+     *
+     * Used to construct token ranges for sstables.
+     */
+    abstract public Token prevValidToken();
+
     public Token getToken()
     {
         return this;

--- a/test/unit/org/apache/cassandra/dht/ByteOrderedPartitionerTest.java
+++ b/test/unit/org/apache/cassandra/dht/ByteOrderedPartitionerTest.java
@@ -17,6 +17,10 @@
  */
 package org.apache.cassandra.dht;
 
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 public class ByteOrderedPartitionerTest extends PartitionerTestCase
 {
     public void initPartitioner()
@@ -27,5 +31,17 @@ public class ByteOrderedPartitionerTest extends PartitionerTestCase
     protected boolean shouldStopRecursion(Token left, Token right)
     {
         return false;
+    }
+
+    @Test
+    public void testNextValidToken()
+    {
+        assertThatThrownBy(() -> tok("b").nextValidToken()).hasMessageContaining("not support token allocation");
+    }
+
+    @Test
+    public void testPrevValidToken()
+    {
+        assertThatThrownBy(() -> tok("b").prevValidToken()).hasMessageContaining("not support token allocation");
     }
 }

--- a/test/unit/org/apache/cassandra/dht/Murmur3PartitionerTest.java
+++ b/test/unit/org/apache/cassandra/dht/Murmur3PartitionerTest.java
@@ -21,6 +21,7 @@ import java.nio.ByteBuffer;
 
 import org.junit.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.quicktheories.QuickTheory.qt;
 import static org.quicktheories.generators.SourceDSL.longs;
 
@@ -87,6 +88,32 @@ public class Murmur3PartitionerTest extends PartitionerTestCase
                 Token constructed = new Murmur3Partitioner.LongToken(token);
                 return constructed.equals(fromLongValue);
             });
+    }
+
+    @Test
+    public void testNextValidToken()
+    {
+        Token token = new Murmur3Partitioner.LongToken(1);
+        assertThat(token.nextValidToken()).isEqualTo(new Murmur3Partitioner.LongToken(2));
+
+        token = Murmur3Partitioner.instance.getMaximumToken();
+        assertThat(token.nextValidToken()).isEqualTo(Murmur3Partitioner.instance.getMinimumToken());
+
+        token = Murmur3Partitioner.instance.getMinimumToken();
+        assertThat(token.nextValidToken()).isEqualTo(new Murmur3Partitioner.LongToken(Long.MIN_VALUE + 1));
+    }
+
+    @Test
+    public void testPrevValidToken()
+    {
+        Token token = new Murmur3Partitioner.LongToken(1);
+        assertThat(token.prevValidToken()).isEqualTo(new Murmur3Partitioner.LongToken(0));
+
+        token = Murmur3Partitioner.instance.getMaximumToken();
+        assertThat(token.prevValidToken()).isEqualTo(new Murmur3Partitioner.LongToken(Long.MAX_VALUE - 1));
+
+        token = Murmur3Partitioner.instance.getMinimumToken();
+        assertThat(token.prevValidToken()).isEqualTo(Murmur3Partitioner.instance.getMaximumToken());
     }
 }
 

--- a/test/unit/org/apache/cassandra/dht/OrderPreservingPartitionerTest.java
+++ b/test/unit/org/apache/cassandra/dht/OrderPreservingPartitionerTest.java
@@ -24,6 +24,8 @@ import org.junit.Test;
 
 import org.apache.cassandra.SchemaLoader;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 public class OrderPreservingPartitionerTest extends PartitionerTestCase
 {
     @BeforeClass
@@ -54,5 +56,17 @@ public class OrderPreservingPartitionerTest extends PartitionerTestCase
         assert tok("a").compareTo(tok("z")) < 0;
         assert tok("asdf").compareTo(tok("asdf")) == 0;
         assert tok("asdz").compareTo(tok("asdf")) > 0;
+    }
+
+    @Test
+    public void testNextValidToken()
+    {
+        assertThatThrownBy(() -> tok("b").nextValidToken()).hasMessageContaining("not support token allocation");
+    }
+
+    @Test
+    public void testPrevValidToken()
+    {
+        assertThatThrownBy(() -> tok("b").prevValidToken()).hasMessageContaining("not support token allocation");
     }
 }

--- a/test/unit/org/apache/cassandra/dht/RandomPartitionerTest.java
+++ b/test/unit/org/apache/cassandra/dht/RandomPartitionerTest.java
@@ -22,6 +22,8 @@ import java.math.BigInteger;
 
 import org.junit.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 public class RandomPartitionerTest extends PartitionerTestCase
 {
     public void initPartitioner()
@@ -54,5 +56,34 @@ public class RandomPartitionerTest extends PartitionerTestCase
         RandomPartitioner.BigIntegerToken left = new RandomPartitioner.BigIntegerToken(RandomPartitioner.MAXIMUM.subtract(BigInteger.valueOf(10)));
 
         assertSplit(left, tok("a"), 16);
+    }
+
+    @Test
+    public void testNextValidToken()
+    {
+        Token token = new RandomPartitioner.BigIntegerToken(BigInteger.ONE);
+        assertThat(token.nextValidToken()).isEqualTo(new RandomPartitioner.BigIntegerToken(BigInteger.TWO));
+
+        token = RandomPartitioner.instance.getMaximumToken();
+        assertThat(token.nextValidToken()).isEqualTo(new RandomPartitioner.BigIntegerToken(BigInteger.ZERO));
+
+        token = RandomPartitioner.instance.getMinimumToken();
+        assertThat(token.nextValidToken()).isEqualTo(new RandomPartitioner.BigIntegerToken(BigInteger.ZERO));
+    }
+
+    @Test
+    public void testPrevValidToken()
+    {
+        Token token = new RandomPartitioner.BigIntegerToken(BigInteger.ONE);
+        assertThat(token.prevValidToken()).isEqualTo(new RandomPartitioner.BigIntegerToken(BigInteger.ZERO));
+
+        token = new RandomPartitioner.BigIntegerToken(BigInteger.ZERO);
+        assertThat(token.prevValidToken()).isEqualTo(RandomPartitioner.MINIMUM);
+
+        token = RandomPartitioner.instance.getMaximumToken();
+        assertThat(token.prevValidToken()).isEqualTo(new RandomPartitioner.BigIntegerToken(RandomPartitioner.MAXIMUM.subtract(BigInteger.ONE)));
+
+        token = RandomPartitioner.instance.getMinimumToken();
+        assertThat(token.prevValidToken()).isEqualTo(RandomPartitioner.instance.getMaximumToken());
     }
 }


### PR DESCRIPTION
https://github.com/riptano/cndb/issues/15478

Port into main-5.0 commit 0be2515
https://github.com/datastax/cassandra/commit/0be2515e79a4f825e9d3a4f54d7358341c67d76b

CNDB-15393: fix ShardManager#coveringRange to decrement left instead of incrementing right (https://github.com/datastax/cassandra/pull/2003)

### What is the issue
[CNDB-15393](https://github.com/riptano/cndb/issues/15393) -
`ShardManager#coveringRange` returns a range missing left position and
the `ShardManager#rangeSpanned` for (min, min] is not 1.

### What does this PR fix and why was it fixed
Create Range with (left-1, right] to make sure both left and right are
included. And make sure range span is 1 for (min, min]