### PR TITLE
CNDB-17045: write zero delta when localDeletionTime overflows an int

### DIFF
--- a/src/java/org/apache/cassandra/db/SerializationHeader.java
+++ b/src/java/org/apache/cassandra/db/SerializationHeader.java
@@ -196,7 +196,13 @@ public class SerializationHeader
     public void writeDeletionTime(DeletionTime dt, DataOutputPlus out) throws IOException
     {
         writeTimestamp(dt.markedForDeleteAt(), out);
-        writeLocalDeletionTime(dt.localDeletionTime(), out);
+        // LIVE DeletionTime has localDeletionTime=Long.MAX_VALUE which overflows the 32-bit delta encoding
+        // (Long.MAX_VALUE - minLocalDeletionTime doesn't fit in an int). Write a zero delta instead;
+        // the read side recognizes LIVE by markedForDeleteAt == Long.MIN_VALUE.
+        if (dt.isLive())
+            writeLocalDeletionTime(stats.minLocalDeletionTime, out);
+        else
+            writeLocalDeletionTime(dt.localDeletionTime(), out);
     }
 
     public long readTimestamp(DataInputPlus in) throws IOException
@@ -218,6 +224,11 @@ public class SerializationHeader
     {
         long markedAt = readTimestamp(in);
         long localDeletionTime = readLocalDeletionTime(in);
+        // markedForDeleteAt == Long.MIN_VALUE means LIVE (no deletion). The localDeletionTime may be corrupt
+        // due to a 32-bit overflow bug in the delta encoding of Long.MAX_VALUE (CASSANDRA-14227), so we
+        // ignore it and return LIVE directly. This handles both old (broken) and new (fixed) sstables.
+        if (markedAt == Long.MIN_VALUE)
+            return DeletionTime.LIVE;
         return DeletionTime.build(markedAt, localDeletionTime);
     }
 
@@ -239,7 +250,7 @@ public class SerializationHeader
     public long deletionTimeSerializedSize(DeletionTime dt)
     {
         return timestampSerializedSize(dt.markedForDeleteAt())
-               + localDeletionTimeSerializedSize(dt.localDeletionTime());
+               + localDeletionTimeSerializedSize(dt.isLive() ? stats.minLocalDeletionTime : dt.localDeletionTime());
     }
 
     public void skipTimestamp(DataInputPlus in) throws IOException

--- a/src/java/org/apache/cassandra/io/sstable/compaction/SortedStringTableCursor.java
+++ b/src/java/org/apache/cassandra/io/sstable/compaction/SortedStringTableCursor.java
@@ -328,7 +328,7 @@ public class SortedStringTableCursor implements SSTableCursor
                         complexDeletion = header.readDeletionTime(dataFile);
                         if (!complexDeletion.validate())
                             UnfilteredValidation.handleInvalid(sstable.metadata(), partitionKey, sstable,
-                                                               "complexColumnDeletion="+complexDeletion.toString());
+                                                               "complexColumnDeletion="+complexDeletion.toString()+" column="+columnMetadata.name);
                         if (helper.isDroppedComplexDeletion(complexDeletion))
                             complexDeletion = DeletionTime.LIVE;
                     }

--- a/test/unit/org/apache/cassandra/cql3/validation/entities/CollectionsTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/entities/CollectionsTest.java
@@ -26,6 +26,8 @@ import com.datastax.driver.core.DataType;
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.utils.UUIDs;
+import org.apache.cassandra.config.Config;
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.CQLTester;
 import org.apache.cassandra.cql3.ColumnSpecification;
 import org.apache.cassandra.cql3.UntypedResultSet;
@@ -2086,6 +2088,55 @@ public class CollectionsTest extends CQLTester
         assertRows(execute("SELECT c[..'t2'] FROM %s"), row(map("t1", 1, "t2", 2)));
         assertRows(execute("SELECT c['t3'..] FROM %s"), row(map("t3", 3, "t4", 4)));
         assertRows(execute("SELECT c[..'t5'] FROM %s"), row(map("t1", 1, "t2", 2, "t3", 3, "t4", 4)));
+    }
+
+    /**
+     * CNDB-17045: When a row has multiple complex columns (e.g. set + map) and only a subset are
+     * updated, untouched columns carry DeletionTime.LIVE as their complex deletion. A 32-bit
+     * overflow in SerializationHeader.writeLocalDeletionTime caused LIVE's localDeletionTime
+     * (Long.MAX_VALUE) to be corrupted during delta encoding. With corrupted_tombstone_strategy
+     * set to exception, this would surface as CorruptSSTableException during compaction or reads.
+     * <p>
+     * Note: BTreeRow.CellResolver.resolve() currently heals the corrupted InvalidDeletionTime
+     * back to DeletionTime.LIVE during row construction, because the overflowed LIVE deletion
+     * has markedForDeleteAt=Long.MIN_VALUE and Long.MIN_VALUE > Long.MIN_VALUE is false. This
+     * makes the corruption invisible to UnfilteredValidation at the CQL level. The primary
+     * protection is the fix in SerializationHeader.writeDeletionTime; this test serves as an
+     * extra regression guard.
+     *
+     * @see BTreeRow.Builder.CellResolver#resolve(Object[], int, int)
+     */
+    @Test
+    public void testMixedComplexDeletionsWithCorruptedTombstoneException() throws Throwable
+    {
+        Config.CorruptedTombstoneStrategy original = DatabaseDescriptor.getCorruptedTombstoneStrategy();
+        try
+        {
+            DatabaseDescriptor.setCorruptedTombstoneStrategy(Config.CorruptedTombstoneStrategy.exception);
+
+            createTable("CREATE TABLE %s (k int PRIMARY KEY, s set<text>, m map<text, text>)");
+
+            // Insert setting only the set column — the map column's complex deletion will be LIVE
+            execute("INSERT INTO %s (k, s) VALUES (1, {'a', 'b'})");
+            flush();
+
+            // Update only the map column — the set column's complex deletion will be LIVE
+            execute("UPDATE %s SET m = m + {'x': '1'} WHERE k = 1");
+            flush();
+
+            // Compaction reads both sstables and re-serializes the merged row.
+            // Before the fix, the LIVE complex deletion on the untouched column would overflow
+            // the 32-bit delta encoding in writeLocalDeletionTime.
+            compact();
+
+            // Read back to verify no CorruptSSTableException and data integrity
+            assertRows(execute("SELECT k, s, m FROM %s WHERE k = 1"),
+                       row(1, set("a", "b"), map("x", "1")));
+        }
+        finally
+        {
+            DatabaseDescriptor.setCorruptedTombstoneStrategy(original);
+        }
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/db/SerializationHeaderTest.java
+++ b/test/unit/org/apache/cassandra/db/SerializationHeaderTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.cassandra.db;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Collections;
@@ -58,6 +59,8 @@ import org.apache.cassandra.io.sstable.format.SSTableWriter;
 import org.apache.cassandra.io.sstable.format.Version;
 import org.apache.cassandra.io.sstable.format.bti.BtiFormat;
 import org.apache.cassandra.io.sstable.metadata.MetadataCollector;
+import org.apache.cassandra.io.util.DataInputBuffer;
+import org.apache.cassandra.io.util.DataOutputBuffer;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.schema.ColumnMetadata;
@@ -243,6 +246,79 @@ public class SerializationHeaderTest
         SerializationHeader header2 = component.toHeader("tab", metadata, versionWithExplicitFrozenTuples, false);
         assertThat(Iterables.find(header2.columns().regulars, md -> md.name.toString().equals("dv")).type.isMultiCell()).isTrue();
         assertThat(Iterables.find(header2.columns().statics, md -> md.name.toString().equals("ds")).type.isMultiCell()).isTrue();
+    }
+
+    /**
+     * Verify that DeletionTime.LIVE round-trips correctly through writeDeletionTime/readDeletionTime
+     * when the header has realistic (non-epoch) encoding stats. This exercises the fix for the 32-bit
+     * overflow bug where Long.MAX_VALUE (LIVE's localDeletionTime) minus a realistic minLocalDeletionTime
+     * doesn't fit in an int.
+     */
+    @Test
+    public void testLiveDeletionTimeRoundTrip() throws IOException
+    {
+        // Use realistic encoding stats — a real compaction would have a recent minLocalDeletionTime,
+        // which makes the delta (Long.MAX_VALUE - minLocalDeletionTime) overflow a 32-bit int.
+        long realisticTimestamp = System.currentTimeMillis() * 1000;
+        long realisticLocalDeletionTime = System.currentTimeMillis() / 1000;
+        EncodingStats stats = new EncodingStats(realisticTimestamp, realisticLocalDeletionTime, 0);
+
+        TableMetadata metadata = TableMetadata.builder("ks", "tab")
+                                              .addPartitionKeyColumn("k", Int32Type.instance)
+                                              .addRegularColumn("v", Int32Type.instance)
+                                              .build();
+        SerializationHeader header = new SerializationHeader(true, metadata, metadata.regularAndStaticColumns(), stats);
+
+        try (DataOutputBuffer out = new DataOutputBuffer())
+        {
+            header.writeDeletionTime(DeletionTime.LIVE, out);
+
+            try (DataInputBuffer in = new DataInputBuffer(out.getData(), 0, out.getLength()))
+            {
+                DeletionTime result = header.readDeletionTime(in);
+                assertThat(result.isLive()).isTrue();
+                assertThat(result).isEqualTo(DeletionTime.LIVE);
+            }
+        }
+    }
+
+    /**
+     * Verify that old (broken) sstables where LIVE DeletionTime was written with the overflow bug
+     * are still read back as LIVE. In the broken encoding, markedForDeleteAt is Long.MIN_VALUE
+     * (correctly delta-encoded) but localDeletionTime is garbage (-1 after 32-bit overflow).
+     * The read side should recognize LIVE by markedForDeleteAt == Long.MIN_VALUE and ignore the
+     * corrupt localDeletionTime.
+     */
+    @Test
+    public void testLiveDeletionTimeReadBackwardCompatibility() throws IOException
+    {
+        long realisticTimestamp = System.currentTimeMillis() * 1000;
+        long realisticLocalDeletionTime = System.currentTimeMillis() / 1000;
+        EncodingStats stats = new EncodingStats(realisticTimestamp, realisticLocalDeletionTime, 0);
+
+        TableMetadata metadata = TableMetadata.builder("ks", "tab")
+                                              .addPartitionKeyColumn("k", Int32Type.instance)
+                                              .addRegularColumn("v", Int32Type.instance)
+                                              .build();
+        SerializationHeader header = new SerializationHeader(true, metadata, metadata.regularAndStaticColumns(), stats);
+
+        // Simulate the old broken encoding: write the timestamp delta for Long.MIN_VALUE (correct),
+        // then write -1 as the localDeletionTime delta (what the old code produced from overflow).
+        try (DataOutputBuffer out = new DataOutputBuffer())
+        {
+            // Write timestamp: Long.MIN_VALUE - stats.minTimestamp (this is what the old code wrote correctly)
+            header.writeTimestamp(Long.MIN_VALUE, out);
+            // Write the overflowed localDeletionTime delta: the old broken code cast
+            // (Long.MAX_VALUE - minLocalDeletionTime) to int, which wraps to -1 for realistic stats.
+            // writeUnsignedVInt32 with -1 (0xFFFFFFFF) produces a specific byte sequence.
+            out.writeUnsignedVInt32(-1);
+
+            try (DataInputBuffer in = new DataInputBuffer(out.getData(), 0, out.getLength()))
+            {
+                DeletionTime result = header.readDeletionTime(in);
+                assertThat(result.isLive()).isTrue();
+            }
+        }
     }
 
 }


### PR DESCRIPTION
### What is the issue
when a row has multiple complex columns but only a subset are updated, the untouched columns carry DeletionTime.LIVE as their complex deletion. This causes SerializationHeader.writeDeletionTime to overflow the localDeletionTime delta encoding, producing invalid sstables that will fail if the `corrupted_tombstone_strategy` is set to `exception`.

### What does this PR fix and why was it fixed
Write DeletionTime.LIVE directly instead of overflowing.