### PR TITLE
[Draft] Allow alternative trace storage engines

### DIFF
--- a/src/java/org/apache/cassandra/concurrent/Stage.java
+++ b/src/java/org/apache/cassandra/concurrent/Stage.java
@@ -217,7 +217,7 @@ public enum Stage
         }, executor());
     }
 
-    private LocalAwareExecutorService executor()
+    public LocalAwareExecutorService executor()
     {
         if (executor == null)
         {

--- a/src/java/org/apache/cassandra/net/Message.java
+++ b/src/java/org/apache/cassandra/net/Message.java
@@ -32,6 +32,7 @@ import com.google.common.primitives.Ints;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import net.openhft.chronicle.values.NotNull;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.exceptions.RequestFailureReason;
 import org.apache.cassandra.io.IVersionedAsymmetricSerializer;
@@ -450,6 +451,11 @@ public class Message<T>
         public UUID traceSession()
         {
             return (UUID) params.get(ParamType.TRACE_SESSION);
+        }
+
+        public boolean tracedProbabilistically()
+        {
+            return (Boolean)params.getOrDefault(ParamType.TRACED_PROBABILISTICALLY, false);
         }
 
         @Nullable

--- a/src/java/org/apache/cassandra/net/ParamType.java
+++ b/src/java/org/apache/cassandra/net/ParamType.java
@@ -66,7 +66,7 @@ public enum ParamType
     /**
      * Failure response messages contain verb name of the incoming message.
      */
-    REQUEST_VERB_NAME   (9, "RequestVerbName", StringSerializer.serializer),
+    REQUEST_VERB_NAME   (10, "RequestVerbName", StringSerializer.serializer),
 
     CUSTOM_MAP          (14, "CUSTOM",       CustomParamsSerializer.serializer);
 

--- a/src/java/org/apache/cassandra/net/ParamType.java
+++ b/src/java/org/apache/cassandra/net/ParamType.java
@@ -24,6 +24,7 @@ import javax.annotation.Nullable;
 import org.apache.cassandra.exceptions.RequestFailureReason;
 import org.apache.cassandra.io.IVersionedSerializer;
 import org.apache.cassandra.tracing.Tracing;
+import org.apache.cassandra.utils.BooleanSerializer;
 import org.apache.cassandra.utils.StringSerializer;
 import org.apache.cassandra.utils.UUIDSerializer;
 
@@ -60,6 +61,8 @@ public enum ParamType
      * Messages with tracing sessions are decorated with the traced keyspace.
      */
     TRACE_KEYSPACE      (8, "TraceKeyspace", StringSerializer.serializer),
+    // TODO(scottfines) is this the optimal way to store and hold the probabilistic tracing information?
+    TRACED_PROBABILISTICALLY       (9, "TracedProbabilistically", BooleanSerializer.serializer),
     /**
      * Failure response messages contain verb name of the incoming message.
      */

--- a/src/java/org/apache/cassandra/tracing/ExpiredTraceState.java
+++ b/src/java/org/apache/cassandra/tracing/ExpiredTraceState.java
@@ -21,6 +21,9 @@
 
 package org.apache.cassandra.tracing;
 
+import java.net.InetAddress;
+import java.util.Map;
+
 import org.apache.cassandra.utils.FBUtilities;
 
 class ExpiredTraceState extends TraceState
@@ -29,7 +32,7 @@ class ExpiredTraceState extends TraceState
 
     ExpiredTraceState(TraceState delegate)
     {
-        super(delegate.clientState, FBUtilities.getBroadcastAddressAndPort(), delegate.sessionId, delegate.traceType);
+        super(delegate.clientState, FBUtilities.getBroadcastAddressAndPort(), delegate.sessionId, delegate.traceType, delegate.isProbabilistic);
         this.delegate = delegate;
     }
 
@@ -51,5 +54,23 @@ class ExpiredTraceState extends TraceState
     TraceState getDelegate()
     {
         return delegate;
+    }
+
+    @Override
+    public TraceStorage getStorage()
+    {
+        return delegate.getStorage();
+    }
+
+    @Override
+    public void stopSession()
+    {
+        delegate.stopSession();
+    }
+
+    @Override
+    public void begin(InetAddress client, String request, Map<String, String> parameters)
+    {
+        delegate.begin(client, request, parameters);
     }
 }

--- a/src/java/org/apache/cassandra/tracing/KeyspaceTraceStorage.java
+++ b/src/java/org/apache/cassandra/tracing/KeyspaceTraceStorage.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.tracing;
+
+import java.net.InetAddress;
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+
+import javax.annotation.Nonnull;
+
+import org.apache.cassandra.concurrent.Stage;
+import org.apache.cassandra.db.ConsistencyLevel;
+import org.apache.cassandra.db.Mutation;
+import org.apache.cassandra.db.partitions.PartitionUpdate;
+import org.apache.cassandra.db.rows.Row;
+import org.apache.cassandra.exceptions.OverloadedException;
+import org.apache.cassandra.exceptions.WriteFailureException;
+import org.apache.cassandra.gms.Gossiper;
+import org.apache.cassandra.metrics.ClientRequestsMetrics;
+import org.apache.cassandra.metrics.ClientRequestsMetricsProvider;
+import org.apache.cassandra.schema.TableMetadata;
+import org.apache.cassandra.service.ClientState;
+import org.apache.cassandra.service.StorageProxy;
+import org.apache.cassandra.utils.FBUtilities;
+import org.apache.cassandra.utils.UUIDGen;
+import org.apache.cassandra.utils.WrappedRunnable;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+/**
+ * Trace storage that pushes trace information to cassandra tables within a keyspace
+ */
+public class KeyspaceTraceStorage implements TraceStorage
+{
+    private final TableMetadata eventsTable;
+    private final TableMetadata sessionsTable;
+
+    public KeyspaceTraceStorage(TableMetadata eventsTable, TableMetadata sessionsTable)
+    {
+        this.eventsTable = eventsTable;
+        this.sessionsTable = sessionsTable;
+    }
+
+    @Override
+    public Future<Void> startSession(TraceState state,
+                                     InetAddress client,
+                                     String request,
+                                     Map<String, String> parameters,
+                                     long startedAt)
+    {
+
+        PartitionUpdate.SimpleBuilder builder = PartitionUpdate.simpleBuilder(sessionsTable, state.sessionId);
+        Row.SimpleBuilder rb = builder.row();
+        rb.ttl(state.ttl)
+          .add("client", client)
+          .add("coordinator", FBUtilities.getBroadcastAddressAndPort().address);
+        if (!Gossiper.instance.hasMajorVersion3Nodes())
+            rb.add("coordinator_port", FBUtilities.getBroadcastAddressAndPort().port);
+        rb.add("request", request)
+          .add("started_at", new Date(startedAt))
+          .add("command", state.traceType.toString())
+          .appendAll("parameters", parameters);
+        addExtraClientData(state.clientState, rb);
+
+        Mutation mutation = builder.buildAsMutation();
+
+        return submit(state.clientState, mutation);
+    }
+
+    /**
+     * By default, this does nothing, but provides a hook if additional trace data needs to be appended that has
+     * to do with the client.
+     *
+     * @param traceRow the row being traced
+     */
+    protected void addExtraClientData(@Nonnull ClientState clientState, @Nonnull Row.SimpleBuilder traceRow)
+    {
+
+    }
+
+    @Override
+    public Future<Void> stopSession(TraceState state)
+    {
+
+        PartitionUpdate.SimpleBuilder builder = PartitionUpdate.simpleBuilder(sessionsTable, state.sessionId);
+        Row.SimpleBuilder rb = builder.row()
+                                      .ttl(state.ttl)
+                                      .add("duration", state.elapsed());
+        addExtraClientData(state.clientState, rb);
+        Mutation mutation = builder.buildAsMutation();
+        return submit(state.clientState, mutation);
+    }
+
+    @Override
+    public Future<Void> recordEvent(TraceState state, String threadName, String message)
+    {
+        return submit(state.clientState, getEventMutation(state.clientState, state.sessionIdBytes, message, state.elapsed(), threadName, state.ttl));
+    }
+
+    @Override
+    public Future<Void> recordNonLocalEvent(ClientState clientState,
+                                            ByteBuffer sessionId,
+                                            String message,
+                                            int elapsedTime,
+                                            String threadName,
+                                            int ttl)
+    {
+        return submit(clientState, getEventMutation(clientState, sessionId, message, elapsedTime, threadName, ttl));
+    }
+
+    private Mutation getEventMutation(ClientState clientState,
+                                      ByteBuffer sessionId,
+                                          String message,
+                                          int elapsedTime,
+                                          String threadName,
+                                          int ttl)
+    {
+        PartitionUpdate.SimpleBuilder builder = PartitionUpdate.simpleBuilder(eventsTable, sessionId);
+        Row.SimpleBuilder rowBuilder = builder.row(UUIDGen.getTimeUUID())
+                                              .ttl(ttl);
+
+        rowBuilder.add("activity", message)
+                  .add("source", FBUtilities.getBroadcastAddressAndPort().address);
+        if (!Gossiper.instance.hasMajorVersion3Nodes())
+            rowBuilder.add("source_port", FBUtilities.getBroadcastAddressAndPort().port);
+        rowBuilder.add("thread", threadName);
+
+        if (elapsedTime >= 0)
+            rowBuilder.add("source_elapsed", elapsedTime);
+
+        addExtraClientData(clientState, rowBuilder);
+        return builder.buildAsMutation();
+    }
+
+    protected static @NonNull CompletableFuture<Void> submit(ClientState state, Mutation mutation)
+    {
+//        return Stage.TRACING.submit(() -> mutateWithCatch(state, mutation));
+        return Stage.TRACING.submit(new WrappedRunnable()
+        {
+            @Override
+            protected void runMayThrow() throws Exception
+            {
+                mutateWithCatch(state, mutation);
+            }
+        });
+    }
+
+    private static void mutateWithCatch(ClientState state, Mutation mutation)
+    {
+        try
+        {
+            Tracing.logger.info("Applying trace mutation {}", mutation);
+            ClientRequestsMetrics metrics = ClientRequestsMetricsProvider.instance.metrics(mutation.getKeyspaceName());
+            StorageProxy.mutate(Collections.singletonList(mutation), ConsistencyLevel.ANY, System.nanoTime(), metrics, state);
+            Tracing.logger.info("Trace mutation complete (mutation={})", mutation);
+        }
+        catch (OverloadedException e)
+        {
+            Tracing.logger.warn("Too many nodes are overloaded to save trace events");
+        }
+        catch(WriteFailureException wfe)
+        {
+            Tracing.logger.error("Write failure: ", wfe);
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/tracing/TraceKeyspace.java
+++ b/src/java/org/apache/cassandra/tracing/TraceKeyspace.java
@@ -29,6 +29,7 @@ import org.apache.cassandra.db.Mutation;
 import org.apache.cassandra.db.partitions.PartitionUpdate;
 import org.apache.cassandra.db.rows.Row;
 import org.apache.cassandra.gms.Gossiper;
+import org.apache.cassandra.schema.Indexes;
 import org.apache.cassandra.schema.KeyspaceMetadata;
 import org.apache.cassandra.schema.KeyspaceParams;
 import org.apache.cassandra.schema.SchemaConstants;

--- a/src/java/org/apache/cassandra/tracing/TraceKeyspace.java
+++ b/src/java/org/apache/cassandra/tracing/TraceKeyspace.java
@@ -20,6 +20,9 @@ package org.apache.cassandra.tracing;
 import java.net.InetAddress;
 import java.nio.ByteBuffer;
 import java.util.*;
+import java.util.concurrent.Future;
+
+import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.cql3.statements.schema.CreateTableStatement;
 import org.apache.cassandra.db.Mutation;
@@ -33,6 +36,7 @@ import org.apache.cassandra.schema.TableId;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.schema.Tables;
 import org.apache.cassandra.utils.FBUtilities;
+import org.apache.cassandra.utils.JVMStabilityInspector;
 import org.apache.cassandra.utils.UUIDGen;
 
 import static java.lang.String.format;
@@ -63,7 +67,7 @@ public final class TraceKeyspace
     public static final String SESSIONS = "sessions";
     public static final String EVENTS = "events";
 
-    private static final TableMetadata Sessions =
+    static final TableMetadata Sessions =
         parse(SESSIONS,
                 "tracing sessions",
                 "CREATE TABLE %s ("
@@ -78,7 +82,7 @@ public final class TraceKeyspace
                 + "started_at timestamp,"
                 + "PRIMARY KEY ((session_id)))");
 
-    private static final TableMetadata Events =
+    static final TableMetadata Events =
         parse(EVENTS,
                 "tracing events",
                 "CREATE TABLE %s ("
@@ -91,7 +95,7 @@ public final class TraceKeyspace
                 + "thread text,"
                 + "PRIMARY KEY ((session_id), event_id))");
 
-    private static TableMetadata parse(String table, String description, String cql)
+    public static TableMetadata parse(String table, String description, String cql)
     {
         return CreateTableStatement.parse(format(cql, table), SchemaConstants.TRACE_KEYSPACE_NAME)
                                    .id(TableId.forSystemTable(SchemaConstants.TRACE_KEYSPACE_NAME, table))
@@ -144,6 +148,13 @@ public final class TraceKeyspace
         PartitionUpdate.SimpleBuilder builder = PartitionUpdate.simpleBuilder(Events, sessionId);
         Row.SimpleBuilder rowBuilder = builder.row(UUIDGen.getTimeUUID())
                                               .ttl(ttl);
+        setEventRow(rowBuilder, message, elapsed, threadName, ttl);
+
+        return builder.buildAsMutation();
+    }
+
+    public static Row.SimpleBuilder setEventRow(Row.SimpleBuilder rowBuilder, String message, int elapsed, String threadName, int ttl)
+    {
 
         rowBuilder.add("activity", message)
                   .add("source", FBUtilities.getBroadcastAddressAndPort().address);
@@ -153,7 +164,13 @@ public final class TraceKeyspace
 
         if (elapsed >= 0)
             rowBuilder.add("source_elapsed", elapsed);
+        return rowBuilder;
+    }
 
-        return builder.buildAsMutation();
+    public static TraceStorage asStorage()
+    {
+        TableMetadata eventsTable = TraceKeyspace.metadata().tables.getNullable(EVENTS);
+        TableMetadata sessionsTable = TraceKeyspace.metadata().tables.getNullable(SESSIONS);
+        return new KeyspaceTraceStorage(eventsTable, sessionsTable);
     }
 }

--- a/src/java/org/apache/cassandra/tracing/TraceKeyspace.java
+++ b/src/java/org/apache/cassandra/tracing/TraceKeyspace.java
@@ -17,28 +17,13 @@
  */
 package org.apache.cassandra.tracing;
 
-import java.net.InetAddress;
-import java.nio.ByteBuffer;
-import java.util.*;
-import java.util.concurrent.Future;
-
-import org.slf4j.LoggerFactory;
-
 import org.apache.cassandra.cql3.statements.schema.CreateTableStatement;
-import org.apache.cassandra.db.Mutation;
-import org.apache.cassandra.db.partitions.PartitionUpdate;
-import org.apache.cassandra.db.rows.Row;
-import org.apache.cassandra.gms.Gossiper;
-import org.apache.cassandra.schema.Indexes;
 import org.apache.cassandra.schema.KeyspaceMetadata;
 import org.apache.cassandra.schema.KeyspaceParams;
 import org.apache.cassandra.schema.SchemaConstants;
 import org.apache.cassandra.schema.TableId;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.schema.Tables;
-import org.apache.cassandra.utils.FBUtilities;
-import org.apache.cassandra.utils.JVMStabilityInspector;
-import org.apache.cassandra.utils.UUIDGen;
 
 import static java.lang.String.format;
 
@@ -112,62 +97,6 @@ public final class TraceKeyspace
         return KeyspaceMetadata.create(SchemaConstants.TRACE_KEYSPACE_NAME,
                                        KeyspaceParams.systemDistributed(2),
                                        Tables.of(Sessions, Events));
-    }
-
-    static Mutation makeStartSessionMutation(ByteBuffer sessionId,
-                                             InetAddress client,
-                                             Map<String, String> parameters,
-                                             String request,
-                                             long startedAt,
-                                             String command,
-                                             int ttl)
-    {
-        PartitionUpdate.SimpleBuilder builder = PartitionUpdate.simpleBuilder(Sessions, sessionId);
-        Row.SimpleBuilder rb = builder.row();
-        rb.ttl(ttl)
-          .add("client", client)
-          .add("coordinator", FBUtilities.getBroadcastAddressAndPort().address);
-        if (!Gossiper.instance.hasMajorVersion3Nodes())
-            rb.add("coordinator_port", FBUtilities.getBroadcastAddressAndPort().port);
-        rb.add("request", request)
-          .add("started_at", new Date(startedAt))
-          .add("command", command)
-          .appendAll("parameters", parameters);
-
-        return builder.buildAsMutation();
-    }
-
-    static Mutation makeStopSessionMutation(ByteBuffer sessionId, int elapsed, int ttl)
-    {
-        PartitionUpdate.SimpleBuilder builder = PartitionUpdate.simpleBuilder(Sessions, sessionId);
-        builder.row()
-               .ttl(ttl)
-               .add("duration", elapsed);
-        return builder.buildAsMutation();
-    }
-
-    static Mutation makeEventMutation(ByteBuffer sessionId, String message, int elapsed, String threadName, int ttl)
-    {
-        PartitionUpdate.SimpleBuilder builder = PartitionUpdate.simpleBuilder(Events, sessionId);
-        Row.SimpleBuilder rowBuilder = builder.row(UUIDGen.getTimeUUID())
-                                              .ttl(ttl);
-        setEventRow(rowBuilder, message, elapsed, threadName, ttl);
-
-        return builder.buildAsMutation();
-    }
-
-    public static Row.SimpleBuilder setEventRow(Row.SimpleBuilder rowBuilder, String message, int elapsed, String threadName, int ttl)
-    {
-
-        rowBuilder.add("activity", message)
-                  .add("source", FBUtilities.getBroadcastAddressAndPort().address);
-        if (!Gossiper.instance.hasMajorVersion3Nodes())
-            rowBuilder.add("source_port", FBUtilities.getBroadcastAddressAndPort().port);
-        rowBuilder.add("thread", threadName);
-
-        if (elapsed >= 0)
-            rowBuilder.add("source_elapsed", elapsed);
-        return rowBuilder;
     }
 
     public static TraceStorage asStorage()

--- a/src/java/org/apache/cassandra/tracing/TraceKeyspace.java
+++ b/src/java/org/apache/cassandra/tracing/TraceKeyspace.java
@@ -80,6 +80,7 @@ public final class TraceKeyspace
                 + "parameters map<text, text>,"
                 + "request text,"
                 + "started_at timestamp,"
+                + "context map<text, text>,"
                 + "PRIMARY KEY ((session_id)))");
 
     static final TableMetadata Events =
@@ -93,6 +94,7 @@ public final class TraceKeyspace
                 + "source_port int,"
                 + "source_elapsed int,"
                 + "thread text,"
+                + "context map<text, text>,"
                 + "PRIMARY KEY ((session_id), event_id))");
 
     public static TableMetadata parse(String table, String description, String cql)

--- a/src/java/org/apache/cassandra/tracing/TraceState.java
+++ b/src/java/org/apache/cassandra/tracing/TraceState.java
@@ -17,8 +17,10 @@
  */
 package org.apache.cassandra.tracing;
 
+import java.net.InetAddress;
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
@@ -49,6 +51,7 @@ public abstract class TraceState implements ProgressEventNotifier
     public final Tracing.TraceType traceType;
     public final int ttl;
     public final ClientState clientState;
+    public final boolean isProbabilistic;
 
     private boolean rangeQuery;
     private String tracedKeyspace;
@@ -70,7 +73,7 @@ public abstract class TraceState implements ProgressEventNotifier
     // See CASSANDRA-7626 for more details.
     private final AtomicInteger references = new AtomicInteger(1);
 
-    protected TraceState(ClientState clientState, InetAddressAndPort coordinator, UUID sessionId, Tracing.TraceType traceType)
+    protected TraceState(ClientState clientState, InetAddressAndPort coordinator, UUID sessionId, Tracing.TraceType traceType, boolean isProbabilistic)
     {
         assert coordinator != null;
         assert sessionId != null;
@@ -83,6 +86,7 @@ public abstract class TraceState implements ProgressEventNotifier
         this.ttl = traceType.getTTL();
         watch = Stopwatch.createStarted();
         this.status = Status.IDLE;
+        this.isProbabilistic = isProbabilistic;
     }
 
     /**
@@ -111,6 +115,8 @@ public abstract class TraceState implements ProgressEventNotifier
         listeners.remove(listener);
     }
 
+    public abstract TraceStorage getStorage();
+
     public boolean isRangeQuery()
     {
         return rangeQuery;
@@ -137,6 +143,11 @@ public abstract class TraceState implements ProgressEventNotifier
     public void tracedKeyspace(String tracedKeyspace)
     {
         this.tracedKeyspace = tracedKeyspace;
+    }
+
+    public boolean isStopped()
+    {
+        return status == Status.STOPPED;
     }
 
     public int elapsed()
@@ -214,6 +225,10 @@ public abstract class TraceState implements ProgressEventNotifier
             listener.progress(tag, ProgressEvent.createNotification(message));
         }
     }
+
+    public abstract void stopSession();
+
+    public abstract void begin(InetAddress client, String request, Map<String, String> parameters);
 
     protected abstract void traceImpl(String message);
 

--- a/src/java/org/apache/cassandra/tracing/TraceStateImpl.java
+++ b/src/java/org/apache/cassandra/tracing/TraceStateImpl.java
@@ -17,7 +17,8 @@
  */
 package org.apache.cassandra.tracing;
 
-import java.util.Collections;
+import java.net.InetAddress;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -30,17 +31,9 @@ import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.cassandra.concurrent.Stage;
-import org.apache.cassandra.db.ConsistencyLevel;
-import org.apache.cassandra.db.Mutation;
-import org.apache.cassandra.exceptions.OverloadedException;
 import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.service.ClientState;
-import org.apache.cassandra.metrics.ClientRequestsMetrics;
-import org.apache.cassandra.metrics.ClientRequestsMetricsProvider;
-import org.apache.cassandra.service.StorageProxy;
 import org.apache.cassandra.utils.JVMStabilityInspector;
-import org.apache.cassandra.utils.WrappedRunnable;
 
 /**
  * ThreadLocal state for a tracing session. The presence of an instance of this class as a ThreadLocal denotes that an
@@ -55,18 +48,46 @@ public class TraceStateImpl extends TraceState
       Integer.parseInt(System.getProperty("cassandra.wait_for_tracing_events_timeout_secs", "0"));
 
     private final Set<Future<?>> pendingFutures = ConcurrentHashMap.newKeySet();
+    private final TraceStorage storage;
 
-    public TraceStateImpl(ClientState state, InetAddressAndPort coordinator, UUID sessionId, Tracing.TraceType traceType)
+    public TraceStateImpl(ClientState state,
+                          InetAddressAndPort coordinator,
+                          UUID sessionId,
+                          Tracing.TraceType traceType,
+                          boolean isProbabilistic,
+                          TraceStorage storage)
     {
-        super(state, coordinator, sessionId, traceType);
+        super(state, coordinator, sessionId, traceType, isProbabilistic);
+        this.storage = storage;
+    }
+
+    @Override
+    public TraceStorage getStorage()
+    {
+        return storage;
+    }
+
+    @Override
+    public void stopSession()
+    {
+        if(!isStopped())
+            pendingFutures.add(storage.stopSession(this));
+    }
+
+    @Override
+    public void begin(InetAddress client, String request, Map<String, String> parameters)
+    {
+        Future<Void> e = storage.startSession(this, client, request, parameters, System.currentTimeMillis());
+        pendingFutures.add(e);
     }
 
     protected void traceImpl(String message)
     {
         final String threadName = Thread.currentThread().getName();
-        final int elapsed = elapsed();
 
-        executeMutation(TraceKeyspace.makeEventMutation(sessionIdBytes, message, elapsed, threadName, ttl));
+        if (!pendingFutures.add(storage.recordEvent(this, threadName, message)))
+            logger.warn("Failed to insert pending future, tracing synchronization may not work");
+
         if (logger.isTraceEnabled())
             logger.trace("Adding <{}> to trace events", message);
     }
@@ -100,34 +121,4 @@ public class TraceStateImpl extends TraceState
             logger.error("Got exception whilst waiting for tracing events to complete", t);
         }
     }
-
-
-    void executeMutation(final Mutation mutation)
-    {
-        CompletableFuture<Void> fut = Stage.TRACING.submit(new WrappedRunnable()
-        {
-            protected void runMayThrow()
-            {
-                mutateWithCatch(clientState, mutation);
-            }
-        });
-
-        boolean ret = pendingFutures.add(fut);
-        if (!ret)
-            logger.warn("Failed to insert pending future, tracing synchronization may not work");
-    }
-
-    static void mutateWithCatch(ClientState state, Mutation mutation)
-    {
-        try
-        {
-            ClientRequestsMetrics metrics = ClientRequestsMetricsProvider.instance.metrics(mutation.getKeyspaceName());
-            StorageProxy.mutate(Collections.singletonList(mutation), ConsistencyLevel.ANY, System.nanoTime(), metrics, state);
-        }
-        catch (OverloadedException e)
-        {
-            Tracing.logger.warn("Too many nodes are overloaded to save trace events");
-        }
-    }
-
 }

--- a/src/java/org/apache/cassandra/tracing/TraceStorage.java
+++ b/src/java/org/apache/cassandra/tracing/TraceStorage.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.tracing;
+
+import java.net.InetAddress;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.concurrent.Future;
+
+import org.apache.cassandra.service.ClientState;
+
+/**
+ * Pluggable interface for different ways to store trace data. By default, this will store in system_traces,
+ * but there may be other options or configurations in different situations(such as exporting to OpenTelemetry).
+ */
+public interface TraceStorage
+{
+
+    Future<Void> startSession(TraceState state,
+                              InetAddress client,
+                              String request,
+                              Map<String, String> parameters,
+                              long startedAt);
+
+    Future<Void> stopSession(TraceState state);
+
+    Future<Void> recordEvent(TraceState state, String threadName, String message);
+
+    // Called for non-local traces (traces that are not initiated by local node == coordinator).
+    Future<Void> recordNonLocalEvent(ClientState clientState,
+                                     ByteBuffer sessionId,
+                                     String message,
+                                     int elapsedTime,
+                                     String threadName,
+                                     int ttl);
+}

--- a/src/java/org/apache/cassandra/tracing/Tracing.java
+++ b/src/java/org/apache/cassandra/tracing/Tracing.java
@@ -204,33 +204,56 @@ public abstract class Tracing implements ExecutorLocal<TraceState>
 
     public UUID newSession(ClientState state, Map<String,ByteBuffer> customPayload)
     {
+        return newSession(state, false, customPayload);
+    }
+
+    public UUID newSession(ClientState state, boolean wasProbabilistic, Map<String,ByteBuffer> customPayload)
+    {
         return newSession(
                 state,
                 TimeUUIDType.instance.compose(ByteBuffer.wrap(UUIDGen.getTimeUUIDBytes())),
                 TraceType.QUERY,
+                wasProbabilistic,
                 customPayload);
     }
 
     public UUID newSession(ClientState state, TraceType traceType)
     {
+        return newSession(state, traceType, false);
+    }
+
+    public UUID newSession(ClientState state, TraceType traceType, boolean wasProbabilistic)
+    {
         return newSession(
                 state,
                 TimeUUIDType.instance.compose(ByteBuffer.wrap(UUIDGen.getTimeUUIDBytes())),
                 traceType,
-                Collections.EMPTY_MAP);
+                wasProbabilistic,
+                Collections.emptyMap());
     }
 
     public UUID newSession(ClientState state, UUID sessionId, Map<String,ByteBuffer> customPayload)
     {
-        return newSession(state, sessionId, TraceType.QUERY, customPayload);
+        return newSession(state, sessionId, false, customPayload);
     }
 
-    /** This method is intended to be overridden in tracing implementations that need access to the customPayload */
-    protected UUID newSession(ClientState state, UUID sessionId, TraceType traceType, Map<String,ByteBuffer> customPayload)
+    public UUID newSession(ClientState state, UUID sessionId, boolean wasProbabilistic, Map<String,ByteBuffer> customPayload)
+    {
+        return newSession(state, sessionId, TraceType.QUERY, wasProbabilistic, customPayload);
+    }
+
+    /**
+     * This method is intended to be overridden in tracing implementations that need access to the customPayload
+     *
+     * @param wasProbabilistic set to True if the session is created due to probabilistic tracing, false if it
+     *                         was set by client request. It is ignored by default, but subclasses can use that
+     *                         information
+     * */
+    protected UUID newSession(ClientState state, UUID sessionId, TraceType traceType, boolean wasProbabilistic, Map<String,ByteBuffer> customPayload)
     {
         assert get() == null;
 
-        TraceState ts = newTraceState(state, FBUtilities.getLocalAddressAndPort(), sessionId, traceType);
+        TraceState ts = newTraceState(state, FBUtilities.getLocalAddressAndPort(), sessionId, traceType, wasProbabilistic);
         set(ts);
         sessions.put(sessionId, ts);
 
@@ -306,7 +329,7 @@ public abstract class Tracing implements ExecutorLocal<TraceState>
         TraceType traceType = header.traceType();
 
         ClientState clientState = TracingClientState.withTracedKeyspace(header.traceKeyspace());
-        ts = newTraceState(clientState, header.from, sessionId, traceType);
+        ts = newTraceState(clientState, header.from, sessionId, traceType, header.tracedProbabilistically());
 
         if (header.verb.isResponse())
         {
@@ -340,6 +363,7 @@ public abstract class Tracing implements ExecutorLocal<TraceState>
                 TraceType traceType = message.traceType();
                 String traceKeyspace = message.header.traceKeyspace();
                 ClientState clientState = TracingClientState.withTracedKeyspace(traceKeyspace);
+                // this is a fire-and-forget execution, the future will not be checked for if it completed.
                 trace(clientState, ByteBuffer.wrap(UUIDGen.decompose(sessionId)), logMessage, traceType.getTTL());
             }
             else
@@ -359,9 +383,11 @@ public abstract class Tracing implements ExecutorLocal<TraceState>
     {
         assert isTracing();
 
-        addToMutable.put(ParamType.TRACE_SESSION, Tracing.instance.getSessionId());
-        addToMutable.put(ParamType.TRACE_TYPE, Tracing.instance.getTraceType());
-        String keyspace = Tracing.instance.get().tracedKeyspace();
+        TraceState traceState = Tracing.instance.get();
+        addToMutable.put(ParamType.TRACE_SESSION, traceState.sessionId);
+        addToMutable.put(ParamType.TRACE_TYPE, traceState.traceType);
+        addToMutable.put(ParamType.TRACED_PROBABILISTICALLY, traceState.isProbabilistic);
+        String keyspace = traceState.tracedKeyspace();
         if (keyspace != null)
         {
             addToMutable.put(ParamType.TRACE_KEYSPACE, keyspace);
@@ -373,7 +399,7 @@ public abstract class Tracing implements ExecutorLocal<TraceState>
         ClientState state,
         InetAddressAndPort coordinator,
         UUID sessionId,
-        Tracing.TraceType traceType);
+        Tracing.TraceType traceType, boolean wasProbabilistic);
 
     // repair just gets a varargs method since it's so heavyweight anyway
     public static void traceRepair(String format, Object... args)

--- a/src/java/org/apache/cassandra/tracing/TracingImpl.java
+++ b/src/java/org/apache/cassandra/tracing/TracingImpl.java
@@ -24,11 +24,12 @@ import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.UUID;
 
-import org.apache.cassandra.concurrent.Stage;
-import org.apache.cassandra.db.Mutation;
+import org.slf4j.LoggerFactory;
+
 import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.service.ClientState;
-import org.apache.cassandra.utils.WrappedRunnable;
+import org.apache.cassandra.utils.FBUtilities;
+import org.apache.cassandra.utils.JVMStabilityInspector;
 
 
 /**
@@ -37,17 +38,42 @@ import org.apache.cassandra.utils.WrappedRunnable;
  */
 class TracingImpl extends Tracing
 {
+    private static final TraceStorage storage;
+
+    static
+    {
+        TraceStorage instance = null;
+        String customTracingClass = System.getProperty("cassandra.custom_tracing_storage_class");
+        if (null != customTracingClass)
+        {
+            try
+            {
+                instance = FBUtilities.construct(customTracingClass, "Tracing Storage");
+                LoggerFactory.getLogger(TraceKeyspace.class).info("Using {} as trace storage (as requested with -Dcassandra.custom_tracing_storage_class)", customTracingClass);
+            }
+            catch (Exception e)
+            {
+                JVMStabilityInspector.inspectThrowable(e);
+                LoggerFactory.getLogger(TraceKeyspace.class)
+                             .error(String.format("Cannot use class %s for trace storage, ignoring by defaulting to normal tracing", customTracingClass), e);
+            }
+        }
+        storage = instance == null ? TraceKeyspace.asStorage() : instance;
+    }
+
     public void stopSessionImpl()
     {
         final TraceStateImpl state = getStateImpl();
         if (state == null)
             return;
 
-        int elapsed = state.elapsed();
-        ByteBuffer sessionId = state.sessionIdBytes;
-        int ttl = state.ttl;
+//        int elapsed = state.elapsed();
+//        ByteBuffer sessionId = state.sessionIdBytes;
+//        int ttl = state.ttl;
 
-        state.executeMutation(TraceKeyspace.makeStopSessionMutation(sessionId, elapsed, ttl));
+        state.stopSession();
+//        storage.stopSession(state);
+//        state.executeMutation(TraceKeyspace.makeStopSessionMutation(sessionId, elapsed, ttl));
     }
 
     public TraceState begin(final String request, final InetAddress client, final Map<String, String> parameters)
@@ -58,11 +84,12 @@ class TracingImpl extends Tracing
         assert state != null;
 
         final long startedAt = System.currentTimeMillis();
-        final ByteBuffer sessionId = state.sessionIdBytes;
-        final String command = state.traceType.toString();
-        final int ttl = state.ttl;
+//        final ByteBuffer sessionId = state.sessionIdBytes;
+//        final String command = state.traceType.toString();
+//        final int ttl = state.ttl;
 
-        state.executeMutation(TraceKeyspace.makeStartSessionMutation(sessionId, client, parameters, request, startedAt, command, ttl));
+        state.begin(client, request, parameters);
+//        state.executeMutation(TraceKeyspace.makeStartSessionMutation(sessionId, client, parameters, request, startedAt, command, ttl));
         return state;
     }
 
@@ -95,9 +122,10 @@ class TracingImpl extends Tracing
     }
 
     @Override
-    protected TraceState newTraceState(ClientState state, InetAddressAndPort coordinator, UUID sessionId, TraceType traceType)
+    protected TraceState newTraceState(ClientState state, InetAddressAndPort coordinator, UUID sessionId, TraceType traceType,
+                                       boolean wasProbabilistic)
     {
-        return new TraceStateImpl(state, coordinator, sessionId, traceType);
+        return new TraceStateImpl(state, coordinator, sessionId, traceType, wasProbabilistic, storage);
     }
 
     /**
@@ -107,13 +135,17 @@ class TracingImpl extends Tracing
     {
         final String threadName = Thread.currentThread().getName();
 
-        Stage.TRACING.execute(new WrappedRunnable()
-        {
-            public void runMayThrow()
-            {
-                Mutation mutation = TraceKeyspace.makeEventMutation(sessionId, message, -1, threadName, ttl);
-                TraceStateImpl.mutateWithCatch(clientState, mutation);
-            }
-        });
+        // TODO(scottfines)this is fire-and-forget. The future will not be checked for completion. This repeats
+        // the prior behavior, so it's PROBABLY ok, but maybe not?
+        storage.recordNonLocalEvent(clientState, sessionId, message, -1, threadName, ttl);
+
+//        Stage.TRACING.execute(new WrappedRunnable()
+//        {
+//            public void runMayThrow()
+//            {
+//                Mutation mutation = TraceKeyspace.makeEventMutation(sessionId, message, -1, threadName, ttl);
+//                TraceStateImpl.mutateWithCatch(clientState, mutation);
+//            }
+//        });
     }
 }

--- a/src/java/org/apache/cassandra/transport/Message.java
+++ b/src/java/org/apache/cassandra/transport/Message.java
@@ -256,12 +256,12 @@ public abstract class Message
                 {
                     shouldTrace = true;
                     tracingSessionId = UUIDGen.getTimeUUID();
-                    Tracing.instance.newSession(queryState.getClientState(), tracingSessionId, getCustomPayload());
+                    Tracing.instance.newSession(queryState.getClientState(), tracingSessionId, false, getCustomPayload());
                 }
                 else if (StorageService.instance.shouldTraceProbablistically())
                 {
                     shouldTrace = true;
-                    Tracing.instance.newSession(queryState.getClientState(), getCustomPayload());
+                    Tracing.instance.newSession(queryState.getClientState(), true, getCustomPayload());
                 }
             }
 

--- a/test/unit/org/apache/cassandra/concurrent/DebuggableThreadPoolExecutorTest.java
+++ b/test/unit/org/apache/cassandra/concurrent/DebuggableThreadPoolExecutorTest.java
@@ -21,6 +21,8 @@ package org.apache.cassandra.concurrent;
  */
 
 
+import java.net.InetAddress;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -42,8 +44,11 @@ import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.service.ClientState;
 import org.apache.cassandra.service.ClientWarn;
+import org.apache.cassandra.tracing.KeyspaceTraceStorage;
+import org.apache.cassandra.tracing.TraceKeyspace;
 import org.apache.cassandra.tracing.TraceState;
 import org.apache.cassandra.tracing.TraceStateImpl;
+import org.apache.cassandra.tracing.TraceStorage;
 import org.apache.cassandra.tracing.Tracing;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.WrappedRunnable;
@@ -139,12 +144,31 @@ public class DebuggableThreadPoolExecutorTest
         Assertions.assertThat(ClientWarn.instance.getWarnings()).isNullOrEmpty();
 
         ConcurrentLinkedQueue<String> q = new ConcurrentLinkedQueue<>();
-        Tracing.instance.set(new TraceState(clientState, FBUtilities.getLocalAddressAndPort(), UUID.randomUUID(), Tracing.TraceType.NONE)
+        Tracing.instance.set(new TraceState(clientState, FBUtilities.getLocalAddressAndPort(), UUID.randomUUID(), Tracing.TraceType.NONE, false)
         {
             @Override
             protected void traceImpl(String message)
             {
                 q.add(message);
+            }
+
+            @Override
+            public TraceStorage getStorage()
+            {
+                Assertions.fail("Should not ask for storage");
+                return null;
+            }
+
+            @Override
+            public void stopSession()
+            {
+                q.add("Stop");
+            }
+
+            @Override
+            public void begin(InetAddress client, String request, Map<String, String> parameters)
+            {
+                q.add("begin");
             }
         });
         Tracing.trace("msg0");
@@ -235,7 +259,10 @@ public class DebuggableThreadPoolExecutorTest
     {
         TraceState state = Tracing.instance.get();
         try {
-            Tracing.instance.set(new TraceStateImpl(ClientState.forInternalCalls(), InetAddressAndPort.getByAddress(InetAddresses.forString("127.0.0.1")), UUID.randomUUID(), Tracing.TraceType.NONE));
+            Tracing.instance.set(new TraceStateImpl(ClientState.forInternalCalls(),
+                                                    InetAddressAndPort.getByAddress(InetAddresses.forString("127.0.0.1")),
+                                                    UUID.randomUUID(), Tracing.TraceType.NONE, false,
+                                                    TraceKeyspace.asStorage()));
             fn.run();
         }
         finally

--- a/test/unit/org/apache/cassandra/tracing/TracingTest.java
+++ b/test/unit/org/apache/cassandra/tracing/TracingTest.java
@@ -307,6 +307,7 @@ public final class TracingTest extends CQLTester
     private static final class ClientStateAccumulatingTracing extends Tracing
     {
         Queue<ClientState> states = new LinkedList<>();
+        TraceStorage storage = TraceKeyspace.asStorage();
 
         @Override
         protected void stopSessionImpl()
@@ -319,9 +320,9 @@ public final class TracingTest extends CQLTester
         }
 
         @Override
-        protected TraceState newTraceState(ClientState state, InetAddressAndPort coordinator, UUID sessionId, TraceType traceType)
+        protected TraceState newTraceState(ClientState state, InetAddressAndPort coordinator, UUID sessionId, TraceType traceType, boolean wasProbabilistic)
         {
-            return new TraceStateImpl(state, coordinator, sessionId, traceType);
+            return new TraceStateImpl(state, coordinator, sessionId, traceType, wasProbabilistic, storage);
         }
 
         @Override

--- a/test/unit/org/apache/cassandra/tracing/TracingTestImpl.java
+++ b/test/unit/org/apache/cassandra/tracing/TracingTestImpl.java
@@ -61,19 +61,19 @@ public final class TracingTestImpl extends Tracing
     }
 
     @Override
-    protected UUID newSession(ClientState state, UUID sessionId, TraceType traceType, Map<String, ByteBuffer> customPayload)
+    protected UUID newSession(ClientState state, UUID sessionId, TraceType traceType, boolean wasProbabilistic, Map<String, ByteBuffer> customPayload)
     {
         if (!customPayload.isEmpty())
             logger.info("adding custom payload items {}", StringUtils.join(customPayload.keySet(), ','));
 
         payloads.putAll(customPayload);
-        return super.newSession(state, sessionId, traceType, customPayload);
+        return super.newSession(state, sessionId, traceType, wasProbabilistic, customPayload);
     }
 
     @Override
-    protected TraceState newTraceState(ClientState state, InetAddressAndPort ia, UUID uuid, TraceType tt)
+    protected TraceState newTraceState(ClientState state, InetAddressAndPort ia, UUID uuid, TraceType tt, boolean wasProbabilistic)
     {
-        return new TraceState(state, ia, uuid, tt)
+        return new TraceState(state, ia, uuid, tt, false)
         {
             protected void traceImpl(String string)
             {
@@ -82,6 +82,24 @@ public final class TracingTestImpl extends Tracing
 
             protected void waitForPendingEvents()
             {
+            }
+
+            @Override
+            public TraceStorage getStorage()
+            {
+                return null;
+            }
+
+            @Override
+            public void stopSession()
+            {
+                traces.add("stop");
+            }
+
+            @Override
+            public void begin(InetAddress client, String request, Map<String, String> parameters)
+            {
+                traces.add("begin");
             }
         };
     }


### PR DESCRIPTION
IMPORTANT NOTE: Please do not merge this! It is part of ongoing development. Feel free to look around and make comments as you feel important, but recognize that it is a work in progress.

### What is the issue
This is part of a POC for [cndb-11350](https://github.com/riptano/cndb/issues/11350). The issue is that we lack the ability to connect tenants to traced queries.


### What does this PR fix and why was it fixed
1. Adds a context entry to TraceKeyspace. This is almost certainly temporary (since the upgrade path for changing a system table in production seems fraught), but it allows us to proceed on other fronts in developing the POC
2. Refactors the trace storage logic to allow for alternative trace storage implementations. This way, we can write our tenant-aware trace logic on the CNDB side without needing any kind of tenancy in CC.
