### PR TITLE
CNDB-15485: Fix ResultRetriever key comparison to prevent dupes in result set

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
@@ -27,6 +27,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.PriorityQueue;
 import java.util.Queue;
 import java.util.function.Supplier;
@@ -307,6 +308,17 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
             return key;
         }
 
+        private boolean isEqualToLastKey(PrimaryKey key)
+        {
+            // We don't want key.equals(lastKey) because some PrimaryKey implementations consider more than just
+            // partition key and clustering for equality. This can break lastKey skipping, which is necessary for
+            // correctness when PrimaryKey doesn't have a clustering (as otherwise, the same partition may get
+            // filtered and considered as a result multiple times).
+            return lastKey != null &&
+                   Objects.equals(lastKey.partitionKey(), key.partitionKey()) &&
+                   Objects.equals(lastKey.clustering(), key.clustering());
+        }
+
         private void fillNextSelectedKeysInPartition(DecoratedKey partitionKey, List<PrimaryKey> nextPrimaryKeys)
         {
             while (operation.hasNext()
@@ -318,7 +330,7 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
                 if (key == null)
                     break;
 
-                if (!controller.selects(key) || key.equals(lastKey))
+                if (!controller.selects(key) || isEqualToLastKey(key))
                     continue;
 
                 nextPrimaryKeys.add(key);
@@ -347,7 +359,7 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
                 if (firstKey == null)
                     return Collections.emptyList();
             }
-            while (!controller.selects(firstKey) || firstKey.equals(lastKey));
+            while (!controller.selects(firstKey) || isEqualToLastKey(firstKey));
 
             lastKey = firstKey;
             threadLocalNextKeys.add(firstKey);

--- a/test/unit/org/apache/cassandra/index/sai/cql/LargePartitionsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/LargePartitionsTest.java
@@ -73,7 +73,10 @@ public class LargePartitionsTest extends VectorTester
             }
         }
 
-        beforeAndAfterFlush( () -> {
+        // Compaction produces sstables differently than flush, so it is necessary to test sstables written by
+        // compaction as well. (For example, AA indexes are written as if they were row aware in compaction, but not
+        // when flushed from the memtable, and that produced the bug fixed in this commit.)
+        runThenFlushThenCompact( () -> {
 
             // test filtering with single partition queries
             int numExpectedRows = LARGE_PARTITION_SIZE / 2;


### PR DESCRIPTION
### What is the issue
https://github.com/riptano/cndb/issues/15485

### What does this PR fix and why was it fixed
This PR fixes a bug introduced to this branch via https://github.com/datastax/cassandra/pull/1884. The bug only impacts SAI file format `aa` when the index file was produced via compaction, which is why the modified test simply adds coverage to compact the table and hit the bug.

The bug happens when an iterator produces the same partition across two different batch fetches from storage. These keys were not collapsed in the `key.equals(lastKey)` logic because compacted indexes use a row id per row instead of per partition, and the logic in `PrimaryKeyWithSource` considers rows with different row ids to be distinct. However, when we went to materialize a batch from storage, we hit this code:

```java
        ClusteringIndexFilter clusteringIndexFilter = command.clusteringIndexFilter(firstKey.partitionKey());
        if (cfs.metadata().comparator.size() == 0 || firstKey.hasEmptyClustering())
        {
            return clusteringIndexFilter;
        }
        else
        {
            nextClusterings.clear();
            for (PrimaryKey key : keys)
                nextClusterings.add(key.clustering());
            return new ClusteringIndexNamesFilter(nextClusterings, clusteringIndexFilter.isReversed());
        }
```

which returned  `clusteringIndexFilter` for `aa` because those indexes do not have the clustering information. Therefore, each batch fetched the whole partition (which was subsequently filtered to the proper results), and produced a multiplier effect where we saw `batch` many duplicates.

This fix works by comparing partition keys and clustering keys directly, which is a return to the old comparison logic from before https://github.com/datastax/cassandra/pull/1884. There was actually a discussion about this in the PR to `main`, but unfortunately, we missed this case https://github.com/datastax/cassandra/pull/1883#discussion_r2213047376.

A more proper long term fix might be to remove the logic of creating a `PrimaryKeyWithSource` for AA indexes. However, I preferred this approach because it is essentially a `revert` instead of fixing forward solution.