### PR TITLE
CNDB-16583: Add new param to failure callback messages - verb name of the incoming message.

### DIFF
--- a/src/java/org/apache/cassandra/net/InboundSink.java
+++ b/src/java/org/apache/cassandra/net/InboundSink.java
@@ -22,14 +22,14 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Predicate;
 
-import org.apache.cassandra.index.IndexBuildInProgressException;
-import org.apache.cassandra.index.sai.utils.AbortedOperationException;
 import org.slf4j.LoggerFactory;
 
 import net.openhft.chronicle.core.util.ThrowingConsumer;
 import org.apache.cassandra.db.filter.TombstoneOverwhelmingException;
 import org.apache.cassandra.exceptions.RequestFailureReason;
+import org.apache.cassandra.index.IndexBuildInProgressException;
 import org.apache.cassandra.index.IndexNotAvailableException;
+import org.apache.cassandra.index.sai.utils.AbortedOperationException;
 import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.utils.NoSpamLogger;
 
@@ -87,7 +87,8 @@ public class InboundSink implements InboundMessageHandlers.MessageConsumer
             InetAddressAndPort to = header.respondTo() != null ? header.respondTo() : header.from;
             Message<RequestFailureReason> response = Message.failureResponse(header.id,
                                                                              header.expiresAtNanos,
-                                                                             RequestFailureReason.forException(failure));
+                                                                             RequestFailureReason.forException(failure),
+                                                                             header.verb);
             messaging.send(response, to);
         }
     }

--- a/src/java/org/apache/cassandra/net/Message.java
+++ b/src/java/org/apache/cassandra/net/Message.java
@@ -290,12 +290,12 @@ public class Message<T>
     /** Builds a failure response Message with an explicit reason, and fields inferred from request Message */
     public Message<RequestFailureReason> failureResponse(RequestFailureReason reason)
     {
-        return failureResponse(id(), expiresAtNanos(), reason);
+        return failureResponse(id(), expiresAtNanos(), reason, verb());
     }
 
-    static Message<RequestFailureReason> failureResponse(long id, long expiresAtNanos, RequestFailureReason reason)
+    static Message<RequestFailureReason> failureResponse(long id, long expiresAtNanos, RequestFailureReason reason, Verb requestVerb)
     {
-        return outWithParam(id, Verb.FAILURE_RSP, expiresAtNanos, reason, null, null).build();
+        return outWithParam(id, Verb.FAILURE_RSP, expiresAtNanos, reason, ParamType.REQUEST_VERB_NAME, requestVerb.name()).build();
     }
 
     Message<T> withCallBackOnFailure()

--- a/src/java/org/apache/cassandra/net/ParamType.java
+++ b/src/java/org/apache/cassandra/net/ParamType.java
@@ -19,7 +19,6 @@ package org.apache.cassandra.net;
 
 import java.util.HashMap;
 import java.util.Map;
-
 import javax.annotation.Nullable;
 
 import org.apache.cassandra.exceptions.RequestFailureReason;
@@ -29,7 +28,6 @@ import org.apache.cassandra.utils.StringSerializer;
 import org.apache.cassandra.utils.UUIDSerializer;
 
 import static java.lang.Math.max;
-
 import static org.apache.cassandra.locator.InetAddressAndPort.FwdFrmSerializer.fwdFrmSerializer;
 
 /**
@@ -62,6 +60,10 @@ public enum ParamType
      * Messages with tracing sessions are decorated with the traced keyspace.
      */
     TRACE_KEYSPACE      (8, "TraceKeyspace", StringSerializer.serializer),
+    /**
+     * Failure callback messages contain verb name of the incoming message.
+     */
+    REQUEST_VERB_NAME   (9, "RequestVerbName", StringSerializer.serializer),
 
     CUSTOM_MAP          (14, "CUSTOM",       CustomParamsSerializer.serializer);
 

--- a/src/java/org/apache/cassandra/net/ParamType.java
+++ b/src/java/org/apache/cassandra/net/ParamType.java
@@ -61,7 +61,7 @@ public enum ParamType
      */
     TRACE_KEYSPACE      (8, "TraceKeyspace", StringSerializer.serializer),
     /**
-     * Failure callback messages contain verb name of the incoming message.
+     * Failure response messages contain verb name of the incoming message.
      */
     REQUEST_VERB_NAME   (9, "RequestVerbName", StringSerializer.serializer),
 

--- a/test/unit/org/apache/cassandra/net/MessageTest.java
+++ b/test/unit/org/apache/cassandra/net/MessageTest.java
@@ -204,6 +204,22 @@ public class MessageTest
     }
 
     @Test
+    public void testNonStaticFailureResponse() throws IOException
+    {
+        Message<String> incomingMessage = Message.builder(Verb.MUTATION_REQ, "some-payload").withId(1).build();
+        Message<RequestFailureReason> msg = incomingMessage.failureResponse(RequestFailureReason.INCOMPATIBLE_SCHEMA);
+
+        assertEquals(1, msg.id());
+        assertEquals(Verb.FAILURE_RSP, msg.verb());
+        assertEquals(incomingMessage.expiresAtNanos(), msg.expiresAtNanos());
+        assertEquals(RequestFailureReason.INCOMPATIBLE_SCHEMA, msg.payload);
+        assertEquals(Verb.MUTATION_REQ.name(), msg.header.params().get(ParamType.REQUEST_VERB_NAME));
+        assertTrue(msg.isFailureResponse());
+
+        testCycle(msg);
+    }
+
+    @Test
     public void testBuilderAddTraceHeaderWhenTraceSessionPresent()
     {
         Stream.of(TraceType.values()).forEach(this::testAddTraceHeaderWithType);

--- a/test/unit/org/apache/cassandra/net/MessageTest.java
+++ b/test/unit/org/apache/cassandra/net/MessageTest.java
@@ -191,12 +191,13 @@ public class MessageTest
     public void testFailureResponse() throws IOException
     {
         long expiresAt = approxTime.now();
-        Message<RequestFailureReason> msg = Message.failureResponse(1, expiresAt, RequestFailureReason.INCOMPATIBLE_SCHEMA);
+        Message<RequestFailureReason> msg = Message.failureResponse(1, expiresAt, RequestFailureReason.INCOMPATIBLE_SCHEMA, Verb.MUTATION_REQ);
 
         assertEquals(1, msg.id());
         assertEquals(Verb.FAILURE_RSP, msg.verb());
         assertEquals(expiresAt, msg.expiresAtNanos());
         assertEquals(RequestFailureReason.INCOMPATIBLE_SCHEMA, msg.payload);
+        assertEquals(Verb.MUTATION_REQ.name(), msg.header.params().get(ParamType.REQUEST_VERB_NAME));
         assertTrue(msg.isFailureResponse());
 
         testCycle(msg);


### PR DESCRIPTION
### What is the issue
We want to use the messaging filter to collect metrics for failure responses coming from writer instances. To properly handle different types of failed requests (Read/Write), we need a way to distinguish between callback responses.

Fixes https://github.com/riptano/cndb/issues/16583

### What does this PR fix and why was it fixed
This PR adds a new parameter to failure callback messages—the verb name of the incoming request. This parameter allows us to differentiate failure responses based on the origin of the request.