### PR TITLE
HCD-200 1.1.3

### DIFF
--- a/src/java/org/apache/cassandra/auth/CassandraRoleManager.java
+++ b/src/java/org/apache/cassandra/auth/CassandraRoleManager.java
@@ -396,7 +396,7 @@ public class CassandraRoleManager implements IRoleManager
             }
             catch (Exception e)
             {
-                logger.info("Setup task failed with error, rescheduling");
+                logger.info("Setup task failed with error, rescheduling", e);
                 scheduleSetupTask(setupTask);
             }
         }, AuthKeyspace.SUPERUSER_SETUP_DELAY, TimeUnit.MILLISECONDS);

--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -499,6 +499,9 @@ public enum CassandraRelevantProperties
      */
     COMPACTION_SKIP_COMPACTING_STATE_CHECKING("cassandra.compaction.skip_compacting_state_checking", "false"),
 
+    /** The length of time to wait for task cessation when we want to run something with compactions disabled. */
+    CESSATION_WAIT_SECONDS("cassandra.task_cessation_wait_seconds"),
+
     /**
      * If true, the searcher object created when opening a SAI index will be replaced by a dummy object and index
      * are never marked queriable (querying one will fail). This is obviously usually undesirable, but can be used if

--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -2796,8 +2796,9 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
         longRunningSerializedOperationsLock.lock();
         try
         {
-            logger.trace("Cancelling in-progress compactions for {}", metadata.name);
+            logger.debug("Started cancelling in-progress compactions for {}", metadata.name);
             Iterable<ColumnFamilyStore> toInterruptFor = concatWith(interruptIndexes, interruptViews);
+
             try (CompactionManager.CompactionPauser pause = CompactionManager.instance.pauseGlobalCompaction();
                  CompactionManager.CompactionPauser pausedStrategies = pauseCompactionStrategies(toInterruptFor))
             {
@@ -2824,6 +2825,10 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
                 {
                     throw new RuntimeException(e);
                 }
+            }
+            finally
+            {
+                logger.debug("Finished cancelling in-progress compactions for {}", metadata.name);
             }
         }
         finally

--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -2832,11 +2832,13 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
     {
         for (ColumnFamilyStore cfs : cfss)
         {
-            if (cfs.getTracker().getCompacting().stream().anyMatch(sstablesPredicate))
+            List<SSTableReader> compactingSatisfyingPredicate = cfs.getCompactingSSTables().stream().filter(sstablesPredicate).collect(Collectors.toList());
+            if (!compactingSatisfyingPredicate.isEmpty())
             {
                 logger.warn("Unable to cancel in-progress compactions for {}.{}.  Perhaps there is an unusually " +
                             "large row in progress somewhere, or the system is simply overloaded.", metadata.keyspace, metadata.name);
-                logger.debug("In-flight compactions: {}", Arrays.toString(cfs.getTracker().getCompacting().toArray()));
+                logger.debug("SSTables in in-flight operations: {}", compactingSatisfyingPredicate);
+                logger.debug("Operations involving these sstables: {}", CompactionManager.instance.getOperationsInvolving(List.of(cfs.metadata()), sstablesPredicate));
                 return false;
             }
         }

--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -2801,8 +2801,12 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
             try (CompactionManager.CompactionPauser pause = CompactionManager.instance.pauseGlobalCompaction();
                  CompactionManager.CompactionPauser pausedStrategies = pauseCompactionStrategies(toInterruptFor))
             {
+                // Cancel scheduled compactions matching predicate. This must be done first because tasks progress from
+                // scheduled to active.
+                CompactionManager.instance.active.cancelScheduledTasksAffecting(toInterruptFor, sstablesPredicate);
                 // interrupt in-progress compactions
                 CompactionManager.instance.interruptCompactionForCFs(toInterruptFor, sstablesPredicate, interruptValidation, trigger);
+
                 CompactionManager.instance.waitForCessation(toInterruptFor, sstablesPredicate);
 
                 // doublecheck that we finished, instead of timing out

--- a/src/java/org/apache/cassandra/db/compaction/AbstractCompactionTask.java
+++ b/src/java/org/apache/cassandra/db/compaction/AbstractCompactionTask.java
@@ -59,11 +59,17 @@ public abstract class AbstractCompactionTask extends WrappedRunnable
 
     private enum ExecutionState
     {
-        CREATED, // Task is created and ready for execution, possibly waiting in a queue.
-        ACTIVE, // Task has started execution and is listed in the active operations.
-        REJECTED // Task has been rejected, either because of an error or cancelled before becoming active.
+        CREATED,  // Task is created and ready for execution, possibly waiting in a queue.
+                  // If it is rejected, the rejecting thread must clean it up.
+        STARTED,  // Task has started execution, but still hasn't entered the active operations.
+                  // It still accepts cancellation requests that may or may not be honored by the executing thread.
+        ACTIVE,   // Task has started execution and is listed in the active operations.
+        COMPLETE, // Task is complete, cleanup done or to be done by executing thread.
+        ABORT,    // Task has been cancelled after entering STARTED state, before becoming ACTIVE
+        REJECTED, // Task has been rejected, either because of an error or cancelled before becoming active.
+                  // Cleanup done or to be done by rejecting thread.
     }
-    private volatile AtomicReference<ExecutionState> executionState = new AtomicReference<>(ExecutionState.CREATED);
+    private final AtomicReference<ExecutionState> executionState = new AtomicReference<>(ExecutionState.CREATED);
 
     /**
      * @param realm
@@ -147,9 +153,10 @@ public abstract class AbstractCompactionTask extends WrappedRunnable
     /** Executes the task */
     public void execute()
     {
-        // Exit immediately if task is already rejected. Note that we don't switch to ACTIVE here, because we want
-        // to do this only if the task moves to the active operations list (which is done by CompactionTask).
-        if (executionState.get() == ExecutionState.REJECTED)
+        // Exit immediately if task is already rejected. Also change the state to STARTED so that a race with rejection
+        // cannot close our resources while we are trying to work; before this point rejecting thread is responsible for
+        // clean-up; after this passes, we are.
+        if (!executionState.compareAndSet(ExecutionState.CREATED, ExecutionState.STARTED))
         {
             cancelledOnStart();
             return;
@@ -177,8 +184,9 @@ public abstract class AbstractCompactionTask extends WrappedRunnable
             // if executeInternal has not switched the task to active state, do it now to remove it from the
             // scheduled set.
             switchToActive();
-
-            Throwables.maybeFail(cleanup(t));
+            // Unless the task has been fully rejected before entering this function, clean it up.
+            if (executionState.getAndSet(ExecutionState.COMPLETE) != ExecutionState.REJECTED)
+                Throwables.maybeFail(cleanup(t));
         }
     }
 
@@ -197,6 +205,13 @@ public abstract class AbstractCompactionTask extends WrappedRunnable
         }
         else
         {
+            // We have another chance to request abort if the task has not become ACTIVE yet.
+            // If this works, the executing thread is currently active, may honor the request and will clean up.
+            if (executionState.compareAndSet(ExecutionState.STARTED, ExecutionState.ABORT))
+            {
+                CompactionManager.instance.active.removeTaskFromScheduled(this);
+                logger.debug("Compaction {} aborted", transaction, t);
+            }
             // We are either already rejected, or racing with switching to active.
             // In the latter case, the operation can now be cancelled through the active operations list.
             return t;
@@ -205,7 +220,7 @@ public abstract class AbstractCompactionTask extends WrappedRunnable
 
     public boolean switchToActive()
     {
-        boolean switched = executionState.compareAndSet(ExecutionState.CREATED, ExecutionState.ACTIVE);
+        boolean switched = executionState.compareAndSet(ExecutionState.STARTED, ExecutionState.ACTIVE);
         if (switched)
             CompactionManager.instance.active.removeTaskFromScheduled(this);
         return switched;
@@ -223,7 +238,7 @@ public abstract class AbstractCompactionTask extends WrappedRunnable
         {
             if (sstablePredicate.test(r))
             {
-                rejected(null);
+                Throwables.maybeFail(rejected(null));
                 return true;
             }
         }

--- a/src/java/org/apache/cassandra/db/compaction/AbstractCompactionTask.java
+++ b/src/java/org/apache/cassandra/db/compaction/AbstractCompactionTask.java
@@ -159,9 +159,6 @@ public abstract class AbstractCompactionTask extends WrappedRunnable
         try
         {
             executeInternal();
-            // if executeInternal has not switched the task to active state, do it now to remove it from the
-            // scheduled set.
-            switchToActive();
         }
         catch (FSDiskFullWriteError e)
         {
@@ -177,6 +174,10 @@ public abstract class AbstractCompactionTask extends WrappedRunnable
         }
         finally
         {
+            // if executeInternal has not switched the task to active state, do it now to remove it from the
+            // scheduled set.
+            switchToActive();
+
             Throwables.maybeFail(cleanup(t));
         }
     }

--- a/src/java/org/apache/cassandra/db/compaction/AbstractCompactionTask.java
+++ b/src/java/org/apache/cassandra/db/compaction/AbstractCompactionTask.java
@@ -22,9 +22,13 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Predicate;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.db.lifecycle.ILifecycleTransaction;
@@ -38,11 +42,13 @@ import static com.google.common.base.Throwables.propagate;
 
 public abstract class AbstractCompactionTask extends WrappedRunnable
 {
+    protected static final Logger logger = LoggerFactory.getLogger(AbstractCompactionTask.class);
+
     // See CNDB-10549
     static final boolean SKIP_REPAIR_STATE_CHECKING =
         CassandraRelevantProperties.COMPACTION_SKIP_REPAIR_STATE_CHECKING.getBoolean();
     static final boolean SKIP_COMPACTING_STATE_CHECKING =
-    CassandraRelevantProperties.COMPACTION_SKIP_COMPACTING_STATE_CHECKING.getBoolean();
+        CassandraRelevantProperties.COMPACTION_SKIP_COMPACTING_STATE_CHECKING.getBoolean();
 
     protected final CompactionRealm realm;
     protected ILifecycleTransaction transaction;
@@ -50,6 +56,14 @@ public abstract class AbstractCompactionTask extends WrappedRunnable
     protected OperationType compactionType;
     protected TableOperationObserver opObserver;
     protected final List<CompactionObserver> compObservers;
+
+    private enum ExecutionState
+    {
+        CREATED, // Task is created and ready for execution, possibly waiting in a queue.
+        ACTIVE, // Task has started execution and is listed in the active operations.
+        REJECTED // Task has been rejected, either because of an error or cancelled before becoming active.
+    }
+    private volatile AtomicReference<ExecutionState> executionState = new AtomicReference<>(ExecutionState.CREATED);
 
     /**
      * @param realm
@@ -80,6 +94,8 @@ public abstract class AbstractCompactionTask extends WrappedRunnable
         {
             propagate(cleanup(err));
         }
+
+        CompactionManager.instance.active.addTaskToScheduled(this);
     }
 
     /**
@@ -131,10 +147,21 @@ public abstract class AbstractCompactionTask extends WrappedRunnable
     /** Executes the task */
     public void execute()
     {
+        // Exit immediately if task is already rejected. Note that we don't switch to ACTIVE here, because we want
+        // to do this only if the task moves to the active operations list (which is done by CompactionTask).
+        if (executionState.get() == ExecutionState.REJECTED)
+        {
+            cancelledOnStart();
+            return;
+        }
+
         Throwable t = null;
         try
         {
             executeInternal();
+            // if executeInternal has not switched the task to active state, do it now to remove it from the
+            // scheduled set.
+            switchToActive();
         }
         catch (FSDiskFullWriteError e)
         {
@@ -154,9 +181,52 @@ public abstract class AbstractCompactionTask extends WrappedRunnable
         }
     }
 
+    public void cancelledOnStart()
+    {
+        // Called when the task starts after being cancelled. Normally nothing to do, overridden by tests.
+    }
+
     public Throwable rejected(Throwable t)
     {
-        return cleanup(t);
+        if (executionState.compareAndSet(ExecutionState.CREATED, ExecutionState.REJECTED))
+        {
+            CompactionManager.instance.active.removeTaskFromScheduled(this);
+            logger.debug("Compaction {} rejected", transaction, t);
+            return cleanup(t);
+        }
+        else
+        {
+            // We are either already rejected, or racing with switching to active.
+            // In the latter case, the operation can now be cancelled through the active operations list.
+            return t;
+        }
+    }
+
+    public boolean switchToActive()
+    {
+        boolean switched = executionState.compareAndSet(ExecutionState.CREATED, ExecutionState.ACTIVE);
+        if (switched)
+            CompactionManager.instance.active.removeTaskFromScheduled(this);
+        return switched;
+    }
+
+    /**
+     * Reject/cancel the task if it affects any sstable that satisfies the given predicate.
+     */
+    public boolean cancelIfAffects(CompactionRealm realm, Predicate<SSTableReader> sstablePredicate)
+    {
+        if (realm != this.realm)
+            return false;
+
+        for (SSTableReader r : transaction.originals())
+        {
+            if (sstablePredicate.test(r))
+            {
+                rejected(null);
+                return true;
+            }
+        }
+        return false;
     }
 
     protected Throwable cleanup(Throwable err)

--- a/src/java/org/apache/cassandra/db/compaction/ActiveOperations.java
+++ b/src/java/org/apache/cassandra/db/compaction/ActiveOperations.java
@@ -25,6 +25,7 @@ import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Predicate;
 
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -33,6 +34,7 @@ import com.google.common.collect.ImmutableList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.utils.NonThrowingCloseable;
 
@@ -43,6 +45,9 @@ public class ActiveOperations implements TableOperationObserver
 
     // The operations ordered by keyspace.table for all the operations that are currently in progress.
     private static final Set<TableOperation> operations = Collections.synchronizedSet(Collections.newSetFromMap(new IdentityHashMap<>()));
+
+    // Compaction tasks that have been created but aren't executing yet.
+    private static final Set<AbstractCompactionTask> scheduledTasks = Collections.synchronizedSet(Collections.newSetFromMap(new IdentityHashMap<>()));
 
     // Keep registered listeners to be called onStart and close
     private final List<CompactionProgressListener> listeners = new CopyOnWriteArrayList<>();
@@ -155,5 +160,28 @@ public class ActiveOperations implements TableOperationObserver
     public boolean isActive(TableOperation op)
     {
         return getTableOperations().contains(op);
+    }
+
+    public void addTaskToScheduled(AbstractCompactionTask task)
+    {
+        scheduledTasks.add(task);
+    }
+
+    public void removeTaskFromScheduled(AbstractCompactionTask task)
+    {
+        scheduledTasks.remove(task);
+    }
+
+    public void cancelScheduledTasksAffecting(Iterable<ColumnFamilyStore> cfss, Predicate<SSTableReader> predicate)
+    {
+        Iterable<AbstractCompactionTask> tasksCopy;
+        synchronized (scheduledTasks)
+        {
+            tasksCopy = new ArrayList<>(scheduledTasks);
+        }
+
+        for (AbstractCompactionTask task : tasksCopy)
+            for (ColumnFamilyStore cfs : cfss)
+                task.cancelIfAffects(cfs, predicate);
     }
 }

--- a/src/java/org/apache/cassandra/db/compaction/ActiveOperations.java
+++ b/src/java/org/apache/cassandra/db/compaction/ActiveOperations.java
@@ -29,6 +29,7 @@ import java.util.function.Predicate;
 
 import javax.annotation.concurrent.ThreadSafe;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 
 import org.slf4j.Logger;
@@ -183,5 +184,14 @@ public class ActiveOperations implements TableOperationObserver
         for (AbstractCompactionTask task : tasksCopy)
             for (ColumnFamilyStore cfs : cfss)
                 task.cancelIfAffects(cfs, predicate);
+    }
+
+    @VisibleForTesting
+    List<AbstractCompactionTask> getScheduledTasks()
+    {
+        synchronized (scheduledTasks)
+        {
+            return new ArrayList<>(scheduledTasks);
+        }
     }
 }

--- a/src/java/org/apache/cassandra/db/compaction/BackgroundCompactionRunner.java
+++ b/src/java/org/apache/cassandra/db/compaction/BackgroundCompactionRunner.java
@@ -334,10 +334,30 @@ public class BackgroundCompactionRunner implements Runnable
 
     private CompletableFuture<Void> startCompactionTasks(ColumnFamilyStore cfs)
     {
+        // Check if we are in a paused state. If so, we shouldn't modify sstable lists until the pause is done.
+        if (!cfs.isCompactionActive())
+            return null;
+
         Collection<AbstractCompactionTask> compactionTasks = cfs.getCompactionStrategy()
                                                                 .getNextBackgroundTasks(CompactionManager.getDefaultGcBefore(cfs, FBUtilities.nowInSeconds()));
-        CompletableFuture<?>[] compactionTaskFutures = startCompactionTasks(cfs, compactionTasks);
-        return compactionTaskFutures != null ? CompletableFuture.allOf(compactionTaskFutures) : null;
+
+        // Re-check if we are in a paused state (this status may have changed between the time the next tasks call
+        // was initiated and now). If so, we shouldn't modify sstable lists until the pause is done.
+        if (cfs.isCompactionActive())
+        {
+
+            CompletableFuture<?>[] compactionTaskFutures = startCompactionTasks(cfs, compactionTasks);
+            return compactionTaskFutures != null ? CompletableFuture.allOf(compactionTaskFutures) : null;
+        }
+        else
+        {
+            logger.debug("Background compactions not issued because compaction is not active.");
+            Throwable t = null;
+            for (var c : compactionTasks)
+                t = c.rejected(t);
+            Throwables.maybeFail(t);
+            return null;
+        }
     }
     
     CompletableFuture<?>[] startCompactionTasks(ColumnFamilyStore cfs, Collection<AbstractCompactionTask> compactionTasks)

--- a/src/java/org/apache/cassandra/db/compaction/BackgroundCompactionRunner.java
+++ b/src/java/org/apache/cassandra/db/compaction/BackgroundCompactionRunner.java
@@ -356,6 +356,10 @@ public class BackgroundCompactionRunner implements Runnable
             for (var c : compactionTasks)
                 t = c.rejected(t);
             Throwables.maybeFail(t);
+            // Note that there is still a race between the compaction pause in `runWithCompactionsDisabled` and task
+            // collection creating the transactions for the tasks above that can cause `runWithCompactionsDisabled` to
+            // fail if we have prepared a compaction task but not reached this point to reject it yet.
+            // This situation, however, should occur very rarely and will resolve itself quickly.
             return null;
         }
     }

--- a/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
@@ -2402,6 +2402,29 @@ public class CompactionManager implements CompactionManagerMBean
         return interrupted;
     }
 
+    public Collection<AbstractTableOperation.OperationProgress> getOperationsInvolving(Iterable<TableMetadata> columnFamilies,
+                                                                                       Predicate<SSTableReader> sstablePredicate)
+    {
+        List<AbstractTableOperation.OperationProgress> result = new ArrayList<>();
+        for (TableOperation operationSource : active.getTableOperations())
+        {
+            AbstractTableOperation.OperationProgress info = operationSource.getProgress();
+
+            if (info.metadata() == null || Iterables.contains(columnFamilies, info.metadata()))
+            {
+                for (SSTableReader ssTableReader : info.sstables())
+                {
+                    if (sstablePredicate.test(ssTableReader))
+                    {
+                        result.add(info);
+                        break;
+                    }
+                }
+            }
+        }
+        return result;
+    }
+
     public boolean interruptCompactionFor(Iterable<TableMetadata> tables, TableOperation.StopTrigger trigger)
     {
         return interruptCompactionFor(tables, Predicates.alwaysTrue(), true, trigger);

--- a/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
@@ -190,7 +190,7 @@ public class CompactionManager implements CompactionManagerMBean
     private final BackgroundCompactionRunner backgroundCompactionRunner = new BackgroundCompactionRunner(executor, active);
 
     // The length of time to wait for task cessation when we want to run with compactions disabled.
-    private final int CESSATION_WAIT_SECONDS = CassandraRelevantProperties.CESSATION_WAIT_SECONDS.getInt(60);
+    private final static int CESSATION_WAIT_SECONDS = CassandraRelevantProperties.CESSATION_WAIT_SECONDS.getInt(60);
 
     // used to temporarily pause non-strategy managed compactions (like index summary redistribution)
     private final AtomicInteger globalCompactionPauseCount = new AtomicInteger(0);

--- a/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
@@ -72,6 +72,7 @@ import org.apache.cassandra.concurrent.DebuggableThreadPoolExecutor;
 import org.apache.cassandra.concurrent.JMXEnabledThreadPoolExecutor;
 import org.apache.cassandra.concurrent.NamedThreadFactory;
 import org.apache.cassandra.concurrent.ScheduledExecutors;
+import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.config.Config;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.ColumnFamilyStore;
@@ -187,6 +188,9 @@ public class CompactionManager implements CompactionManagerMBean
     public final ActiveOperations active = new ActiveOperations();
 
     private final BackgroundCompactionRunner backgroundCompactionRunner = new BackgroundCompactionRunner(executor, active);
+
+    // The length of time to wait for task cessation when we want to run with compactions disabled.
+    private final int CESSATION_WAIT_SECONDS = CassandraRelevantProperties.CESSATION_WAIT_SECONDS.getInt(60);
 
     // used to temporarily pause non-strategy managed compactions (like index summary redistribution)
     private final AtomicInteger globalCompactionPauseCount = new AtomicInteger(0);
@@ -2445,7 +2449,7 @@ public class CompactionManager implements CompactionManagerMBean
     public void waitForCessation(Iterable<ColumnFamilyStore> cfss, Predicate<SSTableReader> sstablePredicate)
     {
         long start = System.nanoTime();
-        long delay = TimeUnit.MINUTES.toNanos(1);
+        long delay = TimeUnit.SECONDS.toNanos(CESSATION_WAIT_SECONDS);
 
         while (System.nanoTime() - start < delay)
         {

--- a/src/java/org/apache/cassandra/db/compaction/CompactionTask.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionTask.java
@@ -198,6 +198,11 @@ public class CompactionTask extends AbstractCompactionTask
         try (CompactionController controller = getCompactionController(inputSSTables());
              CompactionOperation operation = createCompactionOperation(controller, strategy))
         {
+            // Mark the operation as active, rechecking that it has not been cancelled.
+            if (!switchToActive())
+                throw new CompactionInterruptedException(operation.op.getProgress(), TableOperation.StopTrigger.NONE);
+            // If not, the operation is now in the active operations list and can be interrupted from there.
+
             operation.execute();
         }
     }
@@ -394,9 +399,6 @@ public class CompactionTask extends AbstractCompactionTask
                 {
                     debugLogCompactingMessage(taskIdString);
                 }
-
-                if (!controller.realm.isCompactionActive())
-                    throw new CompactionInterruptedException(op.getProgress(), op.trigger());
 
                 estimatedKeys = writer.estimatedKeys();
 

--- a/src/java/org/apache/cassandra/db/compaction/CompositeCompactionTask.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompositeCompactionTask.java
@@ -21,9 +21,11 @@ package org.apache.cassandra.db.compaction;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Predicate;
 
 import com.google.common.annotations.VisibleForTesting;
 
+import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.utils.Throwables;
 
 /// A composition of several compaction tasks into one. This object executes the given tasks sequentially and
@@ -61,6 +63,20 @@ public class CompositeCompactionTask extends AbstractCompactionTask
         for (AbstractCompactionTask task : tasks)
             t = task.rejected(t);
         return super.rejected(t);
+    }
+
+    @Override
+    public boolean cancelIfAffects(CompactionRealm realm, Predicate<SSTableReader> sstablePredicate)
+    {
+        if (realm != this.realm)
+            return false;
+
+        boolean allCancelled = true;
+        for (AbstractCompactionTask task : tasks)
+            allCancelled &= task.cancelIfAffects(realm, sstablePredicate);
+        if (allCancelled)
+            super.rejected(null);
+        return allCancelled;
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/compaction/CompositeCompactionTask.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompositeCompactionTask.java
@@ -38,7 +38,7 @@ public class CompositeCompactionTask extends AbstractCompactionTask
 
     public CompositeCompactionTask(AbstractCompactionTask first)
     {
-        super(first.realm, first.realm.tryModify(Collections.emptyList(), OperationType.COMPACTION, first.transaction.opId()));
+        super(first.realm, first.realm.tryModify(Collections.emptyList(), OperationType.COMPACTION));
         tasks = new ArrayList<>();
         addTask(first);
     }
@@ -68,15 +68,8 @@ public class CompositeCompactionTask extends AbstractCompactionTask
     @Override
     public boolean cancelIfAffects(CompactionRealm realm, Predicate<SSTableReader> sstablePredicate)
     {
-        if (realm != this.realm)
-            return false;
-
-        boolean allCancelled = true;
-        for (AbstractCompactionTask task : tasks)
-            allCancelled &= task.cancelIfAffects(realm, sstablePredicate);
-        if (allCancelled)
-            super.rejected(null);
-        return allCancelled;
+        // Leave cancellation to the individual tasks.
+        return false;
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/compaction/SharedCompactionObserver.java
+++ b/src/java/org/apache/cassandra/db/compaction/SharedCompactionObserver.java
@@ -38,9 +38,13 @@ public class SharedCompactionObserver implements CompactionObserver
     private final AtomicBoolean onCompleteIsSuccess = new AtomicBoolean(true);
     private final AtomicReference<CompactionProgress> inProgressReported = new AtomicReference<>(null);
     private final CompactionObserver observer;
+    private final UUID parentId;
 
-    public SharedCompactionObserver(CompactionObserver observer)
+    public SharedCompactionObserver(UUID parentId, CompactionObserver observer)
     {
+        if (observer == null)
+            throw new IllegalArgumentException("Observer cannot be null");
+        this.parentId = parentId;
         this.observer = observer;
     }
 
@@ -57,7 +61,10 @@ public class SharedCompactionObserver implements CompactionObserver
         if (inProgressReported.compareAndSet(null, progress))
             observer.onInProgress(progress);
         else
+        {
             assert inProgressReported.get() == progress; // progress object must also be shared
+            assert progress.operationId().equals(parentId) : "progress.operationId() must match parentId";
+        }
     }
 
     @Override
@@ -65,10 +72,9 @@ public class SharedCompactionObserver implements CompactionObserver
     {
         onCompleteIsSuccess.compareAndSet(true, isSuccess); // acts like AND
         final int remainingToComplete = toReportOnComplete.decrementAndGet();
-        assert inProgressReported.get() != null : "onCompleted called before onInProgress";
         assert remainingToComplete >= 0 : "onCompleted called without corresponding registerExpectedSubtask";
-        // The individual operation ID given here may be different from the shared ID. Pass on the shared one.
+
         if (remainingToComplete == 0)
-            observer.onCompleted(inProgressReported.get().operationId(), onCompleteIsSuccess.get());
+            observer.onCompleted(parentId, onCompleteIsSuccess.get());
     }
 }

--- a/src/java/org/apache/cassandra/db/compaction/SharedCompactionObserver.java
+++ b/src/java/org/apache/cassandra/db/compaction/SharedCompactionObserver.java
@@ -55,6 +55,12 @@ public class SharedCompactionObserver implements CompactionObserver
             : "Task started before all subtasks registered for operation " + inProgressReported.get().operationId();
     }
 
+    /// Called to disable sending unwanted messages when the attached subtasks are not going to be used.
+    public void disableReportingOnComplete()
+    {
+        toReportOnComplete.set(Integer.MAX_VALUE);
+    }
+
     @Override
     public void onInProgress(CompactionProgress progress)
     {

--- a/src/java/org/apache/cassandra/db/compaction/TableOperation.java
+++ b/src/java/org/apache/cassandra/db/compaction/TableOperation.java
@@ -115,7 +115,7 @@ public interface TableOperation
 
     enum StopTrigger
     {
-        NONE("Unknwon reason", false),
+        NONE("Unknown reason", false),
         TRUNCATE("Truncated table", true),
         DROP_TABLE("Dropped table", true),
         INVALIDATE_INDEX("Index invalidation", true),

--- a/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.java
+++ b/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.java
@@ -697,7 +697,6 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
                                                                 sharedProgress,
                                                                 sharedObserver)
         );
-        compositeTransaction.completeInitialization();
         assert tasks.size() <= parallelism : "Task size: " + tasks.size() + " vs parallelism of: " + parallelism;
         assert tasks.size() <= coveredShardCount : "Task size: " + tasks.size() + " vs covered shard count: " + coveredShardCount;
 
@@ -706,11 +705,18 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
 
         if (tasks.size() == 1) // if there's just one range, make it a non-ranged task (to apply early open etc.)
         {
-            assert tasks.get(0).inputSSTables().equals(sstables);
+            // Reject the already constructed task, so that it is not tracked as an operation still expecting to be run.
+            compositeTransaction.cancelInitialization();
+            UnifiedCompactionTask oneTask = tasks.get(0);
+            Throwables.maybeFail(oneTask.rejected(null));
+            assert oneTask.inputSSTables().equals(sstables);
             return Collections.singletonList(createCompactionTask(transaction, operationRange, keepOriginals, shardingStats, gcBefore));
         }
         else
+        {
+            compositeTransaction.completeInitialization();
             return tasks;
+        }
     }
 
     private ExpirationTask createExpirationTask(LifecycleTransaction transaction)

--- a/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.java
+++ b/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.java
@@ -678,7 +678,7 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
         ShardManager shardManager = getShardManager();
         CompositeLifecycleTransaction compositeTransaction = new CompositeLifecycleTransaction(transaction);
         SharedCompactionProgress sharedProgress = new SharedCompactionProgress(transaction.opId(), transaction.opType(), TableOperation.Unit.BYTES);
-        SharedCompactionObserver sharedObserver = new SharedCompactionObserver(this);
+        SharedCompactionObserver sharedObserver = new SharedCompactionObserver(transaction.opId(), this);
         List<UnifiedCompactionTask> tasks = shardManager.splitSSTablesInShardsLimited(
             sstables,
             operationRange,

--- a/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.java
+++ b/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.java
@@ -707,6 +707,7 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
         {
             // Reject the already constructed task, so that it is not tracked as an operation still expecting to be run.
             compositeTransaction.cancelInitialization();
+            sharedObserver.disableReportingOnComplete();
             UnifiedCompactionTask oneTask = tasks.get(0);
             Throwables.maybeFail(oneTask.rejected(null));
             assert oneTask.inputSSTables().equals(sstables);

--- a/src/java/org/apache/cassandra/db/compaction/writers/CompactionAwareWriter.java
+++ b/src/java/org/apache/cassandra/db/compaction/writers/CompactionAwareWriter.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
+import org.apache.cassandra.utils.Throwables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -182,7 +183,7 @@ public abstract class CompactionAwareWriter extends Transactional.AbstractTransa
     @Override
     protected Throwable doPostCleanup(Throwable accumulate)
     {
-        sstableWriter.close();
+        accumulate = Throwables.close(accumulate, sstableWriter);
         return super.doPostCleanup(accumulate);
     }
 

--- a/src/java/org/apache/cassandra/db/lifecycle/CompositeLifecycleTransaction.java
+++ b/src/java/org/apache/cassandra/db/lifecycle/CompositeLifecycleTransaction.java
@@ -90,6 +90,17 @@ public class CompositeLifecycleTransaction
             logger.trace("Composite transaction {} initialized with {} parts.", mainTransaction.opIdString(), partsCount);
     }
 
+    /// Abort the initialization of the composite transaction. This disconnects the attached operations from the
+    /// transaction, so that they can be properly cancelled.
+    public void cancelInitialization()
+    {
+        wasAborted = true;
+        initializationComplete = true;
+        partsCount = partsToCommitOrAbort.getAndSet(0); // so that no commit or abort fires
+        if (logger.isTraceEnabled())
+            logger.trace("Composite transaction {} with {} parts cancelled.", mainTransaction.opIdString(), partsCount);
+    }
+
     /// Get the number of parts in the composite transaction. 0 if the transaction is not yet initialized.
     public int partsCount()
     {

--- a/src/java/org/apache/cassandra/db/lifecycle/LifecycleTransaction.java
+++ b/src/java/org/apache/cassandra/db/lifecycle/LifecycleTransaction.java
@@ -324,7 +324,7 @@ public class LifecycleTransaction extends Transactional.AbstractTransactional im
     @Override
     protected Throwable doPostCleanup(Throwable accumulate)
     {
-        log.close();
+        accumulate = Throwables.close(accumulate, log);
         return unmarkCompacting(marked, accumulate);
     }
 

--- a/src/java/org/apache/cassandra/db/lifecycle/LifecycleTransaction.java
+++ b/src/java/org/apache/cassandra/db/lifecycle/LifecycleTransaction.java
@@ -188,6 +188,7 @@ public class LifecycleTransaction extends Transactional.AbstractTransactional im
             marked.add(reader);
             identities.add(reader.instanceId);
         }
+        logger.debug("LifecycleTransaction {} created", uuid);
     }
 
     public AbstractLogTransaction log()
@@ -325,7 +326,9 @@ public class LifecycleTransaction extends Transactional.AbstractTransactional im
     protected Throwable doPostCleanup(Throwable accumulate)
     {
         accumulate = Throwables.close(accumulate, log);
-        return unmarkCompacting(marked, accumulate);
+        accumulate = unmarkCompacting(marked, accumulate);
+        logger.debug("LifecycleTransaction {} finalized", opId());
+        return accumulate;
     }
 
     public boolean isOffline()

--- a/src/java/org/apache/cassandra/db/streaming/CassandraStreamReader.java
+++ b/src/java/org/apache/cassandra/db/streaming/CassandraStreamReader.java
@@ -86,7 +86,7 @@ public class CassandraStreamReader implements IStreamReader
         {
             // we should only ever be streaming pending repair
             // sstables if the session has a pending repair id
-            assert session.getPendingRepair().equals(header.pendingRepair);
+            assert session.getPendingRepair().equals(header.pendingRepair) : session.getPendingRepair() + " != " + header.pendingRepair;
         }
         this.session = session;
         this.tableId = header.tableId;

--- a/src/java/org/apache/cassandra/io/sstable/SSTableTxnWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableTxnWriter.java
@@ -34,6 +34,7 @@ import org.apache.cassandra.io.sstable.format.RangeAwareSSTableWriter;
 import org.apache.cassandra.io.sstable.format.SSTableFormat;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.schema.TableMetadataRef;
+import org.apache.cassandra.utils.Throwables;
 import org.apache.cassandra.utils.concurrent.Transactional;
 
 /**
@@ -81,8 +82,7 @@ public class SSTableTxnWriter extends Transactional.AbstractTransactional implem
     @Override
     protected Throwable doPostCleanup(Throwable accumulate)
     {
-        txn.close();
-        writer.close();
+        accumulate = Throwables.close(accumulate, txn, writer);
         return super.doPostCleanup(accumulate);
     }
 

--- a/src/java/org/apache/cassandra/repair/RepairMessageVerbHandler.java
+++ b/src/java/org/apache/cassandra/repair/RepairMessageVerbHandler.java
@@ -223,9 +223,13 @@ public class RepairMessageVerbHandler implements IVerbHandler<RepairMessage>
         }
         catch (Exception e)
         {
-            logger.error("Got error processing {}, removing parent repair session", message.verb());
             if (desc != null && desc.parentSessionId != null)
+            {
+                logger.error("Got error processing {}, removing parent repair session {}", message.verb(), desc.parentSessionId);
                 ActiveRepairService.instance.removeParentRepairSession(desc.parentSessionId);
+            }
+            else
+                logger.error("Got error processing {}, removing parent repair session", message.verb());
             throw new RuntimeException(e);
         }
     }

--- a/src/java/org/apache/cassandra/repair/consistent/LocalSessions.java
+++ b/src/java/org/apache/cassandra/repair/consistent/LocalSessions.java
@@ -791,8 +791,8 @@ public class LocalSessions
         synchronized (session)
         {
             Preconditions.checkArgument(session.getState().canTransitionTo(state),
-                                        "Invalid state transition %s -> %s",
-                                        session.getState(), state);
+                                        "Invalid state transition %s -> %s for session %s",
+                                        session.getState(), state, session.sessionID);
             logger.trace("Changing LocalSession state from {} -> {} for {}", session.getState(), state, session.sessionID);
             boolean wasCompleted = session.isCompleted();
             session.setState(state);

--- a/test/unit/org/apache/cassandra/db/compaction/BackgroundCompactionRunnerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/BackgroundCompactionRunnerTest.java
@@ -112,6 +112,7 @@ public class BackgroundCompactionRunnerTest
 
         when(compactionExecutor.getMaximumPoolSize()).thenReturn(2);
         when(cfs.isAutoCompactionDisabled()).thenReturn(false);
+        when(cfs.isCompactionActive()).thenReturn(true);
         when(cfs.isValid()).thenReturn(true);
         when(checkExecutor.getQueue()).thenReturn(queue);
         when(cfs.getCompactionStrategy()).thenReturn(compactionStrategy);

--- a/test/unit/org/apache/cassandra/db/compaction/CancelCompactionsTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CancelCompactionsTest.java
@@ -34,7 +34,10 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.Uninterruptibles;
 import org.junit.Test;
 
@@ -56,7 +59,6 @@ import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.locator.RangesAtEndpoint;
 import org.apache.cassandra.locator.Replica;
 import org.apache.cassandra.schema.MockSchema;
-import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.service.ActiveRepairService;
 import org.apache.cassandra.streaming.PreviewKind;
 import org.apache.cassandra.utils.FBUtilities;
@@ -105,14 +107,14 @@ public class CancelCompactionsTest extends CQLTester
 
             // cdl.countDown will not get executed until we have aborted all compactions for the sstables in toMarkCompacting
             assertFalse(cdl.await(2, TimeUnit.SECONDS));
-            tct.abort();
+            tct.resumeAndJoin();
             // now the compactions are aborted and we can successfully wait for the latch
             t.join();
             assertTrue(cdl.await(2, TimeUnit.SECONDS));
         }
         finally
         {
-            tct.abort();
+            tct.resumeAndJoin();
         }
     }
 
@@ -162,14 +164,14 @@ public class CancelCompactionsTest extends CQLTester
                 else
                     assertFalse(compaction.isStopRequested());
             }
-            tcts.get(1).abort();
+            tcts.get(1).resumeAndJoin();
             assertEquals(1, CompactionManager.instance.active.getTableOperations().size());
             cdl.await();
             t.join();
         }
         finally
         {
-            tcts.forEach(TestCompactionTask::abort);
+            tcts.forEach(TestCompactionTask::resumeAndJoin);
         }
     }
 
@@ -223,13 +225,64 @@ public class CancelCompactionsTest extends CQLTester
                     assertFalse(compaction.isStopRequested());
             }
             assertEquals(2, toAbort.size());
-            toAbort.forEach(TestCompactionTask::abort);
+            toAbort.forEach(TestCompactionTask::resumeAndJoin);
             t.join();
-
         }
         finally
         {
-            tcts.forEach(TestCompactionTask::abort);
+            tcts.forEach(TestCompactionTask::resumeAndJoin);
+        }
+    }
+
+    /**
+     * Makes sure sub range compaction now only cancels the relevant compactions, not all of them
+     */
+    @Test
+    public void testSubrangeCompactionScheduledNotActive() throws InterruptedException
+    {
+        ColumnFamilyStore cfs = MockSchema.newCFS();
+        List<SSTableReader> sstables = createSSTables(cfs, 10, 0);
+
+        List<TestCompactionTask> tcts = new ArrayList<>();
+        tcts.add(new TestCompactionTask(cfs, new HashSet<>(sstables.subList(0, 2))));
+        tcts.add(new TestCompactionTask(cfs, new HashSet<>(sstables.subList(3, 4))));
+        tcts.add(new TestCompactionTask(cfs, new HashSet<>(sstables.subList(5, 7))));
+        tcts.add(new TestCompactionTask(cfs, new HashSet<>(sstables.subList(8, 9))));
+        try
+        {
+            assertEquals(0, getActiveCompactionsForTable(cfs).size());
+            Range<Token> range = new Range<>(token(0), token(49));
+            Thread t = new Thread(() -> {
+                try
+                {
+                    cfs.forceCompactionForTokenRange(Collections.singleton(range));
+                }
+                catch (Throwable e)
+                {
+                    throw new RuntimeException(e);
+                }
+            });
+
+            t.start();
+            t.join();
+
+            tcts.forEach(TestCompactionTask::start);
+
+            for (TableOperation compaction : getActiveCompactionsForTable(cfs))
+            {
+                if (compaction.getProgress().sstables().stream().anyMatch(sstable -> sstable.intersects(Collections.singleton(range))))
+                {
+                    fail("Affected compaction should have been cancelled.");
+                }
+                else
+                    assertFalse(compaction.isStopRequested());
+            }
+
+            assertEquals(2, getActiveCompactionsForTable(cfs).size());
+        }
+        finally
+        {
+            tcts.forEach(TestCompactionTask::resumeAndJoin);
         }
     }
 
@@ -283,15 +336,15 @@ public class CancelCompactionsTest extends CQLTester
                     assertFalse(compaction.isStopRequested());
             }
             assertEquals(2, toAbort.size());
-            toAbort.forEach(TestCompactionTask::abort);
+            toAbort.forEach(TestCompactionTask::resumeAndJoin);
             fut.get();
             for (SSTableReader sstable : sstables)
                 assertTrue(!sstable.intersects(Collections.singleton(range)) || sstable.isPendingRepair());
         }
         finally
         {
-            tcts.forEach(TestCompactionTask::abort);
-            nonAffectedTcts.forEach(TestCompactionTask::abort);
+            tcts.forEach(TestCompactionTask::resumeAndJoin);
+            nonAffectedTcts.forEach(TestCompactionTask::resumeAndJoin);
         }
     }
 
@@ -382,45 +435,72 @@ public class CancelCompactionsTest extends CQLTester
         return sstables;
     }
 
-    private static class TestCompactionTask
+    private static class TestCompactionTask extends AbstractCompactionTask
     {
         private ColumnFamilyStore cfs;
         private final Set<SSTableReader> sstables;
-        private LifecycleTransaction txn;
         private CompactionController controller;
         private CompactionIterator ci;
         private List<ISSTableScanner> scanners;
         private Closeable closeable;
+        private CountDownLatch resumeLatch = new CountDownLatch(1);
+        private CountDownLatch startedLatch = new CountDownLatch(1);
+        private Future<?> future;
+
 
         public TestCompactionTask(ColumnFamilyStore cfs, Set<SSTableReader> sstables)
         {
+            super(cfs, cfs.getTracker().tryModify(sstables, OperationType.COMPACTION));
             this.cfs = cfs;
             this.sstables = sstables;
         }
 
-        public void start()
+        public void runMayThrow() throws InterruptedException
         {
             scanners = sstables.stream().map(SSTableReader::getScanner).collect(Collectors.toList());
-            txn = cfs.getTracker().tryModify(sstables, OperationType.COMPACTION);
-            assertNotNull(txn);
+            assertNotNull(transaction);
             controller = new CompactionController(cfs, sstables, Integer.MIN_VALUE);
-            ci = new CompactionIterator(txn.opType(), scanners, controller, FBUtilities.nowInSeconds(), UUID.randomUUID());
+            ci = new CompactionIterator(transaction.opType(), scanners, controller, FBUtilities.nowInSeconds(), UUID.randomUUID());
             TableOperation op = ci.getOperation();
             closeable = CompactionManager.instance.active.onOperationStart(op);
+            switchToActive();
+
+            startedLatch.countDown();
+            resumeLatch.await(10, TimeUnit.SECONDS);
+            complete();
         }
 
-        public void abort()
+        public void complete()
         {
             if (controller != null)
                 controller.close();
             if (ci != null)
                 ci.close();
-            if (txn != null)
-                txn.abort();
             if (scanners != null)
                 scanners.forEach(ISSTableScanner::close);
             if (closeable != null)
                 Throwables.maybeFail(Throwables.close(null, closeable));
+        }
+
+        public void resumeAndJoin()
+        {
+            if (future == null)
+                return;
+
+            resumeLatch.countDown();
+            Futures.getUnchecked(future);
+        }
+
+        @Override
+        public void cancelledOnStart()
+        {
+            startedLatch.countDown();
+        }
+
+        public void start()
+        {
+            future = Executors.newSingleThreadExecutor().submit(() -> execute());
+            Uninterruptibles.awaitUninterruptibly(startedLatch,10, TimeUnit.SECONDS);
         }
     }
 
@@ -490,7 +570,7 @@ public class CancelCompactionsTest extends CQLTester
 
         CountDownLatch waitForBeginCompaction = new CountDownLatch(1);
         CountDownLatch waitForStart = new CountDownLatch(1);
-        Iterable<TableMetadata> metadatas = Collections.singleton(getCurrentColumnFamilyStore().metadata());
+        Iterable<ColumnFamilyStore> cfss = Collections.singleton(getCurrentColumnFamilyStore());
         /*
         Here we ask strategies to pause & interrupt compactions right before calling beginCompaction in CompactionTask
         The code running in the separate thread below mimics CFS#runWithCompactionsDisabled but we only allow
@@ -499,7 +579,9 @@ public class CancelCompactionsTest extends CQLTester
         Thread t = new Thread(() -> {
             Uninterruptibles.awaitUninterruptibly(waitForBeginCompaction);
             getCurrentColumnFamilyStore().getCompactionStrategyContainer().pause();
-            CompactionManager.instance.interruptCompactionFor(metadatas, (s) -> true, false, UNIT_TESTS);
+            CompactionManager.instance.active.cancelScheduledTasksAffecting(cfss, Predicates.alwaysTrue());
+            CompactionManager.instance.interruptCompactionFor(Iterables.transform(cfss, ColumnFamilyStore::metadata),
+                                                              Predicates.alwaysTrue(), false, UNIT_TESTS);
             waitForStart.countDown();
             CompactionManager.instance.waitForCessation(Collections.singleton(getCurrentColumnFamilyStore()), (s) -> true);
             getCurrentColumnFamilyStore().getCompactionStrategyContainer().resume();

--- a/test/unit/org/apache/cassandra/db/compaction/CompactionControllerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CompactionControllerTest.java
@@ -396,7 +396,7 @@ public class CompactionControllerTest extends SchemaLoader
         //the overlap iterator should contain sstable2
         //this compaction will be paused by the BMRule
         Thread t = new Thread(() -> {
-            task.executeInternal();
+            task.execute();
         });
 
         //start a compaction for the second sstable (compaction2)

--- a/test/unit/org/apache/cassandra/db/compaction/CompactionTaskTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CompactionTaskTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
+import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableSet;
 import org.junit.Assert;
 import org.junit.Before;
@@ -117,7 +118,7 @@ public class CompactionTaskTest
 
         AbstractCompactionTask task = new CompactionTask(cfs, txn, 0, false, mockStrategy);
         Assert.assertNotNull(task);
-        cfs.getCompactionStrategyContainer().pause();
+        task.cancelIfAffects(cfs, Predicates.alwaysTrue());
         try
         {
             task.execute(CompactionManager.instance.active);

--- a/test/unit/org/apache/cassandra/db/compaction/CompactionTaskTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CompactionTaskTest.java
@@ -100,7 +100,7 @@ public class CompactionTaskTest
     }
 
     @Test
-    public void compactionDisabled() throws Exception
+    public void compactionCancelled() throws Exception
     {
         cfs.getCompactionStrategyContainer().disable();
         QueryProcessor.executeInternal("INSERT INTO ks.tbl (k, v) VALUES (1, 1);");
@@ -116,15 +116,22 @@ public class CompactionTaskTest
         LifecycleTransaction txn = cfs.getTracker().tryModify(sstables, OperationType.COMPACTION);
         Assert.assertNotNull(txn);
 
-        AbstractCompactionTask task = new CompactionTask(cfs, txn, 0, false, mockStrategy);
+        AbstractCompactionTask task = new CompactionTask(cfs, txn, 0, false, mockStrategy)
+        {
+            @Override
+            public void cancelledOnStart()
+            {
+                throw new RuntimeException("Cancelled");
+            }
+        };
         Assert.assertNotNull(task);
         task.cancelIfAffects(cfs, Predicates.alwaysTrue());
         try
         {
             task.execute(CompactionManager.instance.active);
-            Assert.fail("Expected CompactionInterruptedException");
+            Assert.fail("Expected to be cancelled");
         }
-        catch (CompactionInterruptedException e)
+        catch (RuntimeException e)
         {
             // expected
         }

--- a/test/unit/org/apache/cassandra/db/compaction/CompositeCompactionTaskTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CompositeCompactionTaskTest.java
@@ -27,15 +27,13 @@ import java.util.stream.Stream;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.lifecycle.LifecycleTransaction;
 import org.mockito.Mockito;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -52,11 +50,13 @@ public class CompositeCompactionTaskTest
 
     @Before
     public void setUp() {
+        DatabaseDescriptor.toolInitialization(false);
+
         mockRealm = Mockito.mock(CompactionRealm.class);
         mockTransaction = Mockito.mock(LifecycleTransaction.class);
         when(mockTransaction.isOffline()).thenReturn(true);
         when(mockTransaction.opId()).thenReturn(UUID.randomUUID());
-        when(mockRealm.tryModify(any(), any(), any())).thenReturn(mockTransaction);
+        when(mockRealm.tryModify(any(), any())).thenReturn(mockTransaction);
 
         mockTask1 = Mockito.mock(AbstractCompactionTask.class, Mockito.withSettings().useConstructor(mockRealm, mockTransaction));
         mockTask2 = Mockito.mock(AbstractCompactionTask.class, Mockito.withSettings().useConstructor(mockRealm, mockTransaction));

--- a/test/unit/org/apache/cassandra/db/compaction/DisabledRepairStateCheckingTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/DisabledRepairStateCheckingTest.java
@@ -125,7 +125,7 @@ public class DisabledRepairStateCheckingTest
                 assertNotNull(txn);
                 CompactionTask task = new CompactionTask(cfs, txn, 0, false, mockStrategy);
                 assertNotNull(task); // task must be successfully created
-                task.executeInternal(); // and run
+                task.execute(); // and run
                 for (SSTableReader s : txn.current())
                 {
                     assertFalse(s.isRepaired()); // and the resulting files must be marked unrepaired

--- a/test/unit/org/apache/cassandra/db/compaction/RandomizedCancelCompactionsTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/RandomizedCancelCompactionsTest.java
@@ -1,0 +1,498 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.compaction;
+
+import java.io.Closeable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import com.google.common.base.Predicate;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.dht.Murmur3Partitioner;
+import org.apache.cassandra.dht.Range;
+import org.apache.cassandra.dht.Token;
+import org.apache.cassandra.io.sstable.ISSTableScanner;
+import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.schema.MockSchema;
+import org.apache.cassandra.utils.FBUtilities;
+import org.apache.cassandra.utils.Throwables;
+
+import static org.apache.cassandra.db.compaction.TableOperation.StopTrigger.UNIT_TESTS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+
+/// Randomized test for compaction cancellation that verifies:
+/// - Tasks can be cancelled both when queued and when active
+/// - Cancelled tasks always run their cleanup
+/// - No leaks occur in ActiveOperations queues
+/// - The right tasks are cancelled based on predicates
+public class RandomizedCancelCompactionsTest extends CQLTester
+{
+    @BeforeClass
+    public static void setUpClass()
+    {
+        CassandraRelevantProperties.CESSATION_WAIT_SECONDS.setInt(1);
+        CQLTester.setUpClass();
+    }
+
+    private static final Logger logger = LoggerFactory.getLogger(RandomizedCancelCompactionsTest.class);
+    
+    private static final int TEST_DURATION_SECONDS = 40;
+    private static final int MAX_CONCURRENT_COMPACTIONS = 40;
+    private static final int EXECUTOR_THREADS = 4; // Limited threads to keep tasks in queue
+    private static final int SSTABLE_COUNT = 500;
+    private static final int MAX_COMPACTION_SLEEP_MS = 2000;
+    private static final int MIN_COMPACTION_SLEEP_MS = 100;
+    private static final double QUICK_EXIT_CHANCE = 0.05;
+    
+    @Test
+    public void testRandomizedCancellation() throws Exception
+    {
+        ColumnFamilyStore cfs = MockSchema.newCFS();
+        List<SSTableReader> sstables = createSSTables(cfs, SSTABLE_COUNT, 0);
+        
+        Random random = new Random(System.currentTimeMillis());
+        ExecutorService executor = Executors.newFixedThreadPool(EXECUTOR_THREADS);
+        
+        // Track all tasks and their states
+        CopyOnWriteArrayList<RandomizedCompactionTask> allTasks = new CopyOnWriteArrayList<>();
+        AtomicInteger taskIdCounter = new AtomicInteger(0);
+        AtomicBoolean testRunning = new AtomicBoolean(true);
+        
+        // Statistics
+        AtomicInteger tasksCreated = new AtomicInteger(0);
+        AtomicInteger tasksCreationFailed = new AtomicInteger(0);
+        AtomicInteger tasksCompleted = new AtomicInteger(0);
+        AtomicInteger tasksCancelled = new AtomicInteger(0);
+        AtomicInteger tasksCancelledBeforeStart = new AtomicInteger(0);
+        AtomicInteger tasksCancelledAfterStart = new AtomicInteger(0);
+        AtomicInteger cancellationAttempts = new AtomicInteger(0);
+        AtomicInteger cancellationSuccess = new AtomicInteger(0);
+
+        long startTime = System.currentTimeMillis();
+        long endTime = startTime + TimeUnit.SECONDS.toMillis(TEST_DURATION_SECONDS);
+        
+        try
+        {
+            // Thread 1: Randomly create compaction tasks
+            Future<?> taskCreator = executor.submit(() -> {
+                while (testRunning.get() && System.currentTimeMillis() < endTime)
+                {
+                    try
+                    {
+                        // Limit concurrent tasks - count active tasks without stream
+                        int activeTasks = 0;
+                        for (RandomizedCompactionTask t : allTasks)
+                        {
+                            if (!t.isFinished())
+                                activeTasks++;
+                        }
+                        
+                        if (activeTasks < MAX_CONCURRENT_COMPACTIONS && cfs.isCompactionActive())
+                        {
+                            // Select random subset of sstables (1-3 sstables per task)
+                            int count = random.nextInt(3) + 1;
+                            Set<SSTableReader> taskSSTables = new HashSet<>();
+                            for (int i = 0; i < count; i++)
+                            {
+                                taskSSTables.add(sstables.get(random.nextInt(sstables.size())));
+                            }
+                            
+                            int taskId = taskIdCounter.incrementAndGet();
+                            RandomizedCompactionTask task = new RandomizedCompactionTask(
+                                cfs, 
+                                taskSSTables, 
+                                taskId,
+                                random.nextDouble() < QUICK_EXIT_CHANCE ? (random.nextBoolean() ? 0 : -1)
+                                                                        : random.nextInt(MAX_COMPACTION_SLEEP_MS - MIN_COMPACTION_SLEEP_MS) + MIN_COMPACTION_SLEEP_MS,
+                                tasksCompleted,
+                                tasksCancelled,
+                                tasksCancelledBeforeStart,
+                                tasksCancelledAfterStart
+                            );
+                            
+                            // Check if task creation succeeded (tryModify returned non-null transaction)
+                            allTasks.add(task);
+                            task.start(executor);
+                            tasksCreated.incrementAndGet();
+                            logger.debug("Created task {} with {} sstables", taskId, taskSSTables.size());
+                        }
+                        
+                        // Random delay before creating next task
+                        Thread.sleep(random.nextInt(50) + 10);
+                    }
+                    catch (InterruptedException e)
+                    {
+                        Thread.currentThread().interrupt();
+                        break;
+                    }
+                    catch (WasNullException e)
+                    {
+                        tasksCreationFailed.incrementAndGet();
+                    }
+                    catch (Exception e)
+                    {
+                        logger.error("Error creating task", e);
+                        fail("Unexpected error creating task");
+                    }
+                }
+            });
+            
+            // Thread 2: Randomly cancel compactions using runWithCompactionsDisabled
+            Future<?> taskCanceller = executor.submit(() -> {
+                while (testRunning.get() && System.currentTimeMillis() < endTime)
+                {
+                    try
+                    {
+                        // Wait a bit before attempting cancellation
+                        Thread.sleep(random.nextInt(1000) + 500);
+                        
+                        // Select a random token range to cancel
+                        long rangeStart = random.nextInt(SSTABLE_COUNT * 10);
+                        long rangeEnd = rangeStart + random.nextInt(500) + 10;
+                        Range<Token> range = new Range<>(token(rangeStart), token(rangeEnd));
+                        
+                        cancellationAttempts.incrementAndGet();
+                        logger.debug("Attempting cancellation for range [{}, {}]", rangeStart, rangeEnd);
+                        
+                        CountDownLatch cancelLatch = new CountDownLatch(1);
+                        Predicate<SSTableReader> predicate = (sstable) -> sstable.intersects(Collections.singleton(range));
+                        if (cfs.runWithCompactionsDisabled(
+                            () -> {
+                                logger.debug("Successful cancellation for range [{}, {}]", rangeStart, rangeEnd);
+                                cancellationSuccess.incrementAndGet();
+                                assertEquals("No sstables intersecting range may be compacting inside runWithCompactionsDisabled block",
+                                             0, cfs.getCompactingSSTables().stream().filter(predicate).count());
+                                return true;
+                            },
+                            predicate,
+                            false,
+                            false,
+                            false,
+                            UNIT_TESTS
+                        ) == null)
+                            logger.warn("Failed cancellation for range [{}, {}]", rangeStart, rangeEnd);
+                    }
+                    catch (InterruptedException e)
+                    {
+                        Thread.currentThread().interrupt();
+                        break;
+                    }
+                    catch (Exception e)
+                    {
+                        logger.error("Error during cancellation", e);
+                    }
+                }
+            });
+            
+            // Wait for test duration
+            taskCreator.get(TEST_DURATION_SECONDS + 5, TimeUnit.SECONDS);
+            taskCanceller.get(TEST_DURATION_SECONDS + 5, TimeUnit.SECONDS);
+            
+            // Stop test
+            testRunning.set(false);
+            
+            // Wait for all tasks to complete
+            logger.info("Waiting for all tasks to complete...");
+            long waitStart = System.currentTimeMillis();
+            while (allTasks.stream().anyMatch(t -> !t.isFinished()))
+            {
+                if (System.currentTimeMillis() - waitStart > 10000)
+                {
+                    fail("Tasks did not complete within timeout");
+                }
+                Thread.sleep(100);
+            }
+            
+            // Verify all tasks
+            logger.info("Verifying task states...");
+            for (RandomizedCompactionTask task : allTasks)
+            {
+                assertTrue("Task " + task.taskId + " should be finished", task.isFinished());
+                assertTrue("Task " + task.taskId + " should have run cleanup", task.cleanupRan.get());
+                
+                // Only verify wasStopRequested for tasks that were cancelled after becoming active
+                // Tasks cancelled before start or during initialization won't have this flag set
+                if (task.wasCancelled.get() && task.wasStopRequested.get())
+                {
+                    // If wasStopRequested is true, the task must have been cancelled after starting
+                    assertTrue("Task " + task.taskId + " with stop requested should have started", 
+                               task.started.get());
+                }
+            }
+            
+            // Verify no leaks in ActiveOperations
+            List<AbstractCompactionTask> scheduledTestTasks = CompactionManager.instance.active.getScheduledTasks()
+                .stream()
+                .filter(RandomizedCompactionTask.class::isInstance)
+                .collect(Collectors.toList());
+            
+            assertEquals("No operations should be in scheduled list after test", 0, scheduledTestTasks.size());
+            
+            // Verify no test tasks remain in ActiveOperations
+            List<TableOperation> remainingOps = CompactionManager.instance.active.getTableOperations()
+                .stream()
+                .filter(op -> op.getProgress().table().orElse("unknown").equalsIgnoreCase(cfs.name))
+                .collect(Collectors.toList());
+            
+            assertEquals("No test operations should remain in ActiveOperations", 0, remainingOps.size());
+
+            assertEquals("No sstables should be still compacting", 0, cfs.getCompactingSSTables().size());
+            
+            // Print statistics
+            logger.info("Test completed:");
+            logger.info("  Cancellation attempts: {}", cancellationAttempts.get());
+            logger.info("    - Successful: {}", cancellationSuccess.get());
+            logger.info("  Tasks created: {}", tasksCreated.get());
+            logger.info("  Task creation failures: {}", tasksCreationFailed.get());
+            logger.info("  Tasks completed: {}", tasksCompleted.get());
+            logger.info("  Tasks cancelled: {}", tasksCancelled.get());
+            logger.info("    - Cancelled before start: {}", tasksCancelledBeforeStart.get());
+            logger.info("    - Cancelled after start: {}", tasksCancelledAfterStart.get());
+            logger.info("  Total tasks: {}", allTasks.size());
+            
+            // Verify counts
+            assertEquals("All tasks should be accounted for", 
+                         tasksCompleted.get() + tasksCancelled.get(), 
+                         allTasks.size());
+            assertEquals("Cancelled tasks breakdown should match total", 
+                         tasksCancelledBeforeStart.get() + tasksCancelledAfterStart.get(), 
+                         tasksCancelled.get());
+
+            assertEquals("Cancellations should all succeed", cancellationAttempts.get(), cancellationSuccess.get());
+        }
+        finally
+        {
+            testRunning.set(false);
+            executor.shutdownNow();
+            executor.awaitTermination(10, TimeUnit.SECONDS);
+        }
+    }
+    
+    private Token token(long t)
+    {
+        return new Murmur3Partitioner.LongToken(t);
+    }
+    
+    private List<SSTableReader> createSSTables(ColumnFamilyStore cfs, int count, int startGeneration)
+    {
+        List<SSTableReader> sstables = new ArrayList<>();
+        for (int i = 0; i < count; i++)
+        {
+            long first = i * 10;
+            long last = (i + 1) * 10 - 1;
+            sstables.add(MockSchema.sstable(startGeneration + i, 0, true, first, last, cfs));
+        }
+        cfs.disableAutoCompaction();
+        cfs.addSSTables(sstables);
+        return sstables;
+    }
+
+    static class WasNullException extends RuntimeException
+    {
+
+    }
+    
+    /**
+     * A compaction task that sleeps for a random amount of time instead of waiting on signals.
+     * Tracks its lifecycle for verification.
+     */
+    private static class RandomizedCompactionTask extends AbstractCompactionTask
+    {
+        private static final Logger logger = LoggerFactory.getLogger(RandomizedCompactionTask.class);
+        
+        private final ColumnFamilyStore cfs;
+        private final Set<SSTableReader> sstables;
+        private final int taskId;
+        private final int sleepTimeMs;
+        private final AtomicInteger completedCounter;
+        private final AtomicInteger cancelledCounter;
+        private final AtomicInteger cancelledBeforeStartCounter;
+        private final AtomicInteger cancelledAfterStartCounter;
+        
+        private CompactionController controller;
+        private CompactionIterator ci;
+        private List<ISSTableScanner> scanners;
+        private Closeable closeable;
+        
+        // State tracking
+        private final AtomicBoolean started = new AtomicBoolean(false);
+        private final AtomicBoolean finished = new AtomicBoolean(false);
+        private final AtomicBoolean cleanupRan = new AtomicBoolean(false);
+        private final AtomicBoolean wasCancelled = new AtomicBoolean(false);
+        private final AtomicBoolean wasStopRequested = new AtomicBoolean(false);
+        
+        public RandomizedCompactionTask(ColumnFamilyStore cfs, 
+                                       Set<SSTableReader> sstables, 
+                                       int taskId,
+                                       int sleepTimeMs,
+                                       AtomicInteger completedCounter,
+                                       AtomicInteger cancelledCounter,
+                                       AtomicInteger cancelledBeforeStartCounter,
+                                       AtomicInteger cancelledAfterStartCounter)
+        {
+            super(cfs, checkNotNull(cfs.getTracker().tryModify(sstables, OperationType.COMPACTION)));
+            this.cfs = cfs;
+            this.sstables = sstables;
+            this.taskId = taskId;
+            this.sleepTimeMs = sleepTimeMs;
+            this.completedCounter = completedCounter;
+            this.cancelledCounter = cancelledCounter;
+            this.cancelledBeforeStartCounter = cancelledBeforeStartCounter;
+            this.cancelledAfterStartCounter = cancelledAfterStartCounter;
+        }
+        
+        static <T> T checkNotNull(T value)
+        {
+            if (value == null)
+                throw new WasNullException();
+            return value;
+        }
+
+        public void runMayThrow() throws InterruptedException
+        {
+            try
+            {
+                started.set(true);
+                
+                if (transaction == null)
+                {
+                    // Task was cancelled before it could start
+                    logger.debug("Task {} cancelled before start", taskId);
+                    wasCancelled.set(true);
+                    cancelledCounter.incrementAndGet();
+                    cancelledBeforeStartCounter.incrementAndGet();
+                    return;
+                }
+
+                if (sleepTimeMs <= 0)
+                {
+                    // quick exit, to test task not moving to active
+                    logger.debug("Task {} performing quick exit{}", taskId, sleepTimeMs < 0 ? " with exception" : "");
+                    completedCounter.incrementAndGet();
+                    if (sleepTimeMs < 0)
+                        throw new RuntimeException("test");
+                    else
+                        return;
+                }
+
+                scanners = sstables.stream().map(SSTableReader::getScanner).collect(Collectors.toList());
+                controller = new CompactionController(cfs, sstables, Integer.MIN_VALUE);
+                ci = new CompactionIterator(transaction.opType(), scanners, controller, FBUtilities.nowInSeconds(), UUID.randomUUID());
+                TableOperation op = ci.getOperation();
+                closeable = opObserver.onOperationStart(op);
+                switchToActive();
+                
+                logger.debug("Task {} started, sleeping for {}ms", taskId, sleepTimeMs);
+                
+                // Sleep in small increments to check for cancellation
+                int slept = 0;
+                while (slept < sleepTimeMs)
+                {
+                    if (op.isStopRequested())
+                    {
+                        wasStopRequested.set(true);
+                        logger.debug("Task {} stop requested after {}ms", taskId, slept);
+                        break;
+                    }
+                    Thread.sleep(Math.min(100, sleepTimeMs - slept));
+                    slept += 100;
+                }
+                
+                if (wasStopRequested.get())
+                {
+                    wasCancelled.set(true);
+                    cancelledCounter.incrementAndGet();
+                    cancelledAfterStartCounter.incrementAndGet();
+                    logger.debug("Task {} cancelled after start", taskId);
+                }
+                else
+                {
+                    completedCounter.incrementAndGet();
+                    logger.debug("Task {} completed normally", taskId);
+                }
+            }
+            finally
+            {
+                complete();
+                finished.set(true);
+            }
+        }
+        
+        private void complete()
+        {
+            cleanupRan.set(true);
+            
+            if (controller != null)
+                controller.close();
+            if (ci != null)
+                ci.close();
+            if (scanners != null)
+                scanners.forEach(ISSTableScanner::close);
+            if (closeable != null)
+                Throwables.maybeFail(Throwables.close(null, closeable));
+        }
+        
+        @Override
+        public void cancelledOnStart()
+        {
+            started.set(true);
+            finished.set(true);
+            cleanupRan.set(true);
+            wasCancelled.set(true);
+            cancelledCounter.incrementAndGet();
+            cancelledBeforeStartCounter.incrementAndGet();
+            logger.debug("Task {} cancelled on start", taskId);
+        }
+        
+        public void start(ExecutorService executor)
+        {
+            executor.submit(() -> execute(CompactionManager.instance.active));
+        }
+        
+        public boolean isFinished()
+        {
+            return finished.get();
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/db/compaction/SharedCompactionObserverTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/SharedCompactionObserverTest.java
@@ -164,6 +164,15 @@ public class SharedCompactionObserverTest
     }
 
     @Test
+    public void testNoInProgressIsAccepted()
+    {
+        Util.assumeAssertsEnabled();
+        sharedCompactionObserver.registerExpectedSubtask();
+        sharedCompactionObserver.onCompleted(operationId, true);
+        verify(mockObserver, times(1)).onCompleted(operationId, true);
+    }
+
+    @Test
     public void testErrorWrongProgress()
     {
         Util.assumeAssertsEnabled();

--- a/test/unit/org/apache/cassandra/db/compaction/SharedCompactionObserverTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/SharedCompactionObserverTest.java
@@ -50,8 +50,8 @@ public class SharedCompactionObserverTest
     public void setUp()
     {
         mockObserver = Mockito.mock(CompactionObserver.class);
-        sharedCompactionObserver = new SharedCompactionObserver(mockObserver);
         operationId = UUID.randomUUID();
+        sharedCompactionObserver = new SharedCompactionObserver(operationId, mockObserver);
         mockProgress = Mockito.mock(CompactionProgress.class);
         when(mockProgress.operationId()).thenReturn(operationId);
     }
@@ -164,14 +164,6 @@ public class SharedCompactionObserverTest
     }
 
     @Test
-    public void testErrorNoInProgress()
-    {
-        Util.assumeAssertsEnabled();
-        sharedCompactionObserver.registerExpectedSubtask();
-        Assert.assertThrows(AssertionError.class, () -> sharedCompactionObserver.onCompleted(operationId, true));
-    }
-
-    @Test
     public void testErrorWrongProgress()
     {
         Util.assumeAssertsEnabled();
@@ -181,5 +173,24 @@ public class SharedCompactionObserverTest
         var mockProgress2 = Mockito.mock(CompactionProgress.class);
         when(mockProgress2.operationId()).thenReturn(UUID.randomUUID());
         Assert.assertThrows(AssertionError.class, () -> sharedCompactionObserver.onInProgress(mockProgress2));
+    }
+
+    @Test
+    public void testNullPrimaryObserver()
+    {
+        Assert.assertThrows(IllegalArgumentException.class,
+                            () -> new SharedCompactionObserver(operationId, null));
+    }
+
+    @Test
+    public void testErrorWrongProgressId()
+    {
+        Util.assumeAssertsEnabled();
+        sharedCompactionObserver.registerExpectedSubtask();
+        sharedCompactionObserver.registerExpectedSubtask();
+        sharedCompactionObserver.onInProgress(mockProgress);
+
+        when(mockProgress.operationId()).thenReturn(UUID.randomUUID());
+        Assert.assertThrows(AssertionError.class, () -> sharedCompactionObserver.onInProgress(mockProgress));
     }
 }

--- a/test/unit/org/apache/cassandra/db/compaction/unified/ParallelizedTasksTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/unified/ParallelizedTasksTest.java
@@ -102,7 +102,7 @@ public class ParallelizedTasksTest extends ShardingTestBase
         UnifiedCompactionStrategy mockStrategy = strategy;
         strategy.getCompactionLogger().enable();
         SharedCompactionProgress sharedProgress = new SharedCompactionProgress(transaction.opId(), transaction.opType(), TableOperation.Unit.BYTES);
-        SharedCompactionObserver sharedObserver = new SharedCompactionObserver(strategy);
+        SharedCompactionObserver sharedObserver = new SharedCompactionObserver(transaction.opId(), strategy);
 
         List<AbstractCompactionTask> tasks = shardManager.splitSSTablesInShards(
             sstables,


### PR DESCRIPTION
### What is the issue
[HCD-200](https://datastax.jira.com/browse/HCD-200)

### What does this PR fix and why was it fixed
Changes the tracking of compaction tasks to include scheduled in addition to active tasks
by introducing a new queue where `AbstractCompactionTasks` register themselves.

When the tasks execute, `CompactionTasks` move from the scheduled tasks to the active operations list.
Other types of tasks are expected to finish quickly and are removed from the scheduled tasks when
they complete.

`runWithCompactionsDisabled` cancels tasks in both lists and should now be able to reliably cancel
all compactions in flight.

Includes a port of CNDB-16269.

[HCD-200]: https://datastax.jira.com/browse/HCD-200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ