### PR TITLE
CNDB-17127 disable compactions when global property is set

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -480,7 +480,10 @@ public enum CassandraRelevantProperties
      */
     DISABLED_AUTO_COMPACTION_PROPERTY("cassandra.disabled_auto_compaction"),
 
-    LOAD_COMPACTION_ENABLED("cassandra.compaction.enabled", "true"),
+    /**
+     * When set, all compaction logic is shut down and no compactions will execute.
+     */
+    DISABLED_ALL_COMPACTIONS("cassandra.disable_all_compactions", "false"),
 
     /** Which class to use for dynamic snitch severity values */
     DYNAMIC_SNITCH_SEVERITY_PROVIDER("cassandra.dynamic_snitch_severity_provider"),

--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -480,6 +480,8 @@ public enum CassandraRelevantProperties
      */
     DISABLED_AUTO_COMPACTION_PROPERTY("cassandra.disabled_auto_compaction"),
 
+    LOAD_COMPACTION_ENABLED("cassandra.compaction.enabled", "true"),
+
     /** Which class to use for dynamic snitch severity values */
     DYNAMIC_SNITCH_SEVERITY_PROVIDER("cassandra.dynamic_snitch_severity_provider"),
 

--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -194,7 +194,7 @@ import org.json.simple.JSONObject;
 
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static org.apache.cassandra.config.CassandraRelevantProperties.DISABLED_AUTO_COMPACTION_PROPERTY;
-import static org.apache.cassandra.config.CassandraRelevantProperties.LOAD_COMPACTION_ENABLED;
+import static org.apache.cassandra.config.CassandraRelevantProperties.DISABLED_ALL_COMPACTIONS;
 import static org.apache.cassandra.config.CassandraRelevantProperties.UNSAFE_SYSTEM;
 import static org.apache.cassandra.utils.Throwables.maybeFail;
 import static org.apache.cassandra.utils.Throwables.merge;
@@ -617,7 +617,7 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
                         DISABLED_AUTO_COMPACTION_PROPERTY.getBoolean());
             this.strategyContainer.disable();
         }
-        if (!LOAD_COMPACTION_ENABLED.getBoolean())
+        if (DISABLED_ALL_COMPACTIONS.getBoolean())
         {
             this.strategyContainer.shutdown();
         }

--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -194,6 +194,7 @@ import org.json.simple.JSONObject;
 
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static org.apache.cassandra.config.CassandraRelevantProperties.DISABLED_AUTO_COMPACTION_PROPERTY;
+import static org.apache.cassandra.config.CassandraRelevantProperties.LOAD_COMPACTION_ENABLED;
 import static org.apache.cassandra.config.CassandraRelevantProperties.UNSAFE_SYSTEM;
 import static org.apache.cassandra.utils.Throwables.maybeFail;
 import static org.apache.cassandra.utils.Throwables.merge;
@@ -615,6 +616,10 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
                         metadata, strategyContainer.isEnabled(), DISABLED_AUTO_COMPACTION_PROPERTY.getKey(),
                         DISABLED_AUTO_COMPACTION_PROPERTY.getBoolean());
             this.strategyContainer.disable();
+        }
+        if (!LOAD_COMPACTION_ENABLED.getBoolean())
+        {
+            this.strategyContainer.shutdown();
         }
 
         // create the private ColumnFamilyStores for the secondary column indexes

--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -610,16 +610,18 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
                                                         storageHandler.enableAutoCompaction());
         getTracker().subscribe(strategyContainer);
 
-        if (!strategyContainer.isEnabled() || DISABLED_AUTO_COMPACTION_PROPERTY.getBoolean())
+        if (DISABLED_ALL_COMPACTIONS.getBoolean())
         {
+            this.strategyContainer.shutdown();
+            this.strategyContainer.disable();
+        } else if (!strategyContainer.isEnabled() || DISABLED_AUTO_COMPACTION_PROPERTY.getBoolean())
+        {
+            //don't shut down the compaction system, but do turn off auto compactions.
+            
             logger.info("Strategy driven background compactions for {} are disabled: strategy container={}, {}={}",
                         metadata, strategyContainer.isEnabled(), DISABLED_AUTO_COMPACTION_PROPERTY.getKey(),
                         DISABLED_AUTO_COMPACTION_PROPERTY.getBoolean());
             this.strategyContainer.disable();
-        }
-        if (DISABLED_ALL_COMPACTIONS.getBoolean())
-        {
-            this.strategyContainer.shutdown();
         }
 
         // create the private ColumnFamilyStores for the secondary column indexes

--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -193,6 +193,7 @@ import org.json.simple.JSONObject;
 
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static org.apache.cassandra.config.CassandraRelevantProperties.DISABLED_AUTO_COMPACTION_PROPERTY;
+import static org.apache.cassandra.config.CassandraRelevantProperties.LOAD_COMPACTION_ENABLED;
 import static org.apache.cassandra.config.CassandraRelevantProperties.UNSAFE_SYSTEM;
 import static org.apache.cassandra.utils.Throwables.maybeFail;
 import static org.apache.cassandra.utils.Throwables.merge;
@@ -614,6 +615,10 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
                         metadata, strategyContainer.isEnabled(), DISABLED_AUTO_COMPACTION_PROPERTY.getKey(),
                         DISABLED_AUTO_COMPACTION_PROPERTY.getBoolean());
             this.strategyContainer.disable();
+        }
+        if (!LOAD_COMPACTION_ENABLED.getBoolean())
+        {
+            this.strategyContainer.shutdown();
         }
 
         // create the private ColumnFamilyStores for the secondary column indexes

--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -193,7 +193,7 @@ import org.json.simple.JSONObject;
 
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static org.apache.cassandra.config.CassandraRelevantProperties.DISABLED_AUTO_COMPACTION_PROPERTY;
-import static org.apache.cassandra.config.CassandraRelevantProperties.LOAD_COMPACTION_ENABLED;
+import static org.apache.cassandra.config.CassandraRelevantProperties.DISABLED_ALL_COMPACTIONS;
 import static org.apache.cassandra.config.CassandraRelevantProperties.UNSAFE_SYSTEM;
 import static org.apache.cassandra.utils.Throwables.maybeFail;
 import static org.apache.cassandra.utils.Throwables.merge;
@@ -616,7 +616,7 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
                         DISABLED_AUTO_COMPACTION_PROPERTY.getBoolean());
             this.strategyContainer.disable();
         }
-        if (!LOAD_COMPACTION_ENABLED.getBoolean())
+        if (DISABLED_ALL_COMPACTIONS.getBoolean())
         {
             this.strategyContainer.shutdown();
         }

--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -609,16 +609,18 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
                                                         storageHandler.enableAutoCompaction());
         getTracker().subscribe(strategyContainer);
 
-        if (!strategyContainer.isEnabled() || DISABLED_AUTO_COMPACTION_PROPERTY.getBoolean())
+        if (DISABLED_ALL_COMPACTIONS.getBoolean())
         {
+            this.strategyContainer.shutdown();
+            this.strategyContainer.disable();
+        } else if (!strategyContainer.isEnabled() || DISABLED_AUTO_COMPACTION_PROPERTY.getBoolean())
+        {
+            //don't shut down the compaction system, but do turn off auto compactions.
+            
             logger.info("Strategy driven background compactions for {} are disabled: strategy container={}, {}={}",
                         metadata, strategyContainer.isEnabled(), DISABLED_AUTO_COMPACTION_PROPERTY.getKey(),
                         DISABLED_AUTO_COMPACTION_PROPERTY.getBoolean());
             this.strategyContainer.disable();
-        }
-        if (DISABLED_ALL_COMPACTIONS.getBoolean())
-        {
-            this.strategyContainer.shutdown();
         }
 
         // create the private ColumnFamilyStores for the secondary column indexes

--- a/test/unit/org/apache/cassandra/db/ColumnFamilyStoreTest.java
+++ b/test/unit/org/apache/cassandra/db/ColumnFamilyStoreTest.java
@@ -125,12 +125,27 @@ public class ColumnFamilyStoreTest
         // test that compactions are not active if we disable them all.
 
         // we have to first unload the keyspace to ensure that when it reopens it checks compaction flags.
-        Keyspace.open(KEYSPACE1).unload(false);
         System.setProperty(CassandraRelevantProperties.DISABLED_ALL_COMPACTIONS.getKey(), "true");
-        ColumnFamilyStore cfs = Keyspace.open(KEYSPACE1).getColumnFamilyStore(CF_STANDARD1);
+        Keyspace ks = null;
+        try
+        {
+            SchemaLoader.createKeyspace("KS3", KeyspaceParams.simple(1),
+                                        SchemaLoader.standardCFMD("KS3", "S3"));
+            ks = Keyspace.open("KS3");
+            ColumnFamilyStore cfs = ks.getColumnFamilyStore("S3");
 
-        ObjectAssert<CompactionStrategyContainer> containerAssert = assertThat(cfs.getCompactionStrategyContainer());
-        containerAssert.extracting(CompactionStrategyContainer::isActive).isEqualTo(false);
+            ObjectAssert<CompactionStrategyContainer> containerAssert = assertThat(cfs.getCompactionStrategyContainer());
+            containerAssert.extracting(CompactionStrategyContainer::isActive).isEqualTo(false);
+        }
+        finally
+        {
+            System.setProperty(CassandraRelevantProperties.DISABLED_ALL_COMPACTIONS.getKey(), "false");
+            if (ks != null)
+            {
+                //reload the keyspace for other tests to use
+                ks.unload(false);
+            }
+        }
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/db/ColumnFamilyStoreTest.java
+++ b/test/unit/org/apache/cassandra/db/ColumnFamilyStoreTest.java
@@ -33,7 +33,9 @@ import java.util.stream.IntStream;
 
 import com.google.common.collect.Iterators;
 import com.googlecode.concurrenttrees.common.Iterables;
+import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.db.commitlog.CommitLogPosition;
+import org.apache.cassandra.db.compaction.CompactionStrategyContainer;
 import org.apache.cassandra.db.compaction.TableOperation;
 import org.apache.cassandra.db.filter.ColumnFilter;
 import org.apache.cassandra.db.memtable.AbstractAllocatorMemtable;
@@ -43,6 +45,7 @@ import org.apache.cassandra.db.partitions.Partition;
 import org.apache.cassandra.db.partitions.PartitionUpdate;
 import org.apache.cassandra.index.transactions.UpdateTransaction;
 import org.apache.cassandra.utils.concurrent.OpOrder;
+import org.assertj.core.api.ObjectAssert;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
@@ -114,6 +117,20 @@ public class ColumnFamilyStoreTest
         Keyspace.open(KEYSPACE1).getColumnFamilyStore(CF_STANDARD1).truncateBlocking();
         Keyspace.open(KEYSPACE1).getColumnFamilyStore(CF_STANDARD2).truncateBlocking();
         Keyspace.open(KEYSPACE2).getColumnFamilyStore(CF_STANDARD1).truncateBlocking();
+    }
+
+    @Test
+    public void testDisablingCompactionActuallyDisablesCompaction()
+    {
+        // test that compactions are not active if we disable them all.
+
+        // we have to first unload the keyspace to ensure that when it reopens it checks compaction flags.
+        Keyspace.open(KEYSPACE1).unload(false);
+        System.setProperty(CassandraRelevantProperties.DISABLED_ALL_COMPACTIONS.getKey(), "true");
+        ColumnFamilyStore cfs = Keyspace.open(KEYSPACE1).getColumnFamilyStore(CF_STANDARD1);
+
+        ObjectAssert<CompactionStrategyContainer> containerAssert = assertThat(cfs.getCompactionStrategyContainer());
+        containerAssert.extracting(CompactionStrategyContainer::isActive).isEqualTo(false);
     }
 
     @Test


### PR DESCRIPTION
https://github.com/riptano/cndb/issues/17127

### What is the issue
In some environments, compaction is not desirable--it'll never actually run, so we don't want to initialize or manage the related resources (metrics, scheduled tasks, and so forth). In those situations, we want to be able to open a ColumnFamilyStore without initializing Compaction.

Unfortunately, Compaction logic is re-used in ancillary areas (like Schema reads), so we can't just not create the compaction logic. Instead, we need to basically shut it down immediately after creating it.

This manifests as excess resource usage in places like the RegionService, which can be seen in https://github.com/riptano/cndb/issues/17127

### What does this PR fix and why was it fixed
This adds a system property to allow process-wide compaction disabling.  when this flag is set, the compaction strategy is immediately shutdown after being reloaded. This (should) remove scheduled tasks, metrics, etc. and prevent compaction from using resources needlessly.

