### PR TITLE
CNDB-15608 add TokenOnlyPrimaryKey class and isTokenOnly

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/v1/PartitionAwarePrimaryKeyFactory.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/PartitionAwarePrimaryKeyFactory.java
@@ -21,6 +21,8 @@ package org.apache.cassandra.index.sai.disk.v1;
 import java.util.Objects;
 import java.util.function.Supplier;
 
+import javax.annotation.concurrent.NotThreadSafe;
+
 import io.github.jbellis.jvector.util.RamUsageEstimator;
 import org.apache.cassandra.db.Clustering;
 import org.apache.cassandra.db.DecoratedKey;
@@ -36,13 +38,6 @@ import org.apache.cassandra.utils.bytecomparable.ByteSource;
 public class PartitionAwarePrimaryKeyFactory implements PrimaryKey.Factory
 {
     @Override
-    public PrimaryKey createTokenOnly(Token token)
-    {
-        assert token != null;
-        return new PartitionAwarePrimaryKey(token, null, null);
-    }
-
-    @Override
     public PrimaryKey createDeferred(Token token, Supplier<PrimaryKey> primaryKeySupplier)
     {
         assert token != null;
@@ -56,6 +51,7 @@ public class PartitionAwarePrimaryKeyFactory implements PrimaryKey.Factory
         return new PartitionAwarePrimaryKey(partitionKey.getToken(), partitionKey, null);
     }
 
+    @NotThreadSafe
     private class PartitionAwarePrimaryKey implements PrimaryKey
     {
         private final Token token;
@@ -72,10 +68,12 @@ public class PartitionAwarePrimaryKeyFactory implements PrimaryKey.Factory
         @Override
         public PrimaryKey loadDeferred()
         {
-            if (primaryKeySupplier != null && partitionKey == null)
+            if (primaryKeySupplier != null)
             {
+                assert partitionKey == null : "While applying existing primaryKeySupplier to load deferred primaryKey the partition key was unexpectedly already set";
                 this.partitionKey = primaryKeySupplier.get().partitionKey();
                 primaryKeySupplier = null;
+                assert this.token.equals(this.partitionKey.getToken()) : "Deferred primary key must contain the same token";
             }
             return this;
         }
@@ -156,12 +154,26 @@ public class PartitionAwarePrimaryKeyFactory implements PrimaryKey.Factory
             return shallowSize + token.getHeapSize() + preHashedDecoratedKeySize;
         }
 
+        /**
+         * Compares this primary key with another for ordering purposes.
+         * <p>
+         * This implementation uses a two-tier comparison strategy:
+         * <ul>
+         *   <li>If the given primary key is token only, compares by token only</li>
+         *   <li>If both partition keys are available, performs full partition key comparison</li>
+         * </ul>
+         * Note: This comparison is partition-aware only and does not consider clustering keys.
+         *
+         * @param o the primary key to compare with
+         * @return a negative integer, zero, or a positive integer as this primary key is less than,
+         *         equal to, or greater than the specified primary key
+         */
         @Override
         public int compareTo(PrimaryKey o)
         {
-            if (partitionKey == null || o.partitionKey() == null)
+            if (o.isTokenOnly())
                 return token().compareTo(o.token());
-            return partitionKey.compareTo(o.partitionKey());
+            return partitionKey().compareTo(o.partitionKey());
         }
 
         @Override

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/TokenOnlyPrimaryKey.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/TokenOnlyPrimaryKey.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.disk.v2;
+
+import io.github.jbellis.jvector.util.RamUsageEstimator;
+import org.apache.cassandra.db.Clustering;
+import org.apache.cassandra.db.DecoratedKey;
+import org.apache.cassandra.dht.Token;
+import org.apache.cassandra.index.sai.utils.PrimaryKey;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable.Version;
+import org.apache.cassandra.utils.bytecomparable.ByteSource;
+
+public final class TokenOnlyPrimaryKey implements PrimaryKey
+{
+    private final Token token;
+
+    public TokenOnlyPrimaryKey(Token token)
+    {
+        this.token = token;
+    }
+
+    @Override
+    public boolean isTokenOnly()
+    {
+        return true;
+    }
+
+    @Override
+    public Token token()
+    {
+        return token;
+    }
+
+    @Override
+    public DecoratedKey partitionKey()
+    {
+        return null;
+    }
+
+    @Override
+    public Clustering<?> clustering()
+    {
+        return null;
+    }
+
+    @Override
+    public ByteSource asComparableBytes(Version version)
+    {
+        return asComparableBytes(version == ByteComparable.Version.LEGACY ? ByteSource.END_OF_STREAM : ByteSource.TERMINATOR, version, false);
+    }
+
+    @Override
+    public ByteSource asComparableBytesMinPrefix(Version version)
+    {
+        return asComparableBytes(ByteSource.LT_NEXT_COMPONENT, version, true);
+    }
+
+    @Override
+    public ByteSource asComparableBytesMaxPrefix(Version version)
+    {
+        return asComparableBytes(ByteSource.GT_NEXT_COMPONENT, version, true);
+    }
+
+    private ByteSource asComparableBytes(int terminator, ByteComparable.Version version, boolean isPrefix)
+    {
+        ByteSource tokenComparable = token.asComparableBytes(version);
+        // prefix doesn't include null components
+        if (isPrefix)
+            return ByteSource.withTerminator(terminator, tokenComparable);
+        else
+            return ByteSource.withTerminator(terminator, tokenComparable, null, null);
+    }
+
+    @Override
+    public int compareTo(PrimaryKey o)
+    {
+        return token().compareTo(o.token());
+    }
+
+    @Override
+    public long ramBytesUsed()
+    {
+        // Object header + 1 reference (token) + implicit outer reference + token size
+        return RamUsageEstimator.NUM_BYTES_OBJECT_HEADER + RamUsageEstimator.NUM_BYTES_OBJECT_REF + token.getHeapSize();
+    }
+
+    @Override
+    public PrimaryKey forStaticRow()
+    {
+        return this;
+    }
+
+    @Override
+    public PrimaryKey loadDeferred()
+    {
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (o instanceof PrimaryKey)
+            return compareTo((PrimaryKey) o) == 0;
+        return false;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return token().hashCode();
+    }
+
+    @Override
+    public String toString()
+    {
+        return String.format("TokenOnlyPrimaryKey: { token: %s }", token());
+    }
+}

--- a/src/java/org/apache/cassandra/index/sai/iterators/KeyRangeUnionIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/iterators/KeyRangeUnionIterator.java
@@ -125,7 +125,7 @@ public class KeyRangeUnionIterator extends KeyRangeIterator
     private void skipPartition(KeyRangeIterator iterator, DecoratedKey partitionKey)
     {
         // TODO: Push this logic down to the iterator where it can be more efficient
-        while (iterator.hasNext() && iterator.peek().partitionKey() != null && iterator.peek().partitionKey().compareTo(partitionKey) <= 0)
+        while (iterator.hasNext() && !iterator.peek().isTokenOnly() && iterator.peek().partitionKey().compareTo(partitionKey) <= 0)
             iterator.next();
     }
 

--- a/src/java/org/apache/cassandra/index/sai/memory/MemtableKeyRangeIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/MemtableKeyRangeIterator.java
@@ -91,9 +91,9 @@ public class MemtableKeyRangeIterator extends KeyRangeIterator
     @Override
     protected void performSkipTo(PrimaryKey nextKey)
     {
-        PartitionPosition start = nextKey.partitionKey() != null
-                                  ? nextKey.partitionKey()
-                                  : nextKey.token().minKeyBound();
+        PartitionPosition start = nextKey.isTokenOnly()
+                                  ? nextKey.token().minKeyBound()
+                                  : nextKey.partitionKey();
         if (!keyRange.right.isMinimum() && start.compareTo(keyRange.right) > 0)
         {
             partitionIterator = EmptyIterators.unfilteredPartition(memtable.metadata());

--- a/src/java/org/apache/cassandra/index/sai/utils/PrimaryKey.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/PrimaryKey.java
@@ -27,6 +27,7 @@ import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.index.sai.disk.format.IndexFeatureSet;
 import org.apache.cassandra.index.sai.disk.v1.PartitionAwarePrimaryKeyFactory;
 import org.apache.cassandra.index.sai.disk.v2.RowAwarePrimaryKeyFactory;
+import org.apache.cassandra.index.sai.disk.v2.TokenOnlyPrimaryKey;
 import org.apache.cassandra.utils.bytecomparable.ByteComparable;
 import org.apache.cassandra.utils.bytecomparable.ByteSource;
 
@@ -55,7 +56,11 @@ public interface PrimaryKey extends Comparable<PrimaryKey>, Accountable
          * @param token the {@link Token}
          * @return a {@link PrimaryKey} represented by a token only
          */
-        PrimaryKey createTokenOnly(Token token);
+        default PrimaryKey createTokenOnly(Token token)
+        {
+            assert token != null;
+            return new TokenOnlyPrimaryKey(token);
+        }
 
         /**
          * Creates a {@link PrimaryKey} that is represented by a {@link DecoratedKey}.
@@ -117,6 +122,11 @@ public interface PrimaryKey extends Comparable<PrimaryKey>, Accountable
      * @return a {@link PrimaryKey} for the static row
      */
     PrimaryKey forStaticRow();
+
+    default boolean isTokenOnly()
+    {
+        return false;
+    }
 
     /**
      * Returns the {@link Token} associated with this primary key.

--- a/test/unit/org/apache/cassandra/index/sai/disk/v2/RowAwarePrimaryKeyTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v2/RowAwarePrimaryKeyTest.java
@@ -34,7 +34,9 @@ import org.apache.cassandra.index.sai.SAITester;
 import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 public class RowAwarePrimaryKeyTest extends SAITester
@@ -42,7 +44,7 @@ public class RowAwarePrimaryKeyTest extends SAITester
     @Test
     public void testHashCodeForDeferredPrimaryKey()
     {
-        var factory = Version.BA.onDiskFormat().newPrimaryKeyFactory(EMPTY_COMPARATOR);
+        PrimaryKey.Factory factory = Version.BA.onDiskFormat().newPrimaryKeyFactory(EMPTY_COMPARATOR);
 
         // Test relies on this implementation detail
         assertTrue(factory instanceof RowAwarePrimaryKeyFactory);
@@ -69,7 +71,7 @@ public class RowAwarePrimaryKeyTest extends SAITester
     @Test
     public void testHashCodeForLoadedPrimaryKey()
     {
-        var factory = Version.BA.onDiskFormat().newPrimaryKeyFactory(EMPTY_COMPARATOR);
+        PrimaryKey.Factory factory = Version.BA.onDiskFormat().newPrimaryKeyFactory(EMPTY_COMPARATOR);
 
         // Test relies on this implementation detail
         assertTrue(factory instanceof RowAwarePrimaryKeyFactory);
@@ -90,8 +92,8 @@ public class RowAwarePrimaryKeyTest extends SAITester
     @Test
     public void testHashCodeForDeferedPrimaryKeyWithClusteringColumns()
     {
-        var comparator = new ClusteringComparator(Int32Type.instance);
-        var factory = Version.BA.onDiskFormat().newPrimaryKeyFactory(comparator);
+        ClusteringComparator comparator = new ClusteringComparator(Int32Type.instance);
+        PrimaryKey.Factory factory = Version.BA.onDiskFormat().newPrimaryKeyFactory(comparator);
 
         // Test relies on this implementation detail
         assertTrue(factory instanceof RowAwarePrimaryKeyFactory);
@@ -107,5 +109,95 @@ public class RowAwarePrimaryKeyTest extends SAITester
         PrimaryKey primaryKey2 = factory.create(key2, Clustering.make(ByteBuffer.allocate(1)));
 
         assertEquals(primaryKey1.hashCode(), primaryKey2.hashCode());
+    }
+
+    @Test
+    public void testComparisonBetweenTokenOnlyAndFullKey()
+    {
+        PrimaryKey.Factory factory = Version.BA.onDiskFormat().newPrimaryKeyFactory(EMPTY_COMPARATOR);
+
+        // Test relies on this implementation detail
+        assertTrue(factory instanceof RowAwarePrimaryKeyFactory);
+
+        // Create keys with the same token
+        Token token = new Murmur3Partitioner.LongToken(100);
+        DecoratedKey decoratedKey = new BufferDecoratedKey(token, ByteBuffer.allocate(1));
+
+        PrimaryKey tokenOnlyKey = factory.createTokenOnly(token);
+        PrimaryKey fullKey = factory.create(decoratedKey, Clustering.EMPTY);
+
+        // When tokens are equal, token-only key should compare equal to full key.
+        // This is the critical behavior tested in RowAwarePrimaryKeyFactory.compareTo.
+        assertEquals(0, tokenOnlyKey.compareTo(fullKey));
+        assertEquals(0, fullKey.compareTo(tokenOnlyKey));
+
+        // They should be considered equal
+        assertEquals(tokenOnlyKey, fullKey);
+        assertEquals(fullKey, tokenOnlyKey);
+    }
+
+    @Test
+    public void testComparisonBetweenTokenOnlyKeysWithDifferentTokens()
+    {
+        PrimaryKey.Factory factory = Version.BA.onDiskFormat().newPrimaryKeyFactory(EMPTY_COMPARATOR);
+
+        // Test relies on this implementation detail
+        assertTrue(factory instanceof RowAwarePrimaryKeyFactory);
+
+        // Create token-only keys with different tokens
+        Token token1 = new Murmur3Partitioner.LongToken(50);
+        Token token2 = new Murmur3Partitioner.LongToken(100);
+
+        PrimaryKey tokenOnlyKey1 = factory.createTokenOnly(token1);
+        PrimaryKey tokenOnlyKey2 = factory.createTokenOnly(token2);
+
+        // Comparison should be based solely on tokens
+        assertThat(tokenOnlyKey1.compareTo(tokenOnlyKey2)).isLessThan(0);
+        assertThat(tokenOnlyKey2.compareTo(tokenOnlyKey1)).isGreaterThan(0);
+
+        // They should not be equal
+        assertNotEquals(tokenOnlyKey1, tokenOnlyKey2);
+    }
+
+    @Test
+    public void testComparisonWithClusteringColumns()
+    {
+        ClusteringComparator comparator = new ClusteringComparator(Int32Type.instance);
+        PrimaryKey.Factory factory = Version.BA.onDiskFormat().newPrimaryKeyFactory(comparator);
+
+        // Test relies on this implementation detail
+        assertTrue(factory instanceof RowAwarePrimaryKeyFactory);
+
+        // Create keys with the same token but different clustering
+        Token token = new Murmur3Partitioner.LongToken(100);
+        DecoratedKey decoratedKey = new BufferDecoratedKey(token, ByteBuffer.allocate(1));
+
+        PrimaryKey tokenOnlyKey = factory.createTokenOnly(token);
+        PrimaryKey fullKeyWithClustering = factory.create(decoratedKey, Clustering.make(Int32Type.instance.decompose(1)));
+
+        // When one key is token-only, comparison should be based on tokens only
+        // even if the other key has clustering columns
+        assertEquals(0, tokenOnlyKey.compareTo(fullKeyWithClustering));
+        assertEquals(0, fullKeyWithClustering.compareTo(tokenOnlyKey));
+    }
+
+    @Test
+    public void testTokenOnlyKeyHashCode()
+    {
+        PrimaryKey.Factory factory = Version.BA.onDiskFormat().newPrimaryKeyFactory(EMPTY_COMPARATOR);
+
+        // Test relies on this implementation detail
+        assertTrue(factory instanceof RowAwarePrimaryKeyFactory);
+
+        // Create token-only keys with the same token
+        Token token = new Murmur3Partitioner.LongToken(42);
+        PrimaryKey tokenOnlyKey1 = factory.createTokenOnly(token);
+        PrimaryKey tokenOnlyKey2 = factory.createTokenOnly(token);
+
+        // Hash codes should be equal for equal token-only keys
+        assertEquals(tokenOnlyKey1.hashCode(), tokenOnlyKey2.hashCode());
+
+        // Hash code should be based on the token
+        assertEquals(token.hashCode(), tokenOnlyKey1.hashCode());
     }
 }


### PR DESCRIPTION
The patch in CNDB-15608 will remove token from the partition key serialization, thus the case, when only token is provided in primary key, needs to be treated separately. Currently only token primary key case is blurred with complete or deferred primary keys.

This commit implements clear separation for primary keys with token only by introducing own `TokenOnlyPrimaryKey` class.
It also implement `isOnlyToken()` method, which is used instead of comparing partition key with null in appropriate cases (e.g., deferred partition key was loaded). New tests are added to exercise `TokenOnlyPrimaryKey` more and improve code coverage.
