### PR TITLE
CNDB-17469: Allow compaction tasks to override their execution executor

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/AbstractCompactionTask.java
+++ b/src/java/org/apache/cassandra/db/compaction/AbstractCompactionTask.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
+import java.util.concurrent.Executor;
 
 import com.google.common.base.Preconditions;
 
@@ -36,6 +37,8 @@ import org.apache.cassandra.io.FSDiskFullWriteError;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.utils.Throwables;
 import org.apache.cassandra.utils.WrappedRunnable;
+
+import javax.annotation.Nullable;
 
 import static com.google.common.base.Throwables.propagate;
 
@@ -301,6 +304,15 @@ public abstract class AbstractCompactionTask extends WrappedRunnable
      * by CNDB.
      */
     public abstract long getSpaceOverhead();
+
+    /**
+     * Allows subclasses to route the task to a dedicated executor instead of the shared compaction executor.
+     */
+    @Nullable
+    public Executor getCustomExecutor()
+    {
+        return null;
+    }
 
     /**
      * @return The compaction observers for this task. Used by CNDB.

--- a/src/java/org/apache/cassandra/db/compaction/BackgroundCompactionRunner.java
+++ b/src/java/org/apache/cassandra/db/compaction/BackgroundCompactionRunner.java
@@ -27,10 +27,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Random;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
@@ -391,6 +388,7 @@ public class BackgroundCompactionRunner implements Runnable
         ongoingCompactions.incrementAndGet();
         try
         {
+            Executor executor = task.getCustomExecutor() == null ? compactionExecutor : task.getCustomExecutor();
             return CompletableFuture.runAsync(
             () -> {
                 try
@@ -406,7 +404,7 @@ public class BackgroundCompactionRunner implements Runnable
                     //  - a thread has freed up, and a new compaction task (from any CFS) can be scheduled on it
                     markForCompactionCheck(cfs);
                 }
-            }, compactionExecutor);
+            }, executor);
         }
         catch (RejectedExecutionException ex)
         {


### PR DESCRIPTION
### What is the issue
CNDB-17469

### What does this PR fix and why was it fixed
Allow compaction tasks to override their execution executor to avoid CNDB index build task get stuck
