### PR TITLE
CNDB-15064: add block-cache for compression chunk offsets to reduce offheap memory usage

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -857,6 +857,7 @@
         <dependency groupId="com.dynatrace.hash4j" artifactId="hash4j"/>
         <dependency groupId="com.ning" artifactId="compress-lzf"/>
         <dependency groupId="com.google.guava" artifactId="guava"/>
+        <dependency groupId="com.dynatrace.hash4j" artifactId="hash4j"/>
         <dependency groupId="commons-cli" artifactId="commons-cli"/>
         <dependency groupId="commons-codec" artifactId="commons-codec"/>
         <dependency groupId="org.apache.commons" artifactId="commons-lang3"/>

--- a/build.xml
+++ b/build.xml
@@ -857,7 +857,6 @@
         <dependency groupId="com.dynatrace.hash4j" artifactId="hash4j"/>
         <dependency groupId="com.ning" artifactId="compress-lzf"/>
         <dependency groupId="com.google.guava" artifactId="guava"/>
-        <dependency groupId="com.dynatrace.hash4j" artifactId="hash4j"/>
         <dependency groupId="commons-cli" artifactId="commons-cli"/>
         <dependency groupId="commons-codec" artifactId="commons-codec"/>
         <dependency groupId="org.apache.commons" artifactId="commons-lang3"/>

--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -825,7 +825,44 @@ public enum CassandraRelevantProperties
     /**
      * A directory to the default system key location - used by transparent data encryption
      */
-    SYSTEM_KEY_DIRECTORY("cassandra.system_key_directory", "/etc/cassandra/conf");
+    SYSTEM_KEY_DIRECTORY("cassandra.system_key_directory", "/etc/cassandra/conf"),
+
+    /**
+     * Cache size for compression chunk offsets if BLOCK_CACHE is configured. By default, it uses 25% of max direct memory.
+     *
+     * Alternatively, an absolute cache size can be configured, e.g. "10GiB".
+     */
+    COMPRESSION_CHUNK_OFFSETS_BLOCK_CACHE_SIZE("cassandra.compression_chunk_offsets_block_cache_size", "auto@0.25"),
+    /**
+     * Number of bytes per compression chunk offsets cache block. The value divided by {@link Long#BYTES} determines
+     * how many chunk offsets are loaded from the compression info file on each cache miss. Values that are not
+     * divisible by {@link Long#BYTES} are rounded down to a whole offset and floored at one offset.
+     */
+    COMPRESSION_CHUNK_OFFSETS_CACHE_BLOCK_SIZE("cassandra.compression_chunk_offsets_cache_block_size_bytes", "65536"),
+    /**
+     * Selects the {@link org.apache.cassandra.io.compress.CompressionChunkOffsets} implementation. One of:
+     * <ul>
+     *     <li>{@code in_memory} (default): load all offsets into off-heap memory.</li>
+     *     <li>{@code mmap}: memory-map the offsets section of the compression info file. Gives close to in-memory
+     *     performance while leaving page management to the OS, so memory is reclaimed under pressure. Only suitable
+     *     when the compression info file is fully available on local disk.</li>
+     *     <li>{@code block_cache}: use the block cache sized by {@link #COMPRESSION_CHUNK_OFFSETS_BLOCK_CACHE_SIZE}
+     *     and fail configuration validation if that size resolves to zero or less.</li>
+     * </ul>
+     */
+    COMPRESSION_CHUNK_OFFSETS_TYPE("cassandra.compression_chunk_offsets_type", "in_memory"),
+    /**
+     * Maximum size in bytes of a single memory-mapped segment used by the {@code mmap}
+     * {@link org.apache.cassandra.io.compress.CompressionChunkOffsets} implementation. A {@code MappedByteBuffer} can
+     * map at most {@link Integer#MAX_VALUE} bytes, so larger offset sections are split into multiple segments. The
+     * effective value is rounded down to a whole number of 8-byte offsets. Primarily useful for tests that need to
+     * exercise the multi-segment path without creating a multi-TB file.
+     */
+    COMPRESSION_CHUNK_OFFSETS_MMAP_SEGMENT_SIZE("cassandra.compression_chunk_offsets.mmapped_max_segment_size", String.valueOf(Integer.MAX_VALUE)),
+    /**
+     * Factory for initializing {@link org.apache.cassandra.io.compress.CompressionChunkOffsets} instances
+     */
+    COMPRESSION_CHUNK_OFFSETS_FACTORY("cassandra.compression_chunk_offsets_factory");
 
     CassandraRelevantProperties(String key, String defaultVal)
     {

--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -844,11 +844,13 @@ public enum CassandraRelevantProperties
 
     TEST_INTERVAL_TREE_EXPENSIVE_CHECKS("cassandra.test.interval_tree_expensive_checks"),
     /**
-     * Cache size for compression chunk offsets if BLOCK_CACHE is configured. By default, it uses 25% of max direct memory.
+     * Cache size for compression chunk offsets if BLOCK_CACHE is configured. By default, it uses 15% of max direct
+     * memory.
      *
      * Alternatively, an absolute cache size can be configured, e.g. "10GiB".
      */
-    COMPRESSION_CHUNK_OFFSETS_BLOCK_CACHE_SIZE("cassandra.compression_chunk_offsets_block_cache_size", "auto@0.25"),
+    COMPRESSION_CHUNK_OFFSETS_BLOCK_CACHE_SIZE("cassandra.compression_chunk_offsets_block_cache_size",
+                                               "auto@0.15"),
     /**
      * Number of bytes per compression chunk offsets cache block. The value divided by {@link Long#BYTES} determines
      * how many chunk offsets are loaded from the compression info file on each cache miss. Values that are not

--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -842,7 +842,43 @@ public enum CassandraRelevantProperties
      */
     SYSTEM_KEY_DIRECTORY("cassandra.system_key_directory", "/etc/cassandra/conf"),
 
-    TEST_INTERVAL_TREE_EXPENSIVE_CHECKS("cassandra.test.interval_tree_expensive_checks");
+    TEST_INTERVAL_TREE_EXPENSIVE_CHECKS("cassandra.test.interval_tree_expensive_checks"),
+    /**
+     * Cache size for compression chunk offsets if BLOCK_CACHE is configured. By default, it uses 25% of max direct memory.
+     *
+     * Alternatively, an absolute cache size can be configured, e.g. "10GiB".
+     */
+    COMPRESSION_CHUNK_OFFSETS_BLOCK_CACHE_SIZE("cassandra.compression_chunk_offsets_block_cache_size", "auto@0.25"),
+    /**
+     * Number of bytes per compression chunk offsets cache block. The value divided by {@link Long#BYTES} determines
+     * how many chunk offsets are loaded from the compression info file on each cache miss. Values that are not
+     * divisible by {@link Long#BYTES} are rounded down to a whole offset and floored at one offset.
+     */
+    COMPRESSION_CHUNK_OFFSETS_CACHE_BLOCK_SIZE("cassandra.compression_chunk_offsets_cache_block_size_bytes", "65536"),
+    /**
+     * Selects the {@link org.apache.cassandra.io.compress.CompressionChunkOffsets} implementation. One of:
+     * <ul>
+     *     <li>{@code in_memory} (default): load all offsets into off-heap memory.</li>
+     *     <li>{@code mmap}: memory-map the offsets section of the compression info file. Gives close to in-memory
+     *     performance while leaving page management to the OS, so memory is reclaimed under pressure. Only suitable
+     *     when the compression info file is fully available on local disk.</li>
+     *     <li>{@code block_cache}: use the block cache sized by {@link #COMPRESSION_CHUNK_OFFSETS_BLOCK_CACHE_SIZE}
+     *     and fail configuration validation if that size resolves to zero or less.</li>
+     * </ul>
+     */
+    COMPRESSION_CHUNK_OFFSETS_TYPE("cassandra.compression_chunk_offsets_type", "in_memory"),
+    /**
+     * Maximum size in bytes of a single memory-mapped segment used by the {@code mmap}
+     * {@link org.apache.cassandra.io.compress.CompressionChunkOffsets} implementation. A {@code MappedByteBuffer} can
+     * map at most {@link Integer#MAX_VALUE} bytes, so larger offset sections are split into multiple segments. The
+     * effective value is rounded down to a whole number of 8-byte offsets. Primarily useful for tests that need to
+     * exercise the multi-segment path without creating a multi-TB file.
+     */
+    COMPRESSION_CHUNK_OFFSETS_MMAP_SEGMENT_SIZE("cassandra.compression_chunk_offsets.mmapped_max_segment_size", String.valueOf(Integer.MAX_VALUE)),
+    /**
+     * Factory for initializing {@link org.apache.cassandra.io.compress.CompressionChunkOffsets} instances
+     */
+    COMPRESSION_CHUNK_OFFSETS_FACTORY("cassandra.compression_chunk_offsets_factory");
 
     CassandraRelevantProperties(String key, String defaultVal)
     {

--- a/src/java/org/apache/cassandra/db/virtual/CachesTable.java
+++ b/src/java/org/apache/cassandra/db/virtual/CachesTable.java
@@ -18,8 +18,10 @@
 package org.apache.cassandra.db.virtual;
 
 import org.apache.cassandra.cache.ChunkCache;
+import org.apache.cassandra.io.compress.CompressionChunkOffsetCache;
 import org.apache.cassandra.db.marshal.*;
 import org.apache.cassandra.dht.LocalPartitioner;
+import org.apache.cassandra.io.compress.CompressionChunkOffsetsFactory;
 import org.apache.cassandra.metrics.CacheMetrics;
 import org.apache.cassandra.metrics.ChunkCacheMetrics;
 import org.apache.cassandra.schema.TableMetadata;
@@ -87,6 +89,11 @@ final class CachesTable extends AbstractVirtualTable
 
         if (null != ChunkCache.instance)
             addRow(result, "chunks", ChunkCache.instance.metrics);
+        if (CompressionChunkOffsetsFactory.type() == CompressionChunkOffsetsFactory.Type.BLOCK_CACHE)
+        {
+            CompressionChunkOffsetCache compressionCache = CompressionChunkOffsetCache.get();
+            addRow(result, "compression_chunk_offsets", compressionCache.getMetrics());
+        }
         addRow(result, "counters", CacheService.instance.counterCache.getMetrics());
         addRow(result, "keys", CacheService.instance.keyCache.getMetrics());
         addRow(result, "rows", CacheService.instance.rowCache.getMetrics());

--- a/src/java/org/apache/cassandra/io/compress/CompressionChunkOffsetCache.java
+++ b/src/java/org/apache/cassandra/io/compress/CompressionChunkOffsetCache.java
@@ -1,0 +1,340 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.io.compress;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.function.Function;
+
+import javax.annotation.Nullable;
+
+import com.dynatrace.hash4j.hashing.Hasher64;
+import com.dynatrace.hash4j.hashing.Hashing;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.RemovalListener;
+import io.netty.util.internal.PlatformDependent;
+import org.apache.cassandra.cache.CacheSize;
+import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.io.util.FileUtils;
+import org.apache.cassandra.io.util.SimpleCachedBufferPool;
+import org.apache.cassandra.metrics.MicrometerCompressionChunkOffsetCacheMetrics;
+import org.apache.cassandra.utils.FBUtilities;
+
+import static org.apache.cassandra.io.compress.CompressionMetadata.NATIVE_MEMORY_USAGE;
+
+/**
+ * Block cache for compression chunk offsets stored in the compression info file.
+ * <p>
+ * The cache stores blocks of offsets in direct {@link ByteBuffer} instances. Each block is
+ * reference-counted and cleaned on eviction. This cache is intended for use by
+ * {@link org.apache.cassandra.io.compress.CompressionChunkOffsets.BlockCache}.
+ * <p>
+ * Note that Blocks are weighted by direct buffer capacity; key overhead is not included.
+ */
+public class CompressionChunkOffsetCache implements CacheSize
+{
+    private static volatile CompressionChunkOffsetCache INSTANCE;
+
+    public static CompressionChunkOffsetCache get()
+    {
+        // do not initialize the cache if cache size is non-positive
+        long cacheSizeInBytes = getCacheSizeInBytes(PlatformDependent.maxDirectMemory());
+        Preconditions.checkArgument(cacheSizeInBytes > 0, "CompressionChunkOffsetCache size must be postive, but got " + cacheSizeInBytes);
+
+        if (INSTANCE == null)
+        {
+            synchronized (CompressionChunkOffsetCache.class)
+            {
+                if (INSTANCE == null)
+                    INSTANCE = new CompressionChunkOffsetCache(cacheSizeInBytes);
+            }
+        }
+        return INSTANCE;
+    }
+
+    @VisibleForTesting
+    static synchronized void resetCache()
+    {
+        if (INSTANCE != null)
+            INSTANCE.clear();
+
+        INSTANCE = null;
+    }
+
+    static long getCacheSizeInBytes(long maxDirectMemoryInSize)
+    {
+        String configString = CassandraRelevantProperties.COMPRESSION_CHUNK_OFFSETS_BLOCK_CACHE_SIZE.getString();
+        return FBUtilities.parseHumanReadableConfig(maxDirectMemoryInSize, configString);
+    }
+
+    private final Cache<BlockKey, OffsetsBlock> cache;
+    private final MicrometerCompressionChunkOffsetCacheMetrics metrics;
+    private final long maxSizeInBytes;
+    private final SimpleCachedBufferPool bufferPool;
+    private final int blockBufferSize;
+
+    CompressionChunkOffsetCache(long maxSizeInBytes)
+    {
+        this.maxSizeInBytes = maxSizeInBytes;
+        this.metrics = new MicrometerCompressionChunkOffsetCacheMetrics(this, "compression_chunk_offsets_cache");
+        this.blockBufferSize = blockBufferSize();
+        this.bufferPool = createBufferPool(maxSizeInBytes, blockBufferSize);
+        RemovalListener<BlockKey, OffsetsBlock> remover = (key, value, cause) ->
+        {
+            if (value != null)
+                value.release();
+        };
+        cache = Caffeine.newBuilder()
+                        .maximumWeight(maxSizeInBytes)
+                        .weigher((BlockKey key, OffsetsBlock value) -> Math.min(Integer.MAX_VALUE, value.capacity()))
+                        .removalListener(remover)
+                        .recordStats(() -> metrics)
+                        .build();
+    }
+
+    /**
+     * Get a cached offsets block for the provided file id and block index, loading it from disk if absent.
+     *
+     * @param fileId local id for the compression info file
+     * @param blockIndex index of the offsets block
+     * @param blockLoader loader used to create a block on cache miss. The cache key is provided to the loader so
+     *                    callers can reuse one loader instead of allocating a closure per lookup.
+     * @return cached or newly loaded offsets block
+     */
+    OffsetsBlock getBlock(long fileId, int blockIndex, Function<BlockKey, OffsetsBlock> blockLoader)
+    {
+        BlockKey key = new BlockKey(fileId, blockIndex);
+        return cache.get(key, blockLoader);
+    }
+
+    public MicrometerCompressionChunkOffsetCacheMetrics getMetrics()
+    {
+        return metrics;
+    }
+
+    ByteBuffer allocateBlockBuffer(int bytesToRead)
+    {
+        ByteBuffer buffer = bufferPool.createBuffer();
+        Preconditions.checkArgument(bytesToRead <= buffer.capacity());
+        buffer.limit(bytesToRead);
+        return buffer;
+    }
+
+    OffsetsBlock wrapBlockBuffer(ByteBuffer buffer)
+    {
+        return new OffsetsBlock(buffer, bufferPool);
+    }
+
+    void releaseBlockBuffer(ByteBuffer buffer)
+    {
+        bufferPool.releaseBuffer(buffer);
+    }
+
+    void invalidate(BlockKey blockKey)
+    {
+        cache.invalidate(blockKey);
+    }
+
+    @Override
+    public long capacity()
+    {
+        return maxSizeInBytes;
+    }
+
+    @Override
+    public void setCapacity(long capacity)
+    {
+        throw new UnsupportedOperationException("Compression chunk offsets cache size cannot be changed.");
+    }
+
+    @Override
+    public int size()
+    {
+        return cache.asMap().size();
+    }
+
+    @Override
+    public long weightedSize()
+    {
+        return cache.policy()
+                    .eviction()
+                    .map(policy -> policy.weightedSize().orElseGet(cache::estimatedSize))
+                    .orElseGet(cache::estimatedSize);
+    }
+
+    @VisibleForTesting
+    public void clear()
+    {
+        cache.invalidateAll();
+        cache.cleanUp();
+        bufferPool.emptyBufferPool();
+    }
+
+    private static SimpleCachedBufferPool createBufferPool(long maxSizeInBytes, int blockBufferSize)
+    {
+        long blockCount = maxSizeInBytes / blockBufferSize + (maxSizeInBytes % blockBufferSize == 0 ? 0 : 1);
+        long poolSize = blockCount == Long.MAX_VALUE ? Long.MAX_VALUE : blockCount + 1;
+        int maxBufferPoolSize = (int) Math.min(Integer.MAX_VALUE, Math.max(1, poolSize));
+        return new SimpleCachedBufferPool(maxBufferPoolSize, blockBufferSize, BufferType.OFF_HEAP);
+    }
+
+    public static final class BlockKey
+    {
+        private static final Hasher64 hasher = Hashing.metroHash64();
+
+        private final long fileId;
+        private final int blockIndex;
+        private final int hashcode;
+
+        public BlockKey(long fileId, int blockIndex)
+        {
+            this.fileId = fileId;
+            this.blockIndex = blockIndex;
+            this.hashcode = hasher.hashLongLongToInt(fileId, blockIndex);
+        }
+
+        /**
+         * @return index of the offsets block within the compression info file
+         */
+        int blockIndex()
+        {
+            return blockIndex;
+        }
+
+        @Override
+        public boolean equals(Object other)
+        {
+            if (this == other)
+                return true;
+            BlockKey that = (BlockKey) other;
+            return blockIndex == that.blockIndex && fileId == that.fileId;
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return hashcode;
+        }
+    }
+
+    @VisibleForTesting
+    static int blockBufferSize()
+    {
+        int configuredSize = CassandraRelevantProperties.COMPRESSION_CHUNK_OFFSETS_CACHE_BLOCK_SIZE.getInt();
+        // round to multiple of 8 bytes
+        return Math.max(Long.BYTES, (configuredSize / Long.BYTES) * Long.BYTES);
+    }
+
+    /**
+     * A cached block of chunk offsets. It owns off-heap buffer and is reference-counted to ensure the memory
+     * is released only after eviction and last user release.
+     */
+    public static class OffsetsBlock
+    {
+        private static final AtomicIntegerFieldUpdater<OffsetsBlock> referencesUpdater = AtomicIntegerFieldUpdater.newUpdater(OffsetsBlock.class, "references");
+        private final ByteBuffer offsetsBuffer;
+        private final int capacity;
+        private final int length;
+        @Nullable
+        private final SimpleCachedBufferPool bufferPool;
+
+        public volatile int references;
+
+        public OffsetsBlock(ByteBuffer offsetsBuffer)
+        {
+            this(offsetsBuffer, null);
+        }
+
+        private OffsetsBlock(ByteBuffer offsetsBuffer, SimpleCachedBufferPool bufferPool)
+        {
+            this.offsetsBuffer = offsetsBuffer;
+            this.length = offsetsBuffer.remaining();
+            this.capacity = offsetsBuffer.capacity();
+            this.bufferPool = bufferPool;
+            this.references = 1;
+            NATIVE_MEMORY_USAGE.addAndGet(capacity);
+        }
+
+        /**
+         * Increment the reference count if the block has not been released.
+         *
+         * @return true if the reference was acquired; false if already released
+         */
+        boolean ref()
+        {
+            int refCount;
+            do
+            {
+                refCount = references;
+
+                if (refCount == 0)
+                    return false; // Payload was released before we managed to reference it.
+            }
+            while (!referencesUpdater.compareAndSet(this, refCount, refCount + 1));
+
+            return true;
+        }
+
+        /**
+         * Decrement the reference count and free off-heap memory when it reaches zero.
+         */
+        void release()
+        {
+            if (referencesUpdater.decrementAndGet(this) == 0)
+            {
+                if (bufferPool == null)
+                    FileUtils.clean(offsetsBuffer);
+                else
+                    bufferPool.releaseBuffer(offsetsBuffer);
+                NATIVE_MEMORY_USAGE.addAndGet(-capacity);
+            }
+        }
+
+        /**
+         * @return off-heap capacity of this block in bytes
+         */
+        public int capacity()
+        {
+            return capacity;
+        }
+
+        /**
+         * @return number of chunk offsets stored in this block
+         */
+        public int count()
+        {
+            return length / Long.BYTES;
+        }
+
+        /**
+         * Return the chunk offset at the given index within this block. Must be called after successful {@link #ref()}.
+         *
+         * @param index offset index within this block
+         * @return chunk offset value
+         */
+        public long getLongAtIndex(int index)
+        {
+            return offsetsBuffer.getLong(index * Long.BYTES);
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/io/compress/CompressionChunkOffsetCache.java
+++ b/src/java/org/apache/cassandra/io/compress/CompressionChunkOffsetCache.java
@@ -22,21 +22,18 @@ import java.nio.ByteBuffer;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.function.Function;
 
-import javax.annotation.Nullable;
-
 import com.dynatrace.hash4j.hashing.Hasher64;
 import com.dynatrace.hash4j.hashing.Hashing;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.RemovalListener;
+import com.google.common.base.Preconditions;
 import io.netty.util.internal.PlatformDependent;
 import org.apache.cassandra.cache.CacheSize;
 import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.io.util.FileUtils;
-import org.apache.cassandra.io.util.SimpleCachedBufferPool;
 import org.apache.cassandra.metrics.MicrometerCompressionChunkOffsetCacheMetrics;
 import org.apache.cassandra.utils.FBUtilities;
 
@@ -90,15 +87,11 @@ public class CompressionChunkOffsetCache implements CacheSize
     private final Cache<BlockKey, OffsetsBlock> cache;
     private final MicrometerCompressionChunkOffsetCacheMetrics metrics;
     private final long maxSizeInBytes;
-    private final SimpleCachedBufferPool bufferPool;
-    private final int blockBufferSize;
 
     CompressionChunkOffsetCache(long maxSizeInBytes)
     {
         this.maxSizeInBytes = maxSizeInBytes;
         this.metrics = new MicrometerCompressionChunkOffsetCacheMetrics(this, "compression_chunk_offsets_cache");
-        this.blockBufferSize = blockBufferSize();
-        this.bufferPool = createBufferPool(maxSizeInBytes, blockBufferSize);
         RemovalListener<BlockKey, OffsetsBlock> remover = (key, value, cause) ->
         {
             if (value != null)
@@ -130,24 +123,6 @@ public class CompressionChunkOffsetCache implements CacheSize
     public MicrometerCompressionChunkOffsetCacheMetrics getMetrics()
     {
         return metrics;
-    }
-
-    ByteBuffer allocateBlockBuffer(int bytesToRead)
-    {
-        ByteBuffer buffer = bufferPool.createBuffer();
-        Preconditions.checkArgument(bytesToRead <= buffer.capacity());
-        buffer.limit(bytesToRead);
-        return buffer;
-    }
-
-    OffsetsBlock wrapBlockBuffer(ByteBuffer buffer)
-    {
-        return new OffsetsBlock(buffer, bufferPool);
-    }
-
-    void releaseBlockBuffer(ByteBuffer buffer)
-    {
-        bufferPool.releaseBuffer(buffer);
     }
 
     void invalidate(BlockKey blockKey)
@@ -187,15 +162,6 @@ public class CompressionChunkOffsetCache implements CacheSize
     {
         cache.invalidateAll();
         cache.cleanUp();
-        bufferPool.emptyBufferPool();
-    }
-
-    private static SimpleCachedBufferPool createBufferPool(long maxSizeInBytes, int blockBufferSize)
-    {
-        long blockCount = maxSizeInBytes / blockBufferSize + (maxSizeInBytes % blockBufferSize == 0 ? 0 : 1);
-        long poolSize = blockCount == Long.MAX_VALUE ? Long.MAX_VALUE : blockCount + 1;
-        int maxBufferPoolSize = (int) Math.min(Integer.MAX_VALUE, Math.max(1, poolSize));
-        return new SimpleCachedBufferPool(maxBufferPoolSize, blockBufferSize, BufferType.OFF_HEAP);
     }
 
     public static final class BlockKey
@@ -255,22 +221,14 @@ public class CompressionChunkOffsetCache implements CacheSize
         private final ByteBuffer offsetsBuffer;
         private final int capacity;
         private final int length;
-        @Nullable
-        private final SimpleCachedBufferPool bufferPool;
 
         public volatile int references;
 
         public OffsetsBlock(ByteBuffer offsetsBuffer)
         {
-            this(offsetsBuffer, null);
-        }
-
-        private OffsetsBlock(ByteBuffer offsetsBuffer, SimpleCachedBufferPool bufferPool)
-        {
             this.offsetsBuffer = offsetsBuffer;
             this.length = offsetsBuffer.remaining();
             this.capacity = offsetsBuffer.capacity();
-            this.bufferPool = bufferPool;
             this.references = 1;
             NATIVE_MEMORY_USAGE.addAndGet(capacity);
         }
@@ -302,10 +260,7 @@ public class CompressionChunkOffsetCache implements CacheSize
         {
             if (referencesUpdater.decrementAndGet(this) == 0)
             {
-                if (bufferPool == null)
-                    FileUtils.clean(offsetsBuffer);
-                else
-                    bufferPool.releaseBuffer(offsetsBuffer);
+                FileUtils.clean(offsetsBuffer);
                 NATIVE_MEMORY_USAGE.addAndGet(-capacity);
             }
         }

--- a/src/java/org/apache/cassandra/io/compress/CompressionChunkOffsets.java
+++ b/src/java/org/apache/cassandra/io/compress/CompressionChunkOffsets.java
@@ -310,7 +310,7 @@ public interface CompressionChunkOffsets extends AutoCloseable
                 int count = Math.min(offsetsPerBlock, remaining);
                 int bytesToRead = count * Long.BYTES;
                 long position = offsetsStart + ((long) blockStartIndex * Long.BYTES);
-                ByteBuffer buffer = cache.allocateBlockBuffer(bytesToRead);
+                ByteBuffer buffer = ByteBuffer.allocateDirect(bytesToRead);
                 boolean success = false;
                 try
                 {
@@ -326,12 +326,12 @@ public interface CompressionChunkOffsets extends AutoCloseable
                     }
                     buffer.flip();
                     success = true;
-                    return cache.wrapBlockBuffer(buffer);
+                    return new CompressionChunkOffsetCache.OffsetsBlock(buffer);
                 }
                 finally
                 {
                     if (!success)
-                        cache.releaseBlockBuffer(buffer);
+                        FileUtils.clean(buffer);
                 }
             }
             catch (IOException e)

--- a/src/java/org/apache/cassandra/io/compress/CompressionChunkOffsets.java
+++ b/src/java/org/apache/cassandra/io/compress/CompressionChunkOffsets.java
@@ -1,0 +1,492 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.io.compress;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.io.sstable.CorruptSSTableException;
+import org.apache.cassandra.io.storage.StorageProvider;
+import org.apache.cassandra.io.util.File;
+import org.apache.cassandra.io.util.FileUtils;
+import org.apache.cassandra.io.util.Memory;
+import org.apache.cassandra.utils.INativeLibrary;
+import org.apache.cassandra.utils.NoSpamLogger;
+import org.apache.cassandra.utils.concurrent.Ref;
+
+import static org.apache.cassandra.io.compress.CompressionMetadata.NATIVE_MEMORY_USAGE;
+
+/**
+ * Abstraction over chunk offset storage for compression metadata.
+ * <p>
+ * Implementations may keep offsets in memory, read them on-demand from disk, or use a cache.
+ * Offsets are indexed by chunk index relative to the metadata's start chunk.
+ * </p>
+ */
+public interface CompressionChunkOffsets extends AutoCloseable
+{
+    /**
+     * Return the chunk offset at the provided index (0-based within this metadata instance).
+     *
+     * @param index chunk index relative to the start chunk
+     * @return offset of the chunk in the compressed file
+     */
+    long get(int index);
+
+    /**
+     * @return number of offsets in this instance.
+     */
+    int size();
+
+    /**
+     * @return off-heap bytes used by this instance. return 0 if it's backed by cache.
+     */
+    long offHeapMemoryUsed();
+
+    /**
+     * Add any off-heap identities to the provided collection.
+     *
+     * @param identities collection of tracked identities
+     */
+    void addTo(Ref.IdentityCollection identities);
+
+    /**
+     * @return position after the last chunk in the compressed file, adjusted for partial files.
+     */
+    long compressedFileLength();
+
+    /**
+     * Release any resources held by this instance.
+     */
+    void close();
+
+    /**
+     * Open a read channel for the compression info file, honouring the reader type (read-time vs write-time access).
+     */
+    static FileChannel openChannel(File indexFilePath, CompressionMetadataReaderType readerType) throws IOException
+    {
+        if (readerType == CompressionMetadataReaderType.WRITE_TIME)
+            return StorageProvider.instance.writeTimeReadFileChannelFor(indexFilePath);
+        return indexFilePath.newReadChannel();
+    }
+
+    class Empty implements CompressionChunkOffsets
+    {
+        public long get(int index)
+        {
+            throw new IndexOutOfBoundsException("Chunk index " + index + " out of bounds for empty offsets");
+        }
+
+        public int size()
+        {
+            return 0;
+        }
+
+        public long offHeapMemoryUsed()
+        {
+            return 0;
+        }
+
+        public void addTo(Ref.IdentityCollection identities)
+        {
+        }
+
+        @Override
+        public long compressedFileLength()
+        {
+            return 0;
+        }
+
+        public void close()
+        {
+        }
+    }
+
+    class InMemory implements CompressionChunkOffsets
+    {
+        private final Memory.LongArray offsets;
+        private final long compressedOffsetLength;
+
+        public InMemory(Memory.LongArray offsets, long compressedOffsetLength)
+        {
+            this.offsets = offsets;
+            this.compressedOffsetLength = compressedOffsetLength;
+        }
+
+        public long get(int index)
+        {
+            return offsets.get(index);
+        }
+
+        public int size()
+        {
+            return Math.toIntExact(offsets.size());
+        }
+
+        public long offHeapMemoryUsed()
+        {
+            return offsets.memoryUsed();
+        }
+
+        public void addTo(Ref.IdentityCollection identities)
+        {
+            if (offsets.memory != null)
+                identities.add(offsets.memory);
+        }
+
+        @Override
+        public long compressedFileLength()
+        {
+            return compressedOffsetLength;
+        }
+
+        public void close()
+        {
+            NATIVE_MEMORY_USAGE.addAndGet(-offsets.memory.size());
+            offsets.close();
+        }
+    }
+
+
+    class BlockCache implements CompressionChunkOffsets
+    {
+        private static final Logger logger = LoggerFactory.getLogger(BlockCache.class);
+        private static final NoSpamLogger noSpamLogger = NoSpamLogger.getLogger(logger, 1, TimeUnit.MINUTES);
+
+        // Used to retry fetching cache from disk when cache referencing races with concurrent cache eviction. This should be rare and 10 should be sufficient.
+        private static final int MAX_RETRIES = 10;
+
+        private static final AtomicLong nextFileId = new AtomicLong();
+
+        private final File file;
+        // Used to reduce cost of hashing for block cache key. Note that different instances of CompressionChunkOffsets
+        // on the same file will result in different cache key.
+        private final long fileId;
+        private final FileChannel fileChannel;
+        private final long offsetsStart;
+        private final int baseChunkIndex;
+        private final int size;
+        private final int chunkCount;
+        private final long compressedFileLength;
+        private final int offsetsPerBlock;
+        private final CompressionChunkOffsetCache cache;
+        private final Function<CompressionChunkOffsetCache.BlockKey, CompressionChunkOffsetCache.OffsetsBlock> blockLoader;
+
+        public BlockCache(File file,
+                          long offsetsStart,
+                          int baseChunkIndex,
+                          int size,
+                          int endIndex,
+                          int chunkCount,
+                          long compressedFileLength,
+                          CompressionMetadataReaderType readerType,
+                          CompressionChunkOffsetCache cache) throws IOException
+        {
+            this.file = file;
+            this.fileId = nextFileId.incrementAndGet();
+            this.fileChannel = CompressionChunkOffsets.openChannel(file, readerType);
+            this.offsetsStart = offsetsStart;
+            this.baseChunkIndex = baseChunkIndex;
+            this.size = size;
+            this.chunkCount = chunkCount;
+            // We adjust the compressed file length to store the position after the last chunk just to be able to
+            // calculate the offset of the chunk next to the last one (in order to calculate the length of the last chunk).
+            // Obviously, we could use the compressed file length for that purpose but unfortunately, sometimes there is
+            // an empty chunk added to the end of the file thus we cannot rely on the file length.
+            long lastOffset = endIndex < chunkCount ? getFromDisk(endIndex - baseChunkIndex) - getFromDisk(0) : compressedFileLength;
+            this.compressedFileLength = lastOffset;
+            this.offsetsPerBlock = CompressionChunkOffsetCache.blockBufferSize() / Long.BYTES;
+            this.cache = cache;
+            this.blockLoader = this::loadBlock;
+        }
+
+        @Override
+        public long get(int index)
+        {
+            int absoluteIndex = baseChunkIndex + index;
+            int blockIndex = absoluteIndex / offsetsPerBlock;
+            int offsetInBlock = absoluteIndex % offsetsPerBlock;
+
+            if (absoluteIndex < 0 || absoluteIndex >= chunkCount)
+                throw new CorruptSSTableException(new EOFException(String.format("Chunk %d out of bounds: %d", absoluteIndex, chunkCount)), file);
+
+            int retries = MAX_RETRIES;
+            while (retries-- > 0)
+            {
+                CompressionChunkOffsetCache.OffsetsBlock block = cache.getBlock(fileId, blockIndex, blockLoader);
+                if (block.ref())
+                {
+                    try
+                    {
+                        int count = block.count();
+                        if (offsetInBlock >= count)
+                            throw new CorruptSSTableException(new EOFException(String.format("Chunk %d out of bounds: %d", offsetInBlock, count)), file);
+                        return block.getLongAtIndex(offsetInBlock);
+                    }
+                    finally
+                    {
+                        block.release();
+                    }
+                }
+                // let's retry, if the block is concurrently evicted from cache and fails to ref
+            }
+            // fall to read from on-disk offset directly without caching
+            noSpamLogger.warn("Failed to reference cached compression chunk offset block for {} block {} after {} retries; reading chunk {} directly from disk",
+                              file, blockIndex, MAX_RETRIES, absoluteIndex);
+            return getFromDisk(index);
+        }
+
+        private long getFromDisk(int index)
+        {
+            int absoluteIndex = baseChunkIndex + index;
+            if (absoluteIndex < 0 || absoluteIndex >= chunkCount)
+                throw new CorruptSSTableException(new EOFException(String.format("Chunk %d out of bounds: %d", absoluteIndex, chunkCount)), file);
+
+            ByteBuffer buffer = ByteBuffer.allocate(Long.BYTES);
+            try
+            {
+                int read = 0;
+                long position = offsetsStart + (long) absoluteIndex * Long.BYTES;
+                while (read < Long.BYTES)
+                {
+                    int n = fileChannel.read(buffer, position + read);
+                    if (n < 0)
+                        throw new EOFException("EOF reading compression offsets from " + file);
+                    if (n == 0)
+                        continue;
+                    read += n;
+                }
+                buffer.flip();
+                return buffer.getLong();
+            }
+            catch (IOException e)
+            {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public int size()
+        {
+            return size;
+        }
+
+        private CompressionChunkOffsetCache.OffsetsBlock loadBlock(CompressionChunkOffsetCache.BlockKey key)
+        {
+            try
+            {
+                int blockIndex = key.blockIndex();
+                int blockStartIndex = blockIndex * offsetsPerBlock;
+                int remaining = chunkCount - blockStartIndex;
+                if (remaining <= 0)
+                    return new CompressionChunkOffsetCache.OffsetsBlock(ByteBuffer.allocate(0));
+
+                int count = Math.min(offsetsPerBlock, remaining);
+                int bytesToRead = count * Long.BYTES;
+                long position = offsetsStart + ((long) blockStartIndex * Long.BYTES);
+                ByteBuffer buffer = cache.allocateBlockBuffer(bytesToRead);
+                boolean success = false;
+                try
+                {
+                    int read = 0;
+                    while (read < bytesToRead)
+                    {
+                        int n = fileChannel.read(buffer, position + read);
+                        if (n < 0)
+                            throw new EOFException("EOF reading compression offsets from " + file);
+                        if (n == 0)
+                            continue;
+                        read += n;
+                    }
+                    buffer.flip();
+                    success = true;
+                    return cache.wrapBlockBuffer(buffer);
+                }
+                finally
+                {
+                    if (!success)
+                        cache.releaseBlockBuffer(buffer);
+                }
+            }
+            catch (IOException e)
+            {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public long offHeapMemoryUsed()
+        {
+            // offheap memory usage per file is not tracked in cache. return 0 here.
+            return 0;
+        }
+
+        @Override
+        public void addTo(Ref.IdentityCollection identities)
+        {
+            // no-op - cache manages its own memory
+        }
+
+        @Override
+        public long compressedFileLength()
+        {
+            return compressedFileLength;
+        }
+
+        @Override
+        public void close()
+        {
+            // Invalidate all blocks from cache because we don't track what blocks are cached
+            int blockCount = (int) Math.ceil(chunkCount * 1.0 / offsetsPerBlock);
+            for (int i = 0; i < blockCount; i++)
+                cache.invalidate(new CompressionChunkOffsetCache.BlockKey(fileId, i));
+
+            FileUtils.closeQuietly(fileChannel);
+        }
+    }
+
+    class Mmap implements CompressionChunkOffsets
+    {
+        private final File file;
+        private final int baseChunkIndex;
+        private final int size;
+        private final int chunkCount;
+        private final long compressedFileLength;
+        // Bytes per segment, captured once at construction. A single MappedByteBuffer can map at most
+        // Integer.MAX_VALUE bytes, so larger offset sections are split into multiple segments. Rounded down to a whole
+        // number of 8-byte offsets so that no offset straddles a segment boundary, and floored at one offset so a
+        // misconfigured value cannot reach 0.
+        private final int segmentBytes;
+        private final MappedByteBuffer[] segments;
+
+        public Mmap(File file,
+                    long offsetsStart,
+                    int baseChunkIndex,
+                    int size,
+                    int endIndex,
+                    int chunkCount,
+                    long compressedFileLength,
+                    CompressionMetadataReaderType readerType) throws IOException
+        {
+            this.file = file;
+            this.baseChunkIndex = baseChunkIndex;
+            this.size = size;
+            this.chunkCount = chunkCount;
+            int maxSegmentBytes = CassandraRelevantProperties.COMPRESSION_CHUNK_OFFSETS_MMAP_SEGMENT_SIZE.getInt();
+            this.segmentBytes = Math.max(Long.BYTES, (maxSegmentBytes / Long.BYTES) * Long.BYTES);
+            this.segments = mapOffsets(file, offsetsStart, chunkCount, readerType, segmentBytes);
+
+            // We adjust the compressed file length to store the position after the last chunk just to be able to
+            // calculate the offset of the chunk next to the last one (in order to calculate the length of the last
+            // chunk). Obviously, we could use the compressed file length for that purpose but unfortunately, sometimes
+            // there is an empty chunk added to the end of the file thus we cannot rely on the file length.
+            this.compressedFileLength = endIndex < chunkCount ? getAbsolute(endIndex) - getAbsolute(baseChunkIndex)
+                                                              : compressedFileLength;
+        }
+
+        private static MappedByteBuffer[] mapOffsets(File file, long offsetsStart, int chunkCount,
+                                                     CompressionMetadataReaderType readerType, int segmentBytes) throws IOException
+        {
+            long offsetsBytes = (long) chunkCount * Long.BYTES;
+            int segmentCount = Math.toIntExact((offsetsBytes + segmentBytes - 1) / segmentBytes);
+            MappedByteBuffer[] segments = new MappedByteBuffer[segmentCount];
+
+            // The mapping remains valid after the channel is closed, so we don't keep a file descriptor open.
+            try (FileChannel channel = CompressionChunkOffsets.openChannel(file, readerType))
+            {
+                for (int i = 0; i < segmentCount; i++)
+                {
+                    long position = offsetsStart + (long) i * segmentBytes;
+                    long segmentSize = Math.min(segmentBytes, offsetsBytes - (long) i * segmentBytes);
+                    MappedByteBuffer buffer = channel.map(FileChannel.MapMode.READ_ONLY, position, segmentSize);
+                    // Offsets are accessed randomly, so disable OS read-ahead for the mapped region.
+                    INativeLibrary.instance.adviseRandom(buffer, segmentSize, file.path());
+                    segments[i] = buffer;
+                }
+            }
+            catch (IOException | RuntimeException e)
+            {
+                for (MappedByteBuffer buffer : segments)
+                    FileUtils.clean(buffer);
+                throw e;
+            }
+            return segments;
+        }
+
+        private long getAbsolute(int absoluteIndex)
+        {
+            long byteOffset = (long) absoluteIndex * Long.BYTES;
+            int segmentIndex = (int) (byteOffset / segmentBytes);
+            int offsetInSegment = (int) (byteOffset % segmentBytes);
+            return segments[segmentIndex].getLong(offsetInSegment);
+        }
+
+        @Override
+        public long get(int index)
+        {
+            int absoluteIndex = baseChunkIndex + index;
+            if (absoluteIndex < 0 || absoluteIndex >= chunkCount)
+                throw new CorruptSSTableException(new EOFException(String.format("Chunk %d out of bounds: %d", absoluteIndex, chunkCount)), file);
+
+            return getAbsolute(absoluteIndex);
+        }
+
+        @Override
+        public int size()
+        {
+            return size;
+        }
+
+        @Override
+        public long offHeapMemoryUsed()
+        {
+            // memory-mapped pages are managed by the OS page cache, not tracked here.
+            return 0;
+        }
+
+        @Override
+        public void addTo(Ref.IdentityCollection identities)
+        {
+            // no-op - mapped memory is not Cassandra-managed off-heap memory
+        }
+
+        @Override
+        public long compressedFileLength()
+        {
+            return compressedFileLength;
+        }
+
+        @Override
+        public void close()
+        {
+            for (MappedByteBuffer buffer : segments)
+                FileUtils.clean(buffer);
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/io/compress/CompressionChunkOffsets.java
+++ b/src/java/org/apache/cassandra/io/compress/CompressionChunkOffsets.java
@@ -115,6 +115,7 @@ public interface CompressionChunkOffsets extends AutoCloseable
 
         public void addTo(Ref.IdentityCollection identities)
         {
+            // Empty offsets have no backing memory identity to report.
         }
 
         @Override
@@ -125,6 +126,7 @@ public interface CompressionChunkOffsets extends AutoCloseable
 
         public void close()
         {
+            // Empty offsets own no resources that need to be released.
         }
     }
 
@@ -178,6 +180,7 @@ public interface CompressionChunkOffsets extends AutoCloseable
     {
         private static final Logger logger = LoggerFactory.getLogger(BlockCache.class);
         private static final NoSpamLogger noSpamLogger = NoSpamLogger.getLogger(logger, 1, TimeUnit.MINUTES);
+        private static final String CHUNK_OUT_OF_BOUNDS_FORMAT = "Chunk %d out of bounds: %d";
 
         // Used to retry fetching cache from disk when cache referencing races with concurrent cache eviction. This should be rare and 10 should be sufficient.
         private static final int MAX_RETRIES = 10;
@@ -234,7 +237,10 @@ public interface CompressionChunkOffsets extends AutoCloseable
             int offsetInBlock = absoluteIndex % offsetsPerBlock;
 
             if (absoluteIndex < 0 || absoluteIndex >= chunkCount)
-                throw new CorruptSSTableException(new EOFException(String.format("Chunk %d out of bounds: %d", absoluteIndex, chunkCount)), file);
+                throw new CorruptSSTableException(new EOFException(String.format(CHUNK_OUT_OF_BOUNDS_FORMAT,
+                                                                                 absoluteIndex,
+                                                                                 chunkCount)),
+                                                  file);
 
             int retries = MAX_RETRIES;
             while (retries-- > 0)
@@ -246,7 +252,10 @@ public interface CompressionChunkOffsets extends AutoCloseable
                     {
                         int count = block.count();
                         if (offsetInBlock >= count)
-                            throw new CorruptSSTableException(new EOFException(String.format("Chunk %d out of bounds: %d", offsetInBlock, count)), file);
+                            throw new CorruptSSTableException(new EOFException(String.format(CHUNK_OUT_OF_BOUNDS_FORMAT,
+                                                                                             offsetInBlock,
+                                                                                             count)),
+                                                              file);
                         return block.getLongAtIndex(offsetInBlock);
                     }
                     finally
@@ -266,7 +275,10 @@ public interface CompressionChunkOffsets extends AutoCloseable
         {
             int absoluteIndex = baseChunkIndex + index;
             if (absoluteIndex < 0 || absoluteIndex >= chunkCount)
-                throw new CorruptSSTableException(new EOFException(String.format("Chunk %d out of bounds: %d", absoluteIndex, chunkCount)), file);
+                throw new CorruptSSTableException(new EOFException(String.format(CHUNK_OUT_OF_BOUNDS_FORMAT,
+                                                                                 absoluteIndex,
+                                                                                 chunkCount)),
+                                                  file);
 
             ByteBuffer buffer = ByteBuffer.allocate(Long.BYTES);
             try
@@ -452,7 +464,10 @@ public interface CompressionChunkOffsets extends AutoCloseable
         {
             int absoluteIndex = baseChunkIndex + index;
             if (absoluteIndex < 0 || absoluteIndex >= chunkCount)
-                throw new CorruptSSTableException(new EOFException(String.format("Chunk %d out of bounds: %d", absoluteIndex, chunkCount)), file);
+                throw new CorruptSSTableException(new EOFException(String.format(BlockCache.CHUNK_OUT_OF_BOUNDS_FORMAT,
+                                                                                 absoluteIndex,
+                                                                                 chunkCount)),
+                                                  file);
 
             return getAbsolute(absoluteIndex);
         }

--- a/src/java/org/apache/cassandra/io/compress/CompressionChunkOffsetsFactory.java
+++ b/src/java/org/apache/cassandra/io/compress/CompressionChunkOffsetsFactory.java
@@ -1,0 +1,230 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.io.compress;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.util.Locale;
+
+import com.google.common.base.Preconditions;
+
+import io.netty.util.internal.PlatformDependent;
+import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.exceptions.ConfigurationException;
+import org.apache.cassandra.io.FSReadError;
+import org.apache.cassandra.io.sstable.CorruptSSTableException;
+import org.apache.cassandra.io.util.File;
+import org.apache.cassandra.io.util.Memory;
+import org.apache.cassandra.io.util.TrackedDataInputPlus;
+import org.apache.cassandra.utils.FBUtilities;
+
+import static org.apache.cassandra.config.CassandraRelevantProperties.COMPRESSION_CHUNK_OFFSETS_FACTORY;
+import static org.apache.cassandra.config.CassandraRelevantProperties.COMPRESSION_CHUNK_OFFSETS_TYPE;
+import static org.apache.cassandra.io.compress.CompressionMetadata.NATIVE_MEMORY_USAGE;
+
+/**
+ * Factory for {@link CompressionChunkOffsets} implementations.
+ * <p>
+ * The implementation is selected by {@link CassandraRelevantProperties#COMPRESSION_CHUNK_OFFSETS_TYPE}:
+ * </p>
+ * <ul>
+ *     <li>{@code in_memory} (default): use {@link CompressionChunkOffsets.InMemory}, loading all offsets into a single
+ *     Memory.LongArray.</li>
+ *     <li>{@code mmap}: use {@link CompressionChunkOffsets.Mmap}, which memory-maps the offsets section of the
+ *     compression info file. Gives close to in-memory performance while letting the OS reclaim pages under memory
+ *     pressure. Requires the file to be fully present on local disk.</li>
+ *     <li>{@code block_cache}: use {@link CompressionChunkOffsets.BlockCache} sized by
+ *     {@link CassandraRelevantProperties#COMPRESSION_CHUNK_OFFSETS_BLOCK_CACHE_SIZE}.</li>
+ * </ul>
+ */
+public interface CompressionChunkOffsetsFactory
+{
+    CompressionChunkOffsetsFactory instance = COMPRESSION_CHUNK_OFFSETS_FACTORY.isPresent()
+                                              ? FBUtilities.construct(COMPRESSION_CHUNK_OFFSETS_FACTORY.getString(), "Compression Chunk Offsets Factory")
+                                              : new CompressionChunkOffsetsFactory() {};
+
+    enum Type
+    {
+        IN_MEMORY, MMAP, BLOCK_CACHE
+    }
+
+    /**
+     * @return the configured compression chunk offsets type.
+     * @throws ConfigurationException if the configured value is not a recognised type.
+     */
+    static Type type()
+    {
+        String value = COMPRESSION_CHUNK_OFFSETS_TYPE.getString();
+        try
+        {
+            return Type.valueOf(value.trim().toUpperCase(Locale.ROOT));
+        }
+        catch (IllegalArgumentException e)
+        {
+            throw new ConfigurationException(String.format("Invalid value '%s' for %s. Valid values are: in_memory, mmap, block_cache",
+                                                           value, COMPRESSION_CHUNK_OFFSETS_TYPE.getKey()));
+        }
+    }
+
+    /**
+     * Create a {@link CompressionChunkOffsets} implementation from the provided compression metadata stream.
+     *
+     * @param indexFilePath        path to the compression info file
+     * @param input                stream positioned at the start of chunk offsets
+     * @param offsetsStart         position in the metadata file where chunk offsets begin
+     * @param startIndex           first chunk index to include (inclusive)
+     * @param endIndex             last chunk index to include (exclusive)
+     * @param chunkCount           total number of chunks in the file
+     * @param compressedFileLength compressed data file length
+     * @param readerType           read-time or write-time access mode
+     * @return a chunk offsets implementation
+     */
+    default CompressionChunkOffsets getInstance(File indexFilePath, TrackedDataInputPlus input, long offsetsStart,
+                                                int startIndex, int endIndex,
+                                                int chunkCount, long compressedFileLength,
+                                                CompressionMetadataReaderType readerType) throws IOException
+    {
+        if (chunkCount == 0)
+            return new CompressionChunkOffsets.Empty();
+
+        switch (type())
+        {
+            case MMAP:
+                return new CompressionChunkOffsets.Mmap(indexFilePath, offsetsStart, startIndex, endIndex - startIndex,
+                                                        endIndex, chunkCount, compressedFileLength, readerType);
+            case BLOCK_CACHE:
+                CompressionChunkOffsetCache cache = CompressionChunkOffsetCache.get();
+                return new CompressionChunkOffsets.BlockCache(indexFilePath, offsetsStart, startIndex, endIndex - startIndex,
+                                                              endIndex, chunkCount, compressedFileLength, readerType, cache);
+            case IN_MEMORY:
+            default:
+                return createInMemoryOffsets(indexFilePath, input, startIndex, endIndex, chunkCount, compressedFileLength);
+        }
+    }
+
+    /**
+     * Creates a {@link CompressionChunkOffsets} for metadata when opening the CompressionMetadata.Writer for early-open
+     * SSTableReader or final SSTableReader.
+     * <p>
+     * Note that compression info file is written when completing the sstable writing. During early-open, we expect
+     * the compression info file is not present; in that case this method always uses in-memory offsets.
+     * <p>
+     * When it's called after completing sstable writing with compression info, in-memory limit admission is applied and
+     * the writer's in-memory offsets may be released if on-disk offsets are selected.
+     * </p>
+     * @param indexFilePath path to the compression info file
+     * @param memoryChunkOffsets in-memory offsets buffer built by the writer
+     * @param offsetsStart position of the offsets table in the compression info file
+     * @param startIndex first chunk index to include (inclusive)
+     * @param endIndex last chunk index to include (exclusive)
+     * @param chunkCount total number of chunks in the file
+     * @param compressedFileLength compressed data file length
+     * @param isCompressionInfoWritten whether the compression info file is fully written
+     * @return a chunk offsets implementation for use in early-open or final SSTableReader
+     */
+    default CompressionChunkOffsets getInstanceOnWriterComplete(File indexFilePath, Memory.LongArray memoryChunkOffsets,
+                                                                long offsetsStart, int startIndex, int endIndex, int chunkCount,
+                                                                long compressedFileLength, boolean isCompressionInfoWritten) throws IOException
+    {
+        if (chunkCount == 0)
+            return new CompressionChunkOffsets.Empty();
+
+        // When CompressionMetadata.Writer completes, the opened CompressionMetadata is used into the final SSTableReader.
+        // This is considered READ_TIME as sstable has completed writing and the file will be used during READ_TIME
+        CompressionMetadataReaderType readerType = CompressionMetadataReaderType.READ_TIME;
+
+        // During early open, compression info file is not written yet, so use in-memory offsets
+        if (!isCompressionInfoWritten)
+        {
+            NATIVE_MEMORY_USAGE.addAndGet(memoryChunkOffsets.memoryUsed());
+            return new CompressionChunkOffsets.InMemory(memoryChunkOffsets, compressedFileLength);
+        }
+
+        switch (type())
+        {
+            case MMAP:
+                // Release writer's in-memory offsets since the offsets are now read from the mapped file
+                memoryChunkOffsets.close();
+                return new CompressionChunkOffsets.Mmap(indexFilePath, offsetsStart, startIndex, endIndex - startIndex,
+                                                        endIndex, chunkCount, compressedFileLength, readerType);
+            case BLOCK_CACHE:
+                CompressionChunkOffsetCache cache = CompressionChunkOffsetCache.get();
+                // Release writer's in-memory offsets since we'll use block-cached implementation.
+                memoryChunkOffsets.close();
+                return new CompressionChunkOffsets.BlockCache(indexFilePath, offsetsStart, startIndex, endIndex - startIndex,
+                                                              endIndex, chunkCount, compressedFileLength, readerType, cache);
+            case IN_MEMORY:
+            default:
+                NATIVE_MEMORY_USAGE.addAndGet(memoryChunkOffsets.memoryUsed());
+                return new CompressionChunkOffsets.InMemory(memoryChunkOffsets, compressedFileLength);
+        }
+    }
+
+
+
+    static CompressionChunkOffsets createInMemoryOffsets(File indexFilePath, TrackedDataInputPlus input,
+                                                         int startIndex, int endIndex, int chunkCount,
+                                                         long compressedFileLength)
+    {
+        Preconditions.checkState(startIndex < chunkCount, "The start index %s has to be < chunk count %s", startIndex, chunkCount);
+        Preconditions.checkState(endIndex <= chunkCount, "The end index %s has to be <= chunk count %s", endIndex, chunkCount);
+        Preconditions.checkState(startIndex <= endIndex, "The start index %s has to be < end index %s", startIndex, endIndex);
+
+        int chunksToRead = endIndex - startIndex;
+        if (chunksToRead == 0)
+            return new CompressionChunkOffsets.Empty();
+
+        Memory.LongArray offsets = new Memory.LongArray(chunksToRead);
+        long i = 0;
+        try
+        {
+            input.skipBytes(startIndex * 8);
+            long lastOffset;
+            for (i = 0; i < chunksToRead; i++)
+            {
+                lastOffset = input.readLong();
+                offsets.set(i, lastOffset);
+            }
+
+            // We adjust the compressed file length to store the position after the last chunk just to be able to
+            // calculate the offset of the chunk next to the last one (in order to calculate the length of the last chunk).
+            // Obvously, we could use the compressed file length for that purpose but unfortunately, sometimes there is
+            // an empty chunk added to the end of the file thus we cannot rely on the file length.
+            lastOffset = endIndex < chunkCount ? input.readLong() - offsets.get(0) : compressedFileLength;
+            NATIVE_MEMORY_USAGE.getAndAdd(offsets.memoryUsed());
+            return new CompressionChunkOffsets.InMemory(offsets, lastOffset);
+        }
+        catch (EOFException e)
+        {
+            offsets.close();
+            String msg = String.format("Corrupted Index File %s: read %d but expected at least %d chunks.", input, i, chunksToRead);
+            throw new CorruptSSTableException(new IOException(msg, e), indexFilePath.toPath());
+        }
+        catch (IOException e)
+        {
+            offsets.close();
+            throw new FSReadError(e, indexFilePath.toPath());
+        }
+        catch (RuntimeException e)
+        {
+            offsets.close();
+            throw e;
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/io/compress/CompressionChunkOffsetsFactory.java
+++ b/src/java/org/apache/cassandra/io/compress/CompressionChunkOffsetsFactory.java
@@ -24,7 +24,6 @@ import java.util.Locale;
 
 import com.google.common.base.Preconditions;
 
-import io.netty.util.internal.PlatformDependent;
 import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.io.FSReadError;
@@ -129,7 +128,7 @@ public interface CompressionChunkOffsetsFactory
      * the writer's in-memory offsets may be released if on-disk offsets are selected.
      * </p>
      * @param indexFilePath path to the compression info file
-     * @param memoryChunkOffsets in-memory offsets buffer built by the writer
+     * @param memoryChunkOffsets in-memory offsets buffer built by the writer, owned by this method
      * @param offsetsStart position of the offsets table in the compression info file
      * @param startIndex first chunk index to include (inclusive)
      * @param endIndex last chunk index to include (exclusive)
@@ -143,7 +142,11 @@ public interface CompressionChunkOffsetsFactory
                                                                 long compressedFileLength, boolean isCompressionInfoWritten) throws IOException
     {
         if (chunkCount == 0)
+        {
+            // release the writer's shared copy here
+            memoryChunkOffsets.close();
             return new CompressionChunkOffsets.Empty();
+        }
 
         // When CompressionMetadata.Writer completes, the opened CompressionMetadata is used into the final SSTableReader.
         // This is considered READ_TIME as sstable has completed writing and the file will be used during READ_TIME

--- a/src/java/org/apache/cassandra/io/compress/CompressionMetadata.java
+++ b/src/java/org/apache/cassandra/io/compress/CompressionMetadata.java
@@ -293,17 +293,17 @@ public class CompressionMetadata implements AutoCloseable
      */
     public long offHeapSize()
     {
-        return hasOffsets() ? chunkOffsets.offHeapMemoryUsed() : 0;
+        return chunkOffsets != null ? chunkOffsets.offHeapMemoryUsed() : 0;
     }
 
     public boolean hasOffsets()
     {
-        return chunkOffsets != null;
+        return chunkOffsets != null && chunkOffsets.size() > 0;
     }
 
     public void addTo(Ref.IdentityCollection identities)
     {
-        if (hasOffsets())
+        if (chunkOffsets != null)
             chunkOffsets.addTo(identities);
     }
 
@@ -408,7 +408,7 @@ public class CompressionMetadata implements AutoCloseable
 
     public void close()
     {
-        if (hasOffsets())
+        if (chunkOffsets != null)
         {
             chunkOffsets.close();
         }

--- a/src/java/org/apache/cassandra/io/compress/CompressionMetadataReaderType.java
+++ b/src/java/org/apache/cassandra/io/compress/CompressionMetadataReaderType.java
@@ -16,7 +16,7 @@
 
 package org.apache.cassandra.io.compress;
 
-enum CompressionMetadataReaderType
+public enum CompressionMetadataReaderType
 {
     WRITE_TIME,
     READ_TIME

--- a/src/java/org/apache/cassandra/metrics/MicrometerCompressionChunkOffsetCacheMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/MicrometerCompressionChunkOffsetCacheMetrics.java
@@ -1,0 +1,224 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.metrics;
+
+import java.util.ArrayList;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
+import com.github.benmanes.caffeine.cache.RemovalCause;
+import com.github.benmanes.caffeine.cache.stats.StatsCounter;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.Timer;
+import org.apache.cassandra.cache.CacheSize;
+import org.apache.cassandra.io.compress.CompressionChunkOffsetCache;
+import org.apache.cassandra.utils.Pair;
+
+/**
+ * Micrometer implementation for compression chunk offsets cache metrics.
+ */
+public class MicrometerCompressionChunkOffsetCacheMetrics extends MicrometerMetrics implements StatsCounter, CacheMetrics
+{
+    private final CacheSize cache;
+    private final String metricsPrefix;
+
+    // CNDB calls register() after construction to replace the registry and tags. register() removes the old meters
+    // before replacing these delegates, so a live previous registry does not keep exporting stale cache metrics.
+    private volatile MicrometerCacheMetrics metrics;
+    private volatile Timer missLatency;
+    private volatile Counter evictions;
+    private final ConcurrentHashMap<RemovalCause, Counter> evictionByRemovalCause = new ConcurrentHashMap<>();
+
+    public MicrometerCompressionChunkOffsetCacheMetrics(CompressionChunkOffsetCache cache, String metricsPrefix)
+    {
+        this.cache = cache;
+        this.metricsPrefix = metricsPrefix;
+        registerMetrics(registryWithTags().left, registryWithTags().right);
+    }
+
+    private void registerMetrics(MeterRegistry registry, Tags tags)
+    {
+        this.metrics = new MicrometerCacheMetrics(metricsPrefix, cache);
+        this.metrics.register(registry, tags);
+
+        this.missLatency = timer(metricsPrefix + "_miss_latency_seconds");
+        this.evictions = counter(metricsPrefix + "_evictions");
+
+        evictionByRemovalCause.clear();
+        for (RemovalCause cause : RemovalCause.values())
+        {
+            evictionByRemovalCause.put(cause, counter(metricsPrefix + "_evictions_" + cause.toString().toLowerCase()));
+        }
+    }
+
+    private void unregisterMetrics(MeterRegistry registry, Tags tags)
+    {
+        unregisterMeter(registry, tags, metricsPrefix + "_capacity");
+        unregisterMeter(registry, tags, metricsPrefix + "_size");
+        unregisterMeter(registry, tags, metricsPrefix + "_num_entries");
+        unregisterMeter(registry, tags, metricsPrefix + "_hit_rate");
+        unregisterMeter(registry, tags, metricsPrefix + "_misses");
+        unregisterMeter(registry, tags, metricsPrefix + "_hits");
+        unregisterMeter(registry, tags, metricsPrefix + "_requests");
+        unregisterMeter(registry, tags, metricsPrefix + "_miss_latency_seconds");
+        unregisterMeter(registry, tags, metricsPrefix + "_evictions");
+
+        for (RemovalCause cause : RemovalCause.values())
+            unregisterMeter(registry, tags, metricsPrefix + "_evictions_" + cause.toString().toLowerCase());
+    }
+
+    private static void unregisterMeter(MeterRegistry registry, Tags tags, String name)
+    {
+        for (Meter meter : new ArrayList<>(registry.find(name).tags(tags).meters()))
+            registry.remove(meter);
+    }
+
+    @Override
+    public synchronized void register(MeterRegistry newRegistry, Tags newTags)
+    {
+        Pair<MeterRegistry, Tags> current = registryWithTags();
+        if (current.left.equals(newRegistry))
+            throw new IllegalArgumentException("Cannot set the same registry twice!");
+
+        unregisterMetrics(current.left, current.right);
+        super.register(newRegistry, newTags);
+        registerMetrics(newRegistry, newTags);
+    }
+
+    @Override
+    public void recordMisses(int count)
+    {
+        metrics.recordMisses(count);
+    }
+
+    @Override
+    public void recordLoadSuccess(long val)
+    {
+        missLatency.record(val, TimeUnit.NANOSECONDS);
+    }
+
+    @Override
+    public void recordLoadFailure(long val)
+    {
+    }
+
+    @Override
+    public void recordEviction(int weight, RemovalCause removalCause)
+    {
+        if (removalCause.wasEvicted())
+            evictions.increment(1);
+
+        Counter counter = evictionByRemovalCause.get(removalCause);
+        if (counter != null)
+            counter.increment(1);
+    }
+
+    @Override
+    public void recordHits(int count)
+    {
+        metrics.recordHits(count);
+    }
+
+    @Override
+    public double hitRate()
+    {
+        return metrics.hitRate();
+    }
+
+    @Override
+    public double hitOneMinuteRate()
+    {
+        return metrics.hitOneMinuteRate();
+    }
+
+    @Override
+    public double hitFiveMinuteRate()
+    {
+        return metrics.hitFiveMinuteRate();
+    }
+
+    @Override
+    public double hitFifteenMinuteRate()
+    {
+        return metrics.hitFifteenMinuteRate();
+    }
+
+    @Override
+    public double requestsFifteenMinuteRate()
+    {
+        return metrics.requestsFifteenMinuteRate();
+    }
+
+    @Override
+    public long requests()
+    {
+        return metrics.requests();
+    }
+
+    @Override
+    public long capacity()
+    {
+        return metrics.capacity();
+    }
+
+    @Override
+    public long size()
+    {
+        return metrics.size();
+    }
+
+    @Override
+    public long entries()
+    {
+        return metrics.entries();
+    }
+
+    @Override
+    public long hits()
+    {
+        return metrics.hits();
+    }
+
+    @Override
+    public long misses()
+    {
+        return metrics.misses();
+    }
+
+    public double missLatency()
+    {
+        return missLatency.mean(TimeUnit.NANOSECONDS);
+    }
+
+    @Override
+    public CacheStats snapshot()
+    {
+        return CacheStats.of(metrics.hits(), metrics.misses(), missLatency.count(),
+                0L, (long) missLatency.totalTime(TimeUnit.NANOSECONDS), (long) evictions.count(), 0L);
+    }
+
+    @Override
+    public String toString()
+    {
+        return metrics.toString();
+    }
+}

--- a/src/java/org/apache/cassandra/metrics/MicrometerCompressionChunkOffsetCacheMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/MicrometerCompressionChunkOffsetCacheMetrics.java
@@ -17,97 +17,61 @@
  */
 package org.apache.cassandra.metrics;
 
-import java.util.ArrayList;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
-import com.github.benmanes.caffeine.cache.stats.CacheStats;
 import com.github.benmanes.caffeine.cache.RemovalCause;
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
 import com.github.benmanes.caffeine.cache.stats.StatsCounter;
 import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
-import org.apache.cassandra.cache.CacheSize;
 import org.apache.cassandra.io.compress.CompressionChunkOffsetCache;
-import org.apache.cassandra.utils.Pair;
+import org.apache.cassandra.utils.FBUtilities;
 
 /**
- * Micrometer implementation for compression chunk offsets cache metrics.
+ * Micrometer implementation for compression chunk offsets cache metrics: the standard cache metrics extended with
+ * the load and eviction meters required by caffeine's {@link StatsCounter}.
  */
-public class MicrometerCompressionChunkOffsetCacheMetrics extends MicrometerMetrics implements StatsCounter, CacheMetrics
+public class MicrometerCompressionChunkOffsetCacheMetrics extends MicrometerCacheMetrics implements StatsCounter
 {
-    private final CacheSize cache;
     private final String metricsPrefix;
+    private final ConcurrentHashMap<RemovalCause, Counter> evictionByRemovalCause = new ConcurrentHashMap<>();
 
-    // CNDB calls register() after construction to replace the registry and tags. register() removes the old meters
-    // before replacing these delegates, so a live previous registry does not keep exporting stale cache metrics.
-    private volatile MicrometerCacheMetrics metrics;
     private volatile Timer missLatency;
     private volatile Counter evictions;
-    private final ConcurrentHashMap<RemovalCause, Counter> evictionByRemovalCause = new ConcurrentHashMap<>();
 
     public MicrometerCompressionChunkOffsetCacheMetrics(CompressionChunkOffsetCache cache, String metricsPrefix)
     {
-        this.cache = cache;
+        super(metricsPrefix, cache);
         this.metricsPrefix = metricsPrefix;
-        registerMetrics(registryWithTags().left, registryWithTags().right);
+        registerStatsMeters();
     }
 
-    private void registerMetrics(MeterRegistry registry, Tags tags)
+    private void registerStatsMeters()
     {
-        this.metrics = new MicrometerCacheMetrics(metricsPrefix, cache);
-        this.metrics.register(registry, tags);
-
         this.missLatency = timer(metricsPrefix + "_miss_latency_seconds");
         this.evictions = counter(metricsPrefix + "_evictions");
 
-        evictionByRemovalCause.clear();
         for (RemovalCause cause : RemovalCause.values())
-        {
-            evictionByRemovalCause.put(cause, counter(metricsPrefix + "_evictions_" + cause.toString().toLowerCase()));
-        }
+            evictionByRemovalCause.put(cause, counter(evictionMeterName(cause)));
     }
 
-    private void unregisterMetrics(MeterRegistry registry, Tags tags)
+    private String evictionMeterName(RemovalCause cause)
     {
-        unregisterMeter(registry, tags, metricsPrefix + "_capacity");
-        unregisterMeter(registry, tags, metricsPrefix + "_size");
-        unregisterMeter(registry, tags, metricsPrefix + "_num_entries");
-        unregisterMeter(registry, tags, metricsPrefix + "_hit_rate");
-        unregisterMeter(registry, tags, metricsPrefix + "_misses");
-        unregisterMeter(registry, tags, metricsPrefix + "_hits");
-        unregisterMeter(registry, tags, metricsPrefix + "_requests");
-        unregisterMeter(registry, tags, metricsPrefix + "_miss_latency_seconds");
-        unregisterMeter(registry, tags, metricsPrefix + "_evictions");
-
-        for (RemovalCause cause : RemovalCause.values())
-            unregisterMeter(registry, tags, metricsPrefix + "_evictions_" + cause.toString().toLowerCase());
+        return metricsPrefix + "_evictions_" + cause.toString().toLowerCase();
     }
 
-    private static void unregisterMeter(MeterRegistry registry, Tags tags, String name)
-    {
-        for (Meter meter : new ArrayList<>(registry.find(name).tags(tags).meters()))
-            registry.remove(meter);
-    }
-
+    /**
+     * CNDB calls this after construction to replace the registry and tags, so the stats meters have to be recreated
+     * on the new registry, like the cache meters of the parent class.
+     */
     @Override
     public synchronized void register(MeterRegistry newRegistry, Tags newTags)
     {
-        Pair<MeterRegistry, Tags> current = registryWithTags();
-        if (current.left.equals(newRegistry))
-            throw new IllegalArgumentException("Cannot set the same registry twice!");
-
-        unregisterMetrics(current.left, current.right);
         super.register(newRegistry, newTags);
-        registerMetrics(newRegistry, newTags);
-    }
-
-    @Override
-    public void recordMisses(int count)
-    {
-        metrics.recordMisses(count);
+        registerStatsMeters();
     }
 
     @Override
@@ -132,78 +96,6 @@ public class MicrometerCompressionChunkOffsetCacheMetrics extends MicrometerMetr
             counter.increment(1);
     }
 
-    @Override
-    public void recordHits(int count)
-    {
-        metrics.recordHits(count);
-    }
-
-    @Override
-    public double hitRate()
-    {
-        return metrics.hitRate();
-    }
-
-    @Override
-    public double hitOneMinuteRate()
-    {
-        return metrics.hitOneMinuteRate();
-    }
-
-    @Override
-    public double hitFiveMinuteRate()
-    {
-        return metrics.hitFiveMinuteRate();
-    }
-
-    @Override
-    public double hitFifteenMinuteRate()
-    {
-        return metrics.hitFifteenMinuteRate();
-    }
-
-    @Override
-    public double requestsFifteenMinuteRate()
-    {
-        return metrics.requestsFifteenMinuteRate();
-    }
-
-    @Override
-    public long requests()
-    {
-        return metrics.requests();
-    }
-
-    @Override
-    public long capacity()
-    {
-        return metrics.capacity();
-    }
-
-    @Override
-    public long size()
-    {
-        return metrics.size();
-    }
-
-    @Override
-    public long entries()
-    {
-        return metrics.entries();
-    }
-
-    @Override
-    public long hits()
-    {
-        return metrics.hits();
-    }
-
-    @Override
-    public long misses()
-    {
-        return metrics.misses();
-    }
-
     public double missLatency()
     {
         return missLatency.mean(TimeUnit.NANOSECONDS);
@@ -212,13 +104,21 @@ public class MicrometerCompressionChunkOffsetCacheMetrics extends MicrometerMetr
     @Override
     public CacheStats snapshot()
     {
-        return CacheStats.of(metrics.hits(), metrics.misses(), missLatency.count(),
-                0L, (long) missLatency.totalTime(TimeUnit.NANOSECONDS), (long) evictions.count(), 0L);
+        return CacheStats.of(hits(), misses(), missLatency.count(),
+                             0L, (long) missLatency.totalTime(TimeUnit.NANOSECONDS), (long) evictions.count(), 0L);
     }
 
     @Override
     public String toString()
     {
-        return metrics.toString();
+        return "Compression chunk offsets cache metrics: " + System.lineSeparator() +
+               "Miss latency in seconds: " + missLatency() + System.lineSeparator() +
+               "Misses count: " + misses() + System.lineSeparator() +
+               "Hits count: " + hits() + System.lineSeparator() +
+               "Cache requests count: " + requests() + System.lineSeparator() +
+               "Moving hit rate: " + hitRate() + System.lineSeparator() +
+               "Num entries: " + entries() + System.lineSeparator() +
+               "Size in memory: " + FBUtilities.prettyPrintMemory(size()) + System.lineSeparator() +
+               "Capacity: " + FBUtilities.prettyPrintMemory(capacity());
     }
 }

--- a/src/java/org/apache/cassandra/utils/FBUtilities.java
+++ b/src/java/org/apache/cassandra/utils/FBUtilities.java
@@ -1103,6 +1103,34 @@ public class FBUtilities
     }
 
     /**
+     * Parses a human-readable size configuration string.
+     * <p>
+     * Supports plain byte sizes (e.g. {@code 1024B}, {@code 256MiB}, {@code 1GiB}) and relative size via {@code auto}:
+     * {@code auto} or {@code auto@<ratio>} where {@code <ratio>} is a decimal multiplier applied
+     * to {@code maxSizeInBytes}. For example, {@code auto@0.1} returns 10% of {@code maxSizeInBytes}.
+     *
+     * @param maxSizeInBytes base size used when {@code auto} is specified
+     * @param configString user-provided configuration string
+     * @return size in bytes
+     */
+    public static long parseHumanReadableConfig(long maxSizeInBytes, String configString)
+    {
+        long sizeInBytes;
+        Matcher autoPatternMatcher = Pattern.compile("auto(@(\\d+(\\.\\d*)?))?").matcher(configString.toLowerCase());
+        if (autoPatternMatcher.matches())
+        {
+            sizeInBytes = maxSizeInBytes;
+            final String ratioString = autoPatternMatcher.group(2);
+            if (ratioString != null)
+                sizeInBytes = (long) (sizeInBytes * Double.parseDouble(ratioString));
+        }
+        else
+            sizeInBytes = FBUtilities.parseHumanReadableBytes(configString);
+
+        return sizeInBytes;
+    }
+
+    /**
      * Parse an integer value, allowing the string "max" to mean Integer.MAX_VALUE.
      */
     public static int parseIntAllowingMax(String value)

--- a/test/microbench/org/apache/cassandra/test/microbench/CompressionChunkOffsetsBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/CompressionChunkOffsetsBench.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.test.microbench;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.io.compress.CompressionMetadata;
+import org.apache.cassandra.io.util.File;
+import org.apache.cassandra.schema.CompressionParams;
+
+@BenchmarkMode({Mode.Throughput, Mode.AverageTime})
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 1, time = 15)
+@Measurement(iterations = 3, time = 15)
+@Fork(value = 2, jvmArgsAppend = { "-Xms6G", "-Xmx6G"})
+@Threads(4)
+public class CompressionChunkOffsetsBench
+{
+    @State(Scope.Benchmark)
+    public static class BenchmarkState
+    {
+        // Selects the compression chunk offsets implementation to benchmark.
+        @Param({ "IN_MEMORY", "BLOCK_CACHE", "MMAP"})
+        public String offsetsType;
+
+        @Param({ "1000000"})
+        public int chunkCount;
+
+        private static final int CHUNK_LENGTH = 16;
+        private static final int COMPRESSED_LEN = 12;
+        private static final int CHECKSUM_LEN = 4;
+        private static final int OFFSETS_TO_READ = 1024 * 512;
+
+        private CompressionMetadata metadata;
+        private File metadataFile;
+        private long[] positions;
+        private int positionIdx;
+
+        @Setup(Level.Trial)
+        public void setup() throws Exception
+        {
+            DatabaseDescriptor.toolInitialization();
+            switch (offsetsType)
+            {
+                case "MMAP":
+                    CassandraRelevantProperties.COMPRESSION_CHUNK_OFFSETS_TYPE.setString("mmap");
+                    break;
+                case "BLOCK_CACHE":
+                    CassandraRelevantProperties.COMPRESSION_CHUNK_OFFSETS_TYPE.setString("block_cache");
+                    CassandraRelevantProperties.COMPRESSION_CHUNK_OFFSETS_BLOCK_CACHE_SIZE.setString("256MiB");
+                    break;
+                case "IN_MEMORY":
+                default:
+                    CassandraRelevantProperties.COMPRESSION_CHUNK_OFFSETS_TYPE.setString("in_memory");
+                    break;
+            }
+
+            metadataFile = createMetadataFile();
+            long compressedFileLength = computeCompressedFileLength();
+            metadata = new CompressionMetadata(metadataFile, compressedFileLength, true);
+            positions = buildPositions();
+            positionIdx = 0;
+        }
+
+        @TearDown(Level.Trial)
+        public void teardown() throws Exception
+        {
+            if (metadata != null)
+                metadata.close();
+
+            CassandraRelevantProperties.COMPRESSION_CHUNK_OFFSETS_BLOCK_CACHE_SIZE.reset();
+            CassandraRelevantProperties.COMPRESSION_CHUNK_OFFSETS_TYPE.reset();
+        }
+
+        @Setup(Level.Iteration)
+        public void prewarmCache()
+        {
+            // Only prewarm the block-cache type.
+            if (!"BLOCK_CACHE".equals(offsetsType))
+                return;
+
+            for (long position : positions)
+                metadata.chunkFor(position);
+        }
+
+        private File createMetadataFile() throws IOException
+        {
+            Path path = Files.createTempFile("compression_metadata_bench", ".db");
+            CompressionParams params = CompressionParams.snappy(CHUNK_LENGTH);
+            try (CompressionMetadata.Writer writer = CompressionMetadata.Writer.open(params, new File(path)))
+            {
+                long offset = 0;
+                for (int i = 0; i < chunkCount; i++)
+                {
+                    writer.addOffset(offset);
+                    // mock offset
+                    offset += COMPRESSED_LEN + CHECKSUM_LEN;
+                }
+                writer.finalizeLength((long) chunkCount * CHUNK_LENGTH, chunkCount);
+                writer.prepareToCommit();
+                Throwable t = writer.commit(null);
+                if (t != null)
+                    throw new IOException(t);
+            }
+            return new File(path);
+        }
+
+        private long computeCompressedFileLength()
+        {
+            return (long) chunkCount * (COMPRESSED_LEN + CHECKSUM_LEN);
+        }
+
+        private long[] buildPositions()
+        {
+            long[] values = new long[OFFSETS_TO_READ];
+            long maxPosition = (long) chunkCount * CHUNK_LENGTH;
+            long step = Math.max(1L, maxPosition / OFFSETS_TO_READ);
+            long position = 0;
+            for (int i = 0; i < OFFSETS_TO_READ; i++)
+            {
+                values[i] = position;
+                position = Math.min(maxPosition - 1, position + step);
+            }
+            return values;
+        }
+
+        long nextPosition()
+        {
+            // loop through positions
+            int idx = positionIdx++ & (OFFSETS_TO_READ - 1);
+            return positions[idx];
+        }
+    }
+
+    @Benchmark
+    public void chunkForRandom(BenchmarkState state, Blackhole blackhole)
+    {
+//     [java] Benchmark                                    (chunkCount)  (offsetsType)   Mode  Cnt    Score     Error   Units
+//     [java] CompressionChunkOffsetsBench.chunkForRandom       1000000      IN_MEMORY  thrpt    6  175.824 ±  58.879  ops/us
+//     [java] CompressionChunkOffsetsBench.chunkForRandom       1000000    BLOCK_CACHE  thrpt    6    6.029 ±   0.682  ops/us
+//     [java] CompressionChunkOffsetsBench.chunkForRandom       1000000           MMAP  thrpt    6  196.659 ± 206.888  ops/us
+//     [java] CompressionChunkOffsetsBench.chunkForRandom       1000000      IN_MEMORY   avgt    6    0.022 ±   0.008   us/op
+//     [java] CompressionChunkOffsetsBench.chunkForRandom       1000000    BLOCK_CACHE   avgt    6    0.723 ±   0.247   us/op
+//     [java] CompressionChunkOffsetsBench.chunkForRandom       1000000           MMAP   avgt    6    0.028 ±   0.024   us/op
+        CompressionMetadata.Chunk chunk = state.metadata.chunkFor(state.nextPosition());
+        blackhole.consume(chunk.offset);
+        blackhole.consume(chunk.length);
+    }
+}

--- a/test/unit/org/apache/cassandra/io/compress/CQLCompressionChunkOffsetsTest.java
+++ b/test/unit/org/apache/cassandra/io/compress/CQLCompressionChunkOffsetsTest.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.io.compress;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.awaitility.Awaitility;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class CQLCompressionChunkOffsetsTest extends CQLTester
+{
+    @BeforeClass
+    public static void setUpClass()
+    {
+        CQLTester.setUpClass();
+    }
+
+    @Before
+    public void resetConfigs()
+    {
+        CassandraRelevantProperties.COMPRESSION_CHUNK_OFFSETS_BLOCK_CACHE_SIZE.reset();
+        CassandraRelevantProperties.COMPRESSION_CHUNK_OFFSETS_TYPE.reset();
+        CompressionChunkOffsetCache.resetCache();
+    }
+
+    @Test
+    public void testReadWriteWithMmap() throws Throwable
+    {
+        CassandraRelevantProperties.COMPRESSION_CHUNK_OFFSETS_TYPE.setString("mmap");
+
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v text) WITH compression = {'sstable_compression': 'LZ4Compressor', 'chunk_length_in_kb': '1'};");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+
+        long initialMemory = CompressionMetadata.nativeMemoryAllocated();
+
+        populateAndFlush(0, 256);
+        assertEquals(1, cfs.getLiveSSTables().size());
+
+        SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
+        // mmap offsets live in the OS page cache, not in Cassandra-managed off-heap memory
+        assertEquals(0, sstable.getCompressionMetadata().offHeapSize());
+        assertEquals(initialMemory, CompressionMetadata.nativeMemoryAllocated());
+
+        // all rows must be readable from the mmap-backed sstable
+        for (int i = 0; i < 256; i++)
+            assertRows(execute("SELECT v FROM %s WHERE k = ?", i), row(String.format("value_%d_%08000d", i, i)));
+
+        // a compaction reads and rewrites the offsets through the mmap implementation
+        compact();
+        assertEquals(1, cfs.getLiveSSTables().size());
+        SSTableReader compacted = cfs.getLiveSSTables().iterator().next();
+        assertEquals(0, compacted.getCompressionMetadata().offHeapSize());
+
+        for (int i = 0; i < 256; i++)
+            assertRows(execute("SELECT v FROM %s WHERE k = ?", i), row(String.format("value_%d_%08000d", i, i)));
+    }
+
+    @Test
+    public void testNativeMemoryTrackingLifecycleWithInMemory() throws Throwable
+    {
+        CassandraRelevantProperties.COMPRESSION_CHUNK_OFFSETS_BLOCK_CACHE_SIZE.setString("0MiB");
+
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v text) WITH compression = {'sstable_compression': 'LZ4Compressor', 'chunk_length_in_kb': '1'};");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+
+        long initialMemory = CompressionMetadata.nativeMemoryAllocated();
+
+        populateAndFlush(0, 128);
+        assertEquals(1, cfs.getLiveSSTables().size());
+
+        SSTableReader first = cfs.getLiveSSTables().iterator().next();
+        long firstOffHeap = first.getCompressionMetadata().offHeapSize();
+        assertTrue(firstOffHeap > 0);
+        assertEquals(initialMemory + firstOffHeap, CompressionMetadata.nativeMemoryAllocated());
+
+        populateAndFlush(128, 256);
+        assertEquals(2, cfs.getLiveSSTables().size());
+
+        SSTableReader second = cfs.getLiveSSTables().stream().filter(s -> s.descriptor != first.descriptor)
+                                  .findFirst().orElseThrow(() -> new AssertionError("Expected flushed sstable"));
+        long secondOffheap = second.getCompressionMetadata().offHeapSize();
+        assertTrue(secondOffheap > 0);
+        assertEquals(initialMemory + firstOffHeap + secondOffheap, CompressionMetadata.nativeMemoryAllocated());
+
+        // force compaction
+        compact();
+        assertEquals(1, cfs.getLiveSSTables().size());
+
+        SSTableReader compacted = cfs.getLiveSSTables().iterator().next();
+        long compactedOffheap = compacted.getCompressionMetadata().offHeapSize();
+        assertTrue(compactedOffheap > 0);
+        Awaitility.await("Memory released after compaction")
+                  .atMost(10, TimeUnit.SECONDS)
+                  .untilAsserted(() -> {
+                      assertEquals(initialMemory + compactedOffheap, CompressionMetadata.nativeMemoryAllocated());
+                  });
+    }
+
+    @Test
+    public void testNativeMemoryTrackingLifecycleWithBlockCache() throws Throwable
+    {
+        CassandraRelevantProperties.COMPRESSION_CHUNK_OFFSETS_TYPE.setString("block_cache");
+        CassandraRelevantProperties.COMPRESSION_CHUNK_OFFSETS_BLOCK_CACHE_SIZE.setString("1000MiB");
+
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v text) WITH compression = {'sstable_compression': 'LZ4Compressor', 'chunk_length_in_kb': '1'};");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+
+        long initialMemory = CompressionMetadata.nativeMemoryAllocated();
+
+        populateAndFlush(0, 128);
+        assertEquals(1, cfs.getLiveSSTables().size());
+
+        SSTableReader first = cfs.getLiveSSTables().iterator().next();
+        long firstOffHeap = first.getCompressionMetadata().offHeapSize();
+        assertEquals(firstOffHeap, 0);
+
+        // should include memory from allocated block cache buffer
+        long memoryAfterFirstFlush = CompressionMetadata.nativeMemoryAllocated();
+        assertTrue(memoryAfterFirstFlush > initialMemory);
+
+        populateAndFlush(128, 256);
+        assertEquals(2, cfs.getLiveSSTables().size());
+
+        SSTableReader second = cfs.getLiveSSTables().stream().filter(s -> s.descriptor != first.descriptor)
+                                  .findFirst().orElseThrow(() -> new AssertionError("Expected flushed sstable"));
+        long secondOffheap = second.getCompressionMetadata().offHeapSize();
+        assertEquals(secondOffheap, 0);
+
+        long memoryAfterSecondFlush = CompressionMetadata.nativeMemoryAllocated();
+        assertTrue(memoryAfterSecondFlush > memoryAfterFirstFlush);
+
+        // force compaction
+        compact();
+        assertEquals(1, cfs.getLiveSSTables().size());
+
+        SSTableReader compacted = cfs.getLiveSSTables().iterator().next();
+        long compactedOffheap = compacted.getCompressionMetadata().offHeapSize();
+        assertEquals(compactedOffheap, 0);
+        Awaitility.await("Memory released after compaction")
+                  .atMost(10, TimeUnit.SECONDS)
+                  .untilAsserted(() -> {
+                      assertTrue(CompressionMetadata.nativeMemoryAllocated() <= memoryAfterSecondFlush);
+                  });
+    }
+
+    private void populateAndFlush(int start, int end)
+    {
+        for (int i = start; i < end; i++)
+            execute("INSERT INTO %s (k, v) values (?, ?)", i, String.format("value_%d_%08000d", i, i));
+        flush();
+    }
+}

--- a/test/unit/org/apache/cassandra/io/compress/CompressionChunkOffsetCacheTest.java
+++ b/test/unit/org/apache/cassandra/io/compress/CompressionChunkOffsetCacheTest.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.io.compress;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.TimeUnit;
+
+import com.dynatrace.hash4j.hashing.Hashing;
+import org.junit.Test;
+
+import org.awaitility.Awaitility;
+
+import org.apache.cassandra.metrics.MicrometerCompressionChunkOffsetCacheMetrics;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class CompressionChunkOffsetCacheTest
+{
+    @Test
+    public void offsetsBlockRefCounting()
+    {
+        ByteBuffer buffer = ByteBuffer.allocateDirect(16);
+        CompressionChunkOffsetCache.OffsetsBlock block = new CompressionChunkOffsetCache.OffsetsBlock(buffer);
+
+        assertThat(block.references).isEqualTo(1);
+        assertThat(block.ref()).isTrue();
+        assertThat(block.references).isEqualTo(2);
+
+        block.release();
+        assertThat(block.references).isEqualTo(1);
+
+        block.release();
+        assertThat(block.references).isEqualTo(0);
+        assertThat(block.ref()).isFalse();
+    }
+
+    @Test
+    public void testBlockKeyHashUsesFileIdAndBlockIndex()
+    {
+        CompressionChunkOffsetCache.BlockKey key = new CompressionChunkOffsetCache.BlockKey(11L, 7);
+
+        assertThat(key.hashCode()).isEqualTo(Hashing.metroHash64().hashLongLongToInt(11L, 7));
+        assertThat(key).isEqualTo(new CompressionChunkOffsetCache.BlockKey(11L, 7));
+        assertThat(key).isNotEqualTo(new CompressionChunkOffsetCache.BlockKey(12L, 7));
+        assertThat(key).isNotEqualTo(new CompressionChunkOffsetCache.BlockKey(11L, 8));
+        assertThatThrownBy(() -> key.equals(new Object())).isInstanceOf(ClassCastException.class);
+    }
+
+    @Test
+    public void testOffheapMemoryUsage()
+    {
+        long before = CompressionMetadata.nativeMemoryAllocated();
+        CompressionChunkOffsetCache cache = new CompressionChunkOffsetCache(100 * 1024);
+        long fileId = 1;
+
+        CompressionChunkOffsetCache.OffsetsBlock block =
+        cache.getBlock(fileId, 0, key -> new CompressionChunkOffsetCache.OffsetsBlock(ByteBuffer.allocateDirect(1024)));
+
+        Awaitility.await("metrics update")
+                  .atMost(10, TimeUnit.SECONDS)
+                  .untilAsserted(() -> {
+             assertThat(cache.weightedSize()).isEqualTo(1024L);
+             assertThat(CompressionMetadata.nativeMemoryAllocated()).isGreaterThanOrEqualTo(before + 1024L);
+         });
+
+        cache.clear();
+        Awaitility.await("Cache eviction")
+                  .atMost(10, TimeUnit.SECONDS)
+                  .untilAsserted(() -> assertThat(cache.weightedSize()).isEqualTo(0));
+        Awaitility.await("Native memory released")
+                  .atMost(10, TimeUnit.SECONDS)
+                  .untilAsserted(() -> assertThat(CompressionMetadata.nativeMemoryAllocated()).isEqualTo(before));
+    }
+
+    @Test
+    public void testBlockBufferReusedAfterRelease()
+    {
+        long before = CompressionMetadata.nativeMemoryAllocated();
+        CompressionChunkOffsetCache cache = new CompressionChunkOffsetCache(1024);
+
+        ByteBuffer first = cache.allocateBlockBuffer(512);
+        first.position(512);
+        first.flip();
+
+        CompressionChunkOffsetCache.OffsetsBlock block = cache.wrapBlockBuffer(first);
+        assertThat(CompressionMetadata.nativeMemoryAllocated()).isEqualTo(before + first.capacity());
+        assertThat(block.capacity()).isEqualTo(first.capacity());
+        assertThat(block.count()).isEqualTo(64);
+
+        block.release();
+        assertThat(CompressionMetadata.nativeMemoryAllocated()).isEqualTo(before);
+
+        ByteBuffer second = cache.allocateBlockBuffer(512);
+        assertThat(second).isSameAs(first);
+
+        cache.releaseBlockBuffer(second);
+        cache.clear();
+    }
+
+    @Test
+    public void testMetrics()
+    {
+        CompressionChunkOffsetCache cache = new CompressionChunkOffsetCache(1024);
+        MicrometerCompressionChunkOffsetCacheMetrics metrics = cache.getMetrics();
+        assertThat(metrics.hits()).isEqualTo(0);
+        assertThat(metrics.hitRate()).isNaN();
+        assertThat(metrics.misses()).isEqualTo(0);
+        assertThat(metrics.entries()).isEqualTo(0);
+        assertThat(metrics.capacity()).isEqualTo(1024);
+        assertThat(metrics.size()).isEqualTo(0);
+
+        long fileId = 1;
+
+        // 1st miss
+        cache.getBlock(fileId, 0, key -> new CompressionChunkOffsetCache.OffsetsBlock(ByteBuffer.allocateDirect(1024)));
+        Awaitility.await("metrics update")
+                  .atMost(10, TimeUnit.SECONDS)
+                  .untilAsserted(() -> {
+                      assertThat(metrics.hits()).isEqualTo(0);
+                      assertThat(metrics.hitRate()).isNaN();
+                      assertThat(metrics.misses()).isEqualTo(1);
+                      assertThat(metrics.missLatency()).isGreaterThan(0);
+                      assertThat(metrics.entries()).isEqualTo(1);
+                      assertThat(metrics.capacity()).isEqualTo(1024);
+                      assertThat(metrics.size()).isEqualTo(1024);
+                  });
+
+        // 1st hit
+        cache.getBlock(fileId, 0, key -> new CompressionChunkOffsetCache.OffsetsBlock(ByteBuffer.allocateDirect(1024)));
+        Awaitility.await("metrics update")
+                  .atMost(10, TimeUnit.SECONDS)
+                  .untilAsserted(() -> {
+                      assertThat(metrics.hits()).isEqualTo(1);
+                      assertThat(metrics.hitRate()).isEqualTo(0.5);
+                      assertThat(metrics.misses()).isEqualTo(1);
+                      assertThat(metrics.missLatency()).isGreaterThan(0);
+                      assertThat(metrics.entries()).isEqualTo(1);
+                      assertThat(metrics.capacity()).isEqualTo(1024);
+                      assertThat(metrics.size()).isEqualTo(1024);
+                  });
+
+        // load another block to evict previous block
+        cache.getBlock(fileId, 1, key -> new CompressionChunkOffsetCache.OffsetsBlock(ByteBuffer.allocateDirect(1024)));
+        Awaitility.await("metrics update")
+                  .atMost(10, TimeUnit.SECONDS)
+                  .untilAsserted(() -> {
+                      assertThat(metrics.hits()).isEqualTo(1);
+                      assertThat(metrics.hitRate()).isLessThan(0.5).isGreaterThan(0.0);
+                      assertThat(metrics.misses()).isEqualTo(2);
+                      assertThat(metrics.missLatency()).isGreaterThan(0);
+                      assertThat(metrics.entries()).isEqualTo(1);
+                      assertThat(metrics.capacity()).isEqualTo(1024);
+                      assertThat(metrics.size()).isEqualTo(1024);
+                  });
+    }
+}

--- a/test/unit/org/apache/cassandra/io/compress/CompressionChunkOffsetCacheTest.java
+++ b/test/unit/org/apache/cassandra/io/compress/CompressionChunkOffsetCacheTest.java
@@ -89,31 +89,6 @@ public class CompressionChunkOffsetCacheTest
     }
 
     @Test
-    public void testBlockBufferReusedAfterRelease()
-    {
-        long before = CompressionMetadata.nativeMemoryAllocated();
-        CompressionChunkOffsetCache cache = new CompressionChunkOffsetCache(1024);
-
-        ByteBuffer first = cache.allocateBlockBuffer(512);
-        first.position(512);
-        first.flip();
-
-        CompressionChunkOffsetCache.OffsetsBlock block = cache.wrapBlockBuffer(first);
-        assertThat(CompressionMetadata.nativeMemoryAllocated()).isEqualTo(before + first.capacity());
-        assertThat(block.capacity()).isEqualTo(first.capacity());
-        assertThat(block.count()).isEqualTo(64);
-
-        block.release();
-        assertThat(CompressionMetadata.nativeMemoryAllocated()).isEqualTo(before);
-
-        ByteBuffer second = cache.allocateBlockBuffer(512);
-        assertThat(second).isSameAs(first);
-
-        cache.releaseBlockBuffer(second);
-        cache.clear();
-    }
-
-    @Test
     public void testMetrics()
     {
         CompressionChunkOffsetCache cache = new CompressionChunkOffsetCache(1024);

--- a/test/unit/org/apache/cassandra/io/compress/CompressionChunkOffsetCacheTest.java
+++ b/test/unit/org/apache/cassandra/io/compress/CompressionChunkOffsetCacheTest.java
@@ -19,14 +19,19 @@
 package org.apache.cassandra.io.compress;
 
 import java.nio.ByteBuffer;
+import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
 import com.dynatrace.hash4j.hashing.Hashing;
+import com.github.benmanes.caffeine.cache.RemovalCause;
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
+
 import org.junit.Test;
 
 import org.awaitility.Awaitility;
 
 import org.apache.cassandra.metrics.MicrometerCompressionChunkOffsetCacheMetrics;
+import org.apache.cassandra.utils.concurrent.Ref;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -56,10 +61,37 @@ public class CompressionChunkOffsetCacheTest
         CompressionChunkOffsetCache.BlockKey key = new CompressionChunkOffsetCache.BlockKey(11L, 7);
 
         assertThat(key.hashCode()).isEqualTo(Hashing.metroHash64().hashLongLongToInt(11L, 7));
+        assertThat(key.equals(key)).isTrue();
         assertThat(key).isEqualTo(new CompressionChunkOffsetCache.BlockKey(11L, 7));
         assertThat(key).isNotEqualTo(new CompressionChunkOffsetCache.BlockKey(12L, 7));
         assertThat(key).isNotEqualTo(new CompressionChunkOffsetCache.BlockKey(11L, 8));
         assertThatThrownBy(() -> key.equals(new Object())).isInstanceOf(ClassCastException.class);
+    }
+
+    @Test
+    public void testUnsupportedCapacityChange()
+    {
+        CompressionChunkOffsetCache cache = new CompressionChunkOffsetCache(1024);
+
+        assertThatThrownBy(() -> cache.setCapacity(2048))
+            .isInstanceOf(UnsupportedOperationException.class)
+            .hasMessage("Compression chunk offsets cache size cannot be changed.");
+    }
+
+    @Test
+    public void testEmptyOffsets()
+    {
+        CompressionChunkOffsets offsets = new CompressionChunkOffsets.Empty();
+
+        assertThat(offsets.size()).isZero();
+        assertThat(offsets.offHeapMemoryUsed()).isZero();
+        assertThat(offsets.compressedFileLength()).isZero();
+        assertThatThrownBy(() -> offsets.get(0))
+            .isInstanceOf(IndexOutOfBoundsException.class)
+            .hasMessageContaining("Chunk index 0 out of bounds");
+
+        offsets.addTo(new Ref.IdentityCollection(Collections.emptySet()));
+        offsets.close();
     }
 
     @Test
@@ -143,5 +175,24 @@ public class CompressionChunkOffsetCacheTest
                       assertThat(metrics.capacity()).isEqualTo(1024);
                       assertThat(metrics.size()).isEqualTo(1024);
                   });
+
+        assertThat(metrics.requests()).isEqualTo(3);
+        assertThat(metrics.hitOneMinuteRate()).isNaN();
+        assertThat(metrics.hitFiveMinuteRate()).isNaN();
+        assertThat(metrics.hitFifteenMinuteRate()).isNaN();
+        assertThat(metrics.requestsFifteenMinuteRate()).isNaN();
+
+        CacheStats snapshot = metrics.snapshot();
+        assertThat(snapshot.hitCount()).isEqualTo(1);
+        assertThat(snapshot.missCount()).isEqualTo(2);
+        assertThat(snapshot.loadSuccessCount()).isEqualTo(2);
+        assertThat(metrics.toString()).isNotEmpty();
+
+        long evictionCount = snapshot.evictionCount();
+        metrics.recordEviction(1, RemovalCause.EXPIRED);
+        assertThat(metrics.snapshot().evictionCount()).isEqualTo(evictionCount + 1);
+        metrics.recordEviction(1, RemovalCause.REPLACED);
+        assertThat(metrics.snapshot().evictionCount()).isEqualTo(evictionCount + 1);
+        metrics.recordLoadFailure(1L);
     }
 }

--- a/test/unit/org/apache/cassandra/io/compress/CompressionMetadataTest.java
+++ b/test/unit/org/apache/cassandra/io/compress/CompressionMetadataTest.java
@@ -21,21 +21,54 @@ package org.apache.cassandra.io.compress;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.channels.FileChannel;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Consumer;
 
+import org.junit.After;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
+import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.io.compress.CompressionMetadata.Chunk;
 import org.apache.cassandra.io.sstable.format.SSTableReader.PartitionPositionBounds;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.SliceDescriptor;
 import org.apache.cassandra.schema.CompressionParams;
+import org.apache.cassandra.utils.units.SizeUnit;
 
 import static java.util.Arrays.asList;
+import static org.apache.cassandra.io.compress.CompressionChunkOffsetCache.getCacheSizeInBytes;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class CompressionMetadataTest
 {
+    @BeforeClass
+    public static void init()
+    {
+        DatabaseDescriptor.toolInitialization();
+    }
+
+    @After
+    public void tearDown()
+    {
+        CompressionChunkOffsetCache.resetCache();
+        CassandraRelevantProperties.COMPRESSION_CHUNK_OFFSETS_BLOCK_CACHE_SIZE.reset();
+        CassandraRelevantProperties.COMPRESSION_CHUNK_OFFSETS_CACHE_BLOCK_SIZE.reset();
+        CassandraRelevantProperties.COMPRESSION_CHUNK_OFFSETS_TYPE.reset();
+        CassandraRelevantProperties.COMPRESSION_CHUNK_OFFSETS_MMAP_SEGMENT_SIZE.reset();
+        CassandraRelevantProperties.COMPRESSION_CHUNK_OFFSETS_FACTORY.reset();
+    }
+
     private File generateMetaDataFile(long dataLength, long... offsets) throws IOException
     {
         Path path = Files.createTempFile("compression_metadata", ".db");
@@ -60,14 +93,35 @@ public class CompressionMetadataTest
         return new CompressionMetadata(f, compressedFileLength, true);
     }
 
-    private void checkMetadata(CompressionMetadata metadata, long expectedDataLength, long expectedCompressedFileLimit, long expectedOffHeapSize)
+    private void checkMetadata(CompressionMetadata metadata, long expectedDataLength, long expectedCompressedFileLimit, long expectedMemorySize)
     {
         assertThat(metadata.dataLength).isEqualTo(expectedDataLength);
         assertThat(metadata.compressedFileLength).isEqualTo(expectedCompressedFileLimit);
         assertThat(metadata.chunkLength()).isEqualTo(16);
         assertThat(metadata.parameters.chunkLength()).isEqualTo(16);
         assertThat(metadata.parameters.getSstableCompressor().getClass()).isEqualTo(SnappyCompressor.class);
-        assertThat(metadata.offHeapSize()).isEqualTo(expectedOffHeapSize);
+
+        // Only the legacy in-memory implementation holds offsets in Cassandra-managed off-heap memory. The block cache
+        // and mmap implementations report 0 (cache memory is shared, mmap memory lives in the OS page cache).
+        if (offsetsHeldInOffHeapMemory())
+            assertThat(metadata.offHeapSize()).isEqualTo(expectedMemorySize);
+        else
+            assertThat(metadata.offHeapSize()).isEqualTo(0);
+    }
+
+    private static boolean offsetsHeldInOffHeapMemory()
+    {
+        switch (CompressionChunkOffsetsFactory.type())
+        {
+            case MMAP:
+                return false;
+            case BLOCK_CACHE:
+                // in-memory only when the block cache is disabled
+                return CompressionChunkOffsetCache.get() == null;
+            case IN_MEMORY:
+            default:
+                return true;
+        }
     }
 
     private void assertChunks(CompressionMetadata metadata, long from, long to, long expectedOffset, long expectedLength)
@@ -89,7 +143,150 @@ public class CompressionMetadataTest
     }
 
     @Test
-    public void chunkFor() throws IOException
+    public void testLargeFileAccessInMemory() throws IOException
+    {
+        CassandraRelevantProperties.COMPRESSION_CHUNK_OFFSETS_BLOCK_CACHE_SIZE.setString("0B");
+        testLargeFileAccess();
+    }
+
+    @Test
+    public void testLargeFileAccessBlockCache() throws IOException
+    {
+        CassandraRelevantProperties.COMPRESSION_CHUNK_OFFSETS_TYPE.setString("block_cache");
+        CassandraRelevantProperties.COMPRESSION_CHUNK_OFFSETS_BLOCK_CACHE_SIZE.setString("100MiB");
+        testLargeFileAccess();
+    }
+
+    @Test
+    public void testLargeFileAccessMmap() throws IOException
+    {
+        CassandraRelevantProperties.COMPRESSION_CHUNK_OFFSETS_TYPE.setString("mmap");
+        testLargeFileAccess();
+    }
+
+    private void testLargeFileAccess() throws IOException
+    {
+        int chunkCount = 1000_000;
+        int chunkLength = 16;
+        int checksumLength = 4; // payload size is 12 = chunkLength - checksumLength
+        long[] offsets = new long[chunkCount];
+        long offset = 0;
+        for (int i = 0; i < chunkCount; i++)
+        {
+            offsets[i] = offset;
+            offset += chunkLength;
+        }
+
+        File largeFile = generateMetaDataFile((long) chunkCount * chunkLength, offsets);
+        long compressedFileLimit = offset;
+
+        // metadata built under the type configured by the caller (in-memory, block cache or mmap)
+        CompressionMetadata metadataUnderTest = new CompressionMetadata(largeFile, compressedFileLimit, true);
+        checkMetadata(metadataUnderTest, (long) chunkCount * chunkLength, compressedFileLimit, chunkCount * 8L);
+
+        // in-memory baseline to compare offsets against
+        CassandraRelevantProperties.COMPRESSION_CHUNK_OFFSETS_TYPE.setString("in_memory");
+        CompressionMetadata metadataWithInMemory = new CompressionMetadata(largeFile, compressedFileLimit, true);
+        checkMetadata(metadataWithInMemory, (long) chunkCount * chunkLength, compressedFileLimit, chunkCount * 8L);
+        try
+        {
+            for (int i = 0; i < chunkCount; )
+            {
+                long pos = (long) i * chunkLength;
+                Chunk chunkWithInMemory = metadataWithInMemory.chunkFor(pos);
+                assertThat(chunkWithInMemory.offset).isEqualTo((long) i * chunkLength);
+                assertThat(chunkWithInMemory.length).isEqualTo(chunkLength - checksumLength);
+
+                Chunk chunkUnderTest = metadataUnderTest.chunkFor(pos);
+                assertThat(chunkUnderTest.offset).isEqualTo((long) i * chunkLength);
+                assertThat(chunkUnderTest.length).isEqualTo(chunkLength - checksumLength);
+
+                i += ThreadLocalRandom.current().nextInt(100) + 1;
+            }
+        }
+        finally
+        {
+            metadataWithInMemory.close();
+            metadataUnderTest.close();
+        }
+    }
+
+    @Test
+    public void chunkForWithBlockCache() throws IOException
+    {
+        CassandraRelevantProperties.COMPRESSION_CHUNK_OFFSETS_TYPE.setString("block_cache");
+        CassandraRelevantProperties.COMPRESSION_CHUNK_OFFSETS_BLOCK_CACHE_SIZE.setString("100MiB");
+        chunkFor();
+
+        // verify cache is invalidated on closing compression metadata
+        assertThat(CompressionChunkOffsetCache.get().size()).isEqualTo(0);
+    }
+
+    @Test
+    public void chunkForInMemory() throws IOException
+    {
+        CassandraRelevantProperties.COMPRESSION_CHUNK_OFFSETS_BLOCK_CACHE_SIZE.setString("0B");
+        chunkFor();
+    }
+
+    @Test
+    public void chunkForMmap() throws IOException
+    {
+        CassandraRelevantProperties.COMPRESSION_CHUNK_OFFSETS_TYPE.setString("mmap");
+        chunkFor();
+    }
+
+    @Test
+    public void testBlockCacheBlockSizeIsRoundedToWholeOffset()
+    {
+        CassandraRelevantProperties.COMPRESSION_CHUNK_OFFSETS_CACHE_BLOCK_SIZE.setString("15");
+        assertThat(CompressionChunkOffsetCache.blockBufferSize()).isEqualTo(Long.BYTES);
+
+        CassandraRelevantProperties.COMPRESSION_CHUNK_OFFSETS_CACHE_BLOCK_SIZE.setString("17");
+        assertThat(CompressionChunkOffsetCache.blockBufferSize()).isEqualTo(2 * Long.BYTES);
+
+        CassandraRelevantProperties.COMPRESSION_CHUNK_OFFSETS_CACHE_BLOCK_SIZE.setString("1");
+        assertThat(CompressionChunkOffsetCache.blockBufferSize()).isEqualTo(Long.BYTES);
+    }
+
+    @Test
+    public void testMmapMultipleSegments() throws IOException
+    {
+        CassandraRelevantProperties.COMPRESSION_CHUNK_OFFSETS_TYPE.setString("mmap");
+        // A deliberately tiny, non-8-aligned segment size: forces many segment boundaries and verifies the size is
+        // rounded down to a whole number of offsets so that no offset straddles a boundary (would otherwise read past
+        // a segment's limit).
+        CassandraRelevantProperties.COMPRESSION_CHUNK_OFFSETS_MMAP_SEGMENT_SIZE.setString("20");
+
+        int chunkCount = 50;
+        int chunkLength = 16;
+        int checksumLength = 4; // payload size is 12 = chunkLength - checksumLength
+        long[] offsets = new long[chunkCount];
+        long offset = 0;
+        for (int i = 0; i < chunkCount; i++)
+        {
+            offsets[i] = offset;
+            offset += chunkLength;
+        }
+
+        File file = generateMetaDataFile((long) chunkCount * chunkLength, offsets);
+        long compressedFileLimit = offset;
+
+        try (CompressionMetadata mmap = new CompressionMetadata(file, compressedFileLimit, true))
+        {
+            checkMetadata(mmap, (long) chunkCount * chunkLength, compressedFileLimit, chunkCount * 8L);
+
+            // read every chunk, including the ones whose offset would straddle a segment boundary if unaligned
+            for (int i = 0; i < chunkCount; i++)
+            {
+                Chunk chunk = mmap.chunkFor((long) i * chunkLength);
+                assertThat(chunk.offset).isEqualTo((long) i * chunkLength);
+                assertThat(chunk.length).isEqualTo(chunkLength - checksumLength);
+            }
+        }
+    }
+
+    private void chunkFor() throws IOException
     {
         try (CompressionMetadata lessThanOneChunk = createMetadata(10, 7, 0))
         {
@@ -132,7 +329,7 @@ public class CompressionMetadataTest
 
             assertThat(md.getTotalSizeForSections(asList(new PartitionPositionBounds(0, 90)))).isEqualTo(62);
             assertThat(md.getChunksForSections(asList(new PartitionPositionBounds(0, 90)))).containsExactly(new Chunk(0, 3), new Chunk(7, 5), new Chunk(16, 7), new Chunk(27, 11), new Chunk(42, 7), new Chunk(53, 5));
-            
+
             assertThat(md.getTotalSizeForSections(asList(new PartitionPositionBounds(20, 40), new PartitionPositionBounds(50, 70)))).isEqualTo(46);
             assertThat(md.getChunksForSections(asList(new PartitionPositionBounds(20, 40), new PartitionPositionBounds(50, 70)))).containsExactly(new Chunk(7, 5), new Chunk(16, 7), new Chunk(27, 11), new Chunk(42, 7));
         });
@@ -183,6 +380,118 @@ public class CompressionMetadataTest
             assertThat(md.getTotalSizeForSections(asList(new PartitionPositionBounds(30, 40), new PartitionPositionBounds(50, 60)))).isEqualTo(35);
             assertThat(md.getChunksForSections(asList(new PartitionPositionBounds(30, 40), new PartitionPositionBounds(50, 60)))).containsExactly(new Chunk(7, 5), new Chunk(16, 7), new Chunk(27, 11));
         });
+    }
 
+    @Test
+    public void testConcurrentAccessInMemory() throws Exception
+    {
+        CassandraRelevantProperties.COMPRESSION_CHUNK_OFFSETS_BLOCK_CACHE_SIZE.setString("0B");
+        testConcurrentAccess();
+    }
+
+    @Test
+    public void testConcurrentAccessBlockCache() throws Exception
+    {
+        CassandraRelevantProperties.COMPRESSION_CHUNK_OFFSETS_TYPE.setString("block_cache");
+        CassandraRelevantProperties.COMPRESSION_CHUNK_OFFSETS_BLOCK_CACHE_SIZE.setString("100MiB");
+        testConcurrentAccess();
+
+        // verify cache is invalidated on closing compression metadata
+        assertThat(CompressionChunkOffsetCache.get().size()).isEqualTo(0);
+    }
+
+    @Test
+    public void testConcurrentAccessMmap() throws Exception
+    {
+        CassandraRelevantProperties.COMPRESSION_CHUNK_OFFSETS_TYPE.setString("mmap");
+        testConcurrentAccess();
+    }
+
+    private void testConcurrentAccess() throws Exception
+    {
+        int chunkCount = 100_000;
+        int chunkLength = 16;
+        int checksumLength = 4; // payload size is 12 = chunkLength - checksumLength
+        long[] offsets = new long[chunkCount];
+        long offset = 0;
+        for (int i = 0; i < chunkCount; i++)
+        {
+            offsets[i] = offset;
+            offset += chunkLength;
+        }
+
+        File metadataFile = generateMetaDataFile((long) chunkCount * chunkLength, offsets);
+        long compressedFileLength = offset;
+        try (CompressionMetadata metadata = new CompressionMetadata(metadataFile, compressedFileLength, true))
+        {
+            int numThreads = 16;
+            int operationsPerThread = 10000;
+            ExecutorService executor = Executors.newFixedThreadPool(numThreads);
+            List<Callable<Void>> tasks = new ArrayList<>(numThreads);
+
+            for (int i = 0; i < numThreads; i++)
+            {
+                tasks.add(() -> {
+                    for (int j = 0; j < operationsPerThread; j++)
+                    {
+                        long position = ThreadLocalRandom.current().nextLong(metadata.dataLength);
+                        int chunkIndex = (int) (position / chunkLength);
+                        long expectedOffset = (long) chunkIndex * chunkLength;
+                        int expectedLength = chunkLength - checksumLength;
+
+                        Chunk chunk = metadata.chunkFor(position);
+
+                        assertThat(chunk.offset).isEqualTo(expectedOffset);
+                        assertThat(chunk.length).isEqualTo(expectedLength);
+                    }
+                    return null;
+                });
+            }
+
+            List<Future<Void>> futures = executor.invokeAll(tasks);
+            for (Future<Void> future : futures)
+            {
+                future.get(); // This will throw an exception if the task failed
+            }
+            executor.shutdown();
+        }
+    }
+
+    @Test
+    public void testCacheSize()
+    {
+        CassandraRelevantProperties.COMPRESSION_CHUNK_OFFSETS_BLOCK_CACHE_SIZE.setString("0B");
+        assertThat(getCacheSizeInBytes(1000)).isEqualTo(0);
+        CassandraRelevantProperties.COMPRESSION_CHUNK_OFFSETS_BLOCK_CACHE_SIZE.setString("10GiB");
+        assertThat(getCacheSizeInBytes(1000)).isEqualTo(SizeUnit.GIGABYTES.toBytes(10));
+        CassandraRelevantProperties.COMPRESSION_CHUNK_OFFSETS_BLOCK_CACHE_SIZE.setString("10MiB");
+        assertThat(getCacheSizeInBytes(1000)).isEqualTo(SizeUnit.MEGABYTES.toBytes(10));
+
+        CassandraRelevantProperties.COMPRESSION_CHUNK_OFFSETS_BLOCK_CACHE_SIZE.setString("auto");
+        assertThat(getCacheSizeInBytes(1000)).isEqualTo(1000);
+        CassandraRelevantProperties.COMPRESSION_CHUNK_OFFSETS_BLOCK_CACHE_SIZE.setString("auto@1");
+        assertThat(getCacheSizeInBytes(1000)).isEqualTo(1000);
+        CassandraRelevantProperties.COMPRESSION_CHUNK_OFFSETS_BLOCK_CACHE_SIZE.setString("auto@0.1");
+        assertThat(getCacheSizeInBytes(1000)).isEqualTo(100);
+    }
+
+    @Test
+    public void testCompressionMetadataReadError() throws Exception
+    {
+        CassandraRelevantProperties.COMPRESSION_CHUNK_OFFSETS_BLOCK_CACHE_SIZE.setString("0B");
+
+        File f = generateMetaDataFile(64, 0, 16, 32, 48);
+        long sizeBefore = f.length();
+        // corrupt the file to force error while opening
+        try (FileChannel channel = FileChannel.open(f.toPath(), StandardOpenOption.WRITE))
+        {
+            // EOF
+            channel.truncate(sizeBefore - Long.BYTES);
+        }
+
+        long before = CompressionMetadata.nativeMemoryAllocated();
+
+        assertThatThrownBy(() -> new CompressionMetadata(f, 64, true)).isInstanceOf(RuntimeException.class);
+        assertThat(CompressionMetadata.nativeMemoryAllocated()).isEqualTo(before);
     }
 }

--- a/test/unit/org/apache/cassandra/io/compress/CompressionMetadataTest.java
+++ b/test/unit/org/apache/cassandra/io/compress/CompressionMetadataTest.java
@@ -41,6 +41,8 @@ import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.io.compress.CompressionMetadata.Chunk;
 import org.apache.cassandra.io.sstable.format.SSTableReader.PartitionPositionBounds;
 import org.apache.cassandra.io.util.File;
+import org.apache.cassandra.io.util.Memory;
+import org.apache.cassandra.io.util.SafeMemory;
 import org.apache.cassandra.io.util.SliceDescriptor;
 import org.apache.cassandra.schema.CompressionParams;
 import org.apache.cassandra.utils.units.SizeUnit;
@@ -493,5 +495,68 @@ public class CompressionMetadataTest
 
         assertThatThrownBy(() -> new CompressionMetadata(f, 64, true)).isInstanceOf(RuntimeException.class);
         assertThat(CompressionMetadata.nativeMemoryAllocated()).isEqualTo(before);
+    }
+
+    /**
+     * A compression info file for an empty data file holds zero chunks and therefore no chunk offsets at all.
+     */
+    @Test
+    public void testZeroChunkMetadataHasNoOffsetsInMemory() throws IOException
+    {
+        CassandraRelevantProperties.COMPRESSION_CHUNK_OFFSETS_TYPE.setString("in_memory");
+        testZeroChunkMetadataHasNoOffsets();
+    }
+
+    @Test
+    public void testZeroChunkMetadataHasNoOffsetsBlockCache() throws IOException
+    {
+        CassandraRelevantProperties.COMPRESSION_CHUNK_OFFSETS_TYPE.setString("block_cache");
+        CassandraRelevantProperties.COMPRESSION_CHUNK_OFFSETS_BLOCK_CACHE_SIZE.setString("100MiB");
+        testZeroChunkMetadataHasNoOffsets();
+    }
+
+    @Test
+    public void testZeroChunkMetadataHasNoOffsetsMmap() throws IOException
+    {
+        CassandraRelevantProperties.COMPRESSION_CHUNK_OFFSETS_TYPE.setString("mmap");
+        testZeroChunkMetadataHasNoOffsets();
+    }
+
+    private void testZeroChunkMetadataHasNoOffsets() throws IOException
+    {
+        File f = generateMetaDataFile(0);
+
+        try (CompressionMetadata metadata = new CompressionMetadata(f, 0, true))
+        {
+            assertThat(metadata.compressedFileLength).isEqualTo(0);
+            assertThat(metadata.offHeapSize()).isEqualTo(0);
+            assertThat(metadata.hasOffsets()).isFalse();
+        }
+    }
+
+    @Test
+    public void testWriterCompleteReleasesOffsetsWhenThereAreNoChunks() throws IOException
+    {
+        File f = generateMetaDataFile(64, 0, 16, 32, 48);
+
+        SafeMemory offsets = new SafeMemory(4 * 8L);
+        try
+        {
+            SafeMemory sharedCopy = offsets.sharedCopy();
+            CompressionChunkOffsets chunkOffsets = CompressionChunkOffsetsFactory.instance.getInstanceOnWriterComplete(f,
+                                    new Memory.LongArray(sharedCopy, 0), 0, 0, 0, 0, 0, true);
+
+            assertThat(chunkOffsets).isInstanceOf(CompressionChunkOffsets.Empty.class);
+            assertThat(chunkOffsets.size()).isEqualTo(0);
+
+            // sharedCopy() rejects an already-closed SafeMemory, so we know that it was released
+            assertThatThrownBy(sharedCopy::sharedCopy).isInstanceOf(IllegalStateException.class);
+
+            chunkOffsets.close();
+        }
+        finally
+        {
+            offsets.close();
+        }
     }
 }


### PR DESCRIPTION
https://github.com/riptano/cndb/issues/15064

## Block Cache:

- Add `CompressionChunkOffsets.BlockCache` backed by a shared `CompressionChunkOffsetCache`. Instead of loading every compression chunk offset into memory upfront, it reads fixed-size offset blocks from the compression info file on demand. The default block size is 64KiB, i.e. 8192 8-byte offsets.
- In order to minise hashing cost of block cache key, each `CompressionChunkOffsets.BlockCache` instance is assigned with a autto-incrementing id to uniquely identify the offset file and use MetroHash64 to hash the file id and block index for block key hashcode. Note that different `BlockCache` instances for the same file now use different file ids thus different cache block key.
- Added `MicrometerCompressionChunkOffsetCacheMetrics` to expose block cache metrics

## Mmap:

- adds `CompressionChunkOffsets.Mmap` to read offsets from read-only `MappedByteBuffer`s over the compression info file. Each mmap segment is limited to `Integer.MAX_VALUE` bytes.
- doesn't support archive-in-cache and storage service where compression info file is not present on disk
- require provisioning additional non-heap memory to accommodate mmap memory and to avoid OOMKilled when running in k8s.

## Config:
- cassandra.compression_chunk_offsets_factory: optional customizable factory
- cassandra.compression_chunk_offsets_type: default "IN_MEMORY". Available configs: IN_MEMORY, MMAP, BLOCK_CACHE
- cassandra.compression_chunk_offsets_block_cache_size: default "auto@0.15" - size of the block cache. Must be positive
- cassandra.compression_chunk_offsets_cache_block_size_bytes: default 64kb, i.e.  8192 offsets. - size of the block
- cassandra.compression_chunk_offsets.mmapped_max_segment_size: default Int.Max, size of memory mapped segment

## Microbench:

* IN_MEMORY (baseline) and MMAP are the fastest. BLOCK_CACHE (with warmup) is slowest due to ref counting and cache overhead.

```
Benchmark                                    (chunkCount)  (offsetsType)   Mode  Cnt    Score     Error   Units
CompressionChunkOffsetsBench.chunkForRandom       1000000      IN_MEMORY  thrpt    6  175.824 ±  58.879  ops/us
CompressionChunkOffsetsBench.chunkForRandom       1000000    BLOCK_CACHE  thrpt    6    6.029 ±   0.682  ops/us
CompressionChunkOffsetsBench.chunkForRandom       1000000           MMAP  thrpt    6  196.659 ± 206.888  ops/us
CompressionChunkOffsetsBench.chunkForRandom       1000000      IN_MEMORY   avgt    6    0.022 ±   0.008   us/op
CompressionChunkOffsetsBench.chunkForRandom       1000000    BLOCK_CACHE   avgt    6    0.723 ±   0.247   us/op
CompressionChunkOffsetsBench.chunkForRandom       1000000           MMAP   avgt    6    0.028 ±   0.024   us/op
```

### What is the issue
CNDB-15064: OOM due to compression metadata on large dataset

### What does this PR fix and why was it fixed
...
