### PR TITLE
CNDB-16123: Add slow query logger execution info to non-SAI read commands

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -589,6 +589,11 @@ public enum CassandraRelevantProperties
     MEMTABLE_TRIE_SIZE_LIMIT("cassandra.trie_size_limit_mb"),
     MIGRATION_DELAY("cassandra.migration_delay_ms", "60000"),
     MMAPPED_MAX_SEGMENT_SIZE_IN_MB("cassandra.mmapped_max_segment_size"),
+    /**
+     * Whether to log detailed execution info when logging slow non-SAI queries.
+     * For SAI queries, see {@link #SAI_SLOW_QUERY_LOG_EXECUTION_INFO_ENABLED}.
+     */
+    MONITORING_EXECUTION_INFO_ENABLED("cassandra.monitoring_execution_info_enabled", "true"),
     /** Defines the maximum number of unique timed out queries that will be reported in the logs. Use a negative number to remove any limit. */
     MONITORING_MAX_OPERATIONS("cassandra.monitoring_max_operations", "50"),
     /** Defines the interval for reporting any operations that have timed out. */
@@ -793,6 +798,7 @@ public enum CassandraRelevantProperties
     /**
      * Whether to log SAI-specific detailed execution info when logging slow SAI queries.
      * This execution info includes the query metrics and the query plan of the slow queries.
+     * For non-SAI queries, see {@link #MONITORING_EXECUTION_INFO_ENABLED}.
      */
     SAI_SLOW_QUERY_LOG_EXECUTION_INFO_ENABLED("cassandra.sai.slow_query_log.execution_info_enabled", "true"),
 

--- a/src/java/org/apache/cassandra/db/ReadCommand.java
+++ b/src/java/org/apache/cassandra/db/ReadCommand.java
@@ -138,7 +138,7 @@ public abstract class ReadCommand extends AbstractReadQuery
     @Nullable
     protected final Index.QueryPlan indexQueryPlan;
 
-    private volatile Supplier<ExecutionInfo> executionInfoSupplier = ExecutionInfo.EMPTY_SUPPLIER;
+    private Supplier<ExecutionInfo> executionInfoSupplier = ExecutionInfo.EMPTY_SUPPLIER;
 
     protected static abstract class SelectionDeserializer
     {
@@ -516,8 +516,8 @@ public abstract class ReadCommand extends AbstractReadQuery
             Context context = Context.from(this);
             var storageTarget = (null == searcher) ? queryStorage(cfs, executionController)
                                                    : searchStorage(searcher, executionController);
-            if (searcher != null)
-                executionInfoSupplier = searcher.monitorableExecutionInfo();
+            // Prepare the monitorable execution info, which will be null if it's deferred to the index
+            ReadCommandExecutionInfo executionInfo = setupExecutionInfo(searcher);
 
             UnfilteredPartitionIterator iterator = Transformation.apply(storageTarget, new TrackingRowIterator(context));
             iterator = RTBoundValidator.validate(iterator, Stage.MERGED, false);
@@ -530,6 +530,8 @@ public abstract class ReadCommand extends AbstractReadQuery
                 iterator = withReadObserver(iterator);
                 iterator = RTBoundValidator.validate(withoutPurgeableTombstones(iterator, cfs, executionController), Stage.PURGED, false);
                 iterator = withMetricsRecording(iterator, cfs.metric, startTimeNanos);
+                if (executionInfo != null)
+                    iterator = executionInfo.countFetched(iterator, nowInSec());
 
                 // If we've used a 2ndary index, we know the result already satisfy the primary expression used, so
                 // no point in checking it again.
@@ -562,8 +564,13 @@ public abstract class ReadCommand extends AbstractReadQuery
                     iterator = limits().filter(iterator, nowInSec(), selectsFullPartition());
                 }
 
-                // because of the above, we need to append an aritifical end bound if the source iterator was stopped short by a counter.
-                return RTBoundCloser.close(iterator);
+                // because of the above, we need to append an artifical end bound if the source iterator was stopped short by a counter.
+                iterator = RTBoundCloser.close(iterator);
+
+                if (executionInfo != null)
+                    iterator = executionInfo.countReturned(iterator, nowInSec());
+
+                return iterator;
             }
             catch (RuntimeException | Error e)
             {
@@ -1371,5 +1378,29 @@ public abstract class ReadCommand extends AbstractReadQuery
                    + command.selectionSerializedSize(version)
                    + command.indexSerializedSize(version);
         }
+    }
+
+    @Nullable
+    private ReadCommandExecutionInfo setupExecutionInfo(Index.Searcher searcher)
+    {
+        // if we have a searcher, it may use its own custom execution info instead of the generic one
+        if (searcher != null)
+        {
+            Supplier<ExecutionInfo> searcherExecutionInfoSupplier = searcher.monitorableExecutionInfo();
+            if (searcherExecutionInfoSupplier != null)
+            {
+                executionInfoSupplier = searcherExecutionInfoSupplier;
+                return null;
+            }
+        }
+
+        // if execution info is disabled, return null so we will keep using the default empty supplier
+        if (!CassandraRelevantProperties.MONITORING_EXECUTION_INFO_ENABLED.getBoolean())
+            return null;
+
+        // otherwise, create and use the generic execution info
+        ReadCommandExecutionInfo commandExecutionInfo = new ReadCommandExecutionInfo();
+        executionInfoSupplier = () -> commandExecutionInfo;
+        return commandExecutionInfo;
     }
 }

--- a/src/java/org/apache/cassandra/db/ReadCommandExecutionInfo.java
+++ b/src/java/org/apache/cassandra/db/ReadCommandExecutionInfo.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db;
+
+import javax.annotation.concurrent.NotThreadSafe;
+
+import org.apache.cassandra.db.monitoring.Monitorable;
+import org.apache.cassandra.db.partitions.UnfilteredPartitionIterator;
+import org.apache.cassandra.db.rows.RangeTombstoneMarker;
+import org.apache.cassandra.db.rows.Row;
+import org.apache.cassandra.db.rows.UnfilteredRowIterator;
+import org.apache.cassandra.db.transform.Transformation;
+import org.apache.cassandra.index.Index;
+
+/**
+ * A custom {@link Monitorable.ExecutionInfo} implementation for {@link ReadCommand}, to be used unless there is an
+ * {@link Index.Searcher} with its own custom implementation.
+ * </p>
+ * It holds and prints the number of partitions, rows and tombstones fetched and returned by the command.
+ * </p>
+ * Deleted partitions are considered as a partition tombstone.
+ * Deleted rows and range tombstone markers are considered as row tombstones.
+ */
+@NotThreadSafe
+class ReadCommandExecutionInfo implements Monitorable.ExecutionInfo
+{
+    private long partitionsFetched = 0;
+    private long partitionsReturned = 0;
+    private long partitionTombstones = 0;
+    private long rowsFetched = 0;
+    private long rowsReturned = 0;
+    private long rowTombstones = 0;
+
+    /**
+     * Counts the number of fetched partitions and rows in the specified iterator.
+     *
+     * @param partitions the iterator of fetched partitions to count
+     * @param nowInSec the command's time in seconds, used to evaluate whether a partition/row is alive
+     * @return the same iterator
+     */
+    UnfilteredPartitionIterator countFetched(UnfilteredPartitionIterator partitions, long nowInSec)
+    {
+        Transformation<UnfilteredRowIterator> rowCounter = new Transformation<>() {
+            @Override
+            protected Row applyToRow(Row row)
+            {
+                if (row.hasLiveData(nowInSec, false))
+                    rowsFetched++;
+                return row;
+            }
+        };
+        return Transformation.apply(partitions, new Transformation<>() {
+            @Override
+            protected UnfilteredRowIterator applyToPartition(UnfilteredRowIterator partition)
+            {
+                if (!partition.partitionLevelDeletion().deletes(nowInSec))
+                    partitionsFetched++;
+                return Transformation.apply(partition, rowCounter);
+            }
+        });
+    }
+
+    /**
+     * Counts the number of fetched partitions, rows and tombstones in the specified iterator.
+     *
+     * @param partitions the iterator of returned partitions to count
+     * @param nowInSec the command's time in seconds, used to evaluate whether a partition/row is alive
+     * @return the same iterator
+     */
+    UnfilteredPartitionIterator countReturned(UnfilteredPartitionIterator partitions, long nowInSec)
+    {
+        Transformation<UnfilteredRowIterator> rowCounter = new Transformation<>() {
+            @Override
+            protected Row applyToRow(Row row)
+            {
+                if (row.hasLiveData(nowInSec, false))
+                    rowsReturned++;
+                else
+                    rowTombstones++;
+                return row;
+            }
+
+            @Override
+            protected RangeTombstoneMarker applyToMarker(RangeTombstoneMarker marker)
+            {
+                rowTombstones++;
+                return marker;
+            }
+        };
+        return Transformation.apply(partitions, new Transformation<>() {
+            @Override
+            protected UnfilteredRowIterator applyToPartition(UnfilteredRowIterator partition)
+            {
+                if (partition.partitionLevelDeletion().deletes(nowInSec))
+                    partitionTombstones++;
+                else
+                    partitionsReturned++;
+                return Transformation.apply(partition, rowCounter);
+            }
+        });
+    }
+
+    @Override
+    public String toLogString(boolean unique)
+    {
+        StringBuilder sb = new StringBuilder("\n");
+        sb.append(INDENT);
+        sb.append(unique ? "Fetched/returned/tombstones:" : "Slowest fetched/returned/tombstones:");
+        append(sb, "partitions",
+               partitionsFetched,
+               partitionsReturned,
+               partitionTombstones);
+        append(sb, "rows",
+               rowsFetched,
+               rowsReturned,
+               rowTombstones);
+        return sb.toString();
+    }
+
+    private static void append(StringBuilder sb, String name, long fetched, long returned, long tombstones)
+    {
+        sb.append('\n')
+          .append(DOUBLE_INDENT)
+          .append(name)
+          .append(": ")
+          .append(fetched)
+          .append('/')
+          .append(returned)
+          .append('/')
+          .append(tombstones);
+    }
+}

--- a/src/java/org/apache/cassandra/db/monitoring/Monitorable.java
+++ b/src/java/org/apache/cassandra/db/monitoring/Monitorable.java
@@ -54,6 +54,9 @@ public interface Monitorable
      */
     interface ExecutionInfo
     {
+        String INDENT = "  ";
+        String DOUBLE_INDENT = INDENT + INDENT;
+
         /**
          * An empty no-op implementation.
          */

--- a/src/java/org/apache/cassandra/index/Index.java
+++ b/src/java/org/apache/cassandra/index/Index.java
@@ -836,15 +836,16 @@ public interface Index
         UnfilteredPartitionIterator search(ReadExecutionController executionController);
 
         /**
-         * Returns a supplier for the {@link Monitorable.ExecutionInfo} for this query, to be used by
+         * Returns a supplier for the custom {@link Monitorable.ExecutionInfo} for this query, to be used by
          * {@link ReadCommand#executionInfo()} at the end of the query to collect details about the query execution in
          * case it is considered too slow.
          *
-         * @return a supplier for the execution info for this query
+         * @return a supplier for the execution info for this query, or {@code null} if no custom execution info is available
          */
+        @Nullable
         default Supplier<Monitorable.ExecutionInfo> monitorableExecutionInfo()
         {
-            return Monitorable.ExecutionInfo.EMPTY_SUPPLIER;
+            return null;
         }
     }
 

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryMonitorableExecutionInfo.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryMonitorableExecutionInfo.java
@@ -28,9 +28,6 @@ import org.apache.cassandra.index.sai.QueryContext;
  */
 public class QueryMonitorableExecutionInfo implements Monitorable.ExecutionInfo
 {
-    private static final String INDENT = "  ";
-    private static final String DOUBLE_INDENT = INDENT + INDENT;
-
     private final QueryContext.Snapshot metrics;
     private final String plan;
 

--- a/test/distributed/org/apache/cassandra/distributed/test/SlowQueryLoggerTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/SlowQueryLoggerTest.java
@@ -20,14 +20,20 @@ import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
 import net.bytebuddy.implementation.MethodDelegation;
 import net.bytebuddy.implementation.bind.annotation.SuperCall;
+import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.db.ReadCommand;
 import org.apache.cassandra.db.ReadExecutionController;
 import org.apache.cassandra.db.monitoring.MonitoringTask;
@@ -41,73 +47,234 @@ import org.assertj.core.api.Assertions;
 import org.assertj.core.api.ListAssert;
 
 import static net.bytebuddy.matcher.ElementMatchers.named;
-import org.apache.cassandra.config.CassandraRelevantProperties;
 import static org.apache.cassandra.distributed.api.ConsistencyLevel.ALL;
 import static org.apache.cassandra.utils.MonotonicClock.Global.approxTime;
 
 public class SlowQueryLoggerTest extends TestBaseImpl
 {
-    private static final String TABLE = "t";
     private static final int SLOW_QUERY_LOG_TIMEOUT_MS = 100;
+    private static final AtomicInteger SEQ = new AtomicInteger();
+
+    private static Cluster cluster;
+    private static String table;
+    private static ICoordinator coordinator;
+    private static IInvokableInstance node;
+
+    @BeforeClass
+    public static void setupCluster() throws Exception
+    {
+        // effectively disable the scheduled monitoring task so we control it manually for better test stability
+        CassandraRelevantProperties.MONITORING_REPORT_INTERVAL_MS.setLong(TimeUnit.HOURS.toMillis(1));
+
+        cluster = init(Cluster.build(2)
+                              .withInstanceInitializer(SlowQueryLoggerTest.BBHelper::install)
+                              .withConfig(config -> config.set("slow_query_log_timeout_in_ms", SLOW_QUERY_LOG_TIMEOUT_MS))
+                              .start());
+        coordinator = cluster.coordinator(1);
+        node = cluster.get(2);
+    }
+
+    @AfterClass
+    public static void closeCluster()
+    {
+        if (cluster != null)
+            cluster.close();
+    }
+
+    @Before
+    public void before()
+    {
+        CassandraRelevantProperties.MONITORING_EXECUTION_INFO_ENABLED.setBoolean(true);
+        table = "t_" + SEQ.getAndIncrement();
+
+        // trigger the monitoring task to flush any pending slow operations before the test starts
+        node.runOnInstance(() -> MonitoringTask.instance.logOperations(approxTime.now()));
+    }
+
+    @After
+    public void after()
+    {
+        cluster.schemaChange(format("DROP TABLE IF EXISTS %s.%s"));
+    }
 
     /**
      * Test that the slow query logger does not log sensitive data.
      */
     @Test
-    public void testDoesNotLogSensitiveData() throws Throwable
+    public void testDoesNotLogSensitiveData()
     {
-        // effectively disable the scheduled monitoring task so we control it manually for better test stability
-        CassandraRelevantProperties.MONITORING_REPORT_INTERVAL_MS.setLong(TimeUnit.HOURS.toMillis(1));
+        cluster.schemaChange(format("CREATE TABLE %s.%s (k text, c text, v text, b blob, PRIMARY KEY (k, c))"));
+        coordinator.execute(format("INSERT INTO %s.%s (k, c, v) VALUES ('secret_k', 'secret_c', 'secret_v')"), ALL);
 
-        try (Cluster cluster = init(Cluster.build(2)
-                                           .withInstanceInitializer(SlowQueryLoggerTest.BBHelper::install)
-                                           .withConfig(config -> config.set("slow_query_log_timeout_in_ms", SLOW_QUERY_LOG_TIMEOUT_MS))
-                                           .start()))
+        // verify that slow queries are logged with redacted values
+        long mark = node.logs().mark();
+        Object[][] rows = coordinator.execute(format("SELECT * FROM %s.%s WHERE k = 'secret_k' AND c = 'secret_c' AND v = 'secret_v' ALLOW FILTERING"), ALL);
+        Assertions.assertThat(rows).hasNumberOfRows(1);
+        assertLogsContain(mark, node, "operations were slow", format("<SELECT \\* FROM %s\\.%s WHERE k = \\? AND c = \\? AND v = \\? ALLOW FILTERING>"));
+        assertLogsDoNotContain(mark, node, "secret_k", "secret_c", "secret_v");
+
+        // verify that large values include size hints
+        mark = node.logs().mark();
+        String query = format("SELECT * FROM %s.%s WHERE b = ? ALLOW FILTERING");
+        coordinator.execute(query, ALL, ByteBuffer.allocate(100 + 1));
+        coordinator.execute(query, ALL, ByteBuffer.allocate(1024 + 1));
+        coordinator.execute(query, ALL, ByteBuffer.allocate(10 * 1024 + 1));
+        assertLogsContain(mark, node,
+                          format("<SELECT \\* FROM %s\\.%s WHERE b = \\?\\[>100B\\] ALLOW FILTERING>"),
+                          format("<SELECT \\* FROM %s\\.%s WHERE b = \\?\\[>1KiB\\] ALLOW FILTERING>"),
+                          format("<SELECT \\* FROM %s\\.%s WHERE b = \\?\\[>10KiB\\] ALLOW FILTERING>"));
+
+        coordinator.execute(format("SELECT * FROM %s.%s"), ALL);
+    }
+
+    /**
+     * Test that the slow query logger outputs the correct metrics for number of returned partitions, rows, etc.
+     */
+    @Test
+    public void testLogsReadMetrics()
+    {
+        cluster.schemaChange(format("CREATE TABLE %s.%s (k int, c int, v int, l int, s int, PRIMARY KEY (k, c))"));
+        cluster.schemaChange(format("CREATE INDEX legacy_idx ON %s.%s (l)"));
+        cluster.schemaChange(format("CREATE CUSTOM INDEX sai_idx ON %s.%s (s) USING 'StorageAttachedIndex'"));
+        int numPartitions = 10;
+        int numClusterings = 10;
+        int numRows = 0;
+        for (int k = 0; k < numPartitions; k++)
+            for (int c = 0; c < numClusterings; c++)
+                coordinator.execute(format("INSERT INTO %s.%s (k, c, v, l, s) VALUES (?, ?, ?, ?, ?)"),
+                                    ALL, k, c, numRows++, numRows, numRows);
+
+        // unrestricted query
+        long mark = node.logs().mark();
+        Object[][] rows = coordinator.execute(format("SELECT * FROM %s.%s"), ALL);
+        Assertions.assertThat(rows).hasNumberOfRows(numRows);
+        assertLogsContain(mark, node,
+                          format("<SELECT \\* FROM %s\\.%s ALLOW FILTERING>"),
+                          "  Fetched/returned/tombstones:",
+                          "    partitions: 10/10/0",
+                          "    rows: 100/100/0");
+
+        // partition query
+        mark = node.logs().mark();
+        rows = coordinator.execute(format("SELECT * FROM %s.%s WHERE k = 2"), ALL);
+        Assertions.assertThat(rows).hasNumberOfRows(numClusterings);
+        assertLogsContain(mark, node,
+                          format("<SELECT \\* FROM %s\\.%s WHERE k = \\? ALLOW FILTERING>"),
+                          "  Fetched/returned/tombstones:",
+                          "    partitions: 1/1/0",
+                          "    rows: 10/10/0");
+
+        // clustering query
+        mark = node.logs().mark();
+        rows = coordinator.execute(format("SELECT * FROM %s.%s WHERE k = 2 AND c = 2"), ALL);
+        Assertions.assertThat(rows).hasNumberOfRows(1);
+        assertLogsContain(mark, node,
+                          format("<SELECT \\* FROM %s\\.%s WHERE k = \\? AND c = \\? ALLOW FILTERING>"),
+                          "  Fetched/returned/tombstones:",
+                          "    partitions: 1/1/0",
+                          "    rows: 1/1/0");
+
+        // filtered range query
+        mark = node.logs().mark();
+        rows = coordinator.execute(format("SELECT * FROM %s.%s WHERE v < 25 ALLOW FILTERING"), ALL);
+        Assertions.assertThat(rows).hasNumberOfRows(25);
+        assertLogsContain(mark, node,
+                          format("<SELECT \\* FROM %s\\.%s WHERE v < \\? ALLOW FILTERING>"),
+                          "  Fetched/returned/tombstones:",
+                          "    partitions: 10/3/0",
+                          "    rows: 100/25/0");
+
+        // test multiple slow runs of different queries with the same redacted form, it should log the slowest one
+        mark = node.logs().mark();
+        for (int i = 0; i < numPartitions; i++)
         {
-            ICoordinator coordinator = cluster.coordinator(1);
-            IInvokableInstance node = cluster.get(2);
-
-            cluster.schemaChange(format("CREATE TABLE %s.%s (k text, c text, v text, b blob, PRIMARY KEY (k, c))"));
-            coordinator.execute(format("INSERT INTO %s.%s (k, c, v) VALUES ('secret_k', 'secret_c', 'secret_v')"), ALL);
-
-            // verify that slow queries are logged with redacted values
-            long mark = node.logs().mark();
-            coordinator.execute(format("SELECT * FROM %s.%s WHERE k = 'secret_k' AND c = 'secret_c' AND v = 'secret_v' ALLOW FILTERING"), ALL);
-            node.runOnInstance(() -> MonitoringTask.instance.logOperations(approxTime.now()));
-            assertLogsContain(mark, node, "Some operations were slow", format("<SELECT \\* FROM %s\\.%s WHERE k = \\? AND c = \\? AND v = \\? ALLOW FILTERING>"));
-            assertLogsNotContain(mark, node, "secret_k", "secret_c", "secret_v");
-
-            // verify that large values include size hints
-            mark = node.logs().mark();
-            String query = format("SELECT * FROM %s.%s WHERE b = ? ALLOW FILTERING");
-            coordinator.execute(query, ALL, ByteBuffer.allocate(100 + 1));
-            coordinator.execute(query, ALL, ByteBuffer.allocate(1024 + 1));
-            coordinator.execute(query, ALL, ByteBuffer.allocate(10 * 1024 + 1));
-            node.runOnInstance(() -> MonitoringTask.instance.logOperations(approxTime.now()));
-            assertLogsContain(mark, node,
-                              format("<SELECT \\* FROM %s\\.%s WHERE b = \\?\\[>100B\\] ALLOW FILTERING>"),
-                              format("<SELECT \\* FROM %s\\.%s WHERE b = \\?\\[>1KiB\\] ALLOW FILTERING>"),
-                              format("<SELECT \\* FROM %s\\.%s WHERE b = \\?\\[>10KiB\\] ALLOW FILTERING>"));
+            rows = coordinator.execute(format("SELECT * FROM %s.%s WHERE k = " + i), ALL);
+            Assertions.assertThat(rows).hasNumberOfRows(numClusterings);
         }
+        assertLogsContain(mark, node,
+                          format("<SELECT \\* FROM %s\\.%s WHERE k = \\? ALLOW FILTERING>"),
+                          "  Slowest fetched/returned/tombstones:",
+                          "    partitions: 1/1/0",
+                          "    rows: 10/10/0");
+
+        // delete a partition and query again, to see partition tombstone metrics
+        coordinator.execute(format("DELETE FROM %s.%s WHERE k = 0"), ALL);
+        mark = node.logs().mark();
+        rows = coordinator.execute(format("SELECT * FROM %s.%s"), ALL);
+        Assertions.assertThat(rows).hasNumberOfRows(numRows - numClusterings);
+        assertLogsContain(mark, node,
+                          format("<SELECT \\* FROM %s\\.%s ALLOW FILTERING>"),
+                          "  Fetched/returned/tombstones:",
+                          "    partitions: 9/9/1",
+                          "    rows: 90/90/0");
+
+        // delete a row and query again, to see row tombstone metrics
+        coordinator.execute(format("DELETE FROM %s.%s WHERE k = 1 AND c = 1"), ALL);
+        mark = node.logs().mark();
+        rows = coordinator.execute(format("SELECT * FROM %s.%s"), ALL);
+        Assertions.assertThat(rows).hasNumberOfRows(numRows - numClusterings - 1);
+        assertLogsContain(mark, node,
+                          format("<SELECT \\* FROM %s\\.%s ALLOW FILTERING>"),
+                          "  Fetched/returned/tombstones:",
+                          "    partitions: 9/9/1",
+                          "    rows: 89/89/1");
+
+        // delete a range of rows and query again, to see more row tombstone metrics
+        coordinator.execute(format("DELETE FROM %s.%s WHERE k = 2 AND c < 5"), ALL);
+        mark = node.logs().mark();
+        rows = coordinator.execute(format("SELECT * FROM %s.%s"), ALL);
+        Assertions.assertThat(rows).hasNumberOfRows(84);
+        assertLogsContain(mark, node,
+                          format("<SELECT \\* FROM %s\\.%s ALLOW FILTERING>"),
+                          "  Fetched/returned/tombstones:",
+                          "    partitions: 9/9/1",
+                          "    rows: 84/84/3"); // one from before, plus opening and closing bounds
+
+        // query with a legacy index, which doesn't provide its own execution info, so generic execution info should be used
+        mark = node.logs().mark();
+        rows = coordinator.execute(format("SELECT * FROM %s.%s WHERE l = 99"), ALL);
+        Assertions.assertThat(rows).hasNumberOfRows(1);
+        assertLogsContain(mark, node,
+                          format("<SELECT \\* FROM %s\\.%s WHERE l = \\? ALLOW FILTERING>"),
+                          "  Fetched/returned/tombstones:",
+                          "    partitions: 1/1/0",
+                          "    rows: 1/1/0");
+
+        // query with a SAI index, which provides its own execution info, so generic execution info shouldn't be used
+        mark = node.logs().mark();
+        rows = coordinator.execute(format("SELECT * FROM %s.%s WHERE s = 99"), ALL);
+        Assertions.assertThat(rows).hasNumberOfRows(1);
+        assertLogsContain(mark, node, format("<SELECT \\* FROM %s\\.%s WHERE s = \\? ALLOW FILTERING>"));
+        assertLogsDoNotContain(mark, node, "  Fetched/returned/tombstones:");
+
+        // disable execution info logging and verify that info is not logged anymore
+        CassandraRelevantProperties.MONITORING_EXECUTION_INFO_ENABLED.setBoolean(false);
+        mark = node.logs().mark();
+        coordinator.execute(format("SELECT * FROM %s.%s"), ALL);
+        assertLogsContain(mark, node, format("<SELECT \\* FROM %s\\.%s ALLOW FILTERING>"));
+        assertLogsDoNotContain(mark, node, "  Fetched/returned/tombstones:");
     }
 
     private static String format(String query)
     {
-        return String.format(query, KEYSPACE, TABLE);
+        return String.format(query, KEYSPACE, table);
     }
 
-    private static void assertLogsContain(long mark, IInvokableInstance node, String... lines)
+    public static void assertLogsContain(long mark, IInvokableInstance node, String... lines)
     {
         assertLogs(mark, node, AbstractIterableAssert::isNotEmpty, lines);
     }
 
-    private static void assertLogsNotContain(long mark, IInvokableInstance node, String... lines)
+    public static void assertLogsDoNotContain(long mark, IInvokableInstance node, String... lines)
     {
         assertLogs(mark, node, AbstractIterableAssert::isEmpty, lines);
     }
 
-    private static void assertLogs(long mark, IInvokableInstance node, Consumer<ListAssert<String>> listAssert, String... lines)
+    public static void assertLogs(long mark, IInvokableInstance node, Consumer<ListAssert<String>> listAssert, String... lines)
     {
+        // manually trigger the monitoring task to log the slow operations
+        node.runOnInstance(() -> MonitoringTask.instance.logOperations(approxTime.now()));
+
         for (String line : lines)
         {
             List<String> matchingLines = node.logs().grep(mark, line).getResult();
@@ -139,7 +306,7 @@ public class SlowQueryLoggerTest extends TestBaseImpl
         {
             try
             {
-                if (executionController.metadata().name.equals(TABLE))
+                if (executionController.metadata().keyspace.equals(KEYSPACE))
                     Thread.sleep(SLOW_QUERY_LOG_TIMEOUT_MS * 2);
 
                 return zuperCall.call();

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/SlowSAIQueryLoggerTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/SlowSAIQueryLoggerTest.java
@@ -15,14 +15,11 @@
  */
 package org.apache.cassandra.distributed.test.sai;
 
-import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Consumer;
 
 import com.google.common.util.concurrent.Uninterruptibles;
-import org.apache.cassandra.index.sai.plan.QueryController;
 import org.junit.Test;
 
 import net.bytebuddy.ByteBuddy;
@@ -42,14 +39,13 @@ import org.apache.cassandra.distributed.api.ICoordinator;
 import org.apache.cassandra.distributed.api.IInvokableInstance;
 import org.apache.cassandra.distributed.test.TestBaseImpl;
 import org.apache.cassandra.index.SecondaryIndexManager;
+import org.apache.cassandra.index.sai.plan.QueryController;
 import org.apache.cassandra.index.sai.plan.QueryMonitorableExecutionInfo;
-import org.assertj.core.api.AbstractIterableAssert;
-import org.assertj.core.api.Assertions;
-import org.assertj.core.api.ListAssert;
 import org.awaitility.Awaitility;
 
 import static net.bytebuddy.matcher.ElementMatchers.named;
-import static org.apache.cassandra.utils.MonotonicClock.Global.approxTime;
+import static org.apache.cassandra.distributed.test.SlowQueryLoggerTest.assertLogsContain;
+import static org.apache.cassandra.distributed.test.SlowQueryLoggerTest.assertLogsDoNotContain;
 
 /**
  * Tests {@link QueryMonitorableExecutionInfo} combined with the {@link MonitoringTask} mechanism,
@@ -394,16 +390,6 @@ public class SlowSAIQueryLoggerTest extends TestBaseImpl
         }
     }
 
-    private static void assertLogsContain(long mark, IInvokableInstance node, String... lines)
-    {
-        assertLogs(mark, node, AbstractIterableAssert::isNotEmpty, lines);
-    }
-
-    private static void assertLogsDoNotContain(long mark, IInvokableInstance node, String... lines)
-    {
-        assertLogs(mark, node, AbstractIterableAssert::isEmpty, lines);
-    }
-
     private static void assertLogsDoNotContainSAIExecutionInfo(long mark, IInvokableInstance node)
     {
         assertLogsDoNotContain(mark, node,
@@ -411,18 +397,6 @@ public class SlowSAIQueryLoggerTest extends TestBaseImpl
                                "SAI slow query plan:",
                                "SAI slowest query metrics:",
                                "SAI slowest query plan:");
-    }
-
-    private static void assertLogs(long mark, IInvokableInstance node, Consumer<ListAssert<String>> listAssert, String... lines)
-    {
-        // manually trigger the monitoring task to log the slow operations
-        node.runOnInstance(() -> MonitoringTask.instance.logOperations(approxTime.now()));
-
-        for (String line : lines)
-        {
-            List<String> matchingLines = node.logs().grep(mark, line).getResult();
-            listAssert.accept(Assertions.assertThat(matchingLines));
-        }
     }
 
     /**

--- a/test/microbench/org/apache/cassandra/test/microbench/ReadCommandExecutionInfoBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/ReadCommandExecutionInfoBench.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.test.microbench;
+
+
+import java.io.IOException;
+import java.util.Random;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.db.ReadCommand;
+import org.apache.cassandra.db.commitlog.CommitLog;
+import org.apache.cassandra.db.monitoring.Monitorable;
+import org.apache.cassandra.db.monitoring.MonitoringTask;
+import org.apache.cassandra.db.partitions.UnfilteredPartitionIterator;
+import org.apache.cassandra.db.rows.UnfilteredRowIterator;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Benchmarks {@link ReadCommand}'s extended {@link Monitorable.ExecutionInfo}, to verify whether it has a noticeable
+ * performance impact compared to the default {@link Monitorable.ExecutionInfo#EMPTY}.
+ * </p>
+ * The cost of reporting should be evaluated on the context of a slow query, which by default should have taken at least
+ * 500ms, possibly more, as defined by {@link org.apache.cassandra.config.Config#slow_query_log_timeout_in_ms}. Note
+ * that this is a worst case scenario, as repeated slow queries within the same reporting window will be aggregated
+ * and not logged individually.
+ * </p>
+ * This also benchmarks the cost of running a not-slow query that won't produce a log entry, which is the normal case.
+ * This is done to see the cost of keeping track of read items in case the query is later determined to be slow.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 10, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 1)
+@Threads(1)
+@State(Scope.Benchmark)
+public class ReadCommandExecutionInfoBench extends CQLTester
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(ReadCommandExecutionInfoBench.class);
+    private static final Random RANDOM = new Random(1234);
+    private static final String QUERY = "SELECT * FROM %%s WHERE k = %d AND v IN (%d, %<d) ALLOW FILTERING";
+    private static final int NUM_PARTITIONS = 100;
+    private static final int NUM_CLUSTERINGS = 10_000;
+    private static final int NUM_VALUES = 10;
+
+    /**
+     * Whether to enable the execution info logging.
+     */
+    @Param({ "false", "true" })
+    public boolean enabled;
+
+    private ReadCommand command;
+
+    @Setup(Level.Trial)
+    public void setup() throws Throwable
+    {
+        CassandraRelevantProperties.MONITORING_EXECUTION_INFO_ENABLED.setBoolean(enabled);
+        CQLTester.setUpClass();
+        CQLTester.prepareServer();
+        beforeTest();
+
+        // create the schema
+        createTable("CREATE TABLE %s (k int, c int, v int, PRIMARY KEY (k, c))");
+
+        // insert some data
+        for (int k = 0; k < NUM_PARTITIONS; k++)
+        {
+            for (int c = 0; c < NUM_CLUSTERINGS; c++)
+            {
+                int v = RANDOM.nextInt(NUM_VALUES);
+                execute("INSERT INTO %s (k, c, v) VALUES (?, ?, ?)", k, c, v);
+            }
+        }
+        flush();
+    }
+
+    @Setup(Level.Invocation)
+    public void setupTest()
+    {
+        command = generateRunAndConsumeCommand();
+    }
+
+    private ReadCommand generateRunAndConsumeCommand()
+    {
+        int randomKey = RANDOM.nextInt(NUM_PARTITIONS);
+        int randomValue = RANDOM.nextInt(NUM_VALUES);
+        String query = String.format(QUERY, randomKey, randomValue);
+        ReadCommand command = parseReadCommandGroup(query).get(0);
+        try (UnfilteredPartitionIterator partitions = command.executeLocally(command.executionController(false)))
+        {
+            while (partitions.hasNext())
+            {
+                try (UnfilteredRowIterator partition = partitions.next())
+                {
+                    while (partition.hasNext())
+                        partition.next();
+                }
+            }
+        }
+        return command;
+    }
+
+    @TearDown(Level.Trial)
+    public void teardown() throws IOException, ExecutionException, InterruptedException
+    {
+        CommitLog.instance.shutdownBlocking();
+        CQLTester.cleanup();
+    }
+
+    /**
+     * Test the cost of creating the execution info object.
+     */
+    @Benchmark
+    public Object executionInfo()
+    {
+        Monitorable.ExecutionInfo info = command.executionInfo();
+        return info.toLogString(true);
+    }
+
+    /**
+     * Test the cost of creating a slow operation and logging it.
+     */
+    @Benchmark
+    public Object logSlowOperation()
+    {
+        MonitoringTask.SlowOperation operation = new MonitoringTask.SlowOperation(command, 0);
+        String log = operation.getLogMessage();
+        LOGGER.info(log);
+        return log;
+    }
+
+    /**
+     * Test the cost of running a query without logging it as slow, just to see the effect of counting things in case
+     * it is slow.
+     */
+    @Benchmark
+    public Object runFastOperation()
+    {
+        return generateRunAndConsumeCommand();
+    }
+}


### PR DESCRIPTION
Add information about fetched/returned/deleted partitions and rows to the logging reports for non-SAI slow queries.

There is a new system property named `cassandra.monitoring_execution_info_enabled` to disable this feature, which is enabled by default.
