### PR TITLE
Revert CNDB-11311, except TOCComponent

### DIFF
--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
@@ -85,6 +85,7 @@ import org.apache.cassandra.io.sstable.KeyReader;
 import org.apache.cassandra.io.sstable.SSTable;
 import org.apache.cassandra.io.sstable.SSTableIdentityIterator;
 import org.apache.cassandra.io.sstable.SSTableReadsListener;
+import org.apache.cassandra.io.sstable.SSTableWatcher;
 import org.apache.cassandra.io.sstable.format.SSTableFormat.Components;
 import org.apache.cassandra.io.sstable.metadata.CompactionMetadata;
 import org.apache.cassandra.io.sstable.metadata.StatsMetadata;
@@ -446,6 +447,7 @@ public abstract class SSTableReader extends SSTable implements UnfilteredSource,
                                      boolean validate,
                                      boolean isOffline)
     {
+        components = SSTableWatcher.instance.discoverComponents(descriptor, components);
         SSTableReaderLoadingBuilder<?, ?> builder = descriptor.getFormat().getReaderFactory().loadingBuilder(descriptor, metadata, components);
 
         return builder.build(owner, validate, !isOffline);


### PR DESCRIPTION
### What is the issue
Fixes CNDB-15569

### What does this PR fix and why was it fixed
Reverts most of CNDB-11311 that was not necessary and caused problems in CNDB due to changes in where and when `SSTableWatcher.instance.discoverComponents` is called.
