### PR TITLE
CNDB-7197: Added SAI_INDEX_METRICS_ENABLED to be able to enable/disable IndexMetrics

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -587,6 +587,12 @@ public enum CassandraRelevantProperties
     SAI_QUERY_KIND_PER_QUERY_METRICS_ENABLED("cassandra.sai.metrics.query_kind.per_query.enabled", "false"),
 
     /**
+     * Whether to enable SAI index metrics such as memtable flush metrics, compaction metrics, and disk usage metrics.
+     * These metrics include timers, histograms, counters, and gauges for index operations.
+     */
+    SAI_INDEX_METRICS_ENABLED("cassandra.sai.metrics.index.enabled", "true"),
+
+    /**
      * If true, while creating or altering schema, NetworkTopologyStrategy won't check if the DC exists.
      * This is to remain compatible with older workflows that first change the replication before adding the nodes.
      * Otherwise, it will validate that the names match existing DCs before allowing replication change.

--- a/src/java/org/apache/cassandra/index/sai/IndexContext.java
+++ b/src/java/org/apache/cassandra/index/sai/IndexContext.java
@@ -38,7 +38,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
-import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.cql3.Operator;
 import org.apache.cassandra.cql3.statements.schema.IndexTarget;
 import org.apache.cassandra.db.ClusteringComparator;
@@ -73,7 +72,6 @@ import org.apache.cassandra.index.sai.iterators.KeyRangeIterator;
 import org.apache.cassandra.index.sai.iterators.KeyRangeUnionIterator;
 import org.apache.cassandra.index.sai.memory.MemtableIndex;
 import org.apache.cassandra.index.sai.memory.MemtableKeyRangeIterator;
-import org.apache.cassandra.index.sai.memory.TrieMemtableIndex;
 import org.apache.cassandra.index.sai.metrics.ColumnQueryMetrics;
 import org.apache.cassandra.index.sai.metrics.IndexMetrics;
 import org.apache.cassandra.index.sai.plan.Expression;
@@ -93,6 +91,7 @@ import org.apache.cassandra.utils.Pair;
 import org.apache.cassandra.utils.concurrent.OpOrder;
 
 import static org.apache.cassandra.config.CassandraRelevantProperties.SAI_INDEX_READS_DISABLED;
+import static org.apache.cassandra.config.CassandraRelevantProperties.SAI_INDEX_METRICS_ENABLED;
 import static org.apache.cassandra.config.CassandraRelevantProperties.VALIDATE_MAX_TERM_SIZE_AT_COORDINATOR;
 
 /**
@@ -190,7 +189,7 @@ public class IndexContext
             this.vectorSimilarityFunction = indexWriterConfig.getSimilarityFunction();
             this.hasEuclideanSimilarityFunc = vectorSimilarityFunction == VectorSimilarityFunction.EUCLIDEAN;
 
-            this.indexMetrics = new IndexMetrics(this);
+            this.indexMetrics = SAI_INDEX_METRICS_ENABLED.getBoolean() ? new IndexMetrics(this) : null;
             this.columnQueryMetrics = isVector() ? new ColumnQueryMetrics.VectorIndexMetrics(keyspace, table, getIndexName()) :
                                       isLiteral() ? new ColumnQueryMetrics.TrieIndexMetrics(keyspace, table, getIndexName())
                                                   : new ColumnQueryMetrics.BKDIndexMetrics(keyspace, table, getIndexName());
@@ -298,7 +297,8 @@ public class IndexContext
             ByteBuffer value = getValueOf(key, row, FBUtilities.nowInSeconds());
             target.index(key, row.clustering(), value, memtable, opGroup);
         }
-        indexMetrics.memtableIndexWriteLatency.update(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+        if (indexMetrics != null)
+            indexMetrics.memtableIndexWriteLatency.update(System.nanoTime() - start, TimeUnit.NANOSECONDS);
     }
 
     /**
@@ -690,8 +690,10 @@ public class IndexContext
         dropped = true;
         liveMemtables.clear();
         viewManager.invalidate(obsolete);
-        indexMetrics.release();
-        columnQueryMetrics.release();
+        if (indexMetrics != null)
+            indexMetrics.release();
+        if (columnQueryMetrics != null)
+            columnQueryMetrics.release();
 
         analyzerFactory.close();
         if (queryAnalyzerFactory != analyzerFactory)

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/MemtableIndexWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/MemtableIndexWriter.java
@@ -138,7 +138,8 @@ public class MemtableIndexWriter implements PerIndexWriter
         catch (Throwable t)
         {
             logger.error(perIndexComponents.logMessage("Error while flushing index {}"), t.getMessage(), t);
-            indexContext().getIndexMetrics().memtableIndexFlushErrors.inc();
+            if (indexContext().getIndexMetrics() != null)
+                indexContext().getIndexMetrics().memtableIndexFlushErrors.inc();
 
             throw t;
         }
@@ -263,7 +264,8 @@ public class MemtableIndexWriter implements PerIndexWriter
     {
         perIndexComponents.markComplete();
 
-        indexContext().getIndexMetrics().memtableIndexFlushCount.inc();
+        if (indexContext().getIndexMetrics() != null)
+            indexContext().getIndexMetrics().memtableIndexFlushCount.inc();
 
         long elapsedTime = stopwatch.elapsed(TimeUnit.MILLISECONDS);
 
@@ -273,6 +275,7 @@ public class MemtableIndexWriter implements PerIndexWriter
                      elapsedTime - startTime,
                      elapsedTime);
 
-        indexContext().getIndexMetrics().memtableFlushCellsPerSecond.update((long) (cellCount * 1000.0 / Math.max(1, elapsedTime - startTime)));
+        if (indexContext().getIndexMetrics() != null)
+            indexContext().getIndexMetrics().memtableFlushCellsPerSecond.update((long) (cellCount * 1000.0 / Math.max(1, elapsedTime - startTime)));
     }
 }

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/SSTableIndexWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/SSTableIndexWriter.java
@@ -352,7 +352,8 @@ public class SSTableIndexWriter implements PerIndexWriter
             logger.error("Failed to build index for SSTable {}", perIndexComponents.descriptor(), t);
             perIndexComponents.forceDeleteAllComponents();
 
-            indexContext.getIndexMetrics().segmentFlushErrors.inc();
+            if (indexContext.getIndexMetrics() != null)
+                indexContext.getIndexMetrics().segmentFlushErrors.inc();
 
             throw t;
         }

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -378,8 +378,10 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
                 queriedIndexesContexts.add(indexContext);
             return Plan.ControlFlow.Continue;
         });
-        queriedIndexesContexts.forEach(indexContext ->
-                                       indexContext.getIndexMetrics().queriesCount.inc());
+        queriedIndexesContexts.forEach(indexContext -> {
+            if (indexContext.getIndexMetrics() != null)
+                indexContext.getIndexMetrics().queriesCount.inc();
+        });
     }
 
     Plan buildPlan()


### PR DESCRIPTION


### What is the issue
...
We want to be able to enable/disable IndexMetrics

### What does this PR fix and why was it fixed
...
We add a flag to be able to do that - `SAI_INDEX_METRICS_ENABLED("cassandra.sai.metrics.index.enabled", "true")`
Also, added some simple unit tests to test the new parameter.