### PR TITLE
CNDB-16043: Add more tests for mixed version SAI queries

### DIFF
--- a/test/distributed/org/apache/cassandra/distributed/test/sai/datamodels/QueryCellDeletionsUpgradeTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/datamodels/QueryCellDeletionsUpgradeTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test.sai.datamodels;
+
+import org.apache.cassandra.index.sai.cql.datamodels.IndexQuerySupport;
+import org.junit.Test;
+
+public class QueryCellDeletionsUpgradeTest extends MultiNodeQueryTester
+{
+    @Test
+    public void testCellDeletionsAfterUpgrade() throws Throwable
+    {
+        IndexQuerySupport.cellDeletionsAfterUpgrade(executor, dataModel.get(), sets);
+    }
+}

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/datamodels/QueryRowDeletionsUpgradeTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/datamodels/QueryRowDeletionsUpgradeTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test.sai.datamodels;
+
+import org.apache.cassandra.index.sai.cql.datamodels.IndexQuerySupport;
+import org.junit.Test;
+
+public class QueryRowDeletionsUpgradeTest extends MultiNodeQueryTester
+{
+    @Test
+    public void testRowDeletionsAfterUpgrade() throws Throwable
+    {
+        IndexQuerySupport.rowDeletionsAfterUpgrade(executor, dataModel.get(), sets);
+    }
+}

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/datamodels/QueryTimeToLiveUpgradeTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/datamodels/QueryTimeToLiveUpgradeTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test.sai.datamodels;
+
+import org.apache.cassandra.index.sai.cql.datamodels.IndexQuerySupport;
+import org.junit.Test;
+
+public class QueryTimeToLiveUpgradeTest extends MultiNodeQueryTester
+{
+    @Test
+    public void testTimeToLiveAfterUpgrade() throws Throwable
+    {
+        IndexQuerySupport.timeToLiveAfterUpgrade(executor, dataModel.get(), sets);
+    }
+}

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/datamodels/QueryWriteLifecycleUpgradeTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/datamodels/QueryWriteLifecycleUpgradeTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test.sai.datamodels;
+
+import org.apache.cassandra.index.sai.cql.datamodels.IndexQuerySupport;
+import org.junit.Test;
+
+public class QueryWriteLifecycleUpgradeTest extends MultiNodeQueryTester
+{
+    @Test
+    public void testWriteLifecycleAfterUpgrade() throws Throwable
+    {
+        IndexQuerySupport.writeLifecycleAfterUpgrade(executor, dataModel.get(), sets);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/SAITester.java
+++ b/test/unit/org/apache/cassandra/index/sai/SAITester.java
@@ -454,6 +454,36 @@ public class SAITester extends CQLTester
         }
     }
 
+    /**
+     * Returns the set containing all SAI index versions found among all sstable indexes of the given table.
+     * Memtable indexes are not included.
+     */
+    public static Set<Version> getSSTableIndexVersions(String keyspace, String table)
+    {
+        ColumnFamilyStore cfs = Keyspace.open(keyspace).getColumnFamilyStore(table);
+        var group = StorageAttachedIndexGroup.getIndexGroup(cfs);
+        if (group == null)  // no indexes present on the table
+            return Set.of();
+
+        Set<IndexContext> indexContexts = group.getIndexes()
+                                               .stream()
+                                               .map(StorageAttachedIndex::getIndexContext)
+                                               .collect(Collectors.toSet());
+
+        var versions = new HashSet<Version>();
+        for (var sstable : cfs.getLiveSSTables())
+        {
+            var indexDescriptor = group.descriptorFor(sstable);
+            if (indexDescriptor != null)
+            {
+                versions.add(indexDescriptor.perSSTableComponents().version());
+                for (IndexContext indexContext : indexContexts)
+                    versions.add(indexDescriptor.perIndexComponents(indexContext).version());
+            }
+        }
+        return versions;
+    }
+
     protected static void assertFailureReason(ReadFailureException e, RequestFailureReason reason)
     {
         int expected = reason.codeForNativeProtocol();

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryCellDeletionsUpgradeTester.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryCellDeletionsUpgradeTester.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ * Tests cell deletions after upgrade from AA index version (non-row-aware) to all other row-aware index versions.
+ * @see IndexQuerySupport#cellDeletionsAfterUpgrade
+ */
+@Ignore
+abstract class QueryCellDeletionsUpgradeTester extends SingleNodeQueryTester
+{
+    @Test
+    public void testCellDeletions() throws Throwable
+    {
+        IndexQuerySupport.cellDeletionsAfterUpgrade(executor, dataModel, sets);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryCellDeletionsWithBaseDataModelUpgradeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryCellDeletionsWithBaseDataModelUpgradeTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import org.junit.runners.Parameterized;
+
+import java.util.List;
+
+public class QueryCellDeletionsWithBaseDataModelUpgradeTest extends QueryCellDeletionsUpgradeTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(SingleNodeQueryTester::baseDataModelParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryCellDeletionsWithCompositePartitionKeyUpgradeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryCellDeletionsWithCompositePartitionKeyUpgradeTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import org.junit.runners.Parameterized;
+
+import java.util.List;
+
+public class QueryCellDeletionsWithCompositePartitionKeyUpgradeTest extends QueryCellDeletionsUpgradeTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(SingleNodeQueryTester::compositePartitionKeyParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryCellDeletionsWithCompoundKeyUpgradeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryCellDeletionsWithCompoundKeyUpgradeTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import org.junit.runners.Parameterized;
+
+import java.util.List;
+
+public class QueryCellDeletionsWithCompoundKeyUpgradeTest extends QueryCellDeletionsUpgradeTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(SingleNodeQueryTester::compoundKeyParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryCellDeletionsWithCompoundKeyWithStaticsUpgradeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryCellDeletionsWithCompoundKeyWithStaticsUpgradeTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import org.junit.runners.Parameterized;
+
+import java.util.List;
+
+public class QueryCellDeletionsWithCompoundKeyWithStaticsUpgradeTest extends QueryCellDeletionsUpgradeTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(SingleNodeQueryTester::compoundKeyWithStaticsParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryRowDeletionsUpgradeTester.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryRowDeletionsUpgradeTester.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ * Tests row deletions after upgrade from AA index version (non-row-aware) to all other row-aware index versions.
+ * @see IndexQuerySupport#rowDeletionsAfterUpgrade
+ */
+@Ignore
+abstract class QueryRowDeletionsUpgradeTester extends SingleNodeQueryTester
+{
+    @Test
+    public void testRowDeletionsAfterUpgrade() throws Throwable
+    {
+        IndexQuerySupport.rowDeletionsAfterUpgrade(executor, dataModel, sets);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryRowDeletionsWithBaseModelUpgradeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryRowDeletionsWithBaseModelUpgradeTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import org.junit.runners.Parameterized;
+
+import java.util.List;
+
+public class QueryRowDeletionsWithBaseModelUpgradeTest extends QueryRowDeletionsUpgradeTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(SingleNodeQueryTester::baseDataModelParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryRowDeletionsWithCompositePartitionKeyUpgradeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryRowDeletionsWithCompositePartitionKeyUpgradeTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import org.junit.runners.Parameterized;
+
+import java.util.List;
+
+public class QueryRowDeletionsWithCompositePartitionKeyUpgradeTest extends QueryRowDeletionsUpgradeTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(SingleNodeQueryTester::compositePartitionKeyParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryRowDeletionsWithCompoundKeyUpgradeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryRowDeletionsWithCompoundKeyUpgradeTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import org.junit.runners.Parameterized;
+
+import java.util.List;
+
+public class QueryRowDeletionsWithCompoundKeyUpgradeTest extends QueryRowDeletionsUpgradeTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(SingleNodeQueryTester::compoundKeyParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryRowDeletionsWithCompoundKeyWithStaticsUpgradeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryRowDeletionsWithCompoundKeyWithStaticsUpgradeTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import org.junit.runners.Parameterized;
+
+import java.util.List;
+
+public class QueryRowDeletionsWithCompoundKeyWithStaticsUpgradeTest extends QueryRowDeletionsUpgradeTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(SingleNodeQueryTester::compoundKeyWithStaticsParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryTimeToLiveUpgradeTester.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryTimeToLiveUpgradeTester.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ * Tests TTLs after upgrade from AA index version (non-row-aware) to all other row-aware index versions.
+ * @see IndexQuerySupport#timeToLiveAfterUpgrade
+ */
+@Ignore
+abstract class QueryTimeToLiveUpgradeTester extends SingleNodeQueryTester
+{
+    @Test
+    public void testTimeToLive() throws Throwable
+    {
+        IndexQuerySupport.timeToLiveAfterUpgrade(executor, dataModel, sets);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryTimeToLiveWithBaseModelUpgradeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryTimeToLiveWithBaseModelUpgradeTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import org.junit.runners.Parameterized;
+
+import java.util.List;
+
+public class QueryTimeToLiveWithBaseModelUpgradeTest extends QueryTimeToLiveUpgradeTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(SingleNodeQueryTester::baseDataModelParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryTimeToLiveWithCompositePartitionKeyUpgradeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryTimeToLiveWithCompositePartitionKeyUpgradeTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import org.junit.runners.Parameterized;
+
+import java.util.List;
+
+public class QueryTimeToLiveWithCompositePartitionKeyUpgradeTest extends QueryTimeToLiveUpgradeTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(SingleNodeQueryTester::compositePartitionKeyParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryTimeToLiveWithCompoundKeyUpgradeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryTimeToLiveWithCompoundKeyUpgradeTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import org.junit.runners.Parameterized;
+
+import java.util.List;
+
+public class QueryTimeToLiveWithCompoundKeyUpgradeTest extends QueryTimeToLiveUpgradeTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(SingleNodeQueryTester::compoundKeyParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryTimeToLiveWithCompoundKeyWithStaticsUpgradeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryTimeToLiveWithCompoundKeyWithStaticsUpgradeTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import org.junit.runners.Parameterized;
+
+import java.util.List;
+
+public class QueryTimeToLiveWithCompoundKeyWithStaticsUpgradeTest extends QueryTimeToLiveUpgradeTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(SingleNodeQueryTester::compoundKeyWithStaticsParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryWriteLifecycleUpgradeTester.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryWriteLifecycleUpgradeTester.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ * Tests inserts and updates after upgrade from AA index version (non-row-aware) to all other row-aware index versions.
+ * @see IndexQuerySupport#writeLifecycleAfterUpgrade
+ */
+@Ignore
+abstract class QueryWriteLifecycleUpgradeTester extends SingleNodeQueryTester
+{
+    @Test
+    public void testWriteLifecycleAferUpgrade() throws Throwable
+    {
+        IndexQuerySupport.writeLifecycleAfterUpgrade(executor, dataModel, sets);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryWriteLifecycleWithBaseModelUpgradeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryWriteLifecycleWithBaseModelUpgradeTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import org.junit.runners.Parameterized;
+
+import java.util.List;
+
+public class QueryWriteLifecycleWithBaseModelUpgradeTest extends QueryWriteLifecycleUpgradeTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(SingleNodeQueryTester::baseDataModelParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryWriteLifecycleWithCompositePartitionKeyUpgradeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryWriteLifecycleWithCompositePartitionKeyUpgradeTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import org.junit.runners.Parameterized;
+
+import java.util.List;
+
+public class QueryWriteLifecycleWithCompositePartitionKeyUpgradeTest extends QueryWriteLifecycleUpgradeTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(SingleNodeQueryTester::compositePartitionKeyParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryWriteLifecycleWithCompoundKeyUpgradeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryWriteLifecycleWithCompoundKeyUpgradeTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import org.junit.runners.Parameterized;
+
+import java.util.List;
+
+public class QueryWriteLifecycleWithCompoundKeyUpgradeTest extends QueryWriteLifecycleUpgradeTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(SingleNodeQueryTester::compoundKeyParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryWriteLifecycleWithCompoundKeyWithStaticsUpgradeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/QueryWriteLifecycleWithCompoundKeyWithStaticsUpgradeTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import org.junit.runners.Parameterized;
+
+import java.util.List;
+
+public class QueryWriteLifecycleWithCompoundKeyWithStaticsUpgradeTest extends QueryWriteLifecycleUpgradeTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(SingleNodeQueryTester::compoundKeyWithStaticsParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/SingleNodeExecutor.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/SingleNodeExecutor.java
@@ -19,10 +19,13 @@
 package org.apache.cassandra.index.sai.cql.datamodels;
 
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.datastax.driver.core.SimpleStatement;
 import org.apache.cassandra.index.sai.SAITester;
+import org.apache.cassandra.index.sai.SAIUtil;
+import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.inject.Injections;
 
 public class SingleNodeExecutor implements DataModel.Executor
@@ -52,6 +55,12 @@ public class SingleNodeExecutor implements DataModel.Executor
     public void compact(String keyspace, String table)
     {
         tester.compact(keyspace, table);
+    }
+
+    @Override
+    public void setCurrentVersion(Version version)
+    {
+        SAIUtil.setCurrentVersion(version);
     }
 
     @Override
@@ -90,5 +99,11 @@ public class SingleNodeExecutor implements DataModel.Executor
     public long getCounter()
     {
         return counter.get();
+    }
+
+    @Override
+    public Set<Version> getSSTableIndexVersions(String keyspace, String indexedTable)
+    {
+        return SAITester.getSSTableIndexVersions(keyspace, indexedTable);
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryCellDeletionsUpgradeTester.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryCellDeletionsUpgradeTester.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ * Same as {@link QueryCellDeletionsUpgradeTester}, but
+ * force generates segments due to a small RAM size on compaction, to test segment splitting
+ */
+@Ignore
+abstract class TinySegmentQueryCellDeletionsUpgradeTester extends SingleNodeQueryTester
+{
+    @Before
+    public void setSegmentWriteBufferSpace()
+    {
+        DatabaseDescriptor.setSAISegmentWriteBufferSpace(0);
+    }
+
+    @Test
+    public void testCellDeletionsAfterUpgrade() throws Throwable
+    {
+        IndexQuerySupport.cellDeletionsAfterUpgrade(executor, dataModel, sets);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryCellDeletionsWithBaseModelUpgradeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryCellDeletionsWithBaseModelUpgradeTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import org.junit.runners.Parameterized;
+
+import java.util.List;
+
+public class TinySegmentQueryCellDeletionsWithBaseModelUpgradeTest extends TinySegmentQueryCellDeletionsUpgradeTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(SingleNodeQueryTester::baseDataModelParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryCellDeletionsWithCompositePartitionKeyUpgradeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryCellDeletionsWithCompositePartitionKeyUpgradeTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import org.junit.runners.Parameterized;
+
+import java.util.List;
+
+public class TinySegmentQueryCellDeletionsWithCompositePartitionKeyUpgradeTest extends TinySegmentQueryCellDeletionsUpgradeTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(SingleNodeQueryTester::compositePartitionKeyParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryCellDeletionsWithCompoundKeyUpgradeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryCellDeletionsWithCompoundKeyUpgradeTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import org.junit.runners.Parameterized;
+
+import java.util.List;
+
+public class TinySegmentQueryCellDeletionsWithCompoundKeyUpgradeTest extends TinySegmentQueryCellDeletionsUpgradeTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(SingleNodeQueryTester::compoundKeyParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryCellDeletionsWithCompoundKeyWithStaticsUpgradeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryCellDeletionsWithCompoundKeyWithStaticsUpgradeTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import org.junit.runners.Parameterized;
+
+import java.util.List;
+
+public class TinySegmentQueryCellDeletionsWithCompoundKeyWithStaticsUpgradeTest extends TinySegmentQueryCellDeletionsUpgradeTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(SingleNodeQueryTester::compoundKeyWithStaticsParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryRowDeletionsUpgradeTester.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryRowDeletionsUpgradeTester.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ * Same as {@link QueryRowDeletionsUpgradeTester}, but
+ * force generates segments due to a small RAM size on compaction, to test segment splitting
+ */
+@Ignore
+abstract class TinySegmentQueryRowDeletionsUpgradeTester extends SingleNodeQueryTester
+{
+    @Before
+    public void setSegmentWriteBufferSpace()
+    {
+        DatabaseDescriptor.setSAISegmentWriteBufferSpace(0);
+    }
+
+    @Test
+    public void testRowDeletionsAfterUpgrade() throws Throwable
+    {
+        IndexQuerySupport.rowDeletionsAfterUpgrade(executor, dataModel, sets);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryRowDeletionsWithBaseModelUpgradeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryRowDeletionsWithBaseModelUpgradeTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import org.junit.runners.Parameterized;
+
+import java.util.List;
+
+public class TinySegmentQueryRowDeletionsWithBaseModelUpgradeTest extends TinySegmentQueryRowDeletionsUpgradeTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(SingleNodeQueryTester::baseDataModelParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryRowDeletionsWithCompositePartitionKeyUpgradeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryRowDeletionsWithCompositePartitionKeyUpgradeTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import org.junit.runners.Parameterized;
+
+import java.util.List;
+
+public class TinySegmentQueryRowDeletionsWithCompositePartitionKeyUpgradeTest extends TinySegmentQueryRowDeletionsUpgradeTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(SingleNodeQueryTester::compositePartitionKeyParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryRowDeletionsWithCompoundKeyUpgradeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryRowDeletionsWithCompoundKeyUpgradeTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import org.junit.runners.Parameterized;
+
+import java.util.List;
+
+public class TinySegmentQueryRowDeletionsWithCompoundKeyUpgradeTest extends TinySegmentQueryRowDeletionsUpgradeTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(SingleNodeQueryTester::compoundKeyParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryRowDeletionsWithCompoundKeyWithStaticsUpgradeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryRowDeletionsWithCompoundKeyWithStaticsUpgradeTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import org.junit.runners.Parameterized;
+
+import java.util.List;
+
+public class TinySegmentQueryRowDeletionsWithCompoundKeyWithStaticsUpgradeTest extends TinySegmentQueryRowDeletionsUpgradeTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(SingleNodeQueryTester::compoundKeyWithStaticsParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryTimeToLiveUpgradeTester.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryTimeToLiveUpgradeTester.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ * Same as {@link QueryTimeToLiveUpgradeTester}, but
+ * force generates segments due to a small RAM size on compaction, to test segment splitting
+ */
+@Ignore
+abstract class TinySegmentQueryTimeToLiveUpgradeTester extends SingleNodeQueryTester
+{
+    @Before
+    public void setSegmentWriteBufferSpace()
+    {
+        DatabaseDescriptor.setSAISegmentWriteBufferSpace(0);
+    }
+
+    @Test
+    public void testTimeToLive() throws Throwable
+    {
+        IndexQuerySupport.timeToLiveAfterUpgrade(executor, dataModel, sets);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryTimeToLiveWithBaseModelUpgradeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryTimeToLiveWithBaseModelUpgradeTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import org.junit.runners.Parameterized;
+
+import java.util.List;
+
+public class TinySegmentQueryTimeToLiveWithBaseModelUpgradeTest extends TinySegmentQueryTimeToLiveUpgradeTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(SingleNodeQueryTester::baseDataModelParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryTimeToLiveWithCompositePartitionKeyUpgradeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryTimeToLiveWithCompositePartitionKeyUpgradeTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import org.junit.runners.Parameterized;
+
+import java.util.List;
+
+public class TinySegmentQueryTimeToLiveWithCompositePartitionKeyUpgradeTest extends TinySegmentQueryTimeToLiveUpgradeTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(SingleNodeQueryTester::compositePartitionKeyParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryTimeToLiveWithCompoundKeyUpgradeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryTimeToLiveWithCompoundKeyUpgradeTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import org.junit.runners.Parameterized;
+
+import java.util.List;
+
+public class TinySegmentQueryTimeToLiveWithCompoundKeyUpgradeTest extends TinySegmentQueryTimeToLiveUpgradeTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(SingleNodeQueryTester::compoundKeyParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryTimeToLiveWithCompoundKeyWithStaticsUpgradeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryTimeToLiveWithCompoundKeyWithStaticsUpgradeTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import org.junit.runners.Parameterized;
+
+import java.util.List;
+
+public class TinySegmentQueryTimeToLiveWithCompoundKeyWithStaticsUpgradeTest extends TinySegmentQueryTimeToLiveUpgradeTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(SingleNodeQueryTester::compoundKeyWithStaticsParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryWriteLifecycleUpgradeTester.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryWriteLifecycleUpgradeTester.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ * Same as {@link QueryWriteLifecycleUpgradeTester}, but
+ * Force generates segments due to a small RAM size on compaction, to test segment splitting
+ */
+@Ignore
+abstract class TinySegmentQueryWriteLifecycleUpgradeTester extends SingleNodeQueryTester
+{
+    @Before
+    public void setSegmentWriteBufferSpace()
+    {
+        DatabaseDescriptor.setSAISegmentWriteBufferSpace(0);
+    }
+
+    @Test
+    public void testWriteLifecycleAfterUpgrade() throws Throwable
+    {
+        IndexQuerySupport.writeLifecycleAfterUpgrade(executor, dataModel, sets);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryWriteLifecycleWithBaseModelUpgradeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryWriteLifecycleWithBaseModelUpgradeTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import org.junit.runners.Parameterized;
+
+import java.util.List;
+
+public class TinySegmentQueryWriteLifecycleWithBaseModelUpgradeTest extends TinySegmentQueryWriteLifecycleUpgradeTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(SingleNodeQueryTester::baseDataModelParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryWriteLifecycleWithCompositePartitionKeyUpgradeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryWriteLifecycleWithCompositePartitionKeyUpgradeTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import org.junit.runners.Parameterized;
+
+import java.util.List;
+
+public class TinySegmentQueryWriteLifecycleWithCompositePartitionKeyUpgradeTest extends TinySegmentQueryWriteLifecycleUpgradeTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(SingleNodeQueryTester::compositePartitionKeyParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryWriteLifecycleWithCompoundKeyUpgradeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryWriteLifecycleWithCompoundKeyUpgradeTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import org.junit.runners.Parameterized;
+
+import java.util.List;
+
+public class TinySegmentQueryWriteLifecycleWithCompoundKeyUpgradeTest extends TinySegmentQueryWriteLifecycleUpgradeTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(SingleNodeQueryTester::compoundKeyParams);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryWriteLifecycleWithCompoundKeyWithStaticsUpgradeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/TinySegmentQueryWriteLifecycleWithCompoundKeyWithStaticsUpgradeTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import org.junit.runners.Parameterized;
+
+import java.util.List;
+
+public class TinySegmentQueryWriteLifecycleWithCompoundKeyWithStaticsUpgradeTest extends TinySegmentQueryWriteLifecycleUpgradeTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(SingleNodeQueryTester::compoundKeyWithStaticsParams);
+    }
+}


### PR DESCRIPTION
Extends IndexQuerySupport framework with new test scenarios mixing row-aware and non-row-aware index versions.

In the added scenarios, rows are first inserted and flushed into AA indexes, then the node(s) are upgraded to a row-aware index SAI version and finally more rows are inserted and flushed. Then existing workloads are executed against those mixed version indexes. Compaction of mixed version indexes is also tested.

This commit does not add new test queries nor new datamodels, but only reuses the existing tests we had that were executed against a single version at a time.
