### PR TITLE
CNDB-15519 test BM25 after compaction too

### DIFF
--- a/test/unit/org/apache/cassandra/index/sai/cql/BM25Test.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/BM25Test.java
@@ -797,7 +797,7 @@ public class BM25Test extends SAITester
         analyzeDataset("climate");
         analyzeDataset("health");
 
-        beforeAndAfterFlush(
+        runThenFlushThenCompact(
         () -> {
             executeQuery(CLIMATE_QUERY_RESULTS, "SELECT * FROM %s  ORDER BY body BM25 OF ? LIMIT 10",
                          "climate");


### PR DESCRIPTION

### What is the issue

Fixes https://github.com/riptano/cndb/issues/15519
Compaction might write SAI differently than flush, thus it's good to have tests running after compaction.

### What does this PR fix and why was it fixed

Changes to use runThenFlushThenCompact instead of beforeAndAfterFlush in BM25 test. Another test already tests after compaction in addition to memtable and after flush.
