### PR TITLE
CNDB-15485: Fix PrimaryKeyWithSource comparisons

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
@@ -27,7 +27,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.PriorityQueue;
 import java.util.Queue;
 import java.util.function.Supplier;
@@ -308,17 +307,6 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
             return key;
         }
 
-        private boolean isEqualToLastKey(PrimaryKey key)
-        {
-            // We don't want key.equals(lastKey) because some PrimaryKey implementations consider more than just
-            // partition key and clustering for equality. This can break lastKey skipping, which is necessary for
-            // correctness when PrimaryKey doesn't have a clustering (as otherwise, the same partition may get
-            // filtered and considered as a result multiple times).
-            return lastKey != null &&
-                   Objects.equals(lastKey.partitionKey(), key.partitionKey()) &&
-                   Objects.equals(lastKey.clustering(), key.clustering());
-        }
-
         private void fillNextSelectedKeysInPartition(DecoratedKey partitionKey, List<PrimaryKey> nextPrimaryKeys)
         {
             while (operation.hasNext()
@@ -330,7 +318,7 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
                 if (key == null)
                     break;
 
-                if (!controller.selects(key) || isEqualToLastKey(key))
+                if (!controller.selects(key) || key.equals(lastKey))
                     continue;
 
                 nextPrimaryKeys.add(key);
@@ -359,7 +347,7 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
                 if (firstKey == null)
                     return Collections.emptyList();
             }
-            while (!controller.selects(firstKey) || isEqualToLastKey(firstKey));
+            while (!controller.selects(firstKey) || firstKey.equals(lastKey));
 
             lastKey = firstKey;
             threadLocalNextKeys.add(firstKey);


### PR DESCRIPTION
We should not take the quick path and compare rowIds
between keys with no clustering, because rowIds may
differ for the keys within the same partition.
