### PR TITLE
CNDB-16344: SAI Rerankless ANN needs FP sim. score for coordinator's sort

### DIFF
--- a/src/java/org/apache/cassandra/cql3/UntypedResultSet.java
+++ b/src/java/org/apache/cassandra/cql3/UntypedResultSet.java
@@ -418,7 +418,7 @@ public abstract class UntypedResultSet implements Iterable<UntypedResultSet.Row>
             return DoubleType.instance.compose(data.get(column));
         }
 
-        public double getFloat(String column)
+        public float getFloat(String column)
         {
             return FloatType.instance.compose(data.get(column));
         }

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
@@ -306,7 +306,7 @@ public class V2VectorIndexSearcher extends IndexSearcher
             // Rerankless search, so we go straight to the NodeQueueRowIdIterator.
             var iter = segmentOrdinalPairs.mapToSegmentRowIdScoreIterator(scoreFunction);
             approximateScores.pushMany(iter, segmentOrdinalPairs.size());
-            return new NodeQueueRowIdIterator(approximateScores, graph.usesNVQ());
+            return new NodeQueueRowIdIterator(approximateScores, true);
         }
 
         // Store the index of the (rowId, ordinal) pair from the segmentOrdinalPairs in the NodeQueue so that we can

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraDiskAnn.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraDiskAnn.java
@@ -274,18 +274,19 @@ public class CassandraDiskAnn
                           limit, rerankK, isRerankless, usePruning, result.getVisitedCount(), result.getRerankedCount(), result.getNodes().length, source);
             columnQueryMetrics.onSearchResult(result, elapsed, false);
             context.addAnnGraphSearchLatency(elapsed);
+            boolean isScoreApproximate = usesNVQ || isRerankless;
             if (threshold > 0)
             {
                 // Threshold based searches are comprehensive and do not need to resume the search.
                 graphAccessManager.release();
                 nodesVisitedConsumer.accept(result.getVisitedCount());
                 var nodeScores = CloseableIterator.wrap(Arrays.stream(result.getNodes()).iterator());
-                return new NodeScoreToRowIdWithScoreIterator(nodeScores, ordinalsMap.getRowIdsView(), usesNVQ);
+                return new NodeScoreToRowIdWithScoreIterator(nodeScores, ordinalsMap.getRowIdsView(), isScoreApproximate);
             }
             else
             {
                 var nodeScores = new AutoResumingNodeScoreIterator(searcher, graphAccessManager, result, context, columnQueryMetrics, nodesVisitedConsumer, limit, rerankK, false, source.toString());
-                return new NodeScoreToRowIdWithScoreIterator(nodeScores, ordinalsMap.getRowIdsView(), usesNVQ);
+                return new NodeScoreToRowIdWithScoreIterator(nodeScores, ordinalsMap.getRowIdsView(), isScoreApproximate);
             }
         }
         catch (Throwable t)

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorCompactionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorCompactionTest.java
@@ -316,7 +316,7 @@ abstract public class VectorCompactionTest extends VectorTester
             assertEquals(10, r.size());
             for (var row : r)
             {
-                float similarity = (float) row.getFloat("similarity");
+                float similarity = row.getFloat("similarity");
                 assertTrue(similarity <= lastSimilarity);
                 lastSimilarity = similarity;
             }


### PR DESCRIPTION
### What is the issue
Fixes: https://github.com/riptano/cndb/issues/16344

### What does this PR fix and why was it fixed
When `ANN_USE_SYNTHETIC_SCORE` is true, we send the score from the replica to the coordinator. We need that score to be the full precision score to ensure correct ordering. When a query supplies `rerank_k: 0`, the score is approximate though and can produce out of order results, as the test demonstrates. The fix is to configure the `NodeQueueRowIdIterator` appropriately to indicate when the score is in fact approximate. The FP score is only computed when `ANN_USE_SYNTHETIC_SCORE` is true.
