### PR TITLE
Introduce a MetricsFactory which can be used to produce metrics objects at the Table and Keyspace level, and which is customizable

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -518,6 +518,8 @@ public enum CassandraRelevantProperties
     TABLE_METRICS_DEFAULT_HISTOGRAMS_AGGREGATION("cassandra.table_metrics_default_histograms_aggregation", TableMetrics.MetricsAggregation.INDIVIDUAL.name()),
     // Determines if table metrics should be also exported to shared global metric
     TABLE_METRICS_EXPORT_GLOBALS("cassandra.table_metrics_export_globals", "true"),
+    // determines if table metrics are collected.
+    TABLE_METRICS_ENABLED("cassandra.table_metrics.enabled", "true"),
     // Enable/disable replica response size metrics collection
     REPLICA_RESPONSE_SIZE_METRICS_ENABLED("cassandra.replica_response_size_metrics_enabled", "true"),
     FILE_CACHE_SIZE_IN_MB("cassandra.file_cache_size_in_mb", "2048"),

--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -520,6 +520,8 @@ public enum CassandraRelevantProperties
     TABLE_METRICS_EXPORT_GLOBALS("cassandra.table_metrics_export_globals", "true"),
     // determines if table metrics are collected.
     TABLE_METRICS_ENABLED("cassandra.table_metrics.enabled", "true"),
+    // determines if keyspace metrics are collected and published.
+    KEYSPACE_METRICS_ENABLED("cassandra.keyspace_metrics.enabled", "true"),
     // Enable/disable replica response size metrics collection
     REPLICA_RESPONSE_SIZE_METRICS_ENABLED("cassandra.replica_response_size_metrics_enabled", "true"),
     FILE_CACHE_SIZE_IN_MB("cassandra.file_cache_size_in_mb", "2048"),

--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -153,6 +153,7 @@ import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileOutputStreamPlus;
 import org.apache.cassandra.locator.AbstractReplicationStrategy;
 import org.apache.cassandra.metrics.KeyspaceMetrics;
+import org.apache.cassandra.metrics.MetricsFactory;
 import org.apache.cassandra.metrics.Sampler;
 import org.apache.cassandra.metrics.Sampler.Sample;
 import org.apache.cassandra.metrics.Sampler.SamplerType;
@@ -451,7 +452,7 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
         if (metric.metricsAggregation != TableMetrics.MetricsAggregation.fromMetadata(metadata()))
         { // Reload the metrics if histogram aggregation has changed
             metric.release(); // release first because of those static tables containing metric names
-            metric = new TableMetrics(this, memtableFactory.createMemtableMetrics(metadata));
+            metric = MetricsFactory.instance.newTableMetrics(this, memtableFactory.createMemtableMetrics(metadata));
         }
     }
 
@@ -624,7 +625,7 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
             initialBuilds.add(indexManager.addIndex(info, true));
         }
 
-        metric = new TableMetrics(this, memtableFactory.createMemtableMetrics(metadata));
+        metric = MetricsFactory.instance.newTableMetrics(this, memtableFactory.createMemtableMetrics(metadata));
 
         if (data.loadsstables && sstables != null)
         {

--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -152,6 +152,7 @@ import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileOutputStreamPlus;
 import org.apache.cassandra.locator.AbstractReplicationStrategy;
 import org.apache.cassandra.metrics.KeyspaceMetrics;
+import org.apache.cassandra.metrics.MetricsFactory;
 import org.apache.cassandra.metrics.Sampler;
 import org.apache.cassandra.metrics.Sampler.Sample;
 import org.apache.cassandra.metrics.Sampler.SamplerType;
@@ -450,7 +451,7 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
         if (metric.metricsAggregation != TableMetrics.MetricsAggregation.fromMetadata(metadata()))
         { // Reload the metrics if histogram aggregation has changed
             metric.release(); // release first because of those static tables containing metric names
-            metric = new TableMetrics(this, memtableFactory.createMemtableMetrics(metadata));
+            metric = MetricsFactory.instance.newTableMetrics(this, memtableFactory.createMemtableMetrics(metadata));
         }
     }
 
@@ -623,7 +624,7 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
             initialBuilds.add(indexManager.addIndex(info, true));
         }
 
-        metric = new TableMetrics(this, memtableFactory.createMemtableMetrics(metadata));
+        metric = MetricsFactory.instance.newTableMetrics(this, memtableFactory.createMemtableMetrics(metadata));
 
         if (data.loadsstables && sstables != null)
         {

--- a/src/java/org/apache/cassandra/db/Keyspace.java
+++ b/src/java/org/apache/cassandra/db/Keyspace.java
@@ -58,6 +58,7 @@ import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.locator.AbstractReplicationStrategy;
 import org.apache.cassandra.metrics.KeyspaceMetrics;
+import org.apache.cassandra.metrics.MetricsFactory;
 import org.apache.cassandra.nodes.Nodes;
 import org.apache.cassandra.nodes.virtual.NodeConstants;
 import org.apache.cassandra.repair.KeyspaceRepairManager;
@@ -371,7 +372,8 @@ public class Keyspace
             throw new IllegalStateException("Cannot initialize Keyspace with virtual metadata " + keyspaceName);
         createReplicationStrategy(metadata);
 
-        this.metric = new KeyspaceMetrics(this);
+//        this.metric = new KeyspaceMetrics(this);
+        this.metric = MetricsFactory.instance.newKeyspaceMetrics(this);
         this.viewManager = new ViewManager(this);
         for (TableMetadata cfm : metadata.tablesAndViews())
         {
@@ -389,7 +391,7 @@ public class Keyspace
         this.schema = Schema.instance;
         this.metadata = metadata;
         createReplicationStrategy(metadata);
-        this.metric = new KeyspaceMetrics(this);
+        this.metric = MetricsFactory.instance.newKeyspaceMetrics(this);
         this.viewManager = new ViewManager(this);
         this.repairManager = new CassandraKeyspaceRepairManager(this);
         this.writeHandler = new CassandraKeyspaceWriteHandler(this);

--- a/src/java/org/apache/cassandra/metrics/CassandraMetricsRegistry.java
+++ b/src/java/org/apache/cassandra/metrics/CassandraMetricsRegistry.java
@@ -988,6 +988,7 @@ public abstract class CassandraMetricsRegistry extends MetricRegistry
             return NoOpHistogram.instance;
         }
 
+
         @Override
         public Timer timer(MetricName name)
         {

--- a/src/java/org/apache/cassandra/metrics/CassandraMetricsRegistry.java
+++ b/src/java/org/apache/cassandra/metrics/CassandraMetricsRegistry.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import javax.management.MalformedObjectNameException;
@@ -39,12 +40,12 @@ import org.apache.cassandra.utils.MBeanWrapper;
  * The 3.0 API comes with poor JMX integration
  * </p>
  */
-public class CassandraMetricsRegistry extends MetricRegistry
+public abstract class CassandraMetricsRegistry extends MetricRegistry
 {
-    public static final CassandraMetricsRegistry Metrics = new CassandraMetricsRegistry();
+    public static final CassandraMetricsRegistry Metrics = new PublishingMetricsRegistry();
+    public static final CassandraMetricsRegistry NoOpMetrics = new NoOpMetricsRegistry();
     private final Map<String, ThreadPoolMetrics> threadPoolMetrics = new ConcurrentHashMap<>();
 
-    private final MBeanWrapper mBeanServer = MBeanWrapper.instance;
 
     private CassandraMetricsRegistry()
     {
@@ -81,13 +82,7 @@ public class CassandraMetricsRegistry extends MetricRegistry
         return meter;
     }
 
-    public Histogram histogram(MetricName name, boolean considerZeroes)
-    {
-        Histogram histogram = register(name, new ClearableHistogram(new DecayingEstimatedHistogramReservoir(considerZeroes)));
-        registerMBean(histogram, name.getMBeanName());
-
-        return histogram;
-    }
+    public abstract Histogram histogram(MetricName name, boolean considerZeroes);
 
     public Histogram histogram(MetricName name, MetricName alias, boolean considerZeroes)
     {
@@ -96,13 +91,7 @@ public class CassandraMetricsRegistry extends MetricRegistry
         return histogram;
     }
 
-    public Timer timer(MetricName name)
-    {
-        Timer timer = register(name, new Timer(new DecayingEstimatedHistogramReservoir()));
-        registerMBean(timer, name.getMBeanName());
-
-        return timer;
-    }
+    public abstract Timer timer(MetricName name);
 
     public Timer timer(MetricName name, MetricName alias)
     {
@@ -164,13 +153,7 @@ public class CassandraMetricsRegistry extends MetricRegistry
         return ret;
     }
 
-    public boolean remove(MetricName name)
-    {
-        boolean removed = remove(name.getMetricName());
-
-        mBeanServer.unregisterMBean(name.getMBeanName(), MBeanWrapper.OnException.IGNORE);
-        return removed;
-    }
+    public abstract boolean remove(MetricName name);
 
     public boolean remove(MetricName name, MetricName... aliases)
     {
@@ -185,41 +168,12 @@ public class CassandraMetricsRegistry extends MetricRegistry
         return false;
     }
 
-    public void registerMBean(Metric metric, ObjectName name)
-    {
-        AbstractBean mbean;
+    public abstract void registerMBean(Metric metric, ObjectName name);
 
-        if (metric instanceof Gauge)
-            mbean = new JmxGauge((Gauge<?>) metric, name);
-        else if (metric instanceof Counter)
-            mbean = new JmxCounter((Counter) metric, name);
-        else if (metric instanceof Histogram)
-            mbean = new JmxHistogram((Histogram) metric, name);
-        else if (metric instanceof Timer)
-            mbean = new JmxTimer((Timer) metric, name, TimeUnit.SECONDS, TimeUnit.MICROSECONDS);
-        else if (metric instanceof Metered)
-            mbean = new JmxMeter((Metered) metric, name, TimeUnit.SECONDS);
-        else
-            throw new IllegalArgumentException("Unknown metric type: " + metric.getClass());
+    protected abstract void registerAlias(MetricName existingName, MetricName aliasName);
 
-        if (!mBeanServer.isRegistered(name))
-            mBeanServer.registerMBean(mbean, name, MBeanWrapper.OnException.LOG);
-    }
+    protected abstract void removeAlias(MetricName name);
 
-    private void registerAlias(MetricName existingName, MetricName aliasName)
-    {
-        Metric existing = Metrics.getMetrics().get(existingName.getMetricName());
-        assert existing != null : existingName + " not registered";
-
-        registerMBean(existing, aliasName.getMBeanName());
-    }
-
-    private void removeAlias(MetricName name)
-    {
-        if (mBeanServer.isRegistered(name.getMBeanName()))
-            MBeanWrapper.instance.unregisterMBean(name.getMBeanName(), MBeanWrapper.OnException.IGNORE);
-    }
-    
     /**
      * Strips a single final '$' from input
      * 
@@ -941,6 +895,332 @@ public class CassandraMetricsRegistry extends MetricRegistry
                 name = method.getName();
             }
             return name;
+        }
+    }
+
+    private static class PublishingMetricsRegistry extends CassandraMetricsRegistry
+    {
+        private final MBeanWrapper mBeanServer = MBeanWrapper.instance;
+
+        @Override
+        public void registerMBean(Metric metric, ObjectName name)
+        {
+            AbstractBean mbean;
+
+            if (metric instanceof Gauge)
+                mbean = new JmxGauge((Gauge<?>) metric, name);
+            else if (metric instanceof Counter)
+                mbean = new JmxCounter((Counter) metric, name);
+            else if (metric instanceof Histogram)
+                mbean = new JmxHistogram((Histogram) metric, name);
+            else if (metric instanceof Timer)
+                mbean = new JmxTimer((Timer) metric, name, TimeUnit.SECONDS, TimeUnit.MICROSECONDS);
+            else if (metric instanceof Metered)
+                mbean = new JmxMeter((Metered) metric, name, TimeUnit.SECONDS);
+            else
+                throw new IllegalArgumentException("Unknown metric type: " + metric.getClass());
+
+            if (!mBeanServer.isRegistered(name))
+                mBeanServer.registerMBean(mbean, name, MBeanWrapper.OnException.LOG);
+        }
+
+        @Override
+        protected void registerAlias(MetricName existingName, MetricName aliasName)
+        {
+            Metric existing = Metrics.getMetrics().get(existingName.getMetricName());
+            assert existing != null : existingName + " not registered";
+
+            registerMBean(existing, aliasName.getMBeanName());
+        }
+
+        @Override
+        protected void removeAlias(MetricName name)
+        {
+            if (mBeanServer.isRegistered(name.getMBeanName()))
+                MBeanWrapper.instance.unregisterMBean(name.getMBeanName(), MBeanWrapper.OnException.IGNORE);
+        }
+
+        @Override
+        public boolean remove(MetricName name)
+        {
+            boolean removed = remove(name.getMetricName());
+
+            mBeanServer.unregisterMBean(name.getMBeanName(), MBeanWrapper.OnException.IGNORE);
+            return removed;
+        }
+
+        public Histogram histogram(MetricName name, boolean considerZeroes)
+        {
+            Histogram histogram = register(name, new ClearableHistogram(new DecayingEstimatedHistogramReservoir(considerZeroes)));
+            registerMBean(histogram, name.getMBeanName());
+
+            return histogram;
+        }
+
+        public Timer timer(MetricName name)
+        {
+            Timer timer = register(name, new Timer(new DecayingEstimatedHistogramReservoir()));
+            registerMBean(timer, name.getMBeanName());
+
+            return timer;
+        }
+    }
+
+    // Classes relating to the no-op registry. It's held here in order to hide the subclass implementations.
+    private static class NoOpMetricsRegistry extends CassandraMetricsRegistry
+    {
+        @Override
+        public Counter counter(String name)
+        {
+            return NoOpCounter.instance;
+        }
+
+        @Override
+        public Meter meter(String name)
+        {
+            return NoOpMeter.instance;
+        }
+
+        @Override
+        public Histogram histogram(MetricName name, boolean considerZeroes)
+        {
+            return NoOpHistogram.instance;
+        }
+
+        @Override
+        public Timer timer(MetricName name)
+        {
+            return NoOpTimer.instance;
+        }
+
+        @Override
+        public <T extends Metric> T register(MetricName name, T metric)
+        {
+            return metric;
+        }
+
+        @Override
+        public boolean remove(MetricName name)
+        {
+            return false;
+        }
+
+        @Override
+        public void registerMBean(Metric metric, ObjectName name)
+        {
+            //no-op
+        }
+
+        @Override
+        protected void registerAlias(MetricName existingName, MetricName aliasName)
+        {
+            //no-op
+        }
+
+        @Override
+        protected void removeAlias(MetricName name)
+        {
+            //no-op
+        }
+    }
+
+    private static class EmptyReservoir implements Reservoir{
+        public static final EmptyReservoir instance = new EmptyReservoir();
+        private final Snapshot snapshot;
+        private EmptyReservoir(){
+            this.snapshot = new UniformSnapshot(new long[]{0});
+        }
+
+        @Override
+        public int size()
+        {
+            return 0;
+        }
+
+        @Override
+        public void update(long value)
+        {
+
+        }
+
+        @Override
+        public Snapshot getSnapshot()
+        {
+            return snapshot;
+        }
+    }
+
+    private static class NoOpCounter extends Counter
+    {
+        static final NoOpCounter instance = new NoOpCounter();
+        @Override
+        public void inc()
+        {
+        }
+
+        @Override
+        public void inc(long n)
+        {
+        }
+
+        @Override
+        public void dec()
+        {
+        }
+
+        @Override
+        public void dec(long n)
+        {
+        }
+
+        @Override
+        public long getCount()
+        {
+            return 0L;
+        }
+    }
+
+    private static class NoOpMeter extends Meter
+    {
+        static final NoOpMeter instance = new NoOpMeter();
+        private NoOpMeter()
+        {
+
+        }
+
+        @Override
+        public void mark()
+        {
+        }
+
+        @Override
+        public void mark(long n)
+        {
+        }
+
+        @Override
+        public long getCount()
+        {
+            return 0L;
+        }
+
+        @Override
+        public double getFifteenMinuteRate()
+        {
+            return 0d;
+        }
+
+        @Override
+        public double getFiveMinuteRate()
+        {
+            return 0d;
+        }
+
+        @Override
+        public double getMeanRate()
+        {
+            return 0d;
+        }
+
+        @Override
+        public double getOneMinuteRate()
+        {
+            return 0d;
+        }
+    }
+
+    private static class NoOpHistogram extends Histogram
+    {
+        static final NoOpHistogram instance = new NoOpHistogram();
+
+        private final Snapshot snapshot;
+
+        private NoOpHistogram()
+        {
+            super(EmptyReservoir.instance);
+            this.snapshot = new UniformSnapshot(new long[]{0L});
+        }
+        @Override
+        public void update(int value)
+        {
+        }
+
+        @Override
+        public void update(long value)
+        {
+        }
+
+        @Override
+        public long getCount()
+        {
+            return 0L;
+        }
+
+        @Override
+        public Snapshot getSnapshot()
+        {
+            return snapshot;
+        }
+    }
+
+    private static class NoOpTimer extends Timer
+    {
+
+        static final NoOpTimer instance = new NoOpTimer();
+
+        private final Snapshot snapshot;
+
+        private NoOpTimer()
+        {
+            super(EmptyReservoir.instance);
+            this.snapshot = new UniformSnapshot(new long[]{0L});
+        }
+
+        @Override
+        public void update(long duration, TimeUnit unit)
+        {
+        }
+
+        @Override
+        public <T> T time(Callable<T> event) throws Exception
+        {
+            return event.call();
+        }
+
+        @Override
+        public long getCount()
+        {
+            return 0L;
+        }
+
+        @Override
+        public double getFifteenMinuteRate()
+        {
+            return 0d;
+        }
+
+        @Override
+        public double getFiveMinuteRate()
+        {
+            return 0d;
+        }
+
+        @Override
+        public double getMeanRate()
+        {
+            return 0d;
+        }
+
+        @Override
+        public double getOneMinuteRate()
+        {
+            return 0d;
+        }
+
+        @Override
+        public Snapshot getSnapshot()
+        {
+            return snapshot;
         }
     }
 }

--- a/src/java/org/apache/cassandra/metrics/CassandraMetricsRegistry.java
+++ b/src/java/org/apache/cassandra/metrics/CassandraMetricsRegistry.java
@@ -26,6 +26,7 @@ import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.processing.Generated;
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
 

--- a/src/java/org/apache/cassandra/metrics/ClearableHistogram.java
+++ b/src/java/org/apache/cassandra/metrics/ClearableHistogram.java
@@ -44,7 +44,6 @@ public class ClearableHistogram extends Histogram
         this.reservoirRef = reservoir;
     }
 
-    @VisibleForTesting
     public void clear()
     {
         clearCount();

--- a/src/java/org/apache/cassandra/metrics/DefaultMetricsFactory.java
+++ b/src/java/org/apache/cassandra/metrics/DefaultMetricsFactory.java
@@ -42,6 +42,6 @@ public class DefaultMetricsFactory implements MetricsFactory
     @Override
     public @NonNull TableMetrics newTableMetrics(@NonNull ColumnFamilyStore cfs, TableMetrics.ReleasableMetric memtableMetrics)
     {
-        return new TableMetrics(cfs, memtableMetrics);
+        return new TableMetrics(cfs, memtableMetrics, CassandraMetricsRegistry.Metrics);
     }
 }

--- a/src/java/org/apache/cassandra/metrics/DefaultMetricsFactory.java
+++ b/src/java/org/apache/cassandra/metrics/DefaultMetricsFactory.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.metrics;
+
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.Keyspace;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+public class DefaultMetricsFactory implements MetricsFactory
+{
+    private static final DefaultMetricsFactory instance = new DefaultMetricsFactory();
+
+    private DefaultMetricsFactory(){}
+
+    public static MetricsFactory instance()
+    {
+        return instance;
+    }
+
+    @Override
+    public @NonNull KeyspaceMetrics newKeyspaceMetrics(@NonNull Keyspace ks)
+    {
+        return new KeyspaceMetrics(ks, CassandraMetricsRegistry.Metrics);
+    }
+
+    @Override
+    public @NonNull TableMetrics newTableMetrics(@NonNull ColumnFamilyStore cfs, TableMetrics.ReleasableMetric memtableMetrics)
+    {
+        return new TableMetrics(cfs, memtableMetrics);
+    }
+}

--- a/src/java/org/apache/cassandra/metrics/DefaultMetricsFactory.java
+++ b/src/java/org/apache/cassandra/metrics/DefaultMetricsFactory.java
@@ -24,13 +24,13 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 
 public class DefaultMetricsFactory implements MetricsFactory
 {
-    private static final DefaultMetricsFactory instance = new DefaultMetricsFactory();
+    private static final DefaultMetricsFactory factoryInstance = new DefaultMetricsFactory();
 
     private DefaultMetricsFactory(){}
 
     public static MetricsFactory instance()
     {
-        return instance;
+        return factoryInstance;
     }
 
     @Override

--- a/src/java/org/apache/cassandra/metrics/DefaultMetricsFactory.java
+++ b/src/java/org/apache/cassandra/metrics/DefaultMetricsFactory.java
@@ -44,4 +44,10 @@ public class DefaultMetricsFactory implements MetricsFactory
     {
         return new TableMetrics(cfs, memtableMetrics, CassandraMetricsRegistry.Metrics);
     }
+
+    @Override
+    public @NonNull TrieMemtableMetricsView newMemtableMetrics(@NonNull String keyspace, @NonNull String table)
+    {
+        return new TrieMemtableMetricsView(keyspace, table, CassandraMetricsRegistry.Metrics);
+    }
 }

--- a/src/java/org/apache/cassandra/metrics/KeyspaceMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/KeyspaceMetrics.java
@@ -25,6 +25,7 @@ import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.Timer;
+import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.metrics.CassandraMetricsRegistry.MetricName;
@@ -184,6 +185,7 @@ public class KeyspaceMetrics
     public final Timer repairedDataTrackingOverreadTime;
 
     public final MetricNameFactory factory;
+    private final CassandraMetricsRegistry metricsRegistry;
     private Keyspace keyspace;
 
     /** set containing names of all the metrics stored here, for releasing later */
@@ -198,6 +200,8 @@ public class KeyspaceMetrics
     {
         factory = new KeyspaceMetricNameFactory(ks);
         keyspace = ks;
+        this.metricsRegistry = CassandraRelevantProperties.KEYSPACE_METRICS_ENABLED.getBoolean() ? Metrics : CassandraMetricsRegistry.NoOpMetrics;
+
         memtableColumnsCount = createKeyspaceGauge("MemtableColumnsCount",
                 metric -> metric.memtableColumnsCount.getValue());
         memtableLiveDataSize = createKeyspaceGauge("MemtableLiveDataSize",
@@ -306,7 +310,7 @@ public class KeyspaceMetrics
     private Gauge<Long> createKeyspaceGauge(String name, final ToLongFunction<TableMetrics> extractor)
     {
         allMetrics.add(() -> releaseMetric(name));
-        return Metrics.register(factory.createMetricName(name), new Gauge<Long>()
+        return metricsRegistry.register(factory.createMetricName(name), new Gauge<Long>()
         {
             public Long getValue()
             {
@@ -329,7 +333,7 @@ public class KeyspaceMetrics
     private Counter createKeyspaceCounter(String name, final ToLongFunction<TableMetrics> extractor)
     {
         allMetrics.add(() -> releaseMetric(name));
-        return Metrics.register(factory.createMetricName(name), new Counter()
+        return metricsRegistry.register(factory.createMetricName(name), new Counter()
         {
             @Override
             public long getCount()
@@ -347,37 +351,37 @@ public class KeyspaceMetrics
     protected Counter createKeyspaceCounter(String name)
     {
         allMetrics.add(() -> releaseMetric(name));
-        return Metrics.counter(factory.createMetricName(name));
+        return metricsRegistry.counter(factory.createMetricName(name));
     }
 
     protected Histogram createKeyspaceHistogram(String name, boolean considerZeroes)
     {
         allMetrics.add(() -> releaseMetric(name));
-        return Metrics.histogram(factory.createMetricName(name), considerZeroes);
+        return metricsRegistry.histogram(factory.createMetricName(name), considerZeroes);
     }
 
     protected Timer createKeyspaceTimer(String name)
     {
         allMetrics.add(() -> releaseMetric(name));
-        return Metrics.timer(factory.createMetricName(name));
+        return metricsRegistry.timer(factory.createMetricName(name));
     }
 
     protected Meter createKeyspaceMeter(String name)
     {
         allMetrics.add(() -> releaseMetric(name));
-        return Metrics.meter(factory.createMetricName(name));
+        return metricsRegistry.meter(factory.createMetricName(name));
     }
 
     private LatencyMetrics createLatencyMetrics(String name)
     {
-        LatencyMetrics metric = new LatencyMetrics(factory, name);
+        LatencyMetrics metric = new LatencyMetrics(factory, name, metricsRegistry);
         allMetrics.add(() -> metric.release());
         return metric;
     }
 
     private void releaseMetric(String name)
     {
-        Metrics.remove(factory.createMetricName(name));
+        metricsRegistry.remove(factory.createMetricName(name));
     }
 
     static class KeyspaceMetricNameFactory implements MetricNameFactory

--- a/src/java/org/apache/cassandra/metrics/KeyspaceMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/KeyspaceMetrics.java
@@ -196,11 +196,11 @@ public class KeyspaceMetrics
      *
      * @param ks Keyspace to measure metrics
      */
-    public KeyspaceMetrics(final Keyspace ks)
+    public KeyspaceMetrics(final Keyspace ks, CassandraMetricsRegistry metricsRegistry)
     {
         factory = new KeyspaceMetricNameFactory(ks);
         keyspace = ks;
-        this.metricsRegistry = CassandraRelevantProperties.KEYSPACE_METRICS_ENABLED.getBoolean() ? Metrics : CassandraMetricsRegistry.NoOpMetrics;
+        this.metricsRegistry = metricsRegistry;
 
         memtableColumnsCount = createKeyspaceGauge("MemtableColumnsCount",
                 metric -> metric.memtableColumnsCount.getValue());

--- a/src/java/org/apache/cassandra/metrics/LatencyMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/LatencyMetrics.java
@@ -40,6 +40,7 @@ public class LatencyMetrics
     public final LatencyMetricsTimer latency;
     /** Total latency in micro sec */
     public final Counter totalLatency;
+    private final CassandraMetricsRegistry metricsRegistry;
 
     /** parent metrics to replicate any updates to **/
     private List<LatencyMetrics> parents = Lists.newArrayList();
@@ -85,22 +86,28 @@ public class LatencyMetrics
 
     public LatencyMetrics(MetricNameFactory factory, MetricNameFactory aliasFactory, String namePrefix)
     {
+        this(factory,aliasFactory,namePrefix, Metrics);
+    }
+
+    public LatencyMetrics(MetricNameFactory factory, MetricNameFactory aliasFactory, String namePrefix, CassandraMetricsRegistry metricsRegistry)
+    {
         this.factory = factory;
         this.aliasFactory = aliasFactory;
         this.namePrefix = namePrefix;
+        this.metricsRegistry = metricsRegistry;
 
         LatencyMetricsTimer timer = new LatencyMetrics.LatencyMetricsTimer(new DecayingEstimatedHistogramReservoir());
         Counter counter = new LatencyMetricsCounter();
 
         if (aliasFactory == null)
         {
-            latency = Metrics.register(factory.createMetricName(namePrefix + "Latency"), timer);
-            totalLatency = Metrics.register(factory.createMetricName(namePrefix + "TotalLatency"), counter);
+            latency = metricsRegistry.register(factory.createMetricName(namePrefix + "Latency"), timer);
+            totalLatency = metricsRegistry.register(factory.createMetricName(namePrefix + "TotalLatency"), counter);
         }
         else
         {
-            latency = Metrics.register(factory.createMetricName(namePrefix + "Latency"), aliasFactory.createMetricName(namePrefix + "Latency"), timer);
-            totalLatency = Metrics.register(factory.createMetricName(namePrefix + "TotalLatency"), aliasFactory.createMetricName(namePrefix + "TotalLatency"), counter);
+            latency = metricsRegistry.register(factory.createMetricName(namePrefix + "Latency"), aliasFactory.createMetricName(namePrefix + "Latency"), timer);
+            totalLatency = metricsRegistry.register(factory.createMetricName(namePrefix + "TotalLatency"), aliasFactory.createMetricName(namePrefix + "TotalLatency"), counter);
         }
     }
     
@@ -112,9 +119,15 @@ public class LatencyMetrics
      * @param namePrefix Prefix to append to each metric name
      * @param parents any amount of parents to replicate updates to
      */
+
     public LatencyMetrics(MetricNameFactory factory, String namePrefix, LatencyMetrics ... parents)
     {
-        this(factory, null, namePrefix);
+       this(factory,namePrefix, Metrics, parents);
+    }
+
+    public LatencyMetrics(MetricNameFactory factory, String namePrefix, CassandraMetricsRegistry metricsRegistry, LatencyMetrics ... parents)
+    {
+        this(factory, null, namePrefix, metricsRegistry);
         this.parents = Arrays.asList(parents);
         for (LatencyMetrics parent : parents)
         {
@@ -166,13 +179,13 @@ public class LatencyMetrics
         }
         if (aliasFactory == null)
         {
-            Metrics.remove(factory.createMetricName(namePrefix + "Latency"));
-            Metrics.remove(factory.createMetricName(namePrefix + "TotalLatency"));
+            metricsRegistry.remove(factory.createMetricName(namePrefix + "Latency"));
+            metricsRegistry.remove(factory.createMetricName(namePrefix + "TotalLatency"));
         }
         else
         {
-            Metrics.remove(factory.createMetricName(namePrefix + "Latency"), aliasFactory.createMetricName(namePrefix + "Latency"));
-            Metrics.remove(factory.createMetricName(namePrefix + "TotalLatency"), aliasFactory.createMetricName(namePrefix + "TotalLatency"));
+            metricsRegistry.remove(factory.createMetricName(namePrefix + "Latency"), aliasFactory.createMetricName(namePrefix + "Latency"));
+            metricsRegistry.remove(factory.createMetricName(namePrefix + "TotalLatency"), aliasFactory.createMetricName(namePrefix + "TotalLatency"));
         }
     }
 

--- a/src/java/org/apache/cassandra/metrics/MetricsFactory.java
+++ b/src/java/org/apache/cassandra/metrics/MetricsFactory.java
@@ -37,6 +37,9 @@ public interface MetricsFactory
     @Nonnull
     TableMetrics newTableMetrics(@Nonnull final ColumnFamilyStore cfs, TableMetrics.ReleasableMetric memtableMetrics);
 
+    @Nonnull
+    TrieMemtableMetricsView newMemtableMetrics(@Nonnull String keyspace, @Nonnull String table);
+
     static MetricsFactory loadFactory()
     {
         MetricsFactory factory = null;

--- a/src/java/org/apache/cassandra/metrics/MetricsFactory.java
+++ b/src/java/org/apache/cassandra/metrics/MetricsFactory.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.metrics;
+
+import javax.annotation.Nonnull;
+
+import org.slf4j.LoggerFactory;
+
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.utils.FBUtilities;
+import org.apache.cassandra.utils.JVMStabilityInspector;
+
+public interface MetricsFactory
+{
+    MetricsFactory instance = loadFactory();
+
+    @Nonnull
+    KeyspaceMetrics newKeyspaceMetrics(@Nonnull final Keyspace ks);
+
+    @Nonnull
+    TableMetrics newTableMetrics(@Nonnull final ColumnFamilyStore cfs, TableMetrics.ReleasableMetric memtableMetrics);
+
+    static MetricsFactory loadFactory()
+    {
+        MetricsFactory factory = null;
+        String customMetricsFactoryClass = System.getProperty("cassandra.custom_metrics_factory_class");
+        if (null != customMetricsFactoryClass)
+        {
+            try
+            {
+                factory = FBUtilities.construct(customMetricsFactoryClass, "Metrics factory");
+                LoggerFactory.getLogger(MetricsFactory.class)
+                             .info("using {} to generate metrics", customMetricsFactoryClass);
+            }
+            catch (Exception e)
+            {
+                JVMStabilityInspector.inspectThrowable(e);
+                LoggerFactory.getLogger(MetricsFactory.class)
+                             .error(String.format("cannot use class %s for metrics, defaulting to normal metrics factory", customMetricsFactoryClass), e);
+            }
+        }
+        return factory == null ? DefaultMetricsFactory.instance() : factory;
+    }
+}

--- a/src/java/org/apache/cassandra/metrics/MinMaxAvgMetric.java
+++ b/src/java/org/apache/cassandra/metrics/MinMaxAvgMetric.java
@@ -32,6 +32,7 @@ public class MinMaxAvgMetric
     final Gauge<Double> avgGauge;
     final Gauge<Double> stddevGauge;
     final Gauge<Integer> numSamplesGauge;
+    private final CassandraMetricsRegistry metricsRegistry;
 
     private long min;
     private long max;
@@ -39,25 +40,26 @@ public class MinMaxAvgMetric
     private long sumSquares;
     private int numSamples;
 
-    public MinMaxAvgMetric(MetricNameFactory factory, String namePrefix)
+    public MinMaxAvgMetric(MetricNameFactory factory, String namePrefix, CassandraMetricsRegistry metricsRegistry)
     {
         this.factory = factory;
         this.namePrefix = namePrefix;
+        this.metricsRegistry = metricsRegistry;
 
-        minGauge = Metrics.register(factory.createMetricName(namePrefix + " Min"), () -> min);
-        maxGauge = Metrics.register(factory.createMetricName(namePrefix + " Max"), () -> max);
-        avgGauge = Metrics.register(factory.createMetricName(namePrefix + " Avg"), () -> numSamples > 0 ? ((double) sum) / numSamples : 0);
-        stddevGauge = Metrics.register(factory.createMetricName(namePrefix + " StdDev"), () -> stddev());
-        numSamplesGauge = Metrics.register(factory.createMetricName(namePrefix + " NumSamples"), () -> numSamples);
+        minGauge = metricsRegistry.register(factory.createMetricName(namePrefix + " Min"), () -> min);
+        maxGauge = metricsRegistry.register(factory.createMetricName(namePrefix + " Max"), () -> max);
+        avgGauge = metricsRegistry.register(factory.createMetricName(namePrefix + " Avg"), () -> numSamples > 0 ? ((double) sum) / numSamples : 0);
+        stddevGauge = metricsRegistry.register(factory.createMetricName(namePrefix + " StdDev"), () -> stddev());
+        numSamplesGauge = metricsRegistry.register(factory.createMetricName(namePrefix + " NumSamples"), () -> numSamples);
     }
 
     public void release()
     {
-        Metrics.remove(factory.createMetricName(namePrefix + " Min"));
-        Metrics.remove(factory.createMetricName(namePrefix + " Max"));
-        Metrics.remove(factory.createMetricName(namePrefix + " Avg"));
-        Metrics.remove(factory.createMetricName(namePrefix + " StdDev"));
-        Metrics.remove(factory.createMetricName(namePrefix + " NumSamples"));
+        metricsRegistry.remove(factory.createMetricName(namePrefix + " Min"));
+        metricsRegistry.remove(factory.createMetricName(namePrefix + " Max"));
+        metricsRegistry.remove(factory.createMetricName(namePrefix + " Avg"));
+        metricsRegistry.remove(factory.createMetricName(namePrefix + " StdDev"));
+        metricsRegistry.remove(factory.createMetricName(namePrefix + " NumSamples"));
     }
 
     public void reset()

--- a/src/java/org/apache/cassandra/metrics/TableMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/TableMetrics.java
@@ -101,6 +101,7 @@ public class TableMetrics
     private static final Logger logger = LoggerFactory.getLogger(TableMetrics.class);
 
     public static final String TABLE_EXTENSIONS_HISTOGRAMS_METRICS_KEY = "HISTOGRAM_METRICS";
+    private final CassandraMetricsRegistry metricsRegistry;
 
     public enum MetricsAggregation
     {
@@ -436,29 +437,35 @@ public class TableMetrics
         }
         return Pair.create(filtered, total);
     }
+    public static final Gauge<Double> globalPercentRepaired;
+    public static final Gauge<Long> globalBytesRepaired;
+    public static final Gauge<Long> globalBytesUnrepaired;
+    public static final Gauge<Long> globalBytesPendingRepair;
 
-    public static final Gauge<Double> globalPercentRepaired = Metrics.register(GLOBAL_FACTORY.createMetricName("PercentRepaired"),
-                                                                               new Gauge<Double>()
+    static
     {
-        public Double getValue()
-        {
-            Pair<Long, Long> result = totalNonSystemTablesSize(SSTableReader::isRepaired);
-            double repaired = result.left;
-            double total = result.right;
-            return total > 0 ? (repaired / total) * 100 : 100.0;
-        }
-    });
+        CassandraMetricsRegistry metricsRegistry = CassandraRelevantProperties.TABLE_METRICS_ENABLED.getBoolean() ? Metrics : CassandraMetricsRegistry.NoOpMetrics;
 
-    public static final Gauge<Long> globalBytesRepaired = Metrics.register(GLOBAL_FACTORY.createMetricName("BytesRepaired"),
-                                                                           () -> totalNonSystemTablesSize(SSTableReader::isRepaired).left);
+        globalPercentRepaired = metricsRegistry.register(GLOBAL_FACTORY.createMetricName("PercentRepaired"),
+                                                         () -> {
+                                                             Pair<Long, Long> result = totalNonSystemTablesSize(SSTableReader::isRepaired);
+                                                             double repaired = result.left;
+                                                             double total = result.right;
+                                                             return total > 0 ? (repaired / total) * 100 : 100.0;
+                                                         });
 
-    public static final Gauge<Long> globalBytesUnrepaired =
-        Metrics.register(GLOBAL_FACTORY.createMetricName("BytesUnrepaired"),
-                         () -> totalNonSystemTablesSize(s -> !s.isRepaired() && !s.isPendingRepair()).left);
+        globalBytesRepaired = metricsRegistry.register(GLOBAL_FACTORY.createMetricName("BytesRepaired"),
+                                               () -> totalNonSystemTablesSize(SSTableReader::isRepaired).left);
 
-    public static final Gauge<Long> globalBytesPendingRepair =
-        Metrics.register(GLOBAL_FACTORY.createMetricName("BytesPendingRepair"),
-                         () -> totalNonSystemTablesSize(SSTableReader::isPendingRepair).left);
+        globalBytesUnrepaired = metricsRegistry.register(GLOBAL_FACTORY.createMetricName("BytesUnrepaired"),
+                                                 () -> totalNonSystemTablesSize(s -> !s.isRepaired() && !s.isPendingRepair()).left);
+
+        globalBytesPendingRepair = metricsRegistry.register(GLOBAL_FACTORY.createMetricName("BytesPendingRepair"),
+                                                    () -> totalNonSystemTablesSize(SSTableReader::isPendingRepair).left);
+
+    }
+
+
 
     public final Meter readRepairRequests;
     public final Meter shortReadProtectionRequests;
@@ -579,6 +586,7 @@ public class TableMetrics
         samplers.put(SamplerType.CAS_CONTENTIONS, topCasPartitionContention);
         samplers.put(SamplerType.LOCAL_READ_TIME, topLocalReadQueryTime);
 
+        this.metricsRegistry = CassandraRelevantProperties.TABLE_METRICS_ENABLED.getBoolean() ? CassandraMetricsRegistry.Metrics : CassandraMetricsRegistry.NoOpMetrics;
         memtableColumnsCount = createTableGauge("MemtableColumnsCount",
                                                 () -> cfs.getTracker().getView().getCurrentMemtable().getOperations());
 
@@ -1262,10 +1270,10 @@ public class TableMetrics
 
     protected <G,T> Gauge<T> createTableGauge(String name, String alias, Gauge<T> gauge, Gauge<G> globalGauge)
     {
-        Gauge<T> cfGauge = Metrics.register(factory.createMetricName(name), aliasFactory.createMetricName(alias), gauge);
+        Gauge<T> cfGauge = metricsRegistry.register(factory.createMetricName(name), aliasFactory.createMetricName(alias), gauge);
         if (register(name, alias, cfGauge) && globalGauge != null)
         {
-            Metrics.register(GLOBAL_FACTORY.createMetricName(name), GLOBAL_ALIAS_FACTORY.createMetricName(alias), globalGauge);
+            metricsRegistry.register(GLOBAL_FACTORY.createMetricName(name), GLOBAL_ALIAS_FACTORY.createMetricName(alias), globalGauge);
         }
         return cfGauge;
     }
@@ -1282,7 +1290,7 @@ public class TableMetrics
         assert deprecated != null : "no deprecated metric name provided";
         assert globalGauge != null : "no global Gauge metric provided";
         
-        Gauge<T> cfGauge = Metrics.register(factory.createMetricName(name), 
+        Gauge<T> cfGauge = metricsRegistry.register(factory.createMetricName(name),
                                             gauge,
                                             aliasFactory.createMetricName(name),
                                             factory.createMetricName(deprecated),
@@ -1290,7 +1298,7 @@ public class TableMetrics
         
         if (register(name, name, deprecated, cfGauge))
         {
-            Metrics.register(GLOBAL_FACTORY.createMetricName(name),
+            metricsRegistry.register(GLOBAL_FACTORY.createMetricName(name),
                              globalGauge,
                              GLOBAL_ALIAS_FACTORY.createMetricName(name),
                              GLOBAL_FACTORY.createMetricName(deprecated),
@@ -1310,10 +1318,10 @@ public class TableMetrics
 
     protected Counter createTableCounter(final String name, final String alias)
     {
-        Counter cfCounter = Metrics.counter(factory.createMetricName(name), aliasFactory.createMetricName(alias));
+        Counter cfCounter = metricsRegistry.counter(factory.createMetricName(name), aliasFactory.createMetricName(alias));
         if (register(name, alias, cfCounter))
         {
-            Metrics.register(GLOBAL_FACTORY.createMetricName(name),
+            metricsRegistry.register(GLOBAL_FACTORY.createMetricName(name),
                              GLOBAL_ALIAS_FACTORY.createMetricName(alias),
                              new Gauge<Long>()
                              {
@@ -1338,14 +1346,14 @@ public class TableMetrics
 
     private Meter createTableMeter(final String name, final String alias)
     {
-        Meter tableMeter = Metrics.meter(factory.createMetricName(name), aliasFactory.createMetricName(alias));
+        Meter tableMeter = metricsRegistry.meter(factory.createMetricName(name), aliasFactory.createMetricName(alias));
         register(name, alias, tableMeter);
         return tableMeter;
     }
     
     private Histogram createHistogram(String name, boolean considerZeroes)
     {
-        Histogram histogram = Metrics.histogram(factory.createMetricName(name), aliasFactory.createMetricName(name), considerZeroes);
+        Histogram histogram = metricsRegistry.histogram(factory.createMetricName(name), aliasFactory.createMetricName(name), considerZeroes);
         register(name, name, histogram);
         return histogram;
     }
@@ -1390,7 +1398,7 @@ public class TableMetrics
         Histogram globalHistogram = null;
         if (EXPORT_GLOBAL_METRICS)
         {
-            globalHistogram = Metrics.histogram(GLOBAL_FACTORY.createMetricName(name),
+            globalHistogram = metricsRegistry.histogram(GLOBAL_FACTORY.createMetricName(name),
                                                 GLOBAL_ALIAS_FACTORY.createMetricName(alias),
                                                 considerZeroes);
         }
@@ -1398,7 +1406,7 @@ public class TableMetrics
         Histogram tableHistogram = null;
         if (metricsAggregation == MetricsAggregation.INDIVIDUAL)
         {
-            tableHistogram = Metrics.histogram(factory.createMetricName(name), aliasFactory.createMetricName(alias), considerZeroes);
+            tableHistogram = metricsRegistry.histogram(factory.createMetricName(name), aliasFactory.createMetricName(alias), considerZeroes);
             register(name, alias, tableHistogram);
         }
 
@@ -1412,7 +1420,7 @@ public class TableMetrics
 
     protected Histogram createTableHistogram(String name, String alias, boolean considerZeroes)
     {
-        Histogram tableHistogram = Metrics.histogram(factory.createMetricName(name), aliasFactory.createMetricName(alias), considerZeroes);
+        Histogram tableHistogram = metricsRegistry.histogram(factory.createMetricName(name), aliasFactory.createMetricName(alias), considerZeroes);
         register(name, alias, tableHistogram);
         return tableHistogram;
     }
@@ -1422,13 +1430,13 @@ public class TableMetrics
         Timer globalTimer = null;
         if (EXPORT_GLOBAL_METRICS)
         {
-            globalTimer = Metrics.timer(GLOBAL_FACTORY.createMetricName(name), GLOBAL_ALIAS_FACTORY.createMetricName(name));
+            globalTimer = metricsRegistry.timer(GLOBAL_FACTORY.createMetricName(name), GLOBAL_ALIAS_FACTORY.createMetricName(name));
         }
 
         Timer tableTimer = null;
         if (metricsAggregation == MetricsAggregation.INDIVIDUAL)
         {
-            tableTimer = Metrics.timer(factory.createMetricName(name), aliasFactory.createMetricName(name));
+            tableTimer = metricsRegistry.timer(factory.createMetricName(name), aliasFactory.createMetricName(name));
             register(name, name, keyspaceTimer);
         }
 
@@ -1437,7 +1445,7 @@ public class TableMetrics
 
     protected Timer createTableTimer(String name)
     {
-        Timer tableTimer = Metrics.timer(factory.createMetricName(name), aliasFactory.createMetricName(name));
+        Timer tableTimer = metricsRegistry.timer(factory.createMetricName(name), aliasFactory.createMetricName(name));
         register(name, name, tableTimer);
         return tableTimer;
     }
@@ -1452,14 +1460,14 @@ public class TableMetrics
         Meter globalMeter = null;
         if (EXPORT_GLOBAL_METRICS)
         {
-            globalMeter = Metrics.meter(GLOBAL_FACTORY.createMetricName(name),
+            globalMeter = metricsRegistry.meter(GLOBAL_FACTORY.createMetricName(name),
                                         GLOBAL_ALIAS_FACTORY.createMetricName(alias));
         }
 
         Meter tableMeter = null;
         if (metricsAggregation == MetricsAggregation.INDIVIDUAL)
         {
-            tableMeter = Metrics.meter(factory.createMetricName(name), aliasFactory.createMetricName(alias));
+            tableMeter = metricsRegistry.meter(factory.createMetricName(name), aliasFactory.createMetricName(alias));
             register(name, alias, tableMeter);
         }
 
@@ -1514,7 +1522,7 @@ public class TableMetrics
     {
         CassandraMetricsRegistry.MetricName name = factory.createMetricName(tableMetricName);
 
-        final Metric metric = Metrics.getMetrics().get(name.getMetricName());
+        final Metric metric = metricsRegistry.getMetrics().get(name.getMetricName());
         if (metric != null)
         {
             // Metric will be null if we are releasing a view metric.  Views have null for ViewLockAcquireTime and ViewLockReadTime
@@ -1523,11 +1531,11 @@ public class TableMetrics
             
             if (tableMetricAlias != null)
             {
-                Metrics.remove(name, cfAlias, factory.createMetricName(tableMetricAlias), aliasFactory.createMetricName(tableMetricAlias));
+                metricsRegistry.remove(name, cfAlias, factory.createMetricName(tableMetricAlias), aliasFactory.createMetricName(tableMetricAlias));
             }
             else
             {
-                Metrics.remove(name, cfAlias);
+                metricsRegistry.remove(name, cfAlias);
             }
         }
     }

--- a/src/java/org/apache/cassandra/metrics/TableMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/TableMetrics.java
@@ -1481,7 +1481,7 @@ public class TableMetrics
         {
             LatencyMetrics[] parents = Stream.of(Optional.of(keyspace), global).filter(Optional::isPresent)
                                              .map(Optional::get).toArray(LatencyMetrics[]::new);
-            LatencyMetrics innerMetrics = new LatencyMetrics(factory, namePrefix, parents);
+            LatencyMetrics innerMetrics = new LatencyMetrics(factory, namePrefix, metricsRegistry, parents);
             metric = new TableLatencyMetrics.IndividualTableLatencyMetrics(innerMetrics);
         }
         else

--- a/src/java/org/apache/cassandra/metrics/TableMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/TableMetrics.java
@@ -530,7 +530,7 @@ public class TableMetrics
      *
      * @param cfs ColumnFamilyStore to measure metrics
      */
-    public TableMetrics(final ColumnFamilyStore cfs, ReleasableMetric memtableMetrics)
+    public TableMetrics(final ColumnFamilyStore cfs, ReleasableMetric memtableMetrics, CassandraMetricsRegistry metricsRegistry)
     {
         metricsAggregation = MetricsAggregation.fromMetadata(cfs.metadata());
         logger.trace("Using {} histograms for table={}", metricsAggregation, cfs.metadata());
@@ -586,7 +586,7 @@ public class TableMetrics
         samplers.put(SamplerType.CAS_CONTENTIONS, topCasPartitionContention);
         samplers.put(SamplerType.LOCAL_READ_TIME, topLocalReadQueryTime);
 
-        this.metricsRegistry = CassandraRelevantProperties.TABLE_METRICS_ENABLED.getBoolean() ? CassandraMetricsRegistry.Metrics : CassandraMetricsRegistry.NoOpMetrics;
+        this.metricsRegistry = metricsRegistry;
         memtableColumnsCount = createTableGauge("MemtableColumnsCount",
                                                 () -> cfs.getTracker().getView().getCurrentMemtable().getOperations());
 

--- a/src/java/org/apache/cassandra/metrics/TableMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/TableMetrics.java
@@ -527,7 +527,7 @@ public class TableMetrics
      *
      * @param cfs ColumnFamilyStore to measure metrics
      */
-    public TableMetrics(final ColumnFamilyStore cfs, ReleasableMetric memtableMetrics)
+    public TableMetrics(final ColumnFamilyStore cfs, ReleasableMetric memtableMetrics, CassandraMetricsRegistry metricsRegistry)
     {
         metricsAggregation = MetricsAggregation.fromMetadata(cfs.metadata());
         logger.trace("Using {} histograms for table={}", metricsAggregation, cfs.metadata());
@@ -583,7 +583,7 @@ public class TableMetrics
         samplers.put(SamplerType.CAS_CONTENTIONS, topCasPartitionContention);
         samplers.put(SamplerType.LOCAL_READ_TIME, topLocalReadQueryTime);
 
-        this.metricsRegistry = CassandraRelevantProperties.TABLE_METRICS_ENABLED.getBoolean() ? CassandraMetricsRegistry.Metrics : CassandraMetricsRegistry.NoOpMetrics;
+        this.metricsRegistry = metricsRegistry;
         memtableColumnsCount = createTableGauge("MemtableColumnsCount",
                                                 () -> cfs.getTracker().getView().getCurrentMemtable().getOperations());
 

--- a/src/java/org/apache/cassandra/metrics/TableMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/TableMetrics.java
@@ -98,6 +98,7 @@ public class TableMetrics
     private static final Logger logger = LoggerFactory.getLogger(TableMetrics.class);
 
     public static final String TABLE_EXTENSIONS_HISTOGRAMS_METRICS_KEY = "HISTOGRAM_METRICS";
+    private final CassandraMetricsRegistry metricsRegistry;
 
     public enum MetricsAggregation
     {
@@ -433,29 +434,35 @@ public class TableMetrics
         }
         return Pair.create(filtered, total);
     }
+    public static final Gauge<Double> globalPercentRepaired;
+    public static final Gauge<Long> globalBytesRepaired;
+    public static final Gauge<Long> globalBytesUnrepaired;
+    public static final Gauge<Long> globalBytesPendingRepair;
 
-    public static final Gauge<Double> globalPercentRepaired = Metrics.register(GLOBAL_FACTORY.createMetricName("PercentRepaired"),
-                                                                               new Gauge<Double>()
+    static
     {
-        public Double getValue()
-        {
-            Pair<Long, Long> result = totalNonSystemTablesSize(SSTableReader::isRepaired);
-            double repaired = result.left;
-            double total = result.right;
-            return total > 0 ? (repaired / total) * 100 : 100.0;
-        }
-    });
+        CassandraMetricsRegistry metricsRegistry = CassandraRelevantProperties.TABLE_METRICS_ENABLED.getBoolean() ? Metrics : CassandraMetricsRegistry.NoOpMetrics;
 
-    public static final Gauge<Long> globalBytesRepaired = Metrics.register(GLOBAL_FACTORY.createMetricName("BytesRepaired"),
-                                                                           () -> totalNonSystemTablesSize(SSTableReader::isRepaired).left);
+        globalPercentRepaired = metricsRegistry.register(GLOBAL_FACTORY.createMetricName("PercentRepaired"),
+                                                         () -> {
+                                                             Pair<Long, Long> result = totalNonSystemTablesSize(SSTableReader::isRepaired);
+                                                             double repaired = result.left;
+                                                             double total = result.right;
+                                                             return total > 0 ? (repaired / total) * 100 : 100.0;
+                                                         });
 
-    public static final Gauge<Long> globalBytesUnrepaired =
-        Metrics.register(GLOBAL_FACTORY.createMetricName("BytesUnrepaired"),
-                         () -> totalNonSystemTablesSize(s -> !s.isRepaired() && !s.isPendingRepair()).left);
+        globalBytesRepaired = metricsRegistry.register(GLOBAL_FACTORY.createMetricName("BytesRepaired"),
+                                               () -> totalNonSystemTablesSize(SSTableReader::isRepaired).left);
 
-    public static final Gauge<Long> globalBytesPendingRepair =
-        Metrics.register(GLOBAL_FACTORY.createMetricName("BytesPendingRepair"),
-                         () -> totalNonSystemTablesSize(SSTableReader::isPendingRepair).left);
+        globalBytesUnrepaired = metricsRegistry.register(GLOBAL_FACTORY.createMetricName("BytesUnrepaired"),
+                                                 () -> totalNonSystemTablesSize(s -> !s.isRepaired() && !s.isPendingRepair()).left);
+
+        globalBytesPendingRepair = metricsRegistry.register(GLOBAL_FACTORY.createMetricName("BytesPendingRepair"),
+                                                    () -> totalNonSystemTablesSize(SSTableReader::isPendingRepair).left);
+
+    }
+
+
 
     public final Meter readRepairRequests;
     public final Meter shortReadProtectionRequests;
@@ -576,6 +583,7 @@ public class TableMetrics
         samplers.put(SamplerType.CAS_CONTENTIONS, topCasPartitionContention);
         samplers.put(SamplerType.LOCAL_READ_TIME, topLocalReadQueryTime);
 
+        this.metricsRegistry = CassandraRelevantProperties.TABLE_METRICS_ENABLED.getBoolean() ? CassandraMetricsRegistry.Metrics : CassandraMetricsRegistry.NoOpMetrics;
         memtableColumnsCount = createTableGauge("MemtableColumnsCount",
                                                 () -> cfs.getTracker().getView().getCurrentMemtable().getOperations());
 
@@ -1259,10 +1267,10 @@ public class TableMetrics
 
     protected <G,T> Gauge<T> createTableGauge(String name, String alias, Gauge<T> gauge, Gauge<G> globalGauge)
     {
-        Gauge<T> cfGauge = Metrics.register(factory.createMetricName(name), aliasFactory.createMetricName(alias), gauge);
+        Gauge<T> cfGauge = metricsRegistry.register(factory.createMetricName(name), aliasFactory.createMetricName(alias), gauge);
         if (register(name, alias, cfGauge) && globalGauge != null)
         {
-            Metrics.register(GLOBAL_FACTORY.createMetricName(name), GLOBAL_ALIAS_FACTORY.createMetricName(alias), globalGauge);
+            metricsRegistry.register(GLOBAL_FACTORY.createMetricName(name), GLOBAL_ALIAS_FACTORY.createMetricName(alias), globalGauge);
         }
         return cfGauge;
     }
@@ -1279,7 +1287,7 @@ public class TableMetrics
         assert deprecated != null : "no deprecated metric name provided";
         assert globalGauge != null : "no global Gauge metric provided";
         
-        Gauge<T> cfGauge = Metrics.register(factory.createMetricName(name), 
+        Gauge<T> cfGauge = metricsRegistry.register(factory.createMetricName(name),
                                             gauge,
                                             aliasFactory.createMetricName(name),
                                             factory.createMetricName(deprecated),
@@ -1287,7 +1295,7 @@ public class TableMetrics
         
         if (register(name, name, deprecated, cfGauge))
         {
-            Metrics.register(GLOBAL_FACTORY.createMetricName(name),
+            metricsRegistry.register(GLOBAL_FACTORY.createMetricName(name),
                              globalGauge,
                              GLOBAL_ALIAS_FACTORY.createMetricName(name),
                              GLOBAL_FACTORY.createMetricName(deprecated),
@@ -1307,10 +1315,10 @@ public class TableMetrics
 
     protected Counter createTableCounter(final String name, final String alias)
     {
-        Counter cfCounter = Metrics.counter(factory.createMetricName(name), aliasFactory.createMetricName(alias));
+        Counter cfCounter = metricsRegistry.counter(factory.createMetricName(name), aliasFactory.createMetricName(alias));
         if (register(name, alias, cfCounter))
         {
-            Metrics.register(GLOBAL_FACTORY.createMetricName(name),
+            metricsRegistry.register(GLOBAL_FACTORY.createMetricName(name),
                              GLOBAL_ALIAS_FACTORY.createMetricName(alias),
                              new Gauge<Long>()
                              {
@@ -1335,14 +1343,14 @@ public class TableMetrics
 
     private Meter createTableMeter(final String name, final String alias)
     {
-        Meter tableMeter = Metrics.meter(factory.createMetricName(name), aliasFactory.createMetricName(alias));
+        Meter tableMeter = metricsRegistry.meter(factory.createMetricName(name), aliasFactory.createMetricName(alias));
         register(name, alias, tableMeter);
         return tableMeter;
     }
     
     private Histogram createHistogram(String name, boolean considerZeroes)
     {
-        Histogram histogram = Metrics.histogram(factory.createMetricName(name), aliasFactory.createMetricName(name), considerZeroes);
+        Histogram histogram = metricsRegistry.histogram(factory.createMetricName(name), aliasFactory.createMetricName(name), considerZeroes);
         register(name, name, histogram);
         return histogram;
     }
@@ -1387,7 +1395,7 @@ public class TableMetrics
         Histogram globalHistogram = null;
         if (EXPORT_GLOBAL_METRICS)
         {
-            globalHistogram = Metrics.histogram(GLOBAL_FACTORY.createMetricName(name),
+            globalHistogram = metricsRegistry.histogram(GLOBAL_FACTORY.createMetricName(name),
                                                 GLOBAL_ALIAS_FACTORY.createMetricName(alias),
                                                 considerZeroes);
         }
@@ -1395,7 +1403,7 @@ public class TableMetrics
         Histogram tableHistogram = null;
         if (metricsAggregation == MetricsAggregation.INDIVIDUAL)
         {
-            tableHistogram = Metrics.histogram(factory.createMetricName(name), aliasFactory.createMetricName(alias), considerZeroes);
+            tableHistogram = metricsRegistry.histogram(factory.createMetricName(name), aliasFactory.createMetricName(alias), considerZeroes);
             register(name, alias, tableHistogram);
         }
 
@@ -1409,7 +1417,7 @@ public class TableMetrics
 
     protected Histogram createTableHistogram(String name, String alias, boolean considerZeroes)
     {
-        Histogram tableHistogram = Metrics.histogram(factory.createMetricName(name), aliasFactory.createMetricName(alias), considerZeroes);
+        Histogram tableHistogram = metricsRegistry.histogram(factory.createMetricName(name), aliasFactory.createMetricName(alias), considerZeroes);
         register(name, alias, tableHistogram);
         return tableHistogram;
     }
@@ -1419,13 +1427,13 @@ public class TableMetrics
         Timer globalTimer = null;
         if (EXPORT_GLOBAL_METRICS)
         {
-            globalTimer = Metrics.timer(GLOBAL_FACTORY.createMetricName(name), GLOBAL_ALIAS_FACTORY.createMetricName(name));
+            globalTimer = metricsRegistry.timer(GLOBAL_FACTORY.createMetricName(name), GLOBAL_ALIAS_FACTORY.createMetricName(name));
         }
 
         Timer tableTimer = null;
         if (metricsAggregation == MetricsAggregation.INDIVIDUAL)
         {
-            tableTimer = Metrics.timer(factory.createMetricName(name), aliasFactory.createMetricName(name));
+            tableTimer = metricsRegistry.timer(factory.createMetricName(name), aliasFactory.createMetricName(name));
             register(name, name, keyspaceTimer);
         }
 
@@ -1434,7 +1442,7 @@ public class TableMetrics
 
     protected Timer createTableTimer(String name)
     {
-        Timer tableTimer = Metrics.timer(factory.createMetricName(name), aliasFactory.createMetricName(name));
+        Timer tableTimer = metricsRegistry.timer(factory.createMetricName(name), aliasFactory.createMetricName(name));
         register(name, name, tableTimer);
         return tableTimer;
     }
@@ -1449,14 +1457,14 @@ public class TableMetrics
         Meter globalMeter = null;
         if (EXPORT_GLOBAL_METRICS)
         {
-            globalMeter = Metrics.meter(GLOBAL_FACTORY.createMetricName(name),
+            globalMeter = metricsRegistry.meter(GLOBAL_FACTORY.createMetricName(name),
                                         GLOBAL_ALIAS_FACTORY.createMetricName(alias));
         }
 
         Meter tableMeter = null;
         if (metricsAggregation == MetricsAggregation.INDIVIDUAL)
         {
-            tableMeter = Metrics.meter(factory.createMetricName(name), aliasFactory.createMetricName(alias));
+            tableMeter = metricsRegistry.meter(factory.createMetricName(name), aliasFactory.createMetricName(alias));
             register(name, alias, tableMeter);
         }
 
@@ -1511,7 +1519,7 @@ public class TableMetrics
     {
         CassandraMetricsRegistry.MetricName name = factory.createMetricName(tableMetricName);
 
-        final Metric metric = Metrics.getMetrics().get(name.getMetricName());
+        final Metric metric = metricsRegistry.getMetrics().get(name.getMetricName());
         if (metric != null)
         {
             // Metric will be null if we are releasing a view metric.  Views have null for ViewLockAcquireTime and ViewLockReadTime
@@ -1520,11 +1528,11 @@ public class TableMetrics
             
             if (tableMetricAlias != null)
             {
-                Metrics.remove(name, cfAlias, factory.createMetricName(tableMetricAlias), aliasFactory.createMetricName(tableMetricAlias));
+                metricsRegistry.remove(name, cfAlias, factory.createMetricName(tableMetricAlias), aliasFactory.createMetricName(tableMetricAlias));
             }
             else
             {
-                Metrics.remove(name, cfAlias);
+                metricsRegistry.remove(name, cfAlias);
             }
         }
     }

--- a/src/java/org/apache/cassandra/metrics/TableMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/TableMetrics.java
@@ -1478,7 +1478,7 @@ public class TableMetrics
         {
             LatencyMetrics[] parents = Stream.of(Optional.of(keyspace), global).filter(Optional::isPresent)
                                              .map(Optional::get).toArray(LatencyMetrics[]::new);
-            LatencyMetrics innerMetrics = new LatencyMetrics(factory, namePrefix, parents);
+            LatencyMetrics innerMetrics = new LatencyMetrics(factory, namePrefix, metricsRegistry, parents);
             metric = new TableLatencyMetrics.IndividualTableLatencyMetrics(innerMetrics);
         }
         else

--- a/src/java/org/apache/cassandra/metrics/TrieMemtableMetricsView.java
+++ b/src/java/org/apache/cassandra/metrics/TrieMemtableMetricsView.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import com.codahale.metrics.Counter;
+import org.apache.cassandra.config.CassandraRelevantProperties;
 
 import static org.apache.cassandra.metrics.CassandraMetricsRegistry.Metrics;
 
@@ -49,6 +50,7 @@ public class TrieMemtableMetricsView
     private final TrieMemtableMetricNameFactory factory;
     private final String keyspace;
     private final String table;
+    private final CassandraMetricsRegistry metricsRegistry;
 
     public static TrieMemtableMetricsView getOrCreate(String keyspace, String table)
     {
@@ -60,19 +62,20 @@ public class TrieMemtableMetricsView
         this.keyspace = keyspace;
         this.table = table;
         factory = new TrieMemtableMetricNameFactory(keyspace, table);
+        this.metricsRegistry = CassandraRelevantProperties.TABLE_METRICS_ENABLED.getBoolean() ? Metrics : CassandraMetricsRegistry.NoOpMetrics;
         
-        uncontendedPuts = Metrics.counter(factory.createMetricName(UNCONTENDED_PUTS));
-        contendedPuts = Metrics.counter(factory.createMetricName(CONTENDED_PUTS));
-        contentionTime = new LatencyMetrics(factory, CONTENTION_TIME);
-        lastFlushShardDataSizes = new MinMaxAvgMetric(factory, LAST_FLUSH_SHARD_SIZES);
+        uncontendedPuts = metricsRegistry.counter(factory.createMetricName(UNCONTENDED_PUTS));
+        contendedPuts = metricsRegistry.counter(factory.createMetricName(CONTENDED_PUTS));
+        contentionTime = new LatencyMetrics(factory, CONTENTION_TIME, metricsRegistry);
+        lastFlushShardDataSizes = new MinMaxAvgMetric(factory, LAST_FLUSH_SHARD_SIZES, metricsRegistry);
     }
 
     public void release()
     {
         perTableMetrics.remove(getKey(keyspace, table));
 
-        Metrics.remove(factory.createMetricName(UNCONTENDED_PUTS));
-        Metrics.remove(factory.createMetricName(CONTENDED_PUTS));
+        metricsRegistry.remove(factory.createMetricName(UNCONTENDED_PUTS));
+        metricsRegistry.remove(factory.createMetricName(CONTENDED_PUTS));
         contentionTime.release();
         lastFlushShardDataSizes.release();
     }

--- a/src/java/org/apache/cassandra/metrics/TrieMemtableMetricsView.java
+++ b/src/java/org/apache/cassandra/metrics/TrieMemtableMetricsView.java
@@ -54,15 +54,15 @@ public class TrieMemtableMetricsView
 
     public static TrieMemtableMetricsView getOrCreate(String keyspace, String table)
     {
-        return perTableMetrics.computeIfAbsent(getKey(keyspace, table), k -> new TrieMemtableMetricsView(keyspace, table));
+        return perTableMetrics.computeIfAbsent(getKey(keyspace, table), k -> MetricsFactory.instance.newMemtableMetrics(keyspace, table));
     }
 
-    private TrieMemtableMetricsView(String keyspace, String table)
+    public TrieMemtableMetricsView(String keyspace, String table, CassandraMetricsRegistry metricsRegistry)
     {
         this.keyspace = keyspace;
         this.table = table;
         factory = new TrieMemtableMetricNameFactory(keyspace, table);
-        this.metricsRegistry = CassandraRelevantProperties.TABLE_METRICS_ENABLED.getBoolean() ? Metrics : CassandraMetricsRegistry.NoOpMetrics;
+        this.metricsRegistry = metricsRegistry;
         
         uncontendedPuts = metricsRegistry.counter(factory.createMetricName(UNCONTENDED_PUTS));
         contendedPuts = metricsRegistry.counter(factory.createMetricName(CONTENDED_PUTS));

--- a/test/unit/org/apache/cassandra/db/ColumnFamilyMetricTest.java
+++ b/test/unit/org/apache/cassandra/db/ColumnFamilyMetricTest.java
@@ -20,6 +20,7 @@ package org.apache.cassandra.db;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Set;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -32,6 +33,7 @@ import com.codahale.metrics.MetricRegistryListener;
 import com.codahale.metrics.Timer;
 import org.apache.cassandra.SchemaLoader;
 import org.apache.cassandra.Util;
+import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.metrics.CassandraMetricsRegistry;
 import org.apache.cassandra.metrics.TableMetrics;
@@ -62,6 +64,32 @@ public class ColumnFamilyMetricTest
         // OTOH, late initialization of them may have creepy effects (for example NPEs in static initializers)
         // disclaimer: this is not a proper way to fix that
         StorageService.instance.forceKeyspaceFlush(SchemaConstants.SYSTEM_KEYSPACE_NAME);
+    }
+
+    @Test
+    public void testOpeningWithMetricsDisabledDoesNotLoadMetrics()
+    {
+        // remove all the existing metrics, it just simplifies the process
+
+        System.setProperty(CassandraRelevantProperties.TABLE_METRICS_ENABLED.getKey(), "false");
+        try
+        {
+            SchemaLoader.createKeyspace("KS", KeyspaceParams.simple(1),
+                                        SchemaLoader.standardCFMD("KS", "S2"));
+
+            Keyspace keyspace = Keyspace.openWithoutSSTables("KS");
+            ColumnFamilyStore cfs = keyspace.getColumnFamilyStore("S2");
+            Set<String> postLoadMetrics = CassandraMetricsRegistry.Metrics.getNames();
+            // there should be no metrics with name Table or ColumnFamily in it
+            assertEquals("Unexpected table metrics!",
+                         0, postLoadMetrics.stream().filter(name -> name.contains("S2") && name.contains("Table")).count());
+            assertEquals("Unexpected column family metrics!",
+                         0, postLoadMetrics.stream().filter(name -> name.contains("S2") && name.contains("ColumnFamily")).count());
+        }
+        finally {
+            System.setProperty(CassandraRelevantProperties.TABLE_METRICS_ENABLED.getKey(), "true");
+        }
+
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/db/ColumnFamilyMetricTest.java
+++ b/test/unit/org/apache/cassandra/db/ColumnFamilyMetricTest.java
@@ -36,13 +36,17 @@ import org.apache.cassandra.Util;
 import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.metrics.CassandraMetricsRegistry;
+import org.apache.cassandra.metrics.KeyspaceMetrics;
+import org.apache.cassandra.metrics.MetricsFactory;
 import org.apache.cassandra.metrics.TableMetrics;
+import org.apache.cassandra.metrics.TrieMemtableMetricsView;
 import org.apache.cassandra.schema.KeyspaceParams;
 import org.apache.cassandra.schema.SchemaConstants;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.FBUtilities;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 import static org.apache.cassandra.db.ColumnFamilyStore.FlushReason.UNIT_TESTS;
 import static org.apache.cassandra.utils.ByteBufferUtil.bytes;
@@ -66,31 +70,6 @@ public class ColumnFamilyMetricTest
         StorageService.instance.forceKeyspaceFlush(SchemaConstants.SYSTEM_KEYSPACE_NAME);
     }
 
-    @Test
-    public void testOpeningWithMetricsDisabledDoesNotLoadMetrics()
-    {
-        // remove all the existing metrics, it just simplifies the process
-
-        System.setProperty(CassandraRelevantProperties.TABLE_METRICS_ENABLED.getKey(), "false");
-        try
-        {
-            SchemaLoader.createKeyspace("KS", KeyspaceParams.simple(1),
-                                        SchemaLoader.standardCFMD("KS", "S2"));
-
-            Keyspace keyspace = Keyspace.openWithoutSSTables("KS");
-            ColumnFamilyStore cfs = keyspace.getColumnFamilyStore("S2");
-            Set<String> postLoadMetrics = CassandraMetricsRegistry.Metrics.getNames();
-            // there should be no metrics with name Table or ColumnFamily in it
-            assertEquals("Unexpected table metrics!",
-                         0, postLoadMetrics.stream().filter(name -> name.contains("S2") && name.contains("Table")).count());
-            assertEquals("Unexpected column family metrics!",
-                         0, postLoadMetrics.stream().filter(name -> name.contains("S2") && name.contains("ColumnFamily")).count());
-        }
-        finally {
-            System.setProperty(CassandraRelevantProperties.TABLE_METRICS_ENABLED.getKey(), "true");
-        }
-
-    }
 
     @Test
     public void testSizeMetric()

--- a/test/unit/org/apache/cassandra/metrics/CassandraMetricsRegistryTest.java
+++ b/test/unit/org/apache/cassandra/metrics/CassandraMetricsRegistryTest.java
@@ -24,13 +24,19 @@ import static org.junit.Assert.*;
 
 import java.lang.management.ManagementFactory;
 import java.util.Collection;
+import java.util.SortedMap;
 
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+
+import com.codahale.metrics.Gauge;
 import org.apache.cassandra.metrics.CassandraMetricsRegistry.MetricName;
 import org.junit.Test;
 
 import com.codahale.metrics.jvm.BufferPoolMetricSet;
 import com.codahale.metrics.jvm.GarbageCollectorMetricSet;
 import com.codahale.metrics.jvm.MemoryUsageGaugeSet;
+import org.apache.cassandra.utils.MBeanWrapper;
 
 
 public class CassandraMetricsRegistryTest
@@ -106,5 +112,39 @@ public class CassandraMetricsRegistryTest
         long[] count = new long[]{0, 1, 2, 3, 4, 5};
         assertArrayEquals(count, CassandraMetricsRegistry.delta(count, new long[3]));
         assertArrayEquals(new long[6], CassandraMetricsRegistry.delta(count, new long[]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}));
+    }
+
+
+    @Test
+    public void testNoOpMetricsDoesNotRegisterTypes()
+    {
+        // verify that JMX does not register metrics created with the no-op metrics element.
+        CassandraMetricsRegistry registry = CassandraMetricsRegistry.NoOpMetrics;
+        MBeanWrapper mbeanWrapper = MBeanWrapper.instance;
+
+        //check gauges
+        MetricName gaugeName = new MetricName("testGroup","testType","testGauge");
+        registry.register(gaugeName, (Gauge<Long>) () -> 0L);
+        assertFalse("Should not have registered the mbean with JMX", mbeanWrapper.isRegistered(gaugeName.getMBeanName()));
+
+        //check counters
+        MetricName counterName = new MetricName("testGroup","testType","testCounter");
+        registry.counter(counterName);
+        assertFalse("Should not have registered the mbean with JMX", mbeanWrapper.isRegistered(counterName.getMBeanName()));
+
+        //check meters
+        MetricName meterName = new MetricName("testGroup","testType","testMeter");
+        registry.meter(meterName);
+        assertFalse("Should not have registered the mbean with JMX", mbeanWrapper.isRegistered(meterName.getMBeanName()));
+
+        //check histograms
+        MetricName histName = new MetricName("testGroup","testType","testHist");
+        registry.meter(histName);
+        assertFalse("Should not have registered the mbean with JMX", mbeanWrapper.isRegistered(histName.getMBeanName()));
+
+        //check timers
+        MetricName timerName = new MetricName("testGroup","testType","testTimer");
+        registry.meter(timerName);
+        assertFalse("Should not have registered the mbean with JMX", mbeanWrapper.isRegistered(timerName.getMBeanName()));
     }
 }

--- a/test/unit/org/apache/cassandra/metrics/CassandraMetricsRegistryTest.java
+++ b/test/unit/org/apache/cassandra/metrics/CassandraMetricsRegistryTest.java
@@ -29,7 +29,10 @@ import java.util.SortedMap;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 
+import com.codahale.metrics.Counter;
 import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Snapshot;
 import org.apache.cassandra.metrics.CassandraMetricsRegistry.MetricName;
 import org.junit.Test;
 
@@ -139,12 +142,39 @@ public class CassandraMetricsRegistryTest
 
         //check histograms
         MetricName histName = new MetricName("testGroup","testType","testHist");
-        registry.meter(histName);
+        registry.histogram(histName, true);
         assertFalse("Should not have registered the mbean with JMX", mbeanWrapper.isRegistered(histName.getMBeanName()));
 
         //check timers
         MetricName timerName = new MetricName("testGroup","testType","testTimer");
-        registry.meter(timerName);
+        registry.timer(timerName);
         assertFalse("Should not have registered the mbean with JMX", mbeanWrapper.isRegistered(timerName.getMBeanName()));
+    }
+
+    @Test
+    public void testNoOpMetricsDontDoAnything()
+    {
+        // a bit of a silly test, but it confirms that adding to counters, histograms, timers etc. don't
+        // throw any errors
+
+        CassandraMetricsRegistry registry = CassandraMetricsRegistry.NoOpMetrics;
+        Counter c = registry.counter(new MetricName("testGroup", "testType", "testCounter"));
+        c.inc();
+        assertEquals("no-op Counter should not record values!", 0, c.getCount());
+        c.inc(10L);
+        assertEquals("no-op Counter should not record values!", 0, c.getCount());
+
+        Histogram h = registry.histogram(new MetricName("testGroup", "testType", "testHist"), true);
+        h.update(10);
+        assertEquals(0L, h.getCount());
+        h.update(10L);
+        assertEquals(0L, h.getCount());
+        Snapshot s = h.getSnapshot();
+        assertEquals(0, s.getMax());
+        assertEquals(0, s.getMin());
+        //snapshots have to have size 1 or else the underlying codahale logic breaks
+        assertEquals(1, s.size());
+        assertEquals(0d, s.getMean(), 0.000001d);
+        assertEquals(0d, s.getMedian(), 0.000001d);
     }
 }

--- a/test/unit/org/apache/cassandra/metrics/KeyspaceMetricsTest.java
+++ b/test/unit/org/apache/cassandra/metrics/KeyspaceMetricsTest.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.Session;
 import org.apache.cassandra.ServerTestUtils;
+import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.service.EmbeddedCassandraService;
@@ -69,6 +70,29 @@ public class KeyspaceMetricsTest
         session.execute(String.format("DROP KEYSPACE %s;", keyspace));
         // no metrics after drop
         assertEquals(metrics.get().collect(Collectors.joining(",")), 0, metrics.get().count());
+    }
+
+    @Test
+    public void testMetricsNotRecordedWhenDisabled()
+    {
+        System.setProperty(CassandraRelevantProperties.KEYSPACE_METRICS_ENABLED.getKey(), "false");
+        try {
+            String keyspace = "norecorded_keyspace";
+            CassandraMetricsRegistry registry = CassandraMetricsRegistry.Metrics;
+            Supplier<Stream<String>> ksMetrics = () -> registry.getNames().stream().filter(m -> m.contains(keyspace));
+            // no metrics before creating
+            assertEquals(0, ksMetrics.get().count());
+            session.execute(String.format("CREATE KEYSPACE %s WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };", keyspace));
+            //still no metrics
+            assertEquals(0, ksMetrics.get().count());
+
+            session.execute(String.format("DROP KEYSPACE %s;", keyspace));
+            // no metrics after drop
+            assertEquals(ksMetrics.get().collect(Collectors.joining(",")), 0, ksMetrics.get().count());
+        }
+        finally {
+            System.setProperty(CassandraRelevantProperties.KEYSPACE_METRICS_ENABLED.getKey(), "true");
+        }
     }
 
     @AfterClass

--- a/test/unit/org/apache/cassandra/metrics/MetricsFactoryTest.java
+++ b/test/unit/org/apache/cassandra/metrics/MetricsFactoryTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.metrics;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+
+import static org.junit.Assert.assertTrue;
+
+public class MetricsFactoryTest
+{
+    @BeforeClass
+    public static void setup()
+    {
+        DatabaseDescriptor.daemonInitialization();
+    }
+
+    @Test
+    public void testWontLoadMissingClass()
+    {
+        System.setProperty("cassandra.custom_metrics_factory_class", "not.a.real.classpath.MissingMetricsFactory");
+        try
+        {
+            assertTrue("Custom class did not load!", MetricsFactory.instance instanceof DefaultMetricsFactory);
+        } finally {
+            System.clearProperty("cassandra.custom_metrics_factory_class");
+        }
+    }
+}


### PR DESCRIPTION
This ensures that no JMX or other metrics are created for `Keyspace` and `ColumnFamilyStore` objects that are opened without loading SSTables.


Some highlights (and possible reasons why this solution won't work):
* This uses the `openSSTables` flag to determine whether or not metrics are collected. The reasoning being that "If the SSTables are loaded, then we probably don't care about the metrics either". However, that may not be true! In that case, we may want to modify this to include a distinct "metrics" flag, or explicitly pass in a metrics factory, or similar.
* The trivial approach(replace `KeyspaceMetrics` with `null`) is a less disruptive change on the surface, but other code throughout the system appears to implicitly depend on the metrics object not being null. Enough of that existed throughout the codebase that the choice became "guarantee that every possible usage allows for null entries" or "risk a NPE if I am wrong about whether or not this case will always be used correctly". I opted for the slightly more disruptive approach of creating a subclass that doesn't register metrics. If you are a person with more knowledge of the C* codebase and has more confident that the nullity solution will work, then I'm open to being convinced. But this approach seemed to be safer overall.


