### PR TITLE
CNDB-16697: CNDB-16135: reuse table directory from Directories into Descriptor

### DIFF
--- a/src/java/org/apache/cassandra/db/Directories.java
+++ b/src/java/org/apache/cassandra/db/Directories.java
@@ -390,8 +390,7 @@ public class Directories
     {
         Preconditions.checkArgument(dirNumber < dataPaths.length, "Invalid dir number: " + dirNumber);
         File dir = dataPaths[dirNumber];
-        File file = dir.resolve(filename);
-        return Descriptor.fromFile(file);
+        return Descriptor.fromFileWithComponent(new File(dir, filename), true).left;
     }
 
     /**

--- a/src/java/org/apache/cassandra/db/Directories.java
+++ b/src/java/org/apache/cassandra/db/Directories.java
@@ -390,7 +390,7 @@ public class Directories
     {
         Preconditions.checkArgument(dirNumber < dataPaths.length, "Invalid dir number: " + dirNumber);
         File dir = dataPaths[dirNumber];
-        return Descriptor.fromFileWithComponent(new File(dir, filename), true).left;
+        return Descriptor.fromFileWithComponent(dir, filename, true).left;
     }
 
     /**

--- a/src/java/org/apache/cassandra/io/sstable/Descriptor.java
+++ b/src/java/org/apache/cassandra/io/sstable/Descriptor.java
@@ -294,7 +294,7 @@ public class Descriptor
      * @param file the {@code File} object for the filename to parse.
      * @return the descriptor for the parsed file.
      *
-     * @throws IllegalArgumentException if the provided {@code file} does point to a valid sstable filename. This could
+     * @throws IllegalArgumentException if the provided {@code file} does not point to a valid sstable filename. This could
      * mean either that the filename doesn't look like a sstable file, or that it is for an old and unsupported
      * versions.
      */
@@ -352,13 +352,12 @@ public class Descriptor
     }
 
     /**
-     * Parse a sstable filename, extracting both the {@code Descriptor} and {@code Component} part.
-     * The keyspace/table name will be extracted from the directory path.
+     * Parse a sstable file, extracting both the {@code Descriptor} and {@code Component} part.
      *
      * @param file the {@code File} object for the filename to parse.
      * @return a pair of the descriptor and component corresponding to the provided {@code file}.
      *
-     * @throws IllegalArgumentException if the provided {@code file} does point to a valid sstable filename. This could
+     * @throws IllegalArgumentException if the provided {@code file} does not point to a valid sstable filename. This could
      * mean either that the filename doesn't look like a sstable file, or that it is for an old and unsupported
      * versions.
      */

--- a/src/java/org/apache/cassandra/io/sstable/Descriptor.java
+++ b/src/java/org/apache/cassandra/io/sstable/Descriptor.java
@@ -373,7 +373,6 @@ public class Descriptor
         if (!file.isAbsolute())
             file = file.toAbsolute();
 
-        SSTableInfo info = validateAndExtractInfo(file);
         String filename = file.name();
         File tableDirectory = parentOf(filename, file);
         
@@ -433,7 +432,6 @@ public class Descriptor
         }
         else if (validateDirs)
         {
-            logger.debug("Could not extract keyspace/table info from sstable directory {}", file.toString());
             logger.debug("Could not extract keyspace/table info from sstable directory {}", fullPath);
             throw invalidSSTable(name, String.format("cannot extract keyspace and table name from %s; make sure the sstable is in the proper sub-directories", fullPath));
         }

--- a/src/java/org/apache/cassandra/io/sstable/Descriptor.java
+++ b/src/java/org/apache/cassandra/io/sstable/Descriptor.java
@@ -353,6 +353,7 @@ public class Descriptor
 
     /**
      * Parse a sstable file, extracting both the {@code Descriptor} and {@code Component} part.
+     * The keyspace/table name will be extracted from the directory path.
      *
      * @param file the {@code File} object for the filename to parse.
      * @return a pair of the descriptor and component corresponding to the provided {@code file}.

--- a/src/java/org/apache/cassandra/io/sstable/Descriptor.java
+++ b/src/java/org/apache/cassandra/io/sstable/Descriptor.java
@@ -374,17 +374,51 @@ public class Descriptor
             file = file.toAbsolute();
 
         SSTableInfo info = validateAndExtractInfo(file);
-        String name = file.name();
+        String filename = file.name();
+        File tableDirectory = parentOf(filename, file);
+        
+        // Delegate to the new method that accepts directory and filename separately
+        return fromFileWithComponent(tableDirectory, filename, validateDirs);
+    }
+
+    /**
+     * Parse a table directory and sstable file name, extracting both the {@code Descriptor} and {@code Component} part.
+     *
+     * @param tableDirectory the {@code File} object for the sstable directory
+     * @param name the name of the sstable file to parse
+     * @param validateDirs whether to validate that the directory structure matches expected patterns
+     * @return a pair of the descriptor and component corresponding to the provided directory and filename.
+     *
+     * @throws IllegalArgumentException if the provided {@code filename} does not point to a valid sstable filename. This could
+     * mean either that the filename doesn't look like a sstable file, or that it is for an old and unsupported
+     * versions.
+     */
+    public static Pair<Descriptor, Component> fromFileWithComponent(File tableDirectory, String name, boolean validateDirs)
+    {
+        checkNotNull(tableDirectory);
+        checkNotNull(name);
+
+        // We need to extract the keyspace and table names from the parent directories, so make sure we deal with the
+        // absolute path.
+        if (!tableDirectory.isAbsolute())
+            tableDirectory = tableDirectory.toAbsolute();
+
+        SSTableInfo info = validateAndExtractInfo(name);
 
         String keyspaceName = "";
         String tableName = "";
 
-        Matcher sstableDirMatcher = SSTABLE_DIR_PATTERN.matcher(file.toString());
+        String fullPath = tableDirectory.toString();
+        if (!fullPath.endsWith(File.pathSeparator()))
+            fullPath = fullPath + File.pathSeparator();
+        fullPath = fullPath + name;
+
+        Matcher sstableDirMatcher = SSTABLE_DIR_PATTERN.matcher(fullPath);
 
         // Use pre-2.1 SSTable format if current one does not match it
         if (!sstableDirMatcher.find(0))
         {
-            sstableDirMatcher = LEGACY_SSTABLE_DIR_PATTERN.matcher(file.toString());
+            sstableDirMatcher = LEGACY_SSTABLE_DIR_PATTERN.matcher(fullPath);
         }
 
         if (sstableDirMatcher.find(0))
@@ -400,10 +434,12 @@ public class Descriptor
         else if (validateDirs)
         {
             logger.debug("Could not extract keyspace/table info from sstable directory {}", file.toString());
-            throw invalidSSTable(name, String.format("cannot extract keyspace and table name from %s; make sure the sstable is in the proper sub-directories", file));
+            logger.debug("Could not extract keyspace/table info from sstable directory {}", fullPath);
+            throw invalidSSTable(name, String.format("cannot extract keyspace and table name from %s; make sure the sstable is in the proper sub-directories", fullPath));
         }
 
-        return Pair.create(new Descriptor(info.version, parentOf(name, file), keyspaceName, tableName, info.id), info.component);
+        // Use tableDirectory directly, reusing the same File instance across multiple descriptors
+        return Pair.create(new Descriptor(info.version, tableDirectory, keyspaceName, tableName, info.id), info.component);
     }
 
     /**
@@ -426,7 +462,7 @@ public class Descriptor
             return fromFileWithComponent(file);
         }
 
-        SSTableInfo info = validateAndExtractInfo(file);
+        SSTableInfo info = validateAndExtractInfo(file.name());
         return Pair.create(new Descriptor(info.version, parentOf(file.name(), file), keyspace, table, info.id), info.component);
     }
 
@@ -449,9 +485,8 @@ public class Descriptor
         return tokens;
     }
 
-    private static SSTableInfo validateAndExtractInfo(File file)
+    private static SSTableInfo validateAndExtractInfo(String name)
     {
-        String name = file.name();
         List<String> tokens = filenameTokens(name);
 
         String versionString = tokens.get(0);

--- a/test/unit/org/apache/cassandra/db/DirectoriesTest.java
+++ b/test/unit/org/apache/cassandra/db/DirectoriesTest.java
@@ -99,6 +99,8 @@ import org.apache.cassandra.service.snapshot.SnapshotManifest;
 import org.apache.cassandra.service.snapshot.TableSnapshot;
 import org.apache.cassandra.utils.JVMStabilityInspector;
 
+import static org.junit.Assert.assertNotSame;
+
 import static org.apache.cassandra.schema.MockSchema.sstableId;
 import static org.apache.cassandra.utils.Clock.Global.nanoTime;
 import static org.apache.cassandra.utils.FBUtilities.now;
@@ -473,8 +475,19 @@ public class DirectoriesTest
         assertTrue(BigFormat.is(resolved.getFormat()));
         assertEquals(BigFormat.getInstance().getVersion("me"), resolved.version);
         assertEquals("123", resolved.id.toString());
-    }
 
+        Descriptor resolved2 = directories.resolve("me-234-big-Data.db", 0);
+
+        assertEquals(cfm.keyspace, resolved2.ksname);
+        assertEquals(cfm.name, resolved2.cfname);
+        assertTrue(BigFormat.is(resolved2.getFormat()));
+        assertEquals(BigFormat.getInstance().getVersion("me"), resolved2.version);
+        assertEquals("234", resolved2.id.toString());
+
+        // not the same instance because of toCanonical() in Descriptor constructor
+        assertEquals(resolved.directory, resolved2.directory);
+        assertNotSame(resolved.directory, resolved2.directory);;
+    }
 
     @Test
     public void testSecondaryIndexDirectories()

--- a/test/unit/org/apache/cassandra/io/sstable/DescriptorTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/DescriptorTest.java
@@ -100,18 +100,25 @@ public class DescriptorTest
     {
         File file = original.fileFor(Components.DATA);
 
-        Pair<Descriptor, Component> pair = Descriptor.fromFileWithComponent(file);
-        Descriptor desc = pair.left;
+        Pair<Descriptor, Component> pair = Descriptor.fromFilenameWithComponent(file);
+        checkDescriptor(original, pair.left, pair.right);
 
+        pair = Descriptor.fromFilenameWithComponent(new File(file.parent(), file.name()));
+        checkDescriptor(original, pair.left, pair.right);
+
+        assertEquals(Components.DATA, Descriptor.validFilenameWithComponent(file.name()));
+    }
+
+    private void checkDescriptor(Descriptor original, Descriptor desc, Component component)
+    {
         assertEquals(original.directory, desc.directory);
         assertEquals(original.ksname, desc.ksname);
         assertEquals(original.cfname, desc.cfname);
         assertEquals(original.version, desc.version);
         assertEquals(original.id, desc.id);
-        assertEquals(original.fileFor(Components.DATA).toPath(), desc.pathFor(Components.DATA));
-        assertEquals(Components.DATA, pair.right);
 
-        assertEquals(Components.DATA, Descriptor.validFilenameWithComponent(file.name()));
+        assertEquals(original.fileFor(Components.DATA).toPath(), desc.pathFor(Components.DATA));
+        assertEquals(Components.DATA, component);
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/io/sstable/DescriptorTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/DescriptorTest.java
@@ -103,7 +103,7 @@ public class DescriptorTest
         Pair<Descriptor, Component> pair = Descriptor.fromFilenameWithComponent(file);
         checkDescriptor(original, pair.left, pair.right);
 
-        pair = Descriptor.fromFilenameWithComponent(new File(file.parent(), file.name()));
+        pair = Descriptor.fromFileWithComponent(file.parent(), file.name(), true);
         checkDescriptor(original, pair.left, pair.right);
 
         assertEquals(Components.DATA, Descriptor.validFilenameWithComponent(file.name()));


### PR DESCRIPTION
https://github.com/riptano/cndb/issues/16697

Port into main-5.0

commit 79f25c7cf09e9d1b0b9d0ae92707003df8fb3a6d
Author: Zhao Yang <zhaoyangsingapore@gmail.com>
Date:   Tue Dec 9 16:24:25 2025 +0800

    CNDB-16135: reuse table directory from Directories into Descriptor (#2150)

    ### What is the issue
    CNDB-16135: Descriptor uses different instances of `Path directory` for
    the same table as constructor parameter

    ### What does this PR fix and why was it fixed

    Use the table directory from `Directories` in `Descriptor` as
    constructor parameter . `Descriptor#directory` is still different
    instance in C* due to `directory#toCanonical()` which always creates new
    instance in local file system