### PR TITLE
CNDB-15609 test SAI disk size for all versions

### DIFF
--- a/test/unit/org/apache/cassandra/index/sai/functional/SaiDiskSizeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/functional/SaiDiskSizeTest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.functional;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.net.UnknownHostException;
+import java.nio.ByteBuffer;
+import java.util.Collection;
+import java.util.Date;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.cassandra.index.sai.SAITester;
+import org.apache.cassandra.index.sai.SAIUtil;
+import org.apache.cassandra.index.sai.disk.format.Version;
+import org.apache.cassandra.locator.InetAddressAndPort;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(Parameterized.class)
+public class SaiDiskSizeTest extends SAITester
+{
+    private static final Logger logger = LoggerFactory.getLogger(SaiDiskSizeTest.class);
+
+    @Parameterized.Parameter
+    public Version version;
+
+    @Parameterized.Parameter(1)
+    public int size;
+
+    @Parameterized.Parameter(2)
+    public String pkSuffix;
+
+    @Parameterized.Parameter(3)
+    public int rowsPerPartition;
+
+    @Parameterized.Parameters(name = "{0}, size={1}, pk={2}, partitionSize={3}")
+    public static Collection<Object[]> data()
+    {
+        return Version.ALL.stream()
+                          .flatMap(v -> {
+                              switch (v.toString())
+                              {
+                                  case "aa":
+                                      return Stream.of(
+                                      new Object[]{ v, 13014, "pk", 1 },
+                                      new Object[]{ v, 13016, "pk, v_int", 2 },
+                                      new Object[]{ v, 14266, "pk, v_int", 100 });
+                                  case "ba":
+                                  case "ca":
+                                  case "db":
+                                  case "dc":
+                                      return Stream.of(
+                                      new Object[]{ v, 65734, "pk", 1 },
+                                      new Object[]{ v, 57627, "pk, v_int", 2 },
+                                      new Object[]{ v, 28004, "pk, v_int", 100 });
+                                  case "eb":
+                                  case "ec":
+                                      return Stream.of(
+                                      new Object[]{ v, 67370, "pk", 1 },
+                                      new Object[]{ v, 59263, "pk, v_int", 2 },
+                                      new Object[]{ v, 29640, "pk, v_int", 100 });
+                                  case "ed":
+                                      return Stream.of(
+                                      new Object[]{ v, 67378, "pk", 1 },
+                                      new Object[]{ v, 59271, "pk, v_int", 2 },
+                                      new Object[]{ v, 29648, "pk, v_int", 100 });
+                                  default:
+                                      return // A new version assumes the latest size by default
+                                      Stream.of(
+                                      new Object[]{ v, 67378, "pk", 1 },
+                                      new Object[]{ v, 59271, "pk, v_int", 2 },
+                                      new Object[]{ v, 29648, "pk, v_int", 100 });
+                              }
+                          })
+                          .collect(Collectors.toList());
+    }
+
+    @Before
+    public void setVersion()
+    {
+        SAIUtil.setCurrentVersion(version);
+    }
+
+    @Test
+    public void testIndexDiskSizeAcrossVersions() throws UnknownHostException
+    {
+        createTable("CREATE TABLE %s (" +
+                    "pk int, " +
+                    "v_ascii ascii, " +
+                    "v_bigint bigint, " +
+                    "v_blob blob, " +
+                    "v_boolean boolean, " +
+                    "v_decimal decimal, " +
+                    "v_double double, " +
+                    "v_float float, " +
+                    "v_int int, " +
+                    "v_text text, " +
+                    "v_timestamp timestamp, " +
+                    "v_uuid uuid, " +
+                    "v_varchar varchar, " +
+                    "v_varint varint, " +
+                    "v_timeuuid timeuuid, " +
+                    "v_inet inet, " +
+                    "v_date date, " +
+                    "v_time time, " +
+                    "v_smallint smallint, " +
+                    "v_tinyint tinyint, " +
+                    "v_duration duration, " +
+                    "PRIMARY KEY (" + pkSuffix + "))");
+
+        verifyNoIndexFiles();
+        createIndex("CREATE CUSTOM INDEX ON %s(v_int) USING 'StorageAttachedIndex'");
+
+        waitForTableIndexesQueryable();
+
+        // Split data into 2 sstable segments
+        insertRows(0, 1000);
+        flush();
+        insertRows(1000, 1000);
+        flush();
+
+        long diskSize = indexDiskSpaceUse();
+        logger.info("SAI Version: {}, Index Disk Size: {} bytes", version, diskSize);
+        assertThat(diskSize)
+        .as("Disk size for SAI version %s", version)
+        .isLessThanOrEqualTo(size);
+
+        compact();
+
+        diskSize = indexDiskSpaceUse();
+        logger.info("SAI Version: {}, Index Disk Size: {} bytes", version, diskSize);
+        assertThat(diskSize)
+        .as("Disk size for SAI version %s", version)
+        .isLessThanOrEqualTo(size);
+    }
+
+    private void insertRows(int size, int start) throws UnknownHostException
+    {
+        for (int i = start; i < start + size; i++)
+        {
+            execute("INSERT INTO %s (pk, v_ascii, v_bigint, v_blob, v_boolean, v_decimal, " +
+                    "v_double, v_float, v_int, v_text, v_timestamp, v_uuid, v_varchar, " +
+                    "v_varint, v_timeuuid, v_inet, v_date, v_time, v_smallint, v_tinyint, v_duration) " +
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    i % (size / rowsPerPartition), // Have 2 rows per partition
+                    "ascii_" + i,
+                    (long) i * 1000000,
+                    ByteBuffer.wrap(("blob_" + i).getBytes()),
+                    i % 2 == 0,
+                    new BigDecimal(i + ".123"),
+                    i * 1.5,
+                    (float) (i * 2.5),
+                    i * 2,
+                    "text_value_" + i,
+                    new Date(System.currentTimeMillis() + i * 1000L),
+                    UUID.randomUUID(),
+                    "varchar_" + i,
+                    BigInteger.valueOf(i).multiply(BigInteger.valueOf(100)),
+                    UUID.fromString("00000000-0000-1000-8000-" +
+                                    String.format("%012d", i)),
+                    InetAddressAndPort.getByName("127.0.0." + (i % 256)).address,
+                    i + 1,
+                    (long) i * 1000000000L,
+                    (short) (i % 32767),
+                    (byte) (i % 128),
+                    org.apache.cassandra.cql3.Duration.newInstance(i % 12, i % 30, i * 1000000000L)
+            );
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/functional/SaiDiskSizeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/functional/SaiDiskSizeTest.java
@@ -147,7 +147,8 @@ public class SaiDiskSizeTest extends SAITester
         logger.info("SAI Version: {}, Index Disk Size: {} bytes", version, diskSize);
         assertThat(diskSize)
         .as("Disk size for SAI version %s", version)
-        .isLessThanOrEqualTo(size);
+        .isLessThanOrEqualTo(size)
+        .isGreaterThan((long) (size * 0.8));
 
         compact();
 
@@ -155,7 +156,8 @@ public class SaiDiskSizeTest extends SAITester
         logger.info("SAI Version: {}, Index Disk Size: {} bytes", version, diskSize);
         assertThat(diskSize)
         .as("Disk size for SAI version %s", version)
-        .isLessThanOrEqualTo(size);
+        .isLessThanOrEqualTo(size)
+        .isGreaterThan((long) (size * 0.8));
     }
 
     private void insertRows(int size, int start) throws UnknownHostException

--- a/test/unit/org/apache/cassandra/index/sai/functional/SaiDiskSizeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/functional/SaiDiskSizeTest.java
@@ -30,8 +30,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.index.sai.SAITester;
 import org.apache.cassandra.index.sai.SAIUtil;
@@ -43,21 +41,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 @RunWith(Parameterized.class)
 public class SaiDiskSizeTest extends SAITester
 {
-    private static final Logger logger = LoggerFactory.getLogger(SaiDiskSizeTest.class);
-
     @Parameterized.Parameter
     public Version version;
 
     @Parameterized.Parameter(1)
-    public int size;
+    public int expectedDiskSize;
 
     @Parameterized.Parameter(2)
-    public String pkSuffix;
+    public String pkColumns;
 
     @Parameterized.Parameter(3)
     public int rowsPerPartition;
 
-    @Parameterized.Parameters(name = "{0}, size={1}, pk={2}, partitionSize={3}")
+    @Parameterized.Parameters(name = "saiFormat={0}, expectedDiskSize={1}, pkColumns={2}, partitionSize={3}")
     public static Collection<Object[]> data()
     {
         return Version.ALL.stream()
@@ -66,34 +62,30 @@ public class SaiDiskSizeTest extends SAITester
                               {
                                   case "aa":
                                       return Stream.of(
-                                      new Object[]{ v, 13014, "pk", 1 },
-                                      new Object[]{ v, 13016, "pk, v_int", 2 },
-                                      new Object[]{ v, 14266, "pk, v_int", 100 });
+                                      new Object[]{ v, 24991, "pk", 1 },
+                                      new Object[]{ v, 26183, "pk, v_int", 2 },
+                                      new Object[]{ v, 28530, "pk, v_int", 100 });
                                   case "ba":
                                   case "ca":
                                   case "db":
                                   case "dc":
                                       return Stream.of(
-                                      new Object[]{ v, 65734, "pk", 1 },
-                                      new Object[]{ v, 57627, "pk, v_int", 2 },
-                                      new Object[]{ v, 28004, "pk, v_int", 100 });
+                                      new Object[]{ v, 131493, "pk", 1 },
+                                      new Object[]{ v, 115252, "pk, v_int", 2 },
+                                      new Object[]{ v, 55996, "pk, v_int", 100 });
                                   case "eb":
                                   case "ec":
                                       return Stream.of(
-                                      new Object[]{ v, 67370, "pk", 1 },
-                                      new Object[]{ v, 59263, "pk, v_int", 2 },
-                                      new Object[]{ v, 29640, "pk, v_int", 100 });
+                                      new Object[]{ v, 134765, "pk", 1 },
+                                      new Object[]{ v, 118524, "pk, v_int", 2 },
+                                      new Object[]{ v, 59268, "pk, v_int", 100 });
                                   case "ed":
-                                      return Stream.of(
-                                      new Object[]{ v, 67378, "pk", 1 },
-                                      new Object[]{ v, 59271, "pk, v_int", 2 },
-                                      new Object[]{ v, 29648, "pk, v_int", 100 });
+                                  case "fa":
                                   default:
-                                      return // A new version assumes the latest size by default
-                                      Stream.of(
-                                      new Object[]{ v, 67378, "pk", 1 },
-                                      new Object[]{ v, 59271, "pk, v_int", 2 },
-                                      new Object[]{ v, 29648, "pk, v_int", 100 });
+                                      return Stream.of(
+                                      new Object[]{ v, 134781, "pk", 1 },
+                                      new Object[]{ v, 118540, "pk, v_int", 2 },
+                                      new Object[]{ v, 59284, "pk, v_int", 100 });
                               }
                           })
                           .collect(Collectors.toList());
@@ -110,6 +102,7 @@ public class SaiDiskSizeTest extends SAITester
     {
         createTable("CREATE TABLE %s (" +
                     "pk int, " +
+                    "v_int int, " +
                     "v_ascii ascii, " +
                     "v_bigint bigint, " +
                     "v_blob blob, " +
@@ -117,7 +110,6 @@ public class SaiDiskSizeTest extends SAITester
                     "v_decimal decimal, " +
                     "v_double double, " +
                     "v_float float, " +
-                    "v_int int, " +
                     "v_text text, " +
                     "v_timestamp timestamp, " +
                     "v_uuid uuid, " +
@@ -130,7 +122,7 @@ public class SaiDiskSizeTest extends SAITester
                     "v_smallint smallint, " +
                     "v_tinyint tinyint, " +
                     "v_duration duration, " +
-                    "PRIMARY KEY (" + pkSuffix + "))");
+                    "PRIMARY KEY (" + pkColumns + "))");
 
         verifyNoIndexFiles();
         createIndex("CREATE CUSTOM INDEX ON %s(v_int) USING 'StorageAttachedIndex'");
@@ -138,37 +130,36 @@ public class SaiDiskSizeTest extends SAITester
         waitForTableIndexesQueryable();
 
         // Split data into 2 sstable segments
-        insertRows(0, 1000);
+        insertRows(1000, 0);
         flush();
         insertRows(1000, 1000);
         flush();
 
         long diskSize = indexDiskSpaceUse();
-        logger.info("SAI Version: {}, Index Disk Size: {} bytes", version, diskSize);
         assertThat(diskSize)
-        .as("Disk size for SAI version %s", version)
-        .isLessThanOrEqualTo(size)
-        .isGreaterThan((long) (size * 0.8));
+        .as("Disk size for SAI version %s before compaction", version)
+        .isLessThanOrEqualTo(expectedDiskSize)
+        .isGreaterThan((long) (expectedDiskSize * 0.8));
 
         compact();
 
         diskSize = indexDiskSpaceUse();
-        logger.info("SAI Version: {}, Index Disk Size: {} bytes", version, diskSize);
         assertThat(diskSize)
-        .as("Disk size for SAI version %s", version)
-        .isLessThanOrEqualTo(size)
-        .isGreaterThan((long) (size * 0.8));
+        .as("Disk size for SAI version %s after compaction", version)
+        .isLessThanOrEqualTo(expectedDiskSize)
+        .isGreaterThan((long) (expectedDiskSize * 0.8));
     }
 
     private void insertRows(int size, int start) throws UnknownHostException
     {
         for (int i = start; i < start + size; i++)
         {
-            execute("INSERT INTO %s (pk, v_ascii, v_bigint, v_blob, v_boolean, v_decimal, " +
-                    "v_double, v_float, v_int, v_text, v_timestamp, v_uuid, v_varchar, " +
+            execute("INSERT INTO %s (pk, v_int, v_ascii, v_bigint, v_blob, v_boolean, " +
+                    "v_decimal, v_double, v_float, v_text, v_timestamp, v_uuid, v_varchar, " +
                     "v_varint, v_timeuuid, v_inet, v_date, v_time, v_smallint, v_tinyint, v_duration) " +
                     "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                    i % (size / rowsPerPartition), // Have 2 rows per partition
+                    start + i % (size / rowsPerPartition),
+                    i,
                     "ascii_" + i,
                     (long) i * 1000000,
                     ByteBuffer.wrap(("blob_" + i).getBytes()),
@@ -176,7 +167,6 @@ public class SaiDiskSizeTest extends SAITester
                     new BigDecimal(i + ".123"),
                     i * 1.5,
                     (float) (i * 2.5),
-                    i * 2,
                     "text_value_" + i,
                     new Date(System.currentTimeMillis() + i * 1000L),
                     UUID.randomUUID(),

--- a/test/unit/org/apache/cassandra/index/sai/functional/SaiDiskSizeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/functional/SaiDiskSizeTest.java
@@ -53,7 +53,7 @@ public class SaiDiskSizeTest extends SAITester
     public Version saiFormat;
 
     @Parameterized.Parameter(1)
-    public int expectedDiskSize;
+    public int expectedDiskSizeFor2SSTables;
 
     @Parameterized.Parameter(2)
     public String pkColumns;
@@ -68,7 +68,7 @@ public class SaiDiskSizeTest extends SAITester
      *
      * @return a collection of parameters to test
      */
-    @Parameterized.Parameters(name = "saiFormat={0}, expectedDiskSize={1}, pkColumns={2}, rowsPerPartition={3}")
+    @Parameterized.Parameters(name = "saiFormat={0}, expectedDiskSizeFor2SSTables={1}, pkColumns={2}, rowsPerPartition={3}")
     public static Collection<Object[]> generateParameters()
     {
         return Version.ALL.stream()
@@ -154,16 +154,16 @@ public class SaiDiskSizeTest extends SAITester
         logger.info("Disk size for SAI version {}: {}", saiFormat, diskSize);
         assertThat(diskSize)
         .as("Disk size for SAI version %s before compaction", saiFormat)
-        .isLessThanOrEqualTo(expectedDiskSize)
-        .isGreaterThan((long) (expectedDiskSize * 0.8));
+        .isLessThanOrEqualTo(expectedDiskSizeFor2SSTables)
+        .isGreaterThan((long) (expectedDiskSizeFor2SSTables * 0.8));
 
         compact();
 
         diskSize = indexDiskSpaceUse();
         assertThat(diskSize)
         .as("Disk size for SAI version %s after compaction", saiFormat)
-        .isLessThanOrEqualTo(expectedDiskSize)
-        .isGreaterThan((long) (expectedDiskSize * 0.8));
+        .isLessThanOrEqualTo(expectedDiskSizeFor2SSTables)
+        .isGreaterThan((long) (expectedDiskSizeFor2SSTables * 0.8));
     }
 
     private void insertRowsIntoOneSegment(int nrRows, int startRow) throws UnknownHostException

--- a/test/unit/org/apache/cassandra/index/sai/functional/SaiDiskSizeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/functional/SaiDiskSizeTest.java
@@ -46,6 +46,9 @@ public class SaiDiskSizeTest extends SAITester
 {
     private static final Logger logger = LoggerFactory.getLogger(SaiDiskSizeTest.class);
 
+    // Fixed base timestamp for deterministic test data (2024-01-01 00:00:00 UTC)
+    private static final long BASE_TIMESTAMP_MILLIS = 1704067200000L;
+
     @Parameterized.Parameter
     public Version saiFormat;
 
@@ -184,7 +187,7 @@ public class SaiDiskSizeTest extends SAITester
                     i * 1.5,
                     (float) (i * 2.5),
                     "text_value_" + i,
-                    new Date(System.currentTimeMillis() + i * 1000L),
+                    new Date(BASE_TIMESTAMP_MILLIS + i * 1000L),
                     UUID.randomUUID(),
                     "varchar_" + i,
                     BigInteger.valueOf(i).multiply(BigInteger.valueOf(100)),

--- a/test/unit/org/apache/cassandra/index/sai/functional/SaiDiskSizeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/functional/SaiDiskSizeTest.java
@@ -47,7 +47,7 @@ public class SaiDiskSizeTest extends SAITester
     private static final Logger logger = LoggerFactory.getLogger(SaiDiskSizeTest.class);
 
     @Parameterized.Parameter
-    public Version version;
+    public Version saiFormat;
 
     @Parameterized.Parameter(1)
     public int expectedDiskSize;
@@ -65,7 +65,7 @@ public class SaiDiskSizeTest extends SAITester
      *
      * @return a collection of parameters to test
      */
-    @Parameterized.Parameters(name = "saiFormat={0}, expectedDiskSize={1}, pkColumns={2}, partitionSize={3}")
+    @Parameterized.Parameters(name = "saiFormat={0}, expectedDiskSize={1}, pkColumns={2}, rowsPerPartition={3}")
     public static Collection<Object[]> generateParameters()
     {
         return Version.ALL.stream()
@@ -106,7 +106,7 @@ public class SaiDiskSizeTest extends SAITester
     @Before
     public void setVersion()
     {
-        SAIUtil.setCurrentVersion(version);
+        SAIUtil.setCurrentVersion(saiFormat);
     }
 
     @Test
@@ -148,9 +148,9 @@ public class SaiDiskSizeTest extends SAITester
         flush();
 
         long diskSize = indexDiskSpaceUse();
-        logger.info("Disk size for SAI version {}: {}", version, diskSize);
+        logger.info("Disk size for SAI version {}: {}", saiFormat, diskSize);
         assertThat(diskSize)
-        .as("Disk size for SAI version %s before compaction", version)
+        .as("Disk size for SAI version %s before compaction", saiFormat)
         .isLessThanOrEqualTo(expectedDiskSize)
         .isGreaterThan((long) (expectedDiskSize * 0.8));
 
@@ -158,7 +158,7 @@ public class SaiDiskSizeTest extends SAITester
 
         diskSize = indexDiskSpaceUse();
         assertThat(diskSize)
-        .as("Disk size for SAI version %s after compaction", version)
+        .as("Disk size for SAI version %s after compaction", saiFormat)
         .isLessThanOrEqualTo(expectedDiskSize)
         .isGreaterThan((long) (expectedDiskSize * 0.8));
     }
@@ -166,15 +166,15 @@ public class SaiDiskSizeTest extends SAITester
     private void insertRowsIntoOneSegment(int nrRows, int startRow) throws UnknownHostException
     {
         assert nrRows % rowsPerPartition == 0;
-        int partitionSize = nrRows / rowsPerPartition;
-        assert partitionSize > 0;
+        int nrOfPartitions = nrRows / rowsPerPartition;
+        assert nrOfPartitions > 0;
         for (int i = startRow; i < startRow + nrRows; i++)
         {
             execute("INSERT INTO %s (pk, v_int, v_ascii, v_bigint, v_blob, v_boolean, " +
                     "v_decimal, v_double, v_float, v_text, v_timestamp, v_uuid, v_varchar, " +
                     "v_varint, v_timeuuid, v_inet, v_date, v_time, v_smallint, v_tinyint, v_duration) " +
                     "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                    startRow + i % partitionSize, // StartRow allows starting new partitions for new segment
+                    startRow + i % nrOfPartitions, // StartRow allows starting new partitions for new segment
                     i,
                     "ascii_" + i,
                     (long) i * 1000000,

--- a/test/unit/org/apache/cassandra/index/sai/functional/SaiDiskSizeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/functional/SaiDiskSizeTest.java
@@ -31,6 +31,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import org.apache.cassandra.index.sai.SAITester;
 import org.apache.cassandra.index.sai.SAIUtil;
 import org.apache.cassandra.index.sai.disk.format.Version;
@@ -41,6 +44,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 @RunWith(Parameterized.class)
 public class SaiDiskSizeTest extends SAITester
 {
+    private static final Logger logger = LoggerFactory.getLogger(SaiDiskSizeTest.class);
+
     @Parameterized.Parameter
     public Version version;
 
@@ -53,8 +58,15 @@ public class SaiDiskSizeTest extends SAITester
     @Parameterized.Parameter(3)
     public int rowsPerPartition;
 
+    /**
+     * The expected sizes were determined empirically to satisfy the result of both flush and compaction.
+     * To understand the difference check {@link Version} and on disk components.
+     * There are no vectors involved, thus the expected sizes are not affected by chenges to Vector format.
+     *
+     * @return a collection of parameters to test
+     */
     @Parameterized.Parameters(name = "saiFormat={0}, expectedDiskSize={1}, pkColumns={2}, partitionSize={3}")
-    public static Collection<Object[]> data()
+    public static Collection<Object[]> generateParameters()
     {
         return Version.ALL.stream()
                           .flatMap(v -> {
@@ -129,13 +141,14 @@ public class SaiDiskSizeTest extends SAITester
 
         waitForTableIndexesQueryable();
 
-        // Split data into 2 sstable segments
-        insertRows(1000, 0);
+        // Split generateParameters into 2 sstable segments
+        insertRowsIntoOneSegment(1000, 0);
         flush();
-        insertRows(1000, 1000);
+        insertRowsIntoOneSegment(1000, 1000);
         flush();
 
         long diskSize = indexDiskSpaceUse();
+        logger.info("Disk size for SAI version {}: {}", version, diskSize);
         assertThat(diskSize)
         .as("Disk size for SAI version %s before compaction", version)
         .isLessThanOrEqualTo(expectedDiskSize)
@@ -150,15 +163,18 @@ public class SaiDiskSizeTest extends SAITester
         .isGreaterThan((long) (expectedDiskSize * 0.8));
     }
 
-    private void insertRows(int size, int start) throws UnknownHostException
+    private void insertRowsIntoOneSegment(int nrRows, int startRow) throws UnknownHostException
     {
-        for (int i = start; i < start + size; i++)
+        assert nrRows % rowsPerPartition == 0;
+        int partitionSize = nrRows / rowsPerPartition;
+        assert partitionSize > 0;
+        for (int i = startRow; i < startRow + nrRows; i++)
         {
             execute("INSERT INTO %s (pk, v_int, v_ascii, v_bigint, v_blob, v_boolean, " +
                     "v_decimal, v_double, v_float, v_text, v_timestamp, v_uuid, v_varchar, " +
                     "v_varint, v_timeuuid, v_inet, v_date, v_time, v_smallint, v_tinyint, v_duration) " +
                     "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                    start + i % (size / rowsPerPartition),
+                    startRow + i % partitionSize, // StartRow allows starting new partitions for new segment
                     i,
                     "ascii_" + i,
                     (long) i * 1000000,

--- a/test/unit/org/apache/cassandra/index/sai/functional/SaiDiskSizeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/functional/SaiDiskSizeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright DataStax, Inc.
+ * Copyright IBM Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/org/apache/cassandra/index/sai/functional/SaiDiskSizeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/functional/SaiDiskSizeTest.java
@@ -56,9 +56,12 @@ public class SaiDiskSizeTest extends SAITester
     public int expectedDiskSizeFor2SSTables;
 
     @Parameterized.Parameter(2)
-    public String pkColumns;
+    public int expectedDiskSizeForCompactedSSTable;
 
     @Parameterized.Parameter(3)
+    public String pkColumns;
+
+    @Parameterized.Parameter(4)
     public int rowsPerPartition;
 
     /**
@@ -68,7 +71,8 @@ public class SaiDiskSizeTest extends SAITester
      *
      * @return a collection of parameters to test
      */
-    @Parameterized.Parameters(name = "saiFormat={0}, expectedDiskSizeFor2SSTables={1}, pkColumns={2}, rowsPerPartition={3}")
+    @Parameterized.Parameters(name = "saiFormat={0}, expectedDiskSizeFor2SSTables={1}, " +
+                                     "expectedDiskSizeForCompactedSSTable={2}, pkColumns={3}, rowsPerPartition={4}")
     public static Collection<Object[]> generateParameters()
     {
         return Version.ALL.stream()
@@ -77,30 +81,30 @@ public class SaiDiskSizeTest extends SAITester
                               {
                                   case "aa":
                                       return Stream.of(
-                                      new Object[]{ v, 24991, "pk", 1 },
-                                      new Object[]{ v, 26183, "pk, v_int", 2 },
-                                      new Object[]{ v, 28530, "pk, v_int", 100 });
+                                      new Object[]{ v, 24766, 24989, "pk", 1 },
+                                      new Object[]{ v, 26026, 26181, "pk, v_int", 2 },
+                                      new Object[]{ v, 28526, 26603, "pk, v_int", 100 });
                                   case "ba":
                                   case "ca":
                                   case "db":
                                   case "dc":
                                       return Stream.of(
-                                      new Object[]{ v, 131493, "pk", 1 },
-                                      new Object[]{ v, 115252, "pk, v_int", 2 },
-                                      new Object[]{ v, 55996, "pk, v_int", 100 });
+                                      new Object[]{ v, 131489, 131312, "pk", 1 },
+                                      new Object[]{ v, 115177, 115009, "pk, v_int", 2 },
+                                      new Object[]{ v, 55861, 55720, "pk, v_int", 100 });
                                   case "eb":
                                   case "ec":
                                       return Stream.of(
-                                      new Object[]{ v, 134765, "pk", 1 },
-                                      new Object[]{ v, 118524, "pk, v_int", 2 },
-                                      new Object[]{ v, 59268, "pk, v_int", 100 });
+                                      new Object[]{ v, 134761, 132841, "pk", 1 },
+                                      new Object[]{ v, 118449, 116538, "pk, v_int", 2 },
+                                      new Object[]{ v, 59133, 57249, "pk, v_int", 100 });
                                   case "ed":
                                   case "fa":
                                   default:
                                       return Stream.of(
-                                      new Object[]{ v, 134781, "pk", 1 },
-                                      new Object[]{ v, 118540, "pk, v_int", 2 },
-                                      new Object[]{ v, 59284, "pk, v_int", 100 });
+                                      new Object[]{ v, 134777, 132849, "pk", 1 },
+                                      new Object[]{ v, 118465, 116546, "pk, v_int", 2 },
+                                      new Object[]{ v, 59149, 57257, "pk, v_int", 100 });
                               }
                           })
                           .collect(Collectors.toList());
@@ -155,15 +159,15 @@ public class SaiDiskSizeTest extends SAITester
         assertThat(diskSize)
         .as("Disk size for SAI version %s before compaction", saiFormat)
         .isLessThanOrEqualTo(expectedDiskSizeFor2SSTables)
-        .isGreaterThan((long) (expectedDiskSizeFor2SSTables * 0.8));
+        .isGreaterThan((long) (expectedDiskSizeFor2SSTables * 0.95));
 
         compact();
 
         diskSize = indexDiskSpaceUse();
         assertThat(diskSize)
         .as("Disk size for SAI version %s after compaction", saiFormat)
-        .isLessThanOrEqualTo(expectedDiskSizeFor2SSTables)
-        .isGreaterThan((long) (expectedDiskSizeFor2SSTables * 0.8));
+        .isLessThanOrEqualTo(expectedDiskSizeForCompactedSSTable)
+        .isGreaterThan((long) (expectedDiskSizeForCompactedSSTable * 0.95));
     }
 
     private void insertRowsIntoOneSegment(int nrRows, int startRow) throws UnknownHostException


### PR DESCRIPTION
### What is the issue
Switching to row aware formats significantly increased size of SAI files. This wasn't expected and created incidents.

### What does this PR fix and why was it fixed

Fixes https://github.com/riptano/cndb/issues/15609

Adds tests to control simple SAI disk size for different format version and different partition sizes, when data are split into 2 SSTables and after compaction into a single SSTable.
It uses expected size as upper bound and has 5% less for lower bound. The upper bounds were found empirically. The goal of the test is too fail if disk size increases or significantly decreases.

This also should help to see improvements in [#15608 ](https://github.com/riptano/cndb/issues/15608).

Vector and analyzed SAI is outside the scope of this PR.