### PR TITLE
CNDB-17012: Improve TrieMemoryIndex row count estimation

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/v6/TermsDistribution.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v6/TermsDistribution.java
@@ -279,6 +279,10 @@ public class TermsDistribution
         // For non numbers we just reinterpret the bytecomparable representation as decimal of fixed width.
         // Therefore, we don't need to decode anything.
         byte[] fixedLengthBytes = Arrays.copyOf(ByteSourceInverse.readBytes(value.asComparableBytes(byteComparableVersion)), 20);
+        // Flip the first bit to get a correct order for negative values,
+        // because the first bit is interpreted by BigInteger as a sign bit, but bytecomparable interpret all byts as unsigned.
+        // By flipping it, we correctly get values starting with 0 bit smaller than the ones starting with 1.
+        fixedLengthBytes[0] ^= (byte) 0x80;
         return new BigDecimal(new BigInteger(fixedLengthBytes));
     }
 

--- a/src/java/org/apache/cassandra/index/sai/memory/TrieMemoryIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/TrieMemoryIndex.java
@@ -439,73 +439,41 @@ public class TrieMemoryIndex extends MemoryIndex
 
     private long estimateNumRowsMatchingRange(Expression expression)
     {
-        final Trie<PrimaryKeys> subtrie = getSubtrie(expression);
-
-        // We could compute the number of matching rows by iterating the subtrie
-        // and summing the sizes of PrimaryKeys collections. But this could be very costly
-        // if the subtrie is large. Instead, we iterate a limited number of entries, and then we
-        // check how far we got by inspecting the term and comparing it to the start term and the end term.
-        // For now, we assume that term values are distributed uniformly.
-
-        var iterator = subtrie.entryIterator();
-        if (!iterator.hasNext())
+        if (minTerm == null || maxTerm == null)
             return 0;
 
         AbstractType<?> termType = indexContext.getValidator();
-        ByteBuffer endTerm = expression.upper != null && TypeUtil.compare(expression.upper.value.encoded, maxTerm, termType, version) < 0
-                             ? expression.upper.value.encoded
-                             : maxTerm;
+        ByteComparable minTermComparable = version.onDiskFormat().encodeForTrie(minTerm, termType);
+        ByteComparable maxTermComparable = version.onDiskFormat().encodeForTrie(maxTerm, termType);
+        BigDecimal indexLowerBound = toBigDecimal(minTermComparable);
+        BigDecimal indexUpperBound = toBigDecimal(maxTermComparable);
 
-        long pointCount = 0;
-        long keyCount = 0;
+        BigDecimal queryLowerBound = expression.lower != null
+                                     ? toBigDecimal(expression.getEncodedLowerBoundByteComparable(version))
+                                     : indexLowerBound;
+        BigDecimal queryUpperBound = expression.upper != null
+                                     ? toBigDecimal(expression.getEncodedUpperBoundByteComparable(version))
+                                     : indexUpperBound;
 
-        ByteComparable startTerm = null;
-        ByteComparable currentTerm = null;
+        if (queryLowerBound.compareTo(indexUpperBound) > 0 || queryUpperBound.compareTo(indexLowerBound) < 0)
+            return 0;
+        if (queryLowerBound.compareTo(indexUpperBound) == 0 && expression.lower != null && !expression.lower.inclusive)
+            return 0;
+        if (queryUpperBound.compareTo(indexLowerBound) == 0 && expression.upper != null && !expression.upper.inclusive)
+            return 0;
+        if (queryLowerBound.compareTo(indexLowerBound) <= 0 && queryUpperBound.compareTo(indexUpperBound) >= 0)
+            return indexedRows;
 
-        while (iterator.hasNext() && pointCount < 64)
-        {
-            var entry = iterator.next();
-            pointCount += 1;
-            keyCount += entry.getValue().size();
-            currentTerm = entry.getKey();
-            if (startTerm == null)
-                startTerm = currentTerm;
-        }
-        assert currentTerm != null;
+        queryUpperBound = queryUpperBound.min(indexUpperBound).max(indexLowerBound);
+        queryLowerBound = queryLowerBound.max(indexLowerBound).min(indexUpperBound);
+        assert queryLowerBound.compareTo(queryUpperBound) <= 0
+            : "query lower bound (" + queryLowerBound + ") should be less than or equal to query upper bound (" + queryUpperBound + ')';
 
-        // We iterated all points matched by the query, so keyCount contains the exact value of keys.
-        // This is a happy path, because the returned value will be accurate.
-        if (!iterator.hasNext())
-            return keyCount;
-
-        // There are some points remaining; let's estimate their count by extrapolation.
-        // Express the distance we iterated as a double value and the whole subtrie range also as a double.
-        // Then the ratio of those two values would give us a hint on how many total points there
-        // are in the subtrie. This should be fairly accurate assuming values are distributed uniformly.
-        BigDecimal startValue = toBigDecimal(startTerm);
-        BigDecimal endValue = toBigDecimal(endTerm);
-        BigDecimal currentValue = toBigDecimal(currentTerm);
-        double totalDistance = endValue.subtract(startValue).doubleValue() + Double.MIN_NORMAL;
-        double iteratedDistance = currentValue.subtract(startValue).doubleValue() + Double.MIN_NORMAL;
-        assert totalDistance > 0.0;
-        assert iteratedDistance > 0.0;
-
-        double extrapolatedPointCount = Math.min((pointCount - 1) * (totalDistance / iteratedDistance), this.data.valuesCount());
-        double keysPerPoint = (double) keyCount / pointCount;
-        return (long) (extrapolatedPointCount * keysPerPoint);
-    }
-
-    /**
-     * Converts the term to a BigDecimal in a way that it keeps the sort order
-     * (so terms comparing larger yield larger numbers).
-     * Works on raw representation (as passed to the index).
-     *
-     * @see #toBigDecimal(ByteComparable)
-     */
-    private BigDecimal toBigDecimal(ByteBuffer endTerm)
-    {
-        ByteComparable bc = version.onDiskFormat().encodeForTrie(endTerm, indexContext.getValidator());
-        return toBigDecimal(bc);
+        double indexRangeSize = indexUpperBound.subtract(indexLowerBound).doubleValue() + Double.MIN_NORMAL;
+        double queryRangeSize = queryUpperBound.subtract(queryLowerBound).doubleValue() + Double.MIN_NORMAL;
+        double selectivity = queryRangeSize / indexRangeSize;
+        assert selectivity >= 0.0 && selectivity <= 1.0 : "selectivity (" + selectivity + ") should be between 0.0 and 1.0";
+        return Math.round(selectivity * indexedRows);
     }
 
     /**

--- a/test/unit/org/apache/cassandra/index/sai/cql/NonNumericTermsDistributionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/NonNumericTermsDistributionTest.java
@@ -93,10 +93,10 @@ public class NonNumericTermsDistributionTest extends SAITester
         var sai = getIndex();
 
         assertInMemoryEstimateCount(sai, Operator.EQ, "ab", 1);
-        assertInMemoryEstimateCount(sai, Operator.LT, "ab", 2);
-        assertInMemoryEstimateCount(sai, Operator.GT, "ab", 3);
-        assertInMemoryEstimateCount(sai, Operator.LTE, "ab", 3);
-        assertInMemoryEstimateCount(sai, Operator.GTE, "ab", 4);
+        assertInMemoryEstimateCount(sai, Operator.LT, "ab", 2, 1);
+        assertInMemoryEstimateCount(sai, Operator.GT, "ab", 3, 1);
+        assertInMemoryEstimateCount(sai, Operator.LTE, "ab", 3, 1);
+        assertInMemoryEstimateCount(sai, Operator.GTE, "ab", 4, 1);
         assertInMemoryEstimateCount(sai, Operator.EQ, "•", 1);
         assertInMemoryEstimateCount(sai, Operator.EQ, "x", 0);
 
@@ -183,10 +183,10 @@ public class NonNumericTermsDistributionTest extends SAITester
         var sai = getIndex();
 
         assertInMemoryEstimateCount(sai, Operator.EQ, "ab", 1);
-        assertInMemoryEstimateCount(sai, Operator.LT, "ab", 2);
-        assertInMemoryEstimateCount(sai, Operator.GT, "ab", 3);
-        assertInMemoryEstimateCount(sai, Operator.LTE, "ab", 3);
-        assertInMemoryEstimateCount(sai, Operator.GTE, "ab", 4);
+        assertInMemoryEstimateCount(sai, Operator.LT, "ab", 2, 1);
+        assertInMemoryEstimateCount(sai, Operator.GT, "ab", 3, 1);
+        assertInMemoryEstimateCount(sai, Operator.LTE, "ab", 3, 1);
+        assertInMemoryEstimateCount(sai, Operator.GTE, "ab", 4, 1);
         assertInMemoryEstimateCount(sai, Operator.EQ, "x", 0);
 
         flush();
@@ -327,10 +327,10 @@ public class NonNumericTermsDistributionTest extends SAITester
         var sai = getIndex();
 
         assertInMemoryEstimateCount(sai, Operator.EQ, "2024-01-01 12:00:00.000", 1);
-        assertInMemoryEstimateCount(sai, Operator.LT, "2024-01-01 12:00:00.000", 2);
-        assertInMemoryEstimateCount(sai, Operator.GT, "2024-01-01 12:00:00.000", 3);
-        assertInMemoryEstimateCount(sai, Operator.LTE, "2024-01-01 12:00:00.000", 3);
-        assertInMemoryEstimateCount(sai, Operator.GTE, "2024-01-01 12:00:00.000", 4);
+        assertInMemoryEstimateCount(sai, Operator.LT, "2024-01-01 12:00:00.000", 2, 1);
+        assertInMemoryEstimateCount(sai, Operator.GT, "2024-01-01 12:00:00.000", 3, 1);
+        assertInMemoryEstimateCount(sai, Operator.LTE, "2024-01-01 12:00:00.000", 3, 1);
+        assertInMemoryEstimateCount(sai, Operator.GTE, "2024-01-01 12:00:00.000", 4, 1);
         assertInMemoryEstimateCount(sai, Operator.EQ, "2550-01-01 12:00:00", 1);
         assertInMemoryEstimateCount(sai, Operator.EQ, "2550-01-01 12:00:01", 0);
         assertInMemoryEstimateCount(sai, Operator.EQ, "1810-12-31 16:00:00", 1);

--- a/test/unit/org/apache/cassandra/index/sai/cql/NumericTermsDistributionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/NumericTermsDistributionTest.java
@@ -191,7 +191,7 @@ public class NumericTermsDistributionTest extends SAITester
         // of this test relied on the fact overwriting a primary key in the memtables didn't remove the old value
         // from the index. I've updated the test to account for more realistic uncertainty and also added a compact
         // then estimate step since that exercises a different build path in the index.
-        var uncertainty = (testType == CQL3Type.Native.TINYINT) ? 1 : 52;
+        var uncertainty = (testType == CQL3Type.Native.TINYINT) ? 2 : 52;
         assertInMemoryEstimateCount(sai, Operator.LT, MID_POINT, COUNT / 2, 0, uncertainty);
         assertInMemoryEstimateCount(sai, Operator.GT, MID_POINT, COUNT / 2, 0, uncertainty);
         assertInMemoryEstimateCount(sai, Operator.LTE, MID_POINT, COUNT / 2, 1, uncertainty);

--- a/test/unit/org/apache/cassandra/index/sai/disk/v6/TermsDistributionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v6/TermsDistributionTest.java
@@ -23,6 +23,9 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.Random;
 
 import org.junit.Test;
 
@@ -31,12 +34,15 @@ import org.apache.cassandra.db.marshal.DecimalType;
 import org.apache.cassandra.db.marshal.DoubleType;
 import org.apache.cassandra.db.marshal.Int32Type;
 import org.apache.cassandra.db.marshal.IntegerType;
+import org.apache.cassandra.db.marshal.TimestampType;
+import org.apache.cassandra.db.marshal.UTF8Type;
 import org.apache.cassandra.index.sai.SAIUtil;
 import org.apache.cassandra.index.sai.disk.ModernResettableByteBuffersIndexOutput;
 import org.apache.cassandra.index.sai.disk.oldlucene.ByteArrayIndexInput;
 import org.apache.cassandra.index.sai.utils.TypeUtil;
 import org.apache.cassandra.utils.bytecomparable.ByteComparable;
 
+import static org.apache.cassandra.db.marshal.ValueGenerator.randomString;
 import static org.junit.Assert.*;
 
 public class TermsDistributionTest
@@ -270,6 +276,60 @@ public class TermsDistributionTest
         }
     }
 
+    @Test
+    public void testTimestampToBigDecimalPreservesOrder()
+    {
+        var tpe = TimestampType.instance;
+        var format = SAIUtil.currentVersion().onDiskFormat();
+        var timestamps = new long[] { Long.MIN_VALUE, -1000000000L, -1L, 0L, 1L, 1000000000L, Long.MAX_VALUE };
+
+        ByteComparable[] encoded = new ByteComparable[timestamps.length];
+        BigDecimal[] decimals = new BigDecimal[timestamps.length];
+
+        for (int i = 0; i < timestamps.length; i++)
+        {
+            encoded[i] = format.encodeForTrie(tpe.decompose(new Date(timestamps[i])), tpe);
+            decimals[i] = TermsDistribution.toBigDecimal(encoded[i], tpe, SAIUtil.currentVersion(), VERSION);
+        }
+
+        // BigDecimal representaitons should sort the same way as the original timestamps:
+        for (int i = 0; i < decimals.length - 1; i++)
+        {
+            assertTrue(ByteComparable.compare(encoded[i], encoded[i + 1], TypeUtil.BYTE_COMPARABLE_VERSION) < 0);
+            assertTrue(decimals[i].compareTo(decimals[i + 1]) < 0);
+        }
+    }
+
+    @Test
+    public void testStringToBigDecimalPreservesOrder()
+    {
+        var tpe = UTF8Type.instance;
+        var format = SAIUtil.currentVersion().onDiskFormat();
+        String[] strings = new String[100];
+        Random random = new Random(1);
+        for (int i = 0; i < strings.length; i++)
+        {
+            strings[i] = randomString(random);
+        }
+        Arrays.sort(strings);
+
+        ByteComparable[] encoded = new ByteComparable[strings.length];
+        BigDecimal[] decimals = new BigDecimal[strings.length];
+
+        for (int i = 0; i < strings.length; i++)
+        {
+            encoded[i] = format.encodeForTrie(tpe.decompose(strings[i]), tpe);
+            decimals[i] = TermsDistribution.toBigDecimal(encoded[i], tpe, SAIUtil.currentVersion(), VERSION);
+        }
+
+        // BigDecimal representations should sort the same way as the original strings:
+        for (int i = 0; i < decimals.length - 1; i++)
+        {
+            assertTrue(ByteComparable.compare(encoded[i], encoded[i + 1], TypeUtil.BYTE_COMPARABLE_VERSION) < 0);
+            assertTrue(decimals[i].compareTo(decimals[i + 1]) < 0);
+        }
+    }
+
     private ByteComparable encode(int value)
     {
         return v -> Int32Type.instance.asComparableBytes(Int32Type.instance.decompose(value), v);
@@ -291,5 +351,4 @@ public class TermsDistributionTest
         ByteBuffer raw = IntegerType.instance.decompose(BigInteger.valueOf(value));
         return v -> TypeUtil.asComparableBytes(TypeUtil.encode(raw, IntegerType.instance), IntegerType.instance, v);
     }
-
 }

--- a/test/unit/org/apache/cassandra/index/sai/memory/TrieMemoryIndexTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/memory/TrieMemoryIndexTest.java
@@ -19,28 +19,33 @@ package org.apache.cassandra.index.sai.memory;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Date;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
+import java.util.Random;
 import java.util.function.IntFunction;
 
 import org.junit.Before;
 import org.junit.Test;
 
 import org.apache.cassandra.SchemaLoader;
+import org.apache.cassandra.cql3.Operator;
 import org.apache.cassandra.cql3.statements.schema.IndexTarget;
 import org.apache.cassandra.db.Clustering;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.db.marshal.CompositeType;
 import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.db.marshal.LongType;
 import org.apache.cassandra.db.marshal.UTF8Type;
+import org.apache.cassandra.db.marshal.TimestampType;
 import org.apache.cassandra.dht.Murmur3Partitioner;
 import org.apache.cassandra.index.TargetParser;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.StorageAttachedIndex;
+import org.apache.cassandra.index.sai.plan.Expression;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
-import org.apache.cassandra.index.sai.utils.PrimaryKeys;
 import org.apache.cassandra.index.sai.utils.TypeUtil;
 import org.apache.cassandra.schema.CachingParams;
 import org.apache.cassandra.schema.ColumnMetadata;
@@ -54,6 +59,7 @@ import org.apache.cassandra.utils.bytecomparable.ByteSource;
 import org.apache.cassandra.utils.bytecomparable.ByteSourceInverse;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class TrieMemoryIndexTest
 {
@@ -61,6 +67,7 @@ public class TrieMemoryIndexTest
     private static final String TABLE = "test_table";
     private static final String PART_KEY_COL = "key";
     private static final String REG_COL = "col";
+    public static final long[] EMTPY_LONG_ARRAY = {};
 
     private static DecoratedKey key = Murmur3Partitioner.instance.decorateKey(ByteBufferUtil.bytes("key"));
 
@@ -139,6 +146,186 @@ public class TrieMemoryIndexTest
         shouldAcceptPrefixValuesForType(Int32Type.instance, Int32Type.instance::decompose);
     }
 
+    @Test
+    public void testStringRangeEstimates()
+    {
+        IndexContext context = newIndexContext(UTF8Type.instance, UTF8Type.instance);
+        TrieMemoryIndex index = new TrieMemoryIndex(context);
+        int numRows = 10000;
+        String[] values = new String[numRows];
+        Random random = new Random(3);
+
+        for (int i = 0; i < numRows; i++)
+        {
+            values[i] = randomString(random);
+            DecoratedKey pk = makeKey(table, Integer.toString(i));
+            ByteBuffer value = UTF8Type.instance.decompose(values[i]);
+            index.add(pk, Clustering.EMPTY, value, allocatedBytes -> {}, allocatesBytes -> {});
+        }
+
+        for (int i = 0; i < 100; i++)
+        {
+            String s1 = randomString(random);
+            String s2 = randomString(random);
+            String lower = s1.compareTo(s2) < 0 ? s1 : s2;
+            String upper = s1.compareTo(s2) < 0 ? s2 : s1;
+
+            testStringFilterEstimate(context, index, values, lower, upper);
+        }
+    }
+
+    // We're not testing full UTF-8 alphabet because the estimation algorithm is not very good
+    // when data are non-uniformly distributed. If we use a wider character set, there will be likely
+    // huge holes between the code points, and modeling real distribution of characters used by some real
+    // text (as in some existing natural language) becomes hairy very quickly.
+    // I got already much worse results when using a set of {a-z, 0-9}, because of a hole between
+    // encodings of letters and numbers.
+    // This test is to make sure the estimation algorithm works correctly under the assumption that
+    // data are distributed uniformly, so the following contiguous set of letters is good enough.
+    private static final char[] CHARS = "abcdefghijklmnopqrstuvwxyz".toCharArray();
+
+    public static String randomString(Random random)
+    {
+        char[] chars = new char[4 + random.nextInt(32)];
+        for (int i=0; i < chars.length; i++)
+            chars[i] = CHARS[random.nextInt(CHARS.length)];
+        return new String(chars);
+    }
+
+    private void testStringFilterEstimate(IndexContext context, TrieMemoryIndex index, String[] allValues, String lower, String upper)
+    {
+        Expression expression = new Expression(context);
+        expression.add(Operator.GTE, UTF8Type.instance.decompose(lower));
+        expression.add(Operator.LTE, UTF8Type.instance.decompose(upper));
+
+        long estimated = index.estimateMatchingRowsCount(expression);
+        long actual = Arrays.stream(allValues).filter(t -> t.compareTo(lower) >= 0 && t.compareTo(upper) <= 0).count();
+        double ratio = (double) estimated / (actual + 1);
+
+        // the estimation is not very accurate for very narrow text ranges because the distribution of values
+        // is not very uniform; we try to somehow account for that by giving more tolerance for narrower ranges
+        int rangeSize = Math.abs(lower.charAt(0) - upper.charAt(0));
+        double tolerance;
+        switch (rangeSize)
+        {
+            case 0: // same first character, very narrow range
+                tolerance = 20.0;
+                break;
+            case 1: // adjacent first characters, still a narrow range
+                tolerance = 4.0;
+                break;
+            default: // wider range
+                tolerance = 1.5;
+        }
+
+        assertTrue(String.format("Estimated %d, actual %d  (lower %s, upper %s)", estimated, actual, lower, upper),
+                   ratio < tolerance && ratio > 1.0 / tolerance);
+    }
+
+    @Test
+    public void testLongRangeEstimates()
+    {
+        // CNDB-17012 regression test
+        // Why timestamps? Timestamps are encoded internally as 8 byte longs, but they are not treated
+        // as numeric types by the row count estimation code so they go through a generic bytecomparable logic,
+        // which had a bug.
+        IndexContext context = newIndexContext(UTF8Type.instance, LongType.instance);
+        TrieMemoryIndex index = new TrieMemoryIndex(context);
+
+        // Test empty index
+        testLongFilterEstimate(context, index, EMTPY_LONG_ARRAY, Long.MIN_VALUE, Long.MIN_VALUE);
+        testLongFilterEstimate(context, index, EMTPY_LONG_ARRAY, Long.MIN_VALUE, Long.MAX_VALUE);
+        testLongFilterEstimate(context, index, EMTPY_LONG_ARRAY, Long.MAX_VALUE, Long.MAX_VALUE);
+
+        int numRows = 10000;
+        long[] values = new long[numRows];
+        Random random = new Random(1);
+        for (int i = 0; i < numRows; i++)
+        {
+            values[i] = random.nextLong();  // it's important negative longs are also included
+            DecoratedKey pk = makeKey(table, Integer.toString(i));
+            ByteBuffer value = LongType.instance.decompose(values[i]);
+            index.add(pk, Clustering.EMPTY, value, allocatedBytes -> {}, allocatesBytes -> {});
+        }
+
+        for (int i = 0; i < 100; i++)
+        {
+            long l1 = random.nextLong();
+            long l2 = random.nextLong();
+            long lower = Math.min(l1, l2);
+            long upper = Math.max(l1, l2);
+            testLongFilterEstimate(context, index, values, lower, upper);
+        }
+
+        testLongFilterEstimate(context, index, values, Long.MIN_VALUE, Long.MIN_VALUE);
+        testLongFilterEstimate(context, index, values, Long.MIN_VALUE, Long.MAX_VALUE);
+        testLongFilterEstimate(context, index, values, Long.MAX_VALUE, Long.MAX_VALUE);
+    }
+
+    private void testLongFilterEstimate(IndexContext context, TrieMemoryIndex index, long[] allValues, long lower, long upper)
+    {
+        Expression expression = new Expression(context);
+        expression.add(Operator.GTE, LongType.instance.decompose(lower));
+        expression.add(Operator.LTE, LongType.instance.decompose(upper));
+
+        long estimated = index.estimateMatchingRowsCount(expression);
+        long actual = Arrays.stream(allValues).filter(t -> t >= lower && t <= upper).count();
+
+        assertTrue(String.format("Estimated %d, actual %d", estimated, actual), (double) Math.abs(estimated - actual) / (actual + 1) < 0.2);
+    }
+
+    @Test
+    public void testTimestampRangeEstimates()
+    {
+        // CNDB-17012 regression test
+        // Why timestamps? Timestamps are encoded internally as 8 byte longs, but they are not treated
+        // as numeric types by the row count estimation code so they go through a generic bytecomparable logic,
+        // which had a bug.
+        IndexContext context = newIndexContext(UTF8Type.instance, TimestampType.instance);
+        TrieMemoryIndex index = new TrieMemoryIndex(context);
+
+        // Test empty index
+        testTimestampFilterEstimate(context, index, EMTPY_LONG_ARRAY, Long.MIN_VALUE, Long.MIN_VALUE);
+        testTimestampFilterEstimate(context, index, EMTPY_LONG_ARRAY, Long.MIN_VALUE, Long.MAX_VALUE);
+        testTimestampFilterEstimate(context, index, EMTPY_LONG_ARRAY, Long.MAX_VALUE, Long.MAX_VALUE);
+
+        int numRows = 10000;
+        long[] values = new long[numRows];
+        Random random = new Random(1);
+        for (int i = 0; i < numRows; i++)
+        {
+            values[i] = random.nextLong();  // it's important negative longs are also included
+            DecoratedKey pk = makeKey(table, Integer.toString(i));
+            ByteBuffer value = TimestampType.instance.decompose(new Date(values[i]));
+            index.add(pk, Clustering.EMPTY, value, allocatedBytes -> {}, allocatesBytes -> {});
+        }
+
+        for (int i = 0; i < 100; i++)
+        {
+            long l1 = random.nextLong();
+            long l2 = random.nextLong();
+            long lower = Math.min(l1, l2);
+            long upper = Math.max(l1, l2);
+            testTimestampFilterEstimate(context, index, values, lower, upper);
+        }
+
+        testTimestampFilterEstimate(context, index, values, Long.MIN_VALUE, Long.MIN_VALUE);
+        testTimestampFilterEstimate(context, index, values, Long.MIN_VALUE, Long.MAX_VALUE);
+        testTimestampFilterEstimate(context, index, values, Long.MAX_VALUE, Long.MAX_VALUE);
+    }
+
+    private void testTimestampFilterEstimate(IndexContext context, TrieMemoryIndex index, long[] allValues, long lower, long upper)
+    {
+        Expression expression = new Expression(context);
+        expression.add(Operator.GTE, TimestampType.instance.decompose(new Date(lower)));
+        expression.add(Operator.LTE, TimestampType.instance.decompose(new Date(upper)));
+
+        long estimated = index.estimateMatchingRowsCount(expression);
+        long actual = Arrays.stream(allValues).filter(t -> t >= lower && t <= upper).count();
+
+        assertTrue(String.format("Estimated %d, actual %d", estimated, actual), (double) Math.abs(estimated - actual) / (actual + 1) < 0.2);
+    }
+
     private void shouldAcceptPrefixValuesForType(AbstractType<?> type, IntFunction<ByteBuffer> decompose)
     {
         final TrieMemoryIndex index = newTrieMemoryIndex(UTF8Type.instance, type);
@@ -166,7 +353,9 @@ public class TrieMemoryIndexTest
         assertEquals(99, i);
     }
 
-    private TrieMemoryIndex newTrieMemoryIndex(AbstractType<?> partitionKeyType, AbstractType<?> columnType)
+
+    private IndexContext newIndexContext(AbstractType<?> partitionKeyType, AbstractType<?> columnType)
+
     {
         table = TableMetadata.builder(KEYSPACE, TABLE)
                              .addPartitionKeyColumn(PART_KEY_COL, partitionKeyType)
@@ -181,17 +370,20 @@ public class TrieMemoryIndexTest
 
         IndexMetadata indexMetadata = IndexMetadata.fromSchemaMetadata("col_index", IndexMetadata.Kind.CUSTOM, options);
         Pair<ColumnMetadata, IndexTarget.Type> target = TargetParser.parse(table, indexMetadata);
-        IndexContext indexContext = new IndexContext(table.keyspace,
-                                                     table.name,
-                                                     table.id,
-                                                     table.partitionKeyType,
-                                                     table.comparator,
-                                                     target.left,
-                                                     target.right,
-                                                     indexMetadata,
-                                                     MockSchema.newCFS(table));
+        return new IndexContext(table.keyspace,
+                                table.name,
+                                table.id,
+                                table.partitionKeyType,
+                                table.comparator,
+                                target.left,
+                                target.right,
+                                indexMetadata,
+                                MockSchema.newCFS(table));
+    }
 
-        return new TrieMemoryIndex(indexContext);
+    private TrieMemoryIndex newTrieMemoryIndex(AbstractType<?> partitionKeyType, AbstractType<?> columnType)
+    {
+        return new TrieMemoryIndex(newIndexContext(partitionKeyType, columnType));
     }
 
     DecoratedKey makeKey(TableMetadata table, Object...partitionKeys)


### PR DESCRIPTION
Fixes a bug in TermsDistribution#toBigDecimal which didn't preserve
order for some types and broke the assertion
in TrieMemoryIndex#estimateNumRowsMatchingRange.

Additionally, replaces the row count estimation algorithm with a better
one:
- simpler
- more efficient (no need to search and iterate the trie)
- more accurate (especially for wider ranges)
