### PR TITLE
CNDB-15526: Load TOC component before performing component discovery

### DIFF
--- a/src/java/org/apache/cassandra/io/sstable/metadata/MetadataSerializer.java
+++ b/src/java/org/apache/cassandra/io/sstable/metadata/MetadataSerializer.java
@@ -348,8 +348,6 @@ public class MetadataSerializer implements IMetadataSerializer
         }
         
         File compressionFile = desc.fileFor(Components.COMPRESSION_INFO);
-        if (!compressionFile.exists())
-            return null;
 
         try
         {
@@ -364,10 +362,12 @@ public class MetadataSerializer implements IMetadataSerializer
                 return compressor.encryptionOnly();
             return null;
         }
-        catch (Exception e)
+        catch (Throwable t)
         {
-            // If we can't read the compression metadata, assume no encryption
-            logger.debug("Could not read compression metadata for {}: {}", desc, e.getMessage());
+            // If we can't read the compression metadata, assume no encryption.
+            // During flush, the compression file may not be accessible yet in some implementations
+            // causing FSReadError. Catch Throwable to handle both Exception and Error.
+            logger.debug("Could not read compression metadata for {}: {}", desc, t.getMessage());
             return null;
         }
     }


### PR DESCRIPTION
### What is the issue

TOCComponent performs component discovery before loading the TOC. This can be detrimental to custom component loading and can be optimized to try loading the TOC directly first before resorting to discovery.

### What does this PR fix and why was it fixed

Load the TOC component without discovery if possible
