### PR TITLE
CNDB-17333 Create separate db-all artifacts

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1346,6 +1346,117 @@
           <include name="${final.name}-src.tar.gz" />
         </fileset>
       </checksum>
+
+      <!-- ================================================================ -->
+      <!-- Create db-all artifacts (copies of dse-db with new names)       -->
+      <!-- ================================================================ -->
+
+      <!-- Copy parent POM -->
+      <copy file="${build.dir}/${final.name}-parent.pom"
+          tofile="${build.dir}/${new.artifact.name}-parent.pom"
+          failonerror="false"/>
+
+      <!-- Copy main jar -->
+      <copy file="${build.dir}/${final.name}.jar"
+          tofile="${build.dir}/${new.artifact.name}.jar"
+          failonerror="false"/>
+
+      <!-- Copy sources jar -->
+      <copy file="${build.dir}/${final.name}-sources.jar"
+          tofile="${build.dir}/${new.artifact.name}-sources.jar"
+          failonerror="false"/>
+
+      <!-- Copy javadoc jar -->
+      <copy file="${build.dir}/${final.name}-javadoc.jar"
+          tofile="${build.dir}/${new.artifact.name}-javadoc.jar"
+          failonerror="false"/>
+
+      <!-- Create db-all binary tarball (duplicate of dse-db content) -->
+      <tar compression="gzip" longfile="gnu"
+        destfile="${build.dir}/${new.artifact.name}-bin.tar.gz">
+
+        <!-- Everything but bin/ (default mode) -->
+        <tarfileset dir="${dist.dir}" prefix="${new.artifact.name}">
+          <include name="**"/>
+          <exclude name="bin/*" />
+          <exclude name="tools/bin/*"/>
+        </tarfileset>
+        <!-- Shell includes in bin/ (default mode) -->
+        <tarfileset dir="${dist.dir}" prefix="${new.artifact.name}">
+          <include name="bin/*.in.sh" />
+          <include name="tools/bin/*.in.sh" />
+        </tarfileset>
+        <!-- Executable scripts in bin/ -->
+        <tarfileset dir="${dist.dir}" prefix="${new.artifact.name}" mode="755">
+          <include name="bin/*"/>
+          <include name="tools/bin/*"/>
+          <exclude name="bin/*.in.sh" />
+          <exclude name="tools/bin/*.in.sh" />
+        </tarfileset>
+      </tar>
+
+      <!-- Create db-all source tarball (duplicate of dse-db content) -->
+      <tar compression="gzip" longfile="gnu"
+           destfile="${build.dir}/${new.artifact.name}-src.tar.gz">
+
+        <tarfileset dir="${basedir}"
+                    prefix="${new.artifact.name}-src">
+          <include name="**"/>
+          <exclude name="build/**" />
+          <exclude name="lib/**" />
+          <exclude name="src/gen-java/**" />
+          <exclude name=".git/**" />
+          <exclude name="venv/**" />
+          <exclude name="src/resources/org/apache/cassandra/config/version.properties" />
+          <exclude name="conf/hotspot_compiler" />
+          <exclude name="doc/cql3/CQL.html" />
+          <exclude name="doc/build/**" />
+          <exclude name="bin/*" /> <!-- handled separately below -->
+          <exclude name="tools/bin/*" /> <!-- handled separately below -->
+          <!-- exclude python generated files -->
+          <exclude name="**/__pycache__/**" />
+          <!-- exclude Eclipse files -->
+          <exclude name=".project" />
+          <exclude name=".classpath" />
+          <exclude name=".settings/**" />
+          <exclude name=".externalToolBuilders/**" />
+          <!-- exclude NetBeans files -->
+          <exclude name="ide/nbproject/private/**" />
+        </tarfileset>
+
+        <!-- python driver -->
+        <tarfileset dir="${basedir}" prefix="${new.artifact.name}-src">
+          <include name="lib/cassandra-driver-internal-only-**" />
+        </tarfileset>
+
+        <!-- Shell includes in bin/ and tools/bin/ -->
+        <tarfileset dir="${basedir}" prefix="${new.artifact.name}-src">
+          <include name="bin/*.in.sh" />
+          <include name="tools/bin/*.in.sh" />
+        </tarfileset>
+        <!-- Everything else (assumed to be scripts), is executable -->
+        <tarfileset dir="${basedir}" prefix="${new.artifact.name}-src" mode="755">
+          <include name="bin/*"/>
+          <exclude name="bin/*.in.sh" />
+          <include name="tools/bin/*"/>
+          <exclude name="tools/bin/*.in.sh" />
+        </tarfileset>
+      </tar>
+
+      <!-- Generate checksums for db-all tarballs -->
+      <checksum forceOverwrite="yes" todir="${build.dir}" fileext=".sha256" algorithm="SHA-256">
+        <fileset dir="${build.dir}">
+          <include name="${new.artifact.name}-bin.tar.gz" />
+          <include name="${new.artifact.name}-src.tar.gz" />
+        </fileset>
+      </checksum>
+      <checksum forceOverwrite="yes" todir="${build.dir}" fileext=".sha512" algorithm="SHA-512">
+        <fileset dir="${build.dir}">
+          <include name="${new.artifact.name}-bin.tar.gz" />
+          <include name="${new.artifact.name}-src.tar.gz" />
+        </fileset>
+      </checksum>
+
     </target>
 
   <target name="build-jmh" depends="build-test, jar" description="Create JMH uber jar">
@@ -2474,6 +2585,10 @@
     <!-- the distribution -->
     <sign-dist file="${build.dir}/${final.name}-bin.tar.gz" />
     <sign-dist file="${build.dir}/${final.name}-src.tar.gz" />
+
+    <!-- the db-all distribution (separate tarballs, new Maven coordinates com.datastax.db:db-all) -->
+    <sign-dist file="${build.dir}/${new.artifact.name}-bin.tar.gz" />
+    <sign-dist file="${build.dir}/${new.artifact.name}-src.tar.gz" />
 
   </target>
 

--- a/ds/Jenkinsfile
+++ b/ds/Jenkinsfile
@@ -15,6 +15,6 @@
 // This Jenkinsfile uses a shared library from https://github.com/riptano/jenkins-pipeline-lib
 // The pipeline logic is defined in the library rather than in this file.
 
-@Library('ds-pipeline-lib@CNDB-17333-publish-db-all') _
+@Library('ds-pipeline-lib') _
 
 dsCassandraPRGate()

--- a/ds/Jenkinsfile
+++ b/ds/Jenkinsfile
@@ -15,6 +15,6 @@
 // This Jenkinsfile uses a shared library from https://github.com/riptano/jenkins-pipeline-lib
 // The pipeline logic is defined in the library rather than in this file.
 
-@Library('ds-pipeline-lib') _
+@Library('ds-pipeline-lib@CNDB-17333-publish-db-all') _
 
 dsCassandraPRGate()


### PR DESCRIPTION
### What is the issue
CNDB-17333 Support publishing both db-all and dse-db-all artifacts

### What does this PR fix and why was it fixed
Along with changes to jenkins-pipeline-lib, https://github.com/riptano/jenkins-pipeline-lib/pull/254, make sure that CC `db-all` artifacts are created.
