### PR TITLE
CNDB-17175 add feature version support test for FA

### DIFF
--- a/test/distributed/org/apache/cassandra/distributed/test/sai/features/FeaturesVersionSupportFATest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/features/FeaturesVersionSupportFATest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test.sai.features;
+
+import java.io.IOException;
+
+import org.junit.BeforeClass;
+
+import org.apache.cassandra.index.sai.disk.format.Version;
+
+/**
+ * {@link FeaturesVersionSupportTester} for {@link Version#FA}.
+ */
+public class FeaturesVersionSupportFATest extends FeaturesVersionSupportTester
+{
+    @BeforeClass
+    public static void setup() throws IOException
+    {
+        initCluster(Version.FA);
+    }
+}


### PR DESCRIPTION
### What is the issue

When FA format was implemented, this test wasn't added.

### What does this PR fix and why was it fixed

Fixes https://github.com/riptano/cndb/issues/17175

Adds add feature version support test for the latest SAI disk format version FA.
