### PR TITLE
HCD-238 Harden cross cluster node joins checks

### DIFF
--- a/src/java/org/apache/cassandra/gms/ApplicationState.java
+++ b/src/java/org/apache/cassandra/gms/ApplicationState.java
@@ -57,11 +57,6 @@ public enum ApplicationState
     STATUS_WITH_PORT, //Replacement for STATUS
     DISK_USAGE,
     /**
-     * Free style JSON paylod Map<key, value>. Pprevios Enum ordinals approach could easily create
-     * collisions on upgrades, incompatibilities, mismatches, etc.
-     */
-    JSON_PAYLOAD,
-    /**
      * The set of sstable versions on this node. This will usually be only the "current" sstable format (the one with
      * which new sstables are written), but may contain more on newly upgraded nodes before `upgradesstable` has been
      * run.
@@ -71,6 +66,11 @@ public enum ApplicationState
      **/
     SSTABLE_VERSIONS,
     INDEX_STATUS,
+    /**
+     * Free style JSON paylod Map<key, value>. Pprevios Enum ordinals approach could easily create
+     * collisions on upgrades, incompatibilities, mismatches, etc.
+     */
+    JSON_PAYLOAD,
     // DO NOT EDIT OR REMOVE PADDING STATES BELOW - only add new states above.  See CASSANDRA-16484
     X1,
     X2,
@@ -91,11 +91,13 @@ public enum ApplicationState
 
     private static final ObjectMapper jsonMapper = new ObjectMapper();
 
-    public static final Map<String, Object> initialJsonPayload = new HashMap<String, Object>()
-    {{
-        put(JsonPayload.CLUSTER_NAME.name(), DatabaseDescriptor.getClusterName());
-        put(JsonPayload.PARTITIONER_NAME.name(), DatabaseDescriptor.getPartitionerName());
-    }};
+    static final Map<String, Object> initialJsonPayload;
+
+    static {
+        initialJsonPayload = new HashMap<>();
+        initialJsonPayload.put(JsonPayload.CLUSTER_NAME.name(), DatabaseDescriptor.getClusterName());
+        initialJsonPayload.put(JsonPayload.PARTITIONER_NAME.name(), DatabaseDescriptor.getPartitionerName());
+    }
 
     public static Map<String, Object> deserializeJsonPayload(VersionedValue value)
     {

--- a/src/java/org/apache/cassandra/gms/ApplicationState.java
+++ b/src/java/org/apache/cassandra/gms/ApplicationState.java
@@ -17,6 +17,14 @@
  */
 package org.apache.cassandra.gms;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.service.StorageService;
+
 /**
  * The various "states" exchanged through Gossip.
  *
@@ -49,6 +57,11 @@ public enum ApplicationState
     STATUS_WITH_PORT, //Replacement for STATUS
     DISK_USAGE,
     /**
+     * Free style JSON paylod Map<key, value>. Pprevios Enum ordinals approach could easily create
+     * collisions on upgrades, incompatibilities, mismatches, etc.
+     */
+    JSON_PAYLOAD,
+    /**
      * The set of sstable versions on this node. This will usually be only the "current" sstable format (the one with
      * which new sstables are written), but may contain more on newly upgraded nodes before `upgradesstable` has been
      * run.
@@ -68,5 +81,49 @@ public enum ApplicationState
     X7,
     X8,
     X9,
-    X10,
+    X10;
+
+    public enum JsonPayload
+    {
+        CLUSTER_NAME,
+        PARTITIONER_NAME;
+    }
+
+    private static final ObjectMapper jsonMapper = new ObjectMapper();
+
+    public static final Map<String, Object> initialJsonPayload = new HashMap<String, Object>()
+    {{
+        put(JsonPayload.CLUSTER_NAME.name(), DatabaseDescriptor.getClusterName());
+        put(JsonPayload.PARTITIONER_NAME.name(), DatabaseDescriptor.getPartitionerName());
+    }};
+
+    public static Map<String, Object> deserializeJsonPayload(VersionedValue value)
+    {
+        try
+        {
+            if (value == null)
+                return null;
+            else
+                return jsonMapper.readValue(value.value, Map.class);
+        }
+        catch (JsonProcessingException e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static VersionedValue serializeJsonPayload(Map<String, Object> payload)
+    {
+        try
+        {
+            if (payload == null)
+                return null;
+            else
+                return StorageService.instance.valueFactory.datacenter(jsonMapper.writeValueAsString(payload));
+        }
+        catch (JsonProcessingException e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
 }

--- a/src/java/org/apache/cassandra/gms/GossipDigest.java
+++ b/src/java/org/apache/cassandra/gms/GossipDigest.java
@@ -19,6 +19,8 @@ package org.apache.cassandra.gms;
 
 import java.io.*;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import org.apache.cassandra.db.TypeSizes;
 import org.apache.cassandra.io.IVersionedSerializer;
 import org.apache.cassandra.io.util.DataInputPlus;
@@ -44,6 +46,12 @@ public class GossipDigest implements Comparable<GossipDigest>
         endpoint = ep;
         generation = gen;
         maxVersion = version;
+    }
+
+    @VisibleForTesting
+    public static GossipDigest getUnsafeForTest(InetAddressAndPort ep, int gen, int version)
+    {
+        return new GossipDigest(ep, gen, version);
     }
 
     InetAddressAndPort getEndpoint()

--- a/src/java/org/apache/cassandra/gms/GossipDigestAck.java
+++ b/src/java/org/apache/cassandra/gms/GossipDigestAck.java
@@ -22,6 +22,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import org.apache.cassandra.db.TypeSizes;
 import org.apache.cassandra.io.IVersionedSerializer;
 import org.apache.cassandra.io.util.DataInputPlus;
@@ -47,9 +49,21 @@ public class GossipDigestAck
         this.epStateMap = epStateMap;
     }
 
+    @VisibleForTesting
+    public static GossipDigestAck getInstanceUnsafeForTesting(List<GossipDigest> gDigestList, Map<InetAddressAndPort, EndpointState> epStateMap)
+    {
+        return new GossipDigestAck(gDigestList, epStateMap);
+    }
+
     List<GossipDigest> getGossipDigestList()
     {
         return gDigestList;
+    }
+
+    @VisibleForTesting
+    public Map<InetAddressAndPort, EndpointState> getEndpointStateMapUnsafeForTest()
+    {
+        return epStateMap;
     }
 
     Map<InetAddressAndPort, EndpointState> getEndpointStateMap()

--- a/src/java/org/apache/cassandra/gms/GossipDigestAck2.java
+++ b/src/java/org/apache/cassandra/gms/GossipDigestAck2.java
@@ -21,6 +21,8 @@ import java.io.*;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import org.apache.cassandra.db.TypeSizes;
 import org.apache.cassandra.io.IVersionedSerializer;
 import org.apache.cassandra.io.util.DataInputPlus;
@@ -38,6 +40,12 @@ public class GossipDigestAck2
     public static final IVersionedSerializer<GossipDigestAck2> serializer = new GossipDigestAck2Serializer();
 
     final Map<InetAddressAndPort, EndpointState> epStateMap;
+
+    @VisibleForTesting
+    public static GossipDigestAck2 getInstanceUnsafeForTesting(Map<InetAddressAndPort, EndpointState> epStateMap)
+    {
+        return new GossipDigestAck2(epStateMap);
+    }
 
     GossipDigestAck2(Map<InetAddressAndPort, EndpointState> epStateMap)
     {

--- a/src/java/org/apache/cassandra/gms/GossipDigestAck2VerbHandler.java
+++ b/src/java/org/apache/cassandra/gms/GossipDigestAck2VerbHandler.java
@@ -33,11 +33,10 @@ public class GossipDigestAck2VerbHandler extends GossipVerbHandler<GossipDigestA
 
     public void doVerb(Message<GossipDigestAck2> message)
     {
+        InetAddressAndPort from = message.from();
         if (logger.isTraceEnabled())
-        {
-            InetAddressAndPort from = message.from();
             logger.trace("Received a GossipDigestAck2Message from {}", from);
-        }
+
         if (!Gossiper.instance.isEnabled())
         {
             if (logger.isTraceEnabled())
@@ -45,6 +44,12 @@ public class GossipDigestAck2VerbHandler extends GossipVerbHandler<GossipDigestA
             return;
         }
         Map<InetAddressAndPort, EndpointState> remoteEpStateMap = message.payload.getEndpointStateMap();
+
+        // Cross-cluster safety checks
+        if (!Gossiper.maybeBelongsInCluster(from, remoteEpStateMap.get(from)))
+            return;
+        remoteEpStateMap = Gossiper.removeForeignClusterNodes(remoteEpStateMap);
+
         /* Notify the Failure Detector */
         Gossiper.instance.notifyFailureDetector(remoteEpStateMap);
         Gossiper.instance.applyStateLocally(remoteEpStateMap);

--- a/src/java/org/apache/cassandra/gms/GossipDigestAckVerbHandler.java
+++ b/src/java/org/apache/cassandra/gms/GossipDigestAckVerbHandler.java
@@ -53,6 +53,11 @@ public class GossipDigestAckVerbHandler extends GossipVerbHandler<GossipDigestAc
         Map<InetAddressAndPort, EndpointState> epStateMap = gDigestAckMessage.getEndpointStateMap();
         logger.trace("Received ack with {} digests and {} states", gDigestList.size(), epStateMap.size());
 
+        // Cross-cluster safety checks
+        if (!Gossiper.maybeBelongsInCluster(from, epStateMap.get(from)))
+            return;
+        epStateMap = Gossiper.removeForeignClusterNodes(epStateMap);
+
         if (Gossiper.instance.isInShadowRound())
         {
             if (logger.isDebugEnabled())

--- a/src/java/org/apache/cassandra/gms/GossipDigestSynVerbHandler.java
+++ b/src/java/org/apache/cassandra/gms/GossipDigestSynVerbHandler.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,7 +31,9 @@ import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.net.Message;
 import org.apache.cassandra.net.MessagingService;
+import org.apache.cassandra.utils.FBUtilities;
 
+import static org.apache.cassandra.gms.Gossiper.removeForeignClusterNodes;
 import static org.apache.cassandra.net.Verb.GOSSIP_DIGEST_ACK;
 
 public class GossipDigestSynVerbHandler extends GossipVerbHandler<GossipDigestSyn>
@@ -112,11 +115,29 @@ public class GossipDigestSynVerbHandler extends GossipVerbHandler<GossipDigestSy
         super.doVerb(message);
     }
 
+    @VisibleForTesting
+    public static Message<GossipDigestAck> createNormalReplyUnsafeForTest(List<GossipDigest> gDigestList)
+    {
+        return createNormalReply(gDigestList);
+    }
+
     private static Message<GossipDigestAck> createNormalReply(List<GossipDigest> gDigestList)
     {
         List<GossipDigest> deltaGossipDigestList = new ArrayList<>();
         Map<InetAddressAndPort, EndpointState> deltaEpStateMap = new HashMap<>();
         Gossiper.instance.examineGossiper(gDigestList, deltaGossipDigestList, deltaEpStateMap);
+
+        InetAddressAndPort nodeAddress = FBUtilities.getBroadcastAddressAndPort();
+        // Send cluster and partitioner names for cluster foreign node checks
+        if (deltaEpStateMap.get(nodeAddress) != null)
+        {
+            if (!deltaEpStateMap.get(nodeAddress).containsApplicationState(ApplicationState.JSON_PAYLOAD))
+                deltaEpStateMap.get(nodeAddress).addApplicationState(ApplicationState.JSON_PAYLOAD,
+                                                                     ApplicationState.serializeJsonPayload(ApplicationState.initialJsonPayload));
+
+        }
+        deltaEpStateMap = removeForeignClusterNodes(deltaEpStateMap);
+
         logger.trace("sending {} digests and {} deltas", deltaGossipDigestList.size(), deltaEpStateMap.size());
 
         return Message.out(GOSSIP_DIGEST_ACK, new GossipDigestAck(deltaGossipDigestList, deltaEpStateMap));
@@ -125,6 +146,18 @@ public class GossipDigestSynVerbHandler extends GossipVerbHandler<GossipDigestSy
     private static Message<GossipDigestAck> createShadowReply()
     {
         Map<InetAddressAndPort, EndpointState> stateMap = Gossiper.instance.examineShadowState();
+
+        InetAddressAndPort nodeAddress = FBUtilities.getBroadcastAddressAndPort();
+        // Send cluster and partitioner names for cluster foreign node checks
+        if (stateMap.get(nodeAddress) != null)
+        {
+            if (!stateMap.get(nodeAddress).containsApplicationState(ApplicationState.JSON_PAYLOAD))
+                stateMap.get(nodeAddress).addApplicationState(ApplicationState.JSON_PAYLOAD,
+                                                              ApplicationState.serializeJsonPayload(ApplicationState.initialJsonPayload));
+
+        }
+        stateMap = removeForeignClusterNodes(stateMap);
+
         logger.trace("sending 0 digests and {} deltas", stateMap.size());
         return Message.out(GOSSIP_DIGEST_ACK, new GossipDigestAck(Collections.emptyList(), stateMap));
     }

--- a/src/java/org/apache/cassandra/gms/GossipDigestSynVerbHandler.java
+++ b/src/java/org/apache/cassandra/gms/GossipDigestSynVerbHandler.java
@@ -129,11 +129,11 @@ public class GossipDigestSynVerbHandler extends GossipVerbHandler<GossipDigestSy
 
         InetAddressAndPort nodeAddress = FBUtilities.getBroadcastAddressAndPort();
         // Send cluster and partitioner names for cluster foreign node checks
-        if (deltaEpStateMap.get(nodeAddress) != null)
+        if (deltaEpStateMap.get(nodeAddress) != null &&
+            !deltaEpStateMap.get(nodeAddress).containsApplicationState(ApplicationState.JSON_PAYLOAD))
         {
-            if (!deltaEpStateMap.get(nodeAddress).containsApplicationState(ApplicationState.JSON_PAYLOAD))
-                deltaEpStateMap.get(nodeAddress).addApplicationState(ApplicationState.JSON_PAYLOAD,
-                                                                     ApplicationState.serializeJsonPayload(ApplicationState.initialJsonPayload));
+            deltaEpStateMap.get(nodeAddress).addApplicationState(ApplicationState.JSON_PAYLOAD,
+                                                                 ApplicationState.serializeJsonPayload(ApplicationState.initialJsonPayload));
 
         }
         deltaEpStateMap = removeForeignClusterNodes(deltaEpStateMap);
@@ -149,11 +149,11 @@ public class GossipDigestSynVerbHandler extends GossipVerbHandler<GossipDigestSy
 
         InetAddressAndPort nodeAddress = FBUtilities.getBroadcastAddressAndPort();
         // Send cluster and partitioner names for cluster foreign node checks
-        if (stateMap.get(nodeAddress) != null)
+        if (stateMap.get(nodeAddress) != null &&
+            !stateMap.get(nodeAddress).containsApplicationState(ApplicationState.JSON_PAYLOAD))
         {
-            if (!stateMap.get(nodeAddress).containsApplicationState(ApplicationState.JSON_PAYLOAD))
-                stateMap.get(nodeAddress).addApplicationState(ApplicationState.JSON_PAYLOAD,
-                                                              ApplicationState.serializeJsonPayload(ApplicationState.initialJsonPayload));
+            stateMap.get(nodeAddress).addApplicationState(ApplicationState.JSON_PAYLOAD,
+                                                          ApplicationState.serializeJsonPayload(ApplicationState.initialJsonPayload));
 
         }
         stateMap = removeForeignClusterNodes(stateMap);

--- a/src/java/org/apache/cassandra/gms/GossipShutdownVerbHandler.java
+++ b/src/java/org/apache/cassandra/gms/GossipShutdownVerbHandler.java
@@ -36,6 +36,15 @@ public class GossipShutdownVerbHandler implements IVerbHandler
             logger.debug("Ignoring shutdown message from {} because gossip is disabled", message.from());
             return;
         }
+
+        // Cross-cluster safety checks
+        EndpointState fromEpState = Gossiper.instance.getEndpointStateForEndpoint(message.from());
+        if (!Gossiper.maybeBelongsInCluster(message.from(), fromEpState))
+        {
+            logger.error("Ignoring shutdown from {} which doesn't belong in this cluster", message.from());
+            return;
+        }
+
         Gossiper.instance.markAsShutdown(message.from());
     }
 

--- a/src/java/org/apache/cassandra/gms/Gossiper.java
+++ b/src/java/org/apache/cassandra/gms/Gossiper.java
@@ -28,6 +28,7 @@ import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -59,6 +60,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.ListenableFutureTask;
 import com.google.common.util.concurrent.Uninterruptibles;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1327,6 +1329,11 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
         return endpointStateMap.size();
     }
 
+    public Map<InetAddressAndPort, EndpointState> getEndpointStateMapUnsafeForTest()
+    {
+        return getEndpointStateMap();
+    }
+
     Map<InetAddressAndPort, EndpointState> getEndpointStateMap()
     {
         return ImmutableMap.copyOf(endpointStateMap);
@@ -1347,7 +1354,8 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
         return ImmutableSet.copyOf(seedsInShadowRound);
     }
 
-    long getLastProcessedMessageAt()
+    @VisibleForTesting
+    public long getLastProcessedMessageAt()
     {
         return lastProcessedMessageAt;
     }
@@ -1490,6 +1498,9 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
 
     private void markAlive(final InetAddressAndPort addr, final EndpointState localState)
     {
+        if (!maybeBelongsInCluster(addr, localState))
+            logger.error("Not sending ECHO to {} which doesn't belong in this cluster", addr);
+
         if (inflightEcho.contains(addr))
         {
             return;
@@ -1715,6 +1726,14 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
 
             EndpointState localEpStatePtr = endpointStateMap.get(ep);
             EndpointState remoteState = entry.getValue();
+            // Cross-cluster safety checks
+
+            if (!maybeBelongsInCluster(ep, remoteState))
+            {
+                logger.error("Cannot apply state locally for {} because it doesn't seem to belong in this cluster {}", ep, remoteState);
+                continue;
+            }
+
             if (!hasMajorVersion3Nodes())
                 remoteState.removeMajorVersion3LegacyApplicationStates();
 
@@ -2596,4 +2615,69 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
         ExecutorUtils.shutdownAndWait(timeout, unit, executor);
     }
 
+    /**
+     * If available checks for cluster and partitioner name to match. Useful to avoid accidental cross cluster node joins.
+     *
+     * @param nodeAddress The address of the node we're checking against
+     * @param epState     The state Gossip sent us
+     * @return            False if any of the 2 are present and don't match. Otherwise defaults to True
+     */
+    public static boolean maybeBelongsInCluster(InetAddressAndPort nodeAddress, EndpointState epState)
+    {
+        if (nodeAddress!= null && epState != null)
+        {
+            Map<String, Object> jsonMap = ApplicationState.deserializeJsonPayload(epState.getApplicationState(ApplicationState.JSON_PAYLOAD));
+            if (jsonMap != null)
+            {
+                String auxValue = (String) jsonMap.get(ApplicationState.JsonPayload.CLUSTER_NAME.name());
+                if (auxValue != null && !auxValue.equals(DatabaseDescriptor.getClusterName()))
+                {
+                    logger.error("Gossip from {} rejected, its cluster name {} doesn't match the local one {} triggered at {}",
+                                 nodeAddress,
+                                 auxValue,
+                                 DatabaseDescriptor.getClusterName(),
+                                 ExceptionUtils.getStackTrace(new Exception("Cross cluster node detected")));
+                    return false;
+                }
+
+                auxValue = (String) jsonMap.get(ApplicationState.JsonPayload.PARTITIONER_NAME.name());
+                if (auxValue != null && !auxValue.equals(DatabaseDescriptor.getPartitionerName()))
+                {
+                    logger.error("Gossip from {} rejected, its partitioner name {} doesn't match the local one {} triggered at {}",
+                                 nodeAddress,
+                                 auxValue,
+                                 DatabaseDescriptor.getPartitionerName(),
+                                 ExceptionUtils.getStackTrace(new Exception("Cross cluster node detected")));
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Modifies and removes nodes from the map that joined in err and are foreign to this cluster
+     *
+     * @param epStateMap
+     * @return The purged map
+     */
+    public static Map<InetAddressAndPort, EndpointState> removeForeignClusterNodes(Map<InetAddressAndPort, EndpointState> epStateMap)
+    {
+        if (epStateMap == null)
+            return null;
+
+        Iterator<Entry<InetAddressAndPort, EndpointState>> it = epStateMap.entrySet().iterator();
+        while (it.hasNext())
+        {
+            Entry<InetAddressAndPort, EndpointState> entry = it.next();
+            if (!maybeBelongsInCluster(entry.getKey(), entry.getValue()))
+            {
+                logger.error("Ignoring Gossip from node {} because its state has info from other clusters {}", entry.getKey(), entry.getValue());
+                it.remove();
+            }
+        }
+
+        return epStateMap;
+    }
 }

--- a/src/java/org/apache/cassandra/net/Message.java
+++ b/src/java/org/apache/cassandra/net/Message.java
@@ -199,6 +199,11 @@ public class Message<T>
         return outWithParam(nextId(), verb, payload, null, null);
     }
 
+    public static <T> Message<T> synthetic(InetAddressAndPort from, Verb verb, T payload)
+    {
+        return new Message<>(new Header(-1, verb, from, -1, -1, 0, NO_PARAMS), payload);
+    }
+
     public static <T> Message<T> out(Verb verb, T payload, long expiresAtNanos)
     {
         return outWithParam(nextId(), verb, expiresAtNanos, payload, 0, null, null).build();

--- a/src/java/org/apache/cassandra/net/ResponseVerbHandler.java
+++ b/src/java/org/apache/cassandra/net/ResponseVerbHandler.java
@@ -25,6 +25,8 @@ import org.slf4j.LoggerFactory;
 import org.apache.cassandra.db.IMutation;
 import org.apache.cassandra.db.partitions.PartitionUpdate;
 import org.apache.cassandra.exceptions.RequestFailureReason;
+import org.apache.cassandra.gms.EndpointState;
+import org.apache.cassandra.gms.Gossiper;
 import org.apache.cassandra.sensors.Context;
 import org.apache.cassandra.sensors.RequestSensors;
 import org.apache.cassandra.sensors.Sensor;
@@ -46,6 +48,14 @@ public class ResponseVerbHandler implements IVerbHandler
     @Override
     public void doVerb(Message message)
     {
+        // Cross-cluster safety checks
+        EndpointState fromEpState = Gossiper.instance.getEndpointStateForEndpoint(message.from());
+        if (!Gossiper.maybeBelongsInCluster(message.from(), fromEpState))
+        {
+            logger.error("Ignoring received response {} from {} which doesn't belong in this cluster", message.id(), message.from());
+            return;
+        }
+
         RequestCallbacks.CallbackInfo callbackInfo = MessagingService.instance().callbacks.remove(message.id(), message.from());
         if (callbackInfo == null)
         {

--- a/src/java/org/apache/cassandra/service/EchoVerbHandler.java
+++ b/src/java/org/apache/cassandra/service/EchoVerbHandler.java
@@ -20,6 +20,8 @@ package org.apache.cassandra.service;
  *
  */
 import org.apache.cassandra.exceptions.RequestFailureReason;
+import org.apache.cassandra.gms.EndpointState;
+import org.apache.cassandra.gms.Gossiper;
 import org.apache.cassandra.net.IVerbHandler;
 import org.apache.cassandra.net.Message;
 import org.apache.cassandra.net.MessagingService;
@@ -36,6 +38,14 @@ public class EchoVerbHandler implements IVerbHandler<NoPayload>
 
     public void doVerb(Message<NoPayload> message)
     {
+        // Cross-cluster safety checks
+        EndpointState fromEpState = Gossiper.instance.getEndpointStateForEndpoint(message.from());
+        if (!Gossiper.maybeBelongsInCluster(message.from(), fromEpState))
+        {
+            logger.error("Ignoring ECHO request from {} which doesn't belong in this cluster", message.from());
+            return;
+        }
+
         // only respond if we are not shutdown
         if (!StorageService.instance.isShutdown())
         {

--- a/test/distributed/org/apache/cassandra/distributed/test/ring/BootstrapTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/ring/BootstrapTest.java
@@ -29,6 +29,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.distributed.Cluster;
 import org.apache.cassandra.distributed.api.ConsistencyLevel;
 import org.apache.cassandra.distributed.api.ICluster;
@@ -61,6 +62,7 @@ public class BootstrapTest extends TestBaseImpl
         // for each test case, the MIGRATION_DELAY time is adjusted accordingly
         savedMigrationDelay = CassandraRelevantProperties.MIGRATION_DELAY.getLong();
         CassandraRelevantProperties.MIGRATION_DELAY.setLong(ManagementFactory.getRuntimeMXBean().getUptime() + savedMigrationDelay);
+        DatabaseDescriptor.clientInitialization();
     }
 
     @After

--- a/test/distributed/org/apache/cassandra/distributed/test/ring/CleanupFailureTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/ring/CleanupFailureTest.java
@@ -18,8 +18,10 @@
 
 package org.apache.cassandra.distributed.test.ring;
 
+import org.junit.BeforeClass;
 import org.junit.Test;
 
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.distributed.Cluster;
 import org.apache.cassandra.distributed.api.ConsistencyLevel;
 import org.apache.cassandra.distributed.api.IInstanceConfig;
@@ -39,6 +41,12 @@ import static org.apache.cassandra.distributed.api.TokenSupplier.evenlyDistribut
 
 public class CleanupFailureTest extends TestBaseImpl
 {
+    @BeforeClass
+    public static void setup()
+    {
+        DatabaseDescriptor.clientInitialization();
+    }
+
     @Test
     public void cleanupDuringDecommissionTest() throws Throwable
     {

--- a/test/distributed/org/apache/cassandra/distributed/test/ring/NodeNotInRingTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/ring/NodeNotInRingTest.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import org.junit.Assert;
 import org.junit.Test;
 
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.distributed.Cluster;
 import org.apache.cassandra.distributed.action.GossipHelper;
 import org.apache.cassandra.distributed.api.ConsistencyLevel;
@@ -39,6 +40,8 @@ public class NodeNotInRingTest extends TestBaseImpl
     @Test
     public void nodeNotInRingTest() throws Throwable
     {
+        DatabaseDescriptor.clientInitialization();
+
         try (Cluster cluster = builder().withNodes(3)
                                         .withConfig(config -> config.with(NETWORK, GOSSIP))
                                         .start())

--- a/test/distributed/org/apache/cassandra/distributed/test/ring/PendingWritesTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/ring/PendingWritesTest.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import org.junit.Assert;
 import org.junit.Test;
 
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.dht.Range;
 import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.distributed.Cluster;
@@ -56,6 +57,7 @@ public class PendingWritesTest extends TestBaseImpl
         int originalNodeCount = 2;
         int expandedNodeCount = originalNodeCount + 1;
 
+        DatabaseDescriptor.clientInitialization();
         try (Cluster cluster = builder().withNodes(originalNodeCount)
                                         .withTokenSupplier(TokenSupplier.evenlyDistributedTokens(expandedNodeCount))
                                         .withNodeIdTopology(NetworkTopology.singleDcNetworkTopology(expandedNodeCount, "dc0", "rack0"))

--- a/test/unit/org/apache/cassandra/gms/EndpointStateTest.java
+++ b/test/unit/org/apache/cassandra/gms/EndpointStateTest.java
@@ -46,15 +46,14 @@ import static org.junit.Assert.assertTrue;
 
 public class EndpointStateTest
 {
-
     // the following are dse-6.x legacy applicationState ordinals
-    private static final ApplicationState DSE__STATUS = ApplicationState.values()[0];
-    private static final ApplicationState DSE__INTERNAL_IP = ApplicationState.values()[7];
-    private static final ApplicationState DSE__NATIVE_TRANSPORT_PORT = ApplicationState.values()[15];
-    private static final ApplicationState DSE__NATIVE_TRANSPORT_PORT_SSL = ApplicationState.values()[16];
-    private static final ApplicationState DSE__STORAGE_PORT = ApplicationState.values()[17];
-    private static final ApplicationState DSE__SCHEMA_COMPATIBILITY_VERSION = ApplicationState.values()[20];
-    private static final ApplicationState DSE__DISK_USAGE = ApplicationState.values()[21];
+    private final ApplicationState DSE__STATUS = ApplicationState.values()[0];
+    private final ApplicationState DSE__INTERNAL_IP = ApplicationState.values()[7];
+    private final ApplicationState DSE__NATIVE_TRANSPORT_PORT = ApplicationState.values()[15];
+    private final ApplicationState DSE__NATIVE_TRANSPORT_PORT_SSL = ApplicationState.values()[16];
+    private final ApplicationState DSE__STORAGE_PORT = ApplicationState.values()[17];
+    private final ApplicationState DSE__SCHEMA_COMPATIBILITY_VERSION = ApplicationState.values()[20];
+    private final ApplicationState DSE__DISK_USAGE = ApplicationState.values()[21];
 
     public volatile VersionedValue.VersionedValueFactory valueFactory =
         new VersionedValue.VersionedValueFactory(DatabaseDescriptor.getPartitioner());

--- a/test/unit/org/apache/cassandra/net/CrossClusterNodesTest.java
+++ b/test/unit/org/apache/cassandra/net/CrossClusterNodesTest.java
@@ -1,0 +1,354 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.net;
+
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.LoggerFactory;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import org.apache.cassandra.Util;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.db.commitlog.CommitLog;
+import org.apache.cassandra.dht.IPartitioner;
+import org.apache.cassandra.dht.RandomPartitioner;
+import org.apache.cassandra.dht.Token;
+import org.apache.cassandra.gms.EndpointState;
+import org.apache.cassandra.gms.GossipDigest;
+import org.apache.cassandra.gms.GossipDigestAck;
+import org.apache.cassandra.gms.GossipDigestAck2;
+import org.apache.cassandra.gms.GossipDigestAck2VerbHandler;
+import org.apache.cassandra.gms.GossipDigestAckVerbHandler;
+import org.apache.cassandra.gms.GossipDigestSyn;
+import org.apache.cassandra.gms.GossipDigestSynVerbHandler;
+import org.apache.cassandra.gms.Gossiper;
+import org.apache.cassandra.gms.HeartBeatState;
+import org.apache.cassandra.gms.VersionedValue;
+import org.apache.cassandra.locator.InetAddressAndPort;
+import org.apache.cassandra.locator.SeedProvider;
+import org.apache.cassandra.locator.TokenMetadata;
+import org.apache.cassandra.service.EchoVerbHandler;
+import org.apache.cassandra.service.StorageService;
+import org.apache.cassandra.utils.FBUtilities;
+
+import static org.apache.cassandra.gms.ApplicationState.JSON_PAYLOAD;
+import static org.apache.cassandra.gms.ApplicationState.JsonPayload.CLUSTER_NAME;
+import static org.apache.cassandra.gms.ApplicationState.JsonPayload.PARTITIONER_NAME;
+import static org.apache.cassandra.gms.ApplicationState.deserializeJsonPayload;
+import static org.apache.cassandra.gms.ApplicationState.serializeJsonPayload;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class CrossClusterNodesTest
+{
+    static final IPartitioner partitioner = new RandomPartitioner();
+
+    private static final Logger testLogger = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+    private static final ListAppender<ILoggingEvent> logListAppender = new ListAppender<>();
+    private static VersionedValue ORIG_CLUSTER_NAME;
+    private static VersionedValue FOREIGN_CLUSTER_NAME;
+    private static final String FOREIGN_PARTITIONER_NAME = "Foreign_Partitioner_Name";
+
+    private final StorageService ss = StorageService.instance;
+    private final TokenMetadata tmd = StorageService.instance.getTokenMetadata();
+    private final ArrayList<Token> endpointTokens = new ArrayList<>();
+    private final ArrayList<Token> keyTokens = new ArrayList<>();
+    private final List<InetAddressAndPort> hosts = new ArrayList<>();
+    private final List<UUID> hostIds = new ArrayList<>();
+
+    private SeedProvider originalSeedProvider;
+    private InetAddressAndPort remoteHostAddress;
+    private EndpointState nodeEpState;
+
+    @BeforeClass
+    static public void initTest()
+    {
+        System.setProperty(Gossiper.Props.DISABLE_THREAD_VALIDATION, "true");
+
+        DatabaseDescriptor.daemonInitialization();
+        CommitLog.instance.start();
+        logListAppender.start();
+        testLogger.addAppender(logListAppender);
+        Gossiper.instance.start(0);
+
+        ORIG_CLUSTER_NAME = StorageService.instance.valueFactory.datacenter(StorageService.instance.getClusterName());
+        FOREIGN_CLUSTER_NAME = StorageService.instance.valueFactory.datacenter("Foreign_Cluster_Name");
+    }
+
+    @Before
+    public void setup() throws UnknownHostException
+    {
+        Util.createInitialRing(ss, partitioner, endpointTokens, keyTokens, hosts, hostIds, 2);
+        tmd.clearUnsafe();
+
+        remoteHostAddress = hosts.get(1);
+        nodeEpState = Gossiper.instance.getEndpointStateForEndpoint(remoteHostAddress);
+        logListAppender.start();
+    }
+
+    @After
+    public void tearDown()
+    {
+        nodeEpState.addApplicationState(JSON_PAYLOAD, getPayloadWith("", ""));
+        DatabaseDescriptor.setSeedProvider(originalSeedProvider);
+        logListAppender.list.clear();
+    }
+
+    @Test
+    public void testSYNHandlerRejectsForeignNode()
+    {
+        long lastMessageTimestamp = Gossiper.instance.getLastProcessedMessageAt();
+
+        // Bad cluster
+        GossipDigestSyn digest = new GossipDigestSyn(FOREIGN_CLUSTER_NAME.value, DatabaseDescriptor.getPartitionerName(), Collections.emptyList());
+        Message<GossipDigestSyn> message = Message.synthetic(remoteHostAddress, Verb.SYNC_REQ, digest);
+        GossipDigestSynVerbHandler.instance.doVerb(message);
+        logListAppender.stop();
+
+        assertTrue(logListAppender.list.stream().anyMatch(l -> l.getFormattedMessage().contains("ClusterName mismatch")));
+        assertTrue(logListAppender.list.stream().anyMatch(l -> l.getFormattedMessage().contains(FOREIGN_CLUSTER_NAME.value)));
+        assertEquals(lastMessageTimestamp, Gossiper.instance.getLastProcessedMessageAt());
+
+        // Bad partitioner
+        logListAppender.start();
+        digest = new GossipDigestSyn(DatabaseDescriptor.getClusterName(), FOREIGN_PARTITIONER_NAME, Collections.emptyList());
+        message = Message.synthetic(remoteHostAddress, Verb.SYNC_REQ, digest);
+        GossipDigestSynVerbHandler.instance.doVerb(message);
+        logListAppender.stop();
+
+        assertTrue(logListAppender.list.stream().anyMatch(l -> l.getFormattedMessage().contains("Partitioner mismatch")));
+        assertTrue(logListAppender.list.stream().anyMatch(l -> l.getFormattedMessage().contains(FOREIGN_PARTITIONER_NAME)));
+        assertEquals(lastMessageTimestamp, Gossiper.instance.getLastProcessedMessageAt());
+    }
+
+    @Test
+    public void testSYNHandlerPurgesForeignNodes() throws UnknownHostException
+    {
+        List<GossipDigest> digests = Gossiper.instance.getEndpointStateMapUnsafeForTest().keySet().stream().
+                                                                                                   map(e -> GossipDigest.getUnsafeForTest(e,0,0)).
+                                                                                                   collect(Collectors.toList());
+        digests.add(GossipDigest.getUnsafeForTest(InetAddressAndPort.getByName("127.0.0.3"), 0,0));
+
+        Message<GossipDigestAck> ackReply = GossipDigestSynVerbHandler.createNormalReplyUnsafeForTest(digests);
+
+        assertNull(ackReply.payload.getEndpointStateMapUnsafeForTest().get(InetAddressAndPort.getByName("127.0.0.3")));
+    }
+
+    @Test
+    public void testSYNHandlerAddsClusterAndPartitioner()
+    {
+        assertFalse(Gossiper.instance.getEndpointStateForEndpoint(FBUtilities.getBroadcastAddressAndPort()).
+                                     containsApplicationState(JSON_PAYLOAD));
+
+        List<GossipDigest> digests = Gossiper.instance.getEndpointStateMapUnsafeForTest().keySet().stream().
+                                                                                                   map(e -> GossipDigest.getUnsafeForTest(e, 0, 0)).
+                                                                                                   collect(Collectors.toList());
+
+        Message<GossipDigestAck> ackReply = GossipDigestSynVerbHandler.createNormalReplyUnsafeForTest(digests);
+
+        Map<String, Object> jsonPayload = deserializeJsonPayload(ackReply.
+                                                                 payload.
+                                                                 getEndpointStateMapUnsafeForTest().
+                                                                 get(FBUtilities.getBroadcastAddressAndPort()).
+                                                                 getApplicationState(JSON_PAYLOAD));
+        assertEquals(jsonPayload.get(CLUSTER_NAME.name()), ORIG_CLUSTER_NAME.value);
+        assertEquals(jsonPayload.get(PARTITIONER_NAME.name()), DatabaseDescriptor.getPartitionerName());
+    }
+
+    @Test
+    public void testACKHandlerRejectsForeignNode()
+    {
+        GossipDigestAck digest = GossipDigestAck.getInstanceUnsafeForTesting(Collections.emptyList(), ImmutableMap.of(remoteHostAddress, nodeEpState));
+        Message<GossipDigestAck> message = Message.synthetic(remoteHostAddress, Verb.GOSSIP_DIGEST_ACK, digest);
+        nodeEpState.addApplicationState(JSON_PAYLOAD, getPayloadWithForeignNode());
+
+        long lastMessageTimestamp = Gossiper.instance.getLastProcessedMessageAt();
+        GossipDigestAckVerbHandler.instance.doVerb(message);
+        logListAppender.stop();
+
+        assertTrue(logListAppender.list.stream().anyMatch(l -> l.getFormattedMessage().contains("Cross cluster node detected")));
+        assertEquals(lastMessageTimestamp, Gossiper.instance.getLastProcessedMessageAt());
+    }
+
+    @Test
+    public void testACKHandlerPurgesForeignNodes() throws UnknownHostException
+    {
+        EndpointState foreignNodeEpState = fakeState();
+        foreignNodeEpState.addApplicationState(JSON_PAYLOAD, getPayloadWithForeignNode());
+        Map<InetAddressAndPort, EndpointState> pollutedEpStateMap = new HashMap<InetAddressAndPort, EndpointState>()
+        {{
+            put(remoteHostAddress, nodeEpState);
+            put(InetAddressAndPort.getByName("127.0.0.3"), foreignNodeEpState);
+        }};
+
+        GossipDigestAck digest = GossipDigestAck.getInstanceUnsafeForTesting(Collections.emptyList(), pollutedEpStateMap);
+        Message<GossipDigestAck> message = Message.synthetic(remoteHostAddress, Verb.GOSSIP_DIGEST_ACK, digest);
+        GossipDigestAckVerbHandler.instance.doVerb(message);
+
+        assertNull(pollutedEpStateMap.get(InetAddressAndPort.getByName("127.0.0.3")));
+    }
+
+    @Test
+    public void testACK2HandlerRejectsForeignNode()
+    {
+        GossipDigestAck2 digest = GossipDigestAck2.getInstanceUnsafeForTesting(ImmutableMap.of(remoteHostAddress, nodeEpState));
+        Message<GossipDigestAck2> message = Message.synthetic(remoteHostAddress, Verb.GOSSIP_DIGEST_ACK2, digest);
+        nodeEpState.addApplicationState(JSON_PAYLOAD, getPayloadWithForeignNode());
+
+        long lastMessageTimestamp = Gossiper.instance.getLastProcessedMessageAt();
+        GossipDigestAck2VerbHandler.instance.doVerb(message);
+        logListAppender.stop();
+
+        assertTrue(logListAppender.list.stream().anyMatch(l -> l.getFormattedMessage().contains("Cross cluster node detected")));
+        assertEquals(lastMessageTimestamp, Gossiper.instance.getLastProcessedMessageAt());
+    }
+
+    @Test
+    public void testACK2HandlerPurgesForeignNodes() throws UnknownHostException
+    {
+        EndpointState foreignNodeEpState = fakeState();
+        foreignNodeEpState.addApplicationState(JSON_PAYLOAD, getPayloadWithForeignNode());
+        Map<InetAddressAndPort, EndpointState> pollutedEpStateMap = new HashMap<InetAddressAndPort, EndpointState>()
+        {{
+            put(remoteHostAddress, nodeEpState);
+            put(InetAddressAndPort.getByName("127.0.0.3"), foreignNodeEpState);
+        }};
+
+        GossipDigestAck2 digest = GossipDigestAck2.getInstanceUnsafeForTesting(pollutedEpStateMap);
+        Message<GossipDigestAck2> message = Message.synthetic(remoteHostAddress, Verb.GOSSIP_DIGEST_ACK2, digest);
+        GossipDigestAck2VerbHandler.instance.doVerb(message);
+
+        assertNull(pollutedEpStateMap.get(InetAddressAndPort.getByName("127.0.0.3")));
+    }
+
+    @Test
+    public void testECHORequest()
+    {
+        nodeEpState.addApplicationState(JSON_PAYLOAD, getPayloadWithForeignNode());
+        Message<NoPayload> message = Message.synthetic(remoteHostAddress, Verb.ECHO_REQ, null);
+
+        EchoVerbHandler.instance.doVerb(message);
+
+        logListAppender.stop();
+        assertTrue(logListAppender.list.stream().anyMatch(l -> l.getFormattedMessage().contains("Cross cluster node detected")));
+    }
+
+    @Test
+    public void testECHOHandler()
+    {
+        nodeEpState.addApplicationState(JSON_PAYLOAD, getPayloadWithForeignNode());
+        Message<NoPayload> message = Message.synthetic(remoteHostAddress, Verb.ECHO_RSP, null);
+
+        ResponseVerbHandler.instance.doVerb(message);
+
+        logListAppender.stop();
+        assertTrue(logListAppender.list.stream().anyMatch(l -> l.getFormattedMessage().contains("Cross cluster node detected")));
+    }
+
+    @Test
+    public void testApplyStateLocally()
+    {
+        nodeEpState.addApplicationState(JSON_PAYLOAD, getPayloadWithForeignNode());
+        Gossiper.instance.applyStateLocally(ImmutableMap.of(remoteHostAddress, nodeEpState));
+        logListAppender.stop();
+        assertTrue(logListAppender.list.stream().anyMatch(l -> l.getFormattedMessage().contains("Cross cluster node detected")));
+    }
+
+    @Test
+    public void testMaybeBelongsInCluster()
+    {
+        EndpointState testEpState = fakeState();
+
+        // Works with no data
+        assertTrue(Gossiper.maybeBelongsInCluster(remoteHostAddress, testEpState));
+
+        // Works with data
+        testEpState.addApplicationState(JSON_PAYLOAD, getPayloadWithNonForeignNode());
+        assertTrue(Gossiper.maybeBelongsInCluster(remoteHostAddress, testEpState));
+
+        // Rejects bad cluster
+        testEpState.addApplicationState(JSON_PAYLOAD, getPayloadWithForeignNode());
+        assertFalse(Gossiper.maybeBelongsInCluster(remoteHostAddress, testEpState));
+
+        // Rejects bad partitioner
+        testEpState.addApplicationState(JSON_PAYLOAD, getPayloadWithBadPartitioner());
+        assertFalse(Gossiper.maybeBelongsInCluster(remoteHostAddress, testEpState));
+    }
+
+    @Test
+    public void testRemoveCrossClusterNodes() throws UnknownHostException
+    {
+        EndpointState foreignNodeEpState = fakeState();
+        foreignNodeEpState.addApplicationState(JSON_PAYLOAD, getPayloadWithForeignNode());
+        Map<InetAddressAndPort, EndpointState> pollutedEpStateMap = new HashMap<InetAddressAndPort, EndpointState>()
+        {{
+            put(InetAddressAndPort.getByName("127.0.0.3"), foreignNodeEpState);
+        }};
+        pollutedEpStateMap.putAll(Gossiper.instance.getEndpointStateMapUnsafeForTest());
+
+        Map<InetAddressAndPort, EndpointState> sanitizedEpStateMap = Gossiper.removeForeignClusterNodes(pollutedEpStateMap);
+
+        assertEquals(sanitizedEpStateMap.size(), Gossiper.instance.getEndpointStateMapUnsafeForTest().size());
+        assertNull(pollutedEpStateMap.get(InetAddressAndPort.getByName("127.0.0.3")));
+    }
+
+    private static VersionedValue getPayloadWithForeignNode()
+    {
+        return getPayloadWith(CLUSTER_NAME.name(), FOREIGN_CLUSTER_NAME.value);
+    }
+
+    private static VersionedValue getPayloadWithNonForeignNode()
+    {
+        return getPayloadWith(CLUSTER_NAME.name(), ORIG_CLUSTER_NAME.value);
+    }
+
+    private static VersionedValue getPayloadWithBadPartitioner()
+    {
+        return getPayloadWith(PARTITIONER_NAME.name(), FOREIGN_PARTITIONER_NAME);
+    }
+
+    private static VersionedValue getPayloadWith(String key, String value)
+    {
+        Map<String, Object> payload = new HashMap<String, Object>()
+        {{
+            put(key, value);
+        }};
+
+        return serializeJsonPayload(payload);
+    }
+
+    private static EndpointState fakeState()
+    {
+        return new EndpointState(new HeartBeatState((int) System.currentTimeMillis()/1000, 1234));
+    }
+}


### PR DESCRIPTION
This ticket ports DSP-24965 adding cluster membership checks for nodes in some extra code paths to prevent foreign nodes from joining.

### What is the issue
In some rare scenarios, some with bad config, some with the wrong data folders plugged into the wrong node, operator mistake, etc nodes from cluster A can join nodes from cluster B. That breaks topology badly both for A and B.

### What does this PR fix and why was it fixed
This PR extends the original cluster membership check to all other susceptible code paths to prevent these.
