### PR TITLE
HCD-261 Update logback to 1.5.25

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -594,8 +594,8 @@
           <dependency groupId="org.slf4j" artifactId="slf4j-api" version="2.0.9"/>
           <dependency groupId="org.slf4j" artifactId="log4j-over-slf4j" version="2.0.9"/>
           <dependency groupId="org.slf4j" artifactId="jcl-over-slf4j" version="2.0.9" />
-          <dependency groupId="ch.qos.logback" artifactId="logback-core" version="1.4.14"/>
-          <dependency groupId="ch.qos.logback" artifactId="logback-classic" version="1.4.14"/>
+          <dependency groupId="ch.qos.logback" artifactId="logback-core" version="1.5.25"/>
+          <dependency groupId="ch.qos.logback" artifactId="logback-classic" version="1.5.25"/>
           <dependency groupId="com.fasterxml.jackson.core" artifactId="jackson-core" version="2.18.6"/>
           <dependency groupId="com.fasterxml.jackson.core" artifactId="jackson-databind" version="2.18.6"/>
           <dependency groupId="com.fasterxml.jackson.core" artifactId="jackson-annotations" version="2.18.6"/>


### PR DESCRIPTION
Update logback to 1.5.25 to address:
 * CVE-2024-12798
 * CVE-2024-12798
 * CVE-2025-11226

### What is the issue
Some libraries need updating to address CVEs

### What does this PR fix and why was it fixed
The library was updated to the latest version to address said CVEs
