### PR TITLE
CNDB-15537: GuardrailsConfig validates

### DIFF
--- a/src/java/org/apache/cassandra/config/GuardrailsOptions.java
+++ b/src/java/org/apache/cassandra/config/GuardrailsOptions.java
@@ -76,6 +76,7 @@ public class GuardrailsOptions implements GuardrailsConfig
     public GuardrailsOptions(Config config)
     {
         this.config = config;
+        validate();
     }
 
     /**


### PR DESCRIPTION
### What is the issue
GuardrailsOptions never calls validate() on the configuration so exceptions aren't thrown, which breaks the GuardrailsConfigUpdaterTest

### What does this PR fix and why was it fixed
Calls validate(), fixes #15537
