### PR TITLE
CNDB-14371: Revert "CNDB-8885: Add skip_default_role_setup system property to control default role creation (#1233)"

### DIFF
--- a/src/java/org/apache/cassandra/auth/CassandraRoleManager.java
+++ b/src/java/org/apache/cassandra/auth/CassandraRoleManager.java
@@ -81,12 +81,6 @@ public class CassandraRoleManager implements IRoleManager
     static final String DEFAULT_SUPERUSER_NAME = "cassandra";
     static final String DEFAULT_SUPERUSER_PASSWORD = "cassandra";
 
-    // In some cases we want to avoid creating default super user accounts (for security purposes). For example CNDB
-    // can create roles without requiring default SU account. So we need a flag to tell C* to skip creating this role.
-    // Even though this says SKIP it's actually safer to create the user as non super user with no login creds
-    // and a timestamp of 1 in case a user forgets the flag on another node.
-    private static final boolean SKIP_DEFAULT_ROLE_SETUP = Boolean.getBoolean(Config.PROPERTY_PREFIX + "skip_default_role_setup");
-
     // Transform a row in the AuthKeyspace.ROLES to a Role instance
     private static final Function<UntypedResultSet.Row, Role> ROW_TO_ROLE = row ->
     {
@@ -355,14 +349,11 @@ public class CassandraRoleManager implements IRoleManager
             if (!hasExistingRoles())
             {
                 QueryProcessor.process(String.format("INSERT INTO %s.%s (role, is_superuser, can_login, salted_hash) " +
-                                                     "VALUES ('%s', %s, %s, '%s') USING TIMESTAMP %s",
+                                                     "VALUES ('%s', true, true, '%s') USING TIMESTAMP 0",
                                                      SchemaConstants.AUTH_KEYSPACE_NAME,
                                                      AuthKeyspace.ROLES,
                                                      DEFAULT_SUPERUSER_NAME,
-                                                     SKIP_DEFAULT_ROLE_SETUP ? "false" : "true",
-                                                     SKIP_DEFAULT_ROLE_SETUP ? "false" : "true",
-                                                     SKIP_DEFAULT_ROLE_SETUP ? "" : escape(hashpw(DEFAULT_SUPERUSER_PASSWORD)),
-                                                     SKIP_DEFAULT_ROLE_SETUP ? "1" : "0"),
+                                                     escape(hashpw(DEFAULT_SUPERUSER_PASSWORD))),
                                        consistencyForRole(DEFAULT_SUPERUSER_NAME));
                 logger.info("Created default superuser role '{}'", DEFAULT_SUPERUSER_NAME);
             }

--- a/test/distributed/org/apache/cassandra/distributed/test/AuthTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/AuthTest.java
@@ -29,7 +29,6 @@ import org.junit.Test;
 import com.datastax.driver.core.PlainTextAuthProvider;
 import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Session;
-import com.datastax.driver.core.exceptions.AuthenticationException;
 import com.datastax.driver.core.policies.DCAwareRoundRobinPolicy;
 import org.apache.cassandra.auth.CassandraRoleManager;
 import org.apache.cassandra.distributed.Cluster;
@@ -38,21 +37,16 @@ import org.apache.cassandra.distributed.api.ICoordinator;
 import org.apache.cassandra.distributed.api.IInstanceConfig;
 import org.apache.cassandra.distributed.api.IInvokableInstance;
 import org.apache.cassandra.distributed.api.IMessageFilters.Filter;
-import org.apache.cassandra.distributed.api.SimpleQueryResult;
 import org.apache.cassandra.distributed.api.TokenSupplier;
 import org.apache.cassandra.locator.SimpleSeedProvider;
 import org.apache.cassandra.service.StorageService;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.apache.cassandra.distributed.action.GossipHelper.withProperty;
-import static org.apache.cassandra.distributed.api.ConsistencyLevel.ONE;
 import static org.apache.cassandra.distributed.api.Feature.GOSSIP;
 import static org.apache.cassandra.distributed.api.Feature.NATIVE_PROTOCOL;
 import static org.apache.cassandra.distributed.api.Feature.NETWORK;
 import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class AuthTest extends TestBaseImpl
@@ -158,42 +152,6 @@ public class AuthTest extends TestBaseImpl
             doWithSession("127.0.0.1",
                           "datacenter1",
                           "newpassword", session -> session.execute("select * from system.local"));
-        }
-    }
-
-    @Test
-    public void testSkipDefaultRoleCreation() throws Exception
-    {
-        try (Cluster cluster = builder().withDCs(1)
-                                        .withNodes(1)
-                                        .withTokenSupplier(TokenSupplier.evenlyDistributedTokens(1, 1))
-                                        .withConfig(config -> config.with(NETWORK, GOSSIP, NATIVE_PROTOCOL)
-                                                                    .with()
-                                                                    .set("authenticator", "PasswordAuthenticator"))
-                                        .createWithoutStarting()) // don't start the cluster yet as we need to set the skip_default_role_setup property first
-        {
-            withProperty("cassandra.skip_default_role_setup", true,
-                         cluster::startup);
-
-            waitForExistingRoles(cluster.get(1));
-
-            long writeTime = getPasswordWritetime(cluster.coordinator(1));
-            // TIMESTAMP 1 when skip_default_role_setup is true
-            assertEquals(1, writeTime);
-
-            String defaultRoleQuery = "select is_superuser, can_login, salted_hash from system_auth.roles where role = 'cassandra'";
-            SimpleQueryResult result = cluster.coordinator(1).executeWithResult(defaultRoleQuery, ONE);
-            assertTrue(result.hasNext());
-            org.apache.cassandra.distributed.api.Row row = result.next();
-            assertFalse(row.get("is_superuser"));
-            assertFalse(row.get("can_login"));
-            assertEquals("", row.get("salted_hash"));
-
-            // make sure SU cannot really login
-            assertThrows(AuthenticationException.class, () -> doWithSession("127.0.0.1",
-                                                                            "datacenter1",
-                                                                            "cassandra",
-                                                                            session -> session.execute(defaultRoleQuery)));
         }
     }
 


### PR DESCRIPTION

This reverts commit 09368bafaf71dcd3c46aac2d7c470677e9d4378c.

### What is the issue
With CNDB-14371, which configures CNDB to use `NoOpRoleManager` with OPA external auth, this is no longer needed.

### What does this PR fix and why was it fixed
Removes code specific to CNDB from CC

