### PR TITLE
CNDB-17453: fix flaky cleanup timing assertion in FlushFailingOnNotificationSubscriberTest

### DIFF
--- a/test/long/org/apache/cassandra/io/memtable/FlushFailingOnNotificationSubscriberTest.java
+++ b/test/long/org/apache/cassandra/io/memtable/FlushFailingOnNotificationSubscriberTest.java
@@ -209,6 +209,7 @@ public class FlushFailingOnNotificationSubscriberTest extends CQLTester
         {
             failFlushProbability.set(0.0);
             getCurrentColumnFamilyStore().forceFlush(ColumnFamilyStore.FlushReason.UNIT_TESTS).get();
+            lastTimePoolNeededCleaning = System.nanoTime();
             failFlushProbability.set(FLUSH_FAILURE_PROBABILITY);
         }
         catch (InterruptedException | ExecutionException e)


### PR DESCRIPTION
### What does this PR fix and why was it fixed

Reset lastTimePoolNeededCleaning after successful flushes so the cleanup gap measurement doesn't span flush boundaries.

