### PR TITLE
CNDB-15570: Fix handling of mixed file formats in SAI queries

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -844,7 +844,7 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
         "PrimaryKey " + firstKey + " clustering does not match table. There should be a clustering of size " + cfs.metadata().comparator.size();
 
         ClusteringIndexFilter clusteringIndexFilter = command.clusteringIndexFilter(firstKey.partitionKey());
-        if (cfs.metadata().comparator.size() == 0 || firstKey.hasEmptyClustering())
+        if (cfs.metadata().comparator.size() == 0 || firstKey.hasEmptyClustering() || !indexFeatureSet.isRowAware())
         {
             return clusteringIndexFilter;
         }

--- a/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
@@ -345,7 +345,7 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
             // filtered and considered as a result multiple times).
             return lastKey != null &&
                    Objects.equals(lastKey.partitionKey(), key.partitionKey()) &&
-                   Objects.equals(lastKey.clustering(), key.clustering());
+                   (!controller.indexFeatureSet().isRowAware() || Objects.equals(lastKey.clustering(), key.clustering()));
         }
 
         private void fillNextSelectedKeysInPartition(DecoratedKey partitionKey, List<PrimaryKey> nextPrimaryKeys)
@@ -392,7 +392,10 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
 
             lastKey = firstKey;
             threadLocalNextKeys.add(firstKey);
-            fillNextSelectedKeysInPartition(firstKey.partitionKey(), threadLocalNextKeys);
+            // Only makes sense to pull in keys when we're row aware. Notably, we also modified isEqualToLastKey so
+            // that the behavior branches when row aware or not.
+            if (controller.indexFeatureSet().isRowAware())
+                fillNextSelectedKeysInPartition(firstKey.partitionKey(), threadLocalNextKeys);
             return threadLocalNextKeys;
         }
 

--- a/test/unit/org/apache/cassandra/index/sai/cql/NumericIndexMixedVersionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/NumericIndexMixedVersionTest.java
@@ -56,7 +56,7 @@ public class NumericIndexMixedVersionTest extends SAITester
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
 
         // Note that we do not test the multi-version path where compaction produces different sstables, which is
-        // the norm in CNDB. If we had a way to compact individual sstables, we could.
+        // the norm in CNDB. If we had a way to compnact individual sstables, we could.
         disableCompaction();
 
         SAIUtil.setCurrentVersion(Version.AA);

--- a/test/unit/org/apache/cassandra/index/sai/cql/NumericIndexMixedVersionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/NumericIndexMixedVersionTest.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.cql;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+
+import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.index.sai.SAITester;
+import org.apache.cassandra.index.sai.SAIUtil;
+import org.apache.cassandra.index.sai.disk.format.Version;
+
+import static org.junit.Assert.assertEquals;
+
+public class NumericIndexMixedVersionTest extends SAITester
+{
+    // Versions in random order
+    final static List<Version> VERSIONS = getVersions();
+
+    private static List<Version> getVersions()
+    {
+        var versions = new ArrayList<>(Version.ALL);
+        Collections.reverse(versions);
+        // AA is the earliest version and produces different data for flush vs compaction, so we have
+        // special logic to hit that and make this first.
+        assert versions.get(0).equals(Version.AA);
+        logger.info("Running mixed version test with versions: {}", versions);
+        return versions;
+    }
+
+
+    // This test does not trigger an issue. It simply confirms that we can query across versions.
+    @Test
+    public void testMultiVersionCompatibilityNoClusteringColumns() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, val int, PRIMARY KEY(pk))");
+        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+
+        // Note that we do not test the multi-version path where compaction produces different sstables, which is
+        // the norm in CNDB. If we had a way to compact individual sstables, we could.
+        disableCompaction();
+
+        SAIUtil.setCurrentVersion(Version.AA);
+        for (int j = 0; j < 500; j++)
+            execute("INSERT INTO %s (pk, val) VALUES (?, ?)", j, j);
+        flush();
+        compact();
+
+        // Insert 500 rows per version, each with a unique pk but overlapping values.
+        int pk = 0;
+        for (var version : VERSIONS)
+        {
+            SAIUtil.setCurrentVersion(version);
+            for (int i = 0; i < 500; i++)
+                execute("INSERT INTO %s (pk, val) VALUES (?, ?)", pk++, i);
+            flush();
+        }
+
+        // Confirm that compaction (aka rebuilding all indexes onto same version) also produces correct results
+        final int expectedRows = pk;
+        runThenFlushThenCompact(() -> {
+            var batchLimit = CassandraRelevantProperties.SAI_PARTITION_ROW_BATCH_SIZE.getInt();
+            // Query that will hit all sstables and exceed the cassandra.sai.partition_row_batch_size limit
+            var rows = executeNetWithPaging("SELECT pk FROM %s WHERE val >= 0 LIMIT 10000", batchLimit / 2);
+            assertEquals(expectedRows, rows.all().size());
+
+            rows = executeNetWithPaging("SELECT pk FROM %s WHERE val >= 0 LIMIT 10000", batchLimit);
+            assertEquals(expectedRows, rows.all().size());
+
+            rows = executeNetWithPaging("SELECT pk FROM %s WHERE val >= 0 LIMIT 10000", batchLimit * 2);
+            assertEquals(expectedRows, rows.all().size());
+
+            // Test without paging
+            assertNumRows(expectedRows, "SELECT pk FROM %%s WHERE val >= 0 LIMIT 10000");
+        });
+    }
+
+    @Test
+    public void testMultiVersionCompatibilityWithClusteringColumns() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck int, val int, PRIMARY KEY(pk, ck)) WITH CLUSTERING ORDER BY (ck ASC)");
+        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+
+        // Note that we do not test the multi-version path where compaction produces different sstables, which is
+        // the norm in CNDB. If we had a way to compact individual sstables, we could.
+        disableCompaction();
+
+        SAIUtil.setCurrentVersion(Version.AA);
+        int ck = 0;
+        for (int j = 0; j < 500; j++)
+            execute("INSERT INTO %s (pk, ck, val) VALUES (1, ?, ?)", ck++, j);
+        flush();
+        compact();
+
+        // Insert 500 rows per version
+        for (var version : VERSIONS)
+        {
+            SAIUtil.setCurrentVersion(version);
+            for (int j = 0; j < 500; j++)
+                execute("INSERT INTO %s (pk, ck, val) VALUES (1, ?, ?)", ck++, j);
+            flush();
+        }
+
+        // Confirm that compaction (aka rebuilding all indexes onto same version) also produces correct results
+        final int expectedRows = ck;
+        runThenFlushThenCompact(() -> {
+            // When using paging, we get an excessive number of results because of logic within the contoller.select
+            // method that short circuits when one of the indexes is aa (not row aware).
+            var batchLimit = CassandraRelevantProperties.SAI_PARTITION_ROW_BATCH_SIZE.getInt();
+            var rows = executeNetWithPaging("SELECT ck FROM %s WHERE val >= 0 LIMIT 10000", batchLimit / 2);
+            assertEquals(expectedRows, rows.all().size());
+
+            rows = executeNetWithPaging("SELECT ck FROM %s WHERE val >= 0 LIMIT 10000", batchLimit);
+            assertEquals(expectedRows, rows.all().size());
+
+            rows = executeNetWithPaging("SELECT ck FROM %s WHERE val >= 0 LIMIT 10000", batchLimit * 2);
+            assertEquals(expectedRows, rows.all().size());
+
+            // Test without paging. This test actually fails by producing fewer than expected rows because of an issue in
+            // partition-only primary keys and row aware primary keys that are considered equal. When they are unioned
+            // in the iterator, we take one and leave the other (they evaluate to equal after all) but this behavior
+            // filters out a result that would have loaded the whole partition and might have returned a unique result.
+            assertNumRows(expectedRows, "SELECT ck FROM %%s WHERE val >= 0 LIMIT 10000");
+        });
+    }
+
+}


### PR DESCRIPTION
- **CNDB-15570: Reproducer**
- **Only use partitions in ResultRetriever if index not row aware**

### What is the issue
Fixes: https://github.com/riptano/cndb/issues/15570

### What does this PR fix and why was it fixed
This PR fixes two bugs.

First, we can produce the same result set when paging over a table with clustering columns that has mixed index versions of `aa` and some other sai file format (doesn't matter). This happens because of the logic in this method, which is used to determine whether to admit a primary key into the clustering key filter.

```java
    public boolean selects(PrimaryKey key)
    {
        return !indexFeatureSet.isRowAware() ||
               key.hasEmptyClustering() ||
               command.clusteringIndexFilter(key.partitionKey()).selects(key.clustering());
    }
```

When an `aa` index is present, `!indexFeatureSet.isRowAware()` evaluates to true for all keys coming out of the iterator. This is the correct behavior for keys made by `aa` since they do not have clustering columns and fetch the whole partition. But when we have clustering columns, a primary key points to a specific row and we need to utilize the `clusteringIndexFilter` to filter out rows that are not selected. This specifically matters when paging because paging utilizes the `clusteringIndexFilter` to skip the first group of rows already returned. As a result, we fill up the batch of keys to use in the clustering filter and then get them here:

```java
        ClusteringIndexFilter clusteringIndexFilter = command.clusteringIndexFilter(firstKey.partitionKey());
        if (cfs.metadata().comparator.size() == 0 || firstKey.hasEmptyClustering())
        {
            return clusteringIndexFilter;
        }
        else
        {
            nextClusterings.clear();
            for (PrimaryKey key : keys)
                nextClusterings.add(key.clustering());
            return new ClusteringIndexNamesFilter(nextClusterings, clusteringIndexFilter.isReversed());
        }
```

Note that this bug is actually somewhat flaky because it is possible that a primary key from the `aa` index is the `firstKey`, and if that is the case, then `firstKey.hasEmptyClustering()` is true and we use the proper `clusteringIndexFilter`. If it isn't, we hit the `else` branch and filter based on the `keys` that were included incorrectly in the above `selects` method.

Thus, we repeatedly produce the same rows with each call to page. This bug was introduced by https://github.com/datastax/cassandra/pull/1883.

Second, we have had a long standing issue where primary keys are considered equal in the event that they have the same partition key but one is missing a clustering column. As a result, the union within the SAI iterator can filter out the partition only primary key, which would have iterated the whole partition to find matches. When this `aa` produced primary key is filtered out, we produce fewer rows than expected. Again, this is flaky because it isn't deterministic which key "wins" when merging iterators.

Because of this second bug, it is not sufficient to revert #1883.

### Solution

My second commit is a proposed solution. I am not necessarily happy with it. It is not well abstracted and feels quite fragile. It seems that in the case where there is an `aa` index in the query view, we should only ever load primary keys with partitions, and then the logic would be simpler. However, such a change would be much more invasive.

### Note on testing reproductions

Note that compaction produces a different kind of index for `aa` than flush, which is why my tests have two `aa` indexes. It is actually possible that the compacted `aa` index makes it easier to hit this bug (haven't confirmed) which may explain why this one was elusive.

### Not Fixed
Note that https://github.com/riptano/cndb/issues/14198 can result in an incorrect index feature set object. However, the race here is benign as long as we're willing to assume that we always start not row aware and then become row aware.