### PR TITLE
HCD-241: DSE 6.8/9 upgradeability

### DIFF
--- a/src/java/org/apache/cassandra/gms/EndpointState.java
+++ b/src/java/org/apache/cassandra/gms/EndpointState.java
@@ -256,6 +256,8 @@ public class EndpointState
 
 class EndpointStateSerializer implements IVersionedSerializer<EndpointState>
 {
+    private static final Logger logger = LoggerFactory.getLogger(EndpointStateSerializer.class);
+
     public void serialize(EndpointState epState, DataOutputPlus out, int version) throws IOException
     {
         /* serialize the HeartBeatState */
@@ -318,16 +320,39 @@ class EndpointStateSerializer implements IVersionedSerializer<EndpointState>
     {
         assert version < MessagingService.VERSION_40 && !MessagingService.current_version_override;
         VersionedValue vv = state.getValue();
+        if (logger.isTraceEnabled())
+            logger.trace("Fetching the key from state {}({}) with value of {}", state.getKey(), state.getKey().ordinal(), vv);
+        String[] values;
         switch (state.getKey())
         {
             case INTERNAL_ADDRESS_AND_PORT:
-                return Map.of(
-                        ApplicationState.values()[7], VersionedValue.unsafeMakeVersionedValue(vv.value.split(":")[0], vv.version),
-                        ApplicationState.values()[17], VersionedValue.unsafeMakeVersionedValue(vv.value.split(":")[1], vv.version));
+                // DSE sends only out this value as a storage port thus it doesn't contain the address part
+                // If such a state has been saved into the gossip state we cannot read the address out of it
+                // instead we map it to STORAGE_PORT
+                values = splitAddressAndPort(vv);
+                if (values.length > 1)
+                    return Map.of(ApplicationState.values()[7], VersionedValue.unsafeMakeVersionedValue(values[0], vv.version),
+                                  ApplicationState.values()[17], VersionedValue.unsafeMakeVersionedValue(values[1], vv.version));
+                else
+                    return Map.of(ApplicationState.values()[17], VersionedValue.unsafeMakeVersionedValue(vv.value, vv.version));
             case NATIVE_ADDRESS_AND_PORT:
-                return Map.of(ApplicationState.values()[15], VersionedValue.unsafeMakeVersionedValue(vv.value.split(":")[1], vv.version));
+                // DSE sends only out this value as a native transport port thus it doesn't contain the address part
+                // If such a state has been saved into the gossip state we cannot read the address out of it
+                // instead we map it to NATIVE_TRANSPORT_PORT
+                values = splitAddressAndPort(vv);
+                if (values.length > 1)
+                    return Map.of(ApplicationState.values()[15], VersionedValue.unsafeMakeVersionedValue(values[1], vv.version));
+                else
+                    return Map.of(ApplicationState.values()[15], VersionedValue.unsafeMakeVersionedValue(vv.value, vv.version));
             case STATUS_WITH_PORT:
-                return Map.of(ApplicationState.values()[0], VersionedValue.unsafeMakeVersionedValue(vv.value.split("[:,]")[0], vv.version));
+                // DSE sends only out status without port
+                // If such a state has been saved into the gossip state we cannot read the port out of it
+                // instead we map it to STATUS
+                values = splitStatusAndPort(vv);
+                if (values.length > 1)
+                    return Map.of(ApplicationState.values()[0], VersionedValue.unsafeMakeVersionedValue(values[0], vv.version));
+                else
+                    return Map.of(ApplicationState.values()[0], VersionedValue.unsafeMakeVersionedValue(vv.value, vv.version));
             case DISK_USAGE:
                 return Map.of(ApplicationState.values()[21], state.getValue());
             case SSTABLE_VERSIONS:
@@ -344,6 +369,16 @@ class EndpointStateSerializer implements IVersionedSerializer<EndpointState>
         }
     }
 
+    private static String[] splitStatusAndPort(VersionedValue vv)
+    {
+        return vv.value.split("[:,]");
+    }
+
+    private static String[] splitAddressAndPort(VersionedValue vv)
+    {
+        return vv.value.split(":");
+    }
+
     @VisibleForTesting
     static Map<ApplicationState, VersionedValue> filterIncomingStates(Map<ApplicationState, VersionedValue> states, int version)
     {
@@ -353,6 +388,8 @@ class EndpointStateSerializer implements IVersionedSerializer<EndpointState>
             for (Map.Entry<ApplicationState, VersionedValue> state : states.entrySet())
             {
                 VersionedValue vv = state.getValue();
+                if (logger.isTraceEnabled())
+                    logger.trace("Storing the key to state {}({}) with value of {}", state.getKey(), state.getKey().ordinal(), vv);
                 switch (state.getKey().ordinal())
                 {
                     case 15: // NATIVE_TRANSPORT_PORT --> NATIVE_ADDRESS_AND_PORT

--- a/src/java/org/apache/cassandra/net/InboundConnectionInitiator.java
+++ b/src/java/org/apache/cassandra/net/InboundConnectionInitiator.java
@@ -298,6 +298,7 @@ public class InboundConnectionInitiator
                     assert initiate.type.isMessaging();
 
                     // Second message to DSE is sent with version 10 (oss 3.0)
+                    logger.trace("Sending back Pre40 message with accept min {} to {}", settings.acceptMessaging.min, ctx.channel().remoteAddress());
                     ByteBuf response = HandshakeProtocol.Accept.respondPre40(settings.acceptMessaging.min, ctx.alloc());
                     AsyncChannelPromise.writeAndFlush(ctx, response,
                                                       (ChannelFutureListener) future -> {
@@ -307,8 +308,10 @@ public class InboundConnectionInitiator
                 }
                 else
                 {
+
                     int useMessagingVersion = max(accept.min, min(accept.max, initiate.acceptVersions.max));
                     ByteBuf flush = new HandshakeProtocol.Accept(useMessagingVersion, accept.max).encode(ctx.alloc());
+                    logger.trace("Sending back Accept message with messaging version {} and accept max {} to {}", useMessagingVersion, accept.max, ctx.channel().remoteAddress());
                     AsyncChannelPromise.writeAndFlush(ctx, flush, (ChannelFutureListener) future -> {
                         if (!future.isSuccess())
                             exceptionCaught(future.channel(), future.cause());

--- a/src/java/org/apache/cassandra/net/OutboundConnectionInitiator.java
+++ b/src/java/org/apache/cassandra/net/OutboundConnectionInitiator.java
@@ -271,6 +271,12 @@ public class OutboundConnectionInitiator<SuccessType extends OutboundConnectionI
                 int peerMessagingVersion = msg.maxMessagingVersion;
                 logger.trace("received second handshake message from peer {}, msg = {}", settings.connectTo, msg);
 
+                logger.debug("Summary of messaging versions while connecting to {} " +
+                             "peer messaging version {} request messaging version {} " +
+                             "max accept version {} min accept version {}",
+                             settings.connectTo, peerMessagingVersion, requestMessagingVersion,
+                             settings.acceptVersions.max, settings.acceptVersions.min);
+
                 FrameEncoder frameEncoder = null;
                 Result<SuccessType> result;
                 if (useMessagingVersion > 0)
@@ -350,6 +356,8 @@ public class OutboundConnectionInitiator<SuccessType extends OutboundConnectionI
                         AsyncChannelPromise.writeAndFlush(ctx, message.encode());
                     }
                 }
+
+                logger.debug("Result of connection initiation for {} is {}", settings.connectTo, result.outcome);
 
                 ChannelPipeline pipeline = ctx.pipeline();
                 if (result.isSuccess())

--- a/src/java/org/apache/cassandra/net/OutboundConnectionSettings.java
+++ b/src/java/org/apache/cassandra/net/OutboundConnectionSettings.java
@@ -23,6 +23,9 @@ import java.util.Objects;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.netty.channel.WriteBufferWaterMark;
 import org.apache.cassandra.auth.IInternodeAuthenticator;
 import org.apache.cassandra.config.Config;
@@ -46,6 +49,8 @@ import static org.apache.cassandra.utils.FBUtilities.getBroadcastAddressAndPort;
 @SuppressWarnings({ "WeakerAccess", "unused" })
 public class OutboundConnectionSettings
 {
+    private static final Logger logger = LoggerFactory.getLogger(OutboundConnectionSettings.class);
+
     private static final String INTRADC_TCP_NODELAY_PROPERTY = Config.PROPERTY_PREFIX + "otc_intradc_tcp_nodelay";
     /**
      * Enabled/disable TCP_NODELAY for intradc connections. Defaults to enabled.
@@ -527,6 +532,7 @@ public class OutboundConnectionSettings
 
     private static InetAddressAndPort maybeWithSecurePort(InetAddressAndPort address, int messagingVersion, boolean isEncrypted)
     {
+        logger.debug("Selecting port for a connection to {}, encrypted: {}, messaging version: {}", address.address, isEncrypted, messagingVersion);
         if (!isEncrypted || messagingVersion >= VERSION_40)
             return address;
 
@@ -538,6 +544,7 @@ public class OutboundConnectionSettings
         // Also as of 4.0 we will propagate the "regular" port (which will support both SSL and non-SSL) via gossip so
         // for SSL and version 4.0 always connect to the gossiped port because if SSL is enabled it should ALWAYS
         // listen for SSL on the "regular" port.
+        logger.debug("Decided to use ssl storage port for connection to {}", address.address);
         return address.withPort(DatabaseDescriptor.getSSLStoragePort());
     }
 

--- a/src/java/org/apache/cassandra/net/StartupClusterConnectivityChecker.java
+++ b/src/java/org/apache/cassandra/net/StartupClusterConnectivityChecker.java
@@ -196,7 +196,11 @@ public class StartupClusterConnectivityChecker
         Message<PingRequest> large = Message.out(PING_REQ, PingRequest.forLarge);
         for (InetAddressAndPort peer : peers)
         {
-            if (MessagingService.instance().versions.get(peer) < MessagingService.VERSION_40 && !MessagingService.current_version_override)
+            boolean known = MessagingService.instance().versions.knows(peer);
+            logger.debug("Peer {} is known with version {}", peer, known ? MessagingService.instance().versions.getRaw(peer) : "null");
+            // DSE 6.8/6.9 advertises itself with value higher than VERSION_40, thus we need to compare it with VERSION_DSE_68
+            boolean detectedDse = known && MessagingService.instance().versions.getRaw(peer) >= MessagingService.VERSION_DSE_68;
+            if ((MessagingService.instance().versions.get(peer) < MessagingService.VERSION_40 || detectedDse) && !MessagingService.current_version_override)
                 // DSE 6.x doesn't support PING_REQ, and while C* 3.x does, PING only improves rolling restart times. CASSANDRA-13993 → CASSANDRA-14447
                 continue;
 

--- a/test/unit/org/apache/cassandra/gms/EndpointStateDeserializationEdgeCasesTest.java
+++ b/test/unit/org/apache/cassandra/gms/EndpointStateDeserializationEdgeCasesTest.java
@@ -1,0 +1,288 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.gms;
+
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.net.MessagingService;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for HCD-241: Fix gossip state deserialization edge cases.
+ * 
+ * This test verifies that the EndpointState serializer correctly handles malformed or edge-case
+ * values when deserializing gossip state from pre-4.0 nodes. Specifically, it tests the scenario
+ * where address/port values may not contain the expected delimiter (colon), which would previously
+ * cause an ArrayIndexOutOfBoundsException.
+ * 
+ * The bug occurred in the filterOutgoingState method when converting 4.0+ format states
+ * (e.g., INTERNAL_ADDRESS_AND_PORT: "10.0.0.1:7000") to pre-4.0 format states
+ * (e.g., INTERNAL_IP: "10.0.0.1", STORAGE_PORT: "7000"). If the value didn't contain
+ * a colon separator, the code would attempt to access array index [1] after splitting,
+ * causing an exception.
+ * 
+ * This test ensures that:
+ * 1. Values without delimiters are handled gracefully
+ * 2. The system falls back to using the entire value when no delimiter is present
+ * 3. No ArrayIndexOutOfBoundsException is thrown during deserialization
+ */
+public class EndpointStateDeserializationEdgeCasesTest
+{
+    // DSE 6.x legacy ApplicationState ordinals used for backward compatibility
+    private static final ApplicationState DSE__STATUS = ApplicationState.values()[0];
+    private static final ApplicationState DSE__INTERNAL_IP = ApplicationState.values()[7];
+    private static final ApplicationState DSE__NATIVE_TRANSPORT_PORT = ApplicationState.values()[15];
+    private static final ApplicationState DSE__STORAGE_PORT = ApplicationState.values()[17];
+
+    @BeforeClass
+    public static void setupDD()
+    {
+        DatabaseDescriptor.daemonInitialization();
+    }
+
+    /**
+     * Test Case 1: INTERNAL_ADDRESS_AND_PORT without port delimiter
+     * 
+     * Scenario: A gossip message contains an INTERNAL_ADDRESS_AND_PORT value that is just
+     * an IP address without a port (e.g., "10.0.0.1" instead of "10.0.0.1:7000").
+     * 
+     * Expected behavior:
+     * - WITHOUT fix: ArrayIndexOutOfBoundsException when accessing split(":")[1]
+     * - WITH fix: The entire value is used as STORAGE_PORT, no exception thrown
+     * 
+     * This can occur in edge cases where:
+     * - Configuration errors result in malformed gossip data
+     * - Network issues corrupt the gossip message
+     * - Legacy nodes send incomplete state information
+     */
+    @Test
+    public void testInternalAddressAndPortWithoutPortDelimiter()
+    {
+        // Create a VersionedValue with just an IP address (no port)
+        VersionedValue valueWithoutPort = VersionedValue.unsafeMakeVersionedValue("10.0.0.1", 1);
+        Map.Entry<ApplicationState, VersionedValue> entry = 
+            Map.entry(ApplicationState.INTERNAL_ADDRESS_AND_PORT, valueWithoutPort);
+
+        // Filter for pre-4.0 messaging version (VERSION_30)
+        Set<Map.Entry<ApplicationState, VersionedValue>> filtered = 
+            EndpointStateSerializer.filterOutgoingStates(Set.of(entry), MessagingService.VERSION_30);
+
+        // Convert to map for easier assertion
+        Map<ApplicationState, VersionedValue> filteredMap = new EnumMap<>(ApplicationState.class);
+        for (Map.Entry<ApplicationState, VersionedValue> e : filtered)
+            filteredMap.put(e.getKey(), e.getValue());
+
+        // Verify the behavior:
+        // - Should not throw ArrayIndexOutOfBoundsException
+        // - Should map the entire value to STORAGE_PORT (since no colon delimiter exists)
+        // - Should NOT create an INTERNAL_IP entry (since split only produces one element)
+        assertNotNull("Filtered map should not be null", filteredMap);
+        assertTrue("Should contain STORAGE_PORT mapping", 
+                   filteredMap.containsKey(DSE__STORAGE_PORT));
+        assertEquals("STORAGE_PORT should contain the full IP address", 
+                     "10.0.0.1", 
+                     filteredMap.get(DSE__STORAGE_PORT).value);
+        
+        // When there's no colon, we only get one element from split, so only STORAGE_PORT is set
+        assertEquals("Should only have one entry when no delimiter present", 
+                     1, 
+                     filteredMap.size());
+    }
+
+    /**
+     * Test Case 2: INTERNAL_ADDRESS_AND_PORT with proper port delimiter
+     * 
+     * Scenario: Normal case where INTERNAL_ADDRESS_AND_PORT contains both IP and port
+     * separated by a colon (e.g., "10.0.0.1:7000").
+     * 
+     * Expected behavior:
+     * - Should split correctly into INTERNAL_IP and STORAGE_PORT
+     * - This verifies the fix doesn't break the normal case
+     */
+    @Test
+    public void testInternalAddressAndPortWithPortDelimiter()
+    {
+        // Create a VersionedValue with IP and port
+        VersionedValue valueWithPort = VersionedValue.unsafeMakeVersionedValue("10.0.0.1:7000", 1);
+        Map.Entry<ApplicationState, VersionedValue> entry = 
+            Map.entry(ApplicationState.INTERNAL_ADDRESS_AND_PORT, valueWithPort);
+
+        // Filter for pre-4.0 messaging version
+        Set<Map.Entry<ApplicationState, VersionedValue>> filtered = 
+            EndpointStateSerializer.filterOutgoingStates(Set.of(entry), MessagingService.VERSION_30);
+
+        Map<ApplicationState, VersionedValue> filteredMap = new EnumMap<>(ApplicationState.class);
+        for (Map.Entry<ApplicationState, VersionedValue> e : filtered)
+            filteredMap.put(e.getKey(), e.getValue());
+
+        // Verify normal behavior is preserved
+        assertEquals("Should have two entries when delimiter present", 
+                     2, 
+                     filteredMap.size());
+        assertEquals("INTERNAL_IP should contain IP address", 
+                     "10.0.0.1", 
+                     filteredMap.get(DSE__INTERNAL_IP).value);
+        assertEquals("STORAGE_PORT should contain port", 
+                     "7000", 
+                     filteredMap.get(DSE__STORAGE_PORT).value);
+    }
+
+    /**
+     * Test Case 3: NATIVE_ADDRESS_AND_PORT without port delimiter
+     * 
+     * Scenario: A gossip message contains a NATIVE_ADDRESS_AND_PORT value without a port
+     * (e.g., "127.0.0.1" instead of "127.0.0.1:9042").
+     * 
+     * Expected behavior:
+     * - WITHOUT fix: ArrayIndexOutOfBoundsException when accessing split(":")[1]
+     * - WITH fix: The entire value is used as NATIVE_TRANSPORT_PORT
+     */
+    @Test
+    public void testNativeAddressAndPortWithoutPortDelimiter()
+    {
+        VersionedValue valueWithoutPort = VersionedValue.unsafeMakeVersionedValue("127.0.0.1", 1);
+        Map.Entry<ApplicationState, VersionedValue> entry = 
+            Map.entry(ApplicationState.NATIVE_ADDRESS_AND_PORT, valueWithoutPort);
+
+        Set<Map.Entry<ApplicationState, VersionedValue>> filtered = 
+            EndpointStateSerializer.filterOutgoingStates(Set.of(entry), MessagingService.VERSION_30);
+
+        Map<ApplicationState, VersionedValue> filteredMap = new EnumMap<>(ApplicationState.class);
+        for (Map.Entry<ApplicationState, VersionedValue> e : filtered)
+            filteredMap.put(e.getKey(), e.getValue());
+
+        assertNotNull("Filtered map should not be null", filteredMap);
+        assertTrue("Should contain NATIVE_TRANSPORT_PORT mapping", 
+                   filteredMap.containsKey(DSE__NATIVE_TRANSPORT_PORT));
+        assertEquals("NATIVE_TRANSPORT_PORT should contain the full IP address", 
+                     "127.0.0.1", 
+                     filteredMap.get(DSE__NATIVE_TRANSPORT_PORT).value);
+        assertEquals("Should only have one entry when no delimiter present", 
+                     1, 
+                     filteredMap.size());
+    }
+
+    /**
+     * Test Case 4: NATIVE_ADDRESS_AND_PORT with proper port delimiter
+     * 
+     * Scenario: Normal case where NATIVE_ADDRESS_AND_PORT contains both IP and port.
+     * 
+     * Expected behavior:
+     * - Should extract only the port for NATIVE_TRANSPORT_PORT
+     * - This verifies the fix doesn't break the normal case
+     */
+    @Test
+    public void testNativeAddressAndPortWithPortDelimiter()
+    {
+        VersionedValue valueWithPort = VersionedValue.unsafeMakeVersionedValue("127.0.0.1:9042", 1);
+        Map.Entry<ApplicationState, VersionedValue> entry = 
+            Map.entry(ApplicationState.NATIVE_ADDRESS_AND_PORT, valueWithPort);
+
+        Set<Map.Entry<ApplicationState, VersionedValue>> filtered = 
+            EndpointStateSerializer.filterOutgoingStates(Set.of(entry), MessagingService.VERSION_30);
+
+        Map<ApplicationState, VersionedValue> filteredMap = new EnumMap<>(ApplicationState.class);
+        for (Map.Entry<ApplicationState, VersionedValue> e : filtered)
+            filteredMap.put(e.getKey(), e.getValue());
+
+        assertEquals("Should have one entry", 
+                     1, 
+                     filteredMap.size());
+        assertEquals("NATIVE_TRANSPORT_PORT should contain only the port", 
+                     "9042", 
+                     filteredMap.get(DSE__NATIVE_TRANSPORT_PORT).value);
+    }
+
+    /**
+     * Test Case 5: STATUS_WITH_PORT without delimiters
+     * 
+     * Scenario: A gossip message contains a STATUS_WITH_PORT value without the expected
+     * delimiters (e.g., "NORMAL" instead of "NORMAL,address:port").
+     * 
+     * Expected behavior:
+     * - WITHOUT fix: ArrayIndexOutOfBoundsException when accessing split("[:,]")[0]
+     * - WITH fix: The entire value is used as STATUS
+     */
+    @Test
+    public void testStatusWithPortWithoutDelimiters()
+    {
+        VersionedValue valueWithoutDelimiters = VersionedValue.unsafeMakeVersionedValue("NORMAL", 1);
+        Map.Entry<ApplicationState, VersionedValue> entry = 
+            Map.entry(ApplicationState.STATUS_WITH_PORT, valueWithoutDelimiters);
+
+        Set<Map.Entry<ApplicationState, VersionedValue>> filtered = 
+            EndpointStateSerializer.filterOutgoingStates(Set.of(entry), MessagingService.VERSION_30);
+
+        Map<ApplicationState, VersionedValue> filteredMap = new EnumMap<>(ApplicationState.class);
+        for (Map.Entry<ApplicationState, VersionedValue> e : filtered)
+            filteredMap.put(e.getKey(), e.getValue());
+
+        assertNotNull("Filtered map should not be null", filteredMap);
+        assertTrue("Should contain STATUS mapping", 
+                   filteredMap.containsKey(DSE__STATUS));
+        assertEquals("STATUS should contain the full value", 
+                     "NORMAL", 
+                     filteredMap.get(DSE__STATUS).value);
+        assertEquals("Should only have one entry", 
+                     1, 
+                     filteredMap.size());
+    }
+
+    /**
+     * Test Case 6: STATUS_WITH_PORT with proper delimiters
+     * 
+     * Scenario: Normal case where STATUS_WITH_PORT contains status with additional data
+     * separated by colon or comma (e.g., "NORMAL,address:port").
+     * 
+     * Expected behavior:
+     * - Should extract only the first part (status) for STATUS
+     * - This verifies the fix doesn't break the normal case
+     */
+    @Test
+    public void testStatusWithPortWithDelimiters()
+    {
+        VersionedValue valueWithDelimiters = 
+            VersionedValue.unsafeMakeVersionedValue("NORMAL,127.0.0.1:7000", 1);
+        Map.Entry<ApplicationState, VersionedValue> entry = 
+            Map.entry(ApplicationState.STATUS_WITH_PORT, valueWithDelimiters);
+
+        Set<Map.Entry<ApplicationState, VersionedValue>> filtered = 
+            EndpointStateSerializer.filterOutgoingStates(Set.of(entry), MessagingService.VERSION_30);
+
+        Map<ApplicationState, VersionedValue> filteredMap = new EnumMap<>(ApplicationState.class);
+        for (Map.Entry<ApplicationState, VersionedValue> e : filtered)
+            filteredMap.put(e.getKey(), e.getValue());
+
+        assertEquals("Should have one entry", 
+                     1, 
+                     filteredMap.size());
+        assertEquals("STATUS should contain only the first part", 
+                     "NORMAL", 
+                     filteredMap.get(DSE__STATUS).value);
+    }
+}

--- a/test/unit/org/apache/cassandra/net/StartupClusterConnectivityCheckerTest.java
+++ b/test/unit/org/apache/cassandra/net/StartupClusterConnectivityCheckerTest.java
@@ -186,6 +186,17 @@ public class StartupClusterConnectivityCheckerTest
     }
 
     @Test
+    public void execute_LocalQuorum_dse() throws UnknownHostException
+    {
+        Set<InetAddressAndPort> available = new HashSet<>();
+        copyCount(peersAMinusLocal, available, NUM_PER_DC - 2);
+        InetAddressAndPort dsePeer = InetAddressAndPort.getByName("127.0.1.1:7012");
+        MessagingService.instance().versions.set(dsePeer, MessagingService.VERSION_DSE_68);
+        checkAvailable(localQuorumConnectivityChecker, available, false);
+        MessagingService.instance().versions.reset(dsePeer);
+    }
+
+    @Test
     public void execute_Noop()
     {
         checkAvailable(noopChecker, new HashSet<>(), true);


### PR DESCRIPTION
This PR addresses critical compatibility issues discovered during DSE to HCD (Hyper-Converged Database) upgrade scenarios. The changes focus on ensuring smooth interoperability between DSE 6.8+ nodes and HCD nodes during mixed-version cluster operations.

## What Problems Do These Changes Fix?

### 1. **Enhanced Debugging Capabilities for Upgrade Scenarios**
**Problem:** When upgrading from DSE to HCD, troubleshooting connection and gossip issues was difficult due to insufficient logging.

**Solution:** Added comprehensive logging throughout the handshake and gossip processes, including:
- Port selection logic for DSE → HCD upgrades
- Messaging version negotiation during handshake
- Protocol proposals from DSE peers
- Gossip state values (both loaded and saved)
- Connection initialization events

**Why it matters:** This gives operators visibility into what's happening during the upgrade process, making it much easier to diagnose and resolve issues in production environments.

---

### 2. **Gossip Deserialization Crash Prevention**
**Problem:** Nodes would crash with `ArrayIndexOutOfBoundsException` when processing gossip messages from pre-4.0 nodes. This happened because the code assumed certain delimiters would always be present in address and status values, but older nodes sent data in different formats. Both INTERNAL_ADDRESS_AND_PORT and NATIVE_ADDRESS_AND_PORT could arrive without port delimiters (e.g., "10.0.0.1" instead of "10.0.0.1:7000"), and STATUS_WITH_PORT could arrive without additional port information.

**Solution:** Added defensive length checks after splitting gossip values to gracefully handle cases where expected delimiters are missing:
- Internal and native IP addresses without ports (e.g., "10.0.0.1" vs "10.0.0.1:7000")
- Status values without additional port information

**Why it matters:** Prevents cluster instability and crashes during mixed-version operations.

---

### 3. **DSE 6.8+ PING Request Compatibility**
**Problem:** During startup connectivity checks, HCD nodes were attempting to send PING requests to DSE 6.8+ peers, but these versions don't support PING_REQ messages (similar to DSE 6.x and Cassandra 3.x). This resulted in noisy error logs during cluster startup.

**Solution:** Extended the existing version detection logic to recognize and skip PING requests for DSE 6.8+ peers during the startup connectivity check phase.

**Why it matters:** Eliminates unnecessary error logs when HCD nodes join or restart in a mixed DSE/HCD environment.

---

### 4. **User-Defined Type Preservation During Schema Migration**
**Problem:** When keyspace schemas were updated during migration, User-Defined Types (UDTs) from the previous schema could be lost if they weren't explicitly present in the new schema. This caused failures when inherited tables depended on these types.

**Solution:** Modified the schema transformation logic to preserve UDTs from the previous schema when they don't exist in the new schema, ensuring dependent tables continue to function correctly.

**Why it matters:** Prevents data model corruption and application failures during schema migrations, particularly important when dealing with complex schemas that use inheritance and UDTs.

---

## Overall Impact

These changes collectively improve the robustness and reliability of DSE to HCD upgrades by:
- Making issues easier to diagnose through better logging
- Preventing crashes from malformed gossip data
- Ensuring protocol compatibility across versions
- Preserving schema integrity during migrations

Latest test run: http://10.169.74.112:8081/job/ds-cassandra-build/2117/
Baseline: http://10.169.74.112:8081/job/ds-cassandra-build/10/

## Review corpus

- ccm: [HCD-267: Fix the node UP/DOWN detection for DSE nodes by szymon-miezal · Pull Request #3 · datastax/cassandra-ccm](https://github.com/datastax/cassandra-ccm/pull/3) 
- dtest: [HCD-241: Add a dedicated DSE 6.9 upgrade test by szymon-miezal · Pull Request #90 · datastax/cassandra-dtest](https://github.com/datastax/cassandra-dtest/pull/90) 
- CC: [HCD-241: DSE 6.8/9 upgradeability by szymon-miezal · Pull Request #2240 · datastax/cassandra](https://github.com/datastax/cassandra/pull/2240)
- CNDB https://github.com/riptano/cndb/pull/17404 & ticket https://github.com/riptano/cndb/issues/17405