### PR TITLE
CNDB-16363: Improve matched rows estimation accuracy for memory indexes

### DIFF
--- a/src/java/org/apache/cassandra/db/filter/RowFilter.java
+++ b/src/java/org/apache/cassandra/db/filter/RowFilter.java
@@ -150,6 +150,14 @@ public class RowFilter
     }
 
     /**
+     * Returns a copy of this {@link RowFilter} with ordering expressions removed
+     */
+    public RowFilter withoutOrderingExpressions()
+    {
+        return restrict(e -> !e.isOrderingExpression());
+    }
+
+    /**
      * @return the {@link ANNOptions} of the ANN expression in this filter, or {@link ANNOptions#NONE} if there is
      * no ANN expression.
      */

--- a/src/java/org/apache/cassandra/index/sai/SSTableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/SSTableIndex.java
@@ -154,9 +154,9 @@ public class SSTableIndex implements Comparable<SSTableIndex>
      *
      * @return an approximate number of the matching rows
      */
-    public long estimateMatchingRowsCount(Expression predicate, AbstractBounds<PartitionPosition> keyRange)
+    public long estimateMatchingRowsCount(Expression predicate)
     {
-        return searchableIndex.estimateMatchingRowsCount(predicate, keyRange);
+        return searchableIndex.estimateMatchingRowsCount(predicate);
     }
 
     /**

--- a/src/java/org/apache/cassandra/index/sai/disk/EmptyIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/EmptyIndex.java
@@ -129,7 +129,7 @@ public class EmptyIndex implements SearchableIndex
     }
 
     @Override
-    public long estimateMatchingRowsCount(Expression predicate, AbstractBounds<PartitionPosition> keyRange)
+    public long estimateMatchingRowsCount(Expression predicate)
     {
         return 0;
     }

--- a/src/java/org/apache/cassandra/index/sai/disk/SearchableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/SearchableIndex.java
@@ -88,5 +88,5 @@ public interface SearchableIndex extends Closeable
 
     void populateSystemView(SimpleDataSet dataSet, SSTableReader sstable);
 
-    long estimateMatchingRowsCount(Expression predicate, AbstractBounds<PartitionPosition> keyRange);
+    long estimateMatchingRowsCount(Expression predicate);
 }

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/Segment.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/Segment.java
@@ -234,7 +234,7 @@ public class Segment implements Closeable
         return proportionalLimit;
     }
 
-    public long estimateMatchingRowsCount(Expression predicate, AbstractBounds<PartitionPosition> keyRange)
+    public long estimateMatchingRowsCount(Expression predicate)
     {
         return metadata.estimateNumRowsMatching(predicate);
     }

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/V1SearchableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/V1SearchableIndex.java
@@ -289,12 +289,12 @@ public class V1SearchableIndex implements SearchableIndex
     }
 
     @Override
-    public long estimateMatchingRowsCount(Expression predicate, AbstractBounds<PartitionPosition> keyRange)
+    public long estimateMatchingRowsCount(Expression predicate)
     {
         long rowCount = 0;
         for (Segment segment: segments)
         {
-            long c = segment.estimateMatchingRowsCount(predicate, keyRange);
+            long c = segment.estimateMatchingRowsCount(predicate);
             assert c >= 0 : "Estimated row count must not be negative: " + c + " (predicate: " + predicate + ')';
             rowCount += c;
         }

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/VectorMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/VectorMemtableIndex.java
@@ -217,15 +217,9 @@ public class VectorMemtableIndex extends AbstractMemtableIndex
     }
 
     @Override
-    public long estimateMatchingRowsCountUsingFirstShard(Expression expression, AbstractBounds<PartitionPosition> keyRange)
+    public long estimateMatchingRowsCount(Expression expression)
     {
         // For BOUNDED_ANN we use the old way of estimating cardinality - by running the search.
-        throw new UnsupportedOperationException("Cardinality estimation not supported by vector indexes");
-    }
-
-    @Override
-    public long estimateMatchingRowsCountUsingAllShards(Expression expression, AbstractBounds<PartitionPosition> keyRange)
-    {
         throw new UnsupportedOperationException("Cardinality estimation not supported by vector indexes");
     }
 

--- a/src/java/org/apache/cassandra/index/sai/memory/MemoryIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/MemoryIndex.java
@@ -78,7 +78,7 @@ public abstract class MemoryIndex
 
     public abstract KeyRangeIterator search(Expression expression, AbstractBounds<PartitionPosition> keyRange);
 
-    public abstract long estimateMatchingRowsCount(Expression expression, AbstractBounds<PartitionPosition> keyRange);
+    public abstract long estimateMatchingRowsCount(Expression expression);
 
     public abstract ByteBuffer getMinTerm();
 

--- a/src/java/org/apache/cassandra/index/sai/memory/MemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/MemtableIndex.java
@@ -77,25 +77,14 @@ public interface MemtableIndex extends MemtableOrdering
 
     /**
      * Estimates the number of rows that would be returned by this index given the predicate.
-     * It is extrapolated from the first shard.
-     * Note that this is not a guarantee of the number of rows that will actually be returned.
+     * The estimate is intended for query plan optimization and is
+     * not guaranteed to be very accurate, but should be usually at the right
+     * level of magnitude. Being off by +/-50% is not a bug.
      *
      * @param expression predicate to match
-     * @param keyRange   the key range to search within
      * @return an approximate number of the matching rows
      */
-    long estimateMatchingRowsCountUsingFirstShard(Expression expression, AbstractBounds<PartitionPosition> keyRange);
-
-    /**
-     * Estimates the number of rows that would be returned by this index given the predicate.
-     * It estimates from all relevant shards individually.
-     * Note that this is not a guarantee of the number of rows that will actually be returned.
-     *
-     * @param expression predicate to match
-     * @param keyRange   the key range to search within
-     * @return an estimated number of the matching rows
-     */
-    long estimateMatchingRowsCountUsingAllShards(Expression expression, AbstractBounds<PartitionPosition> keyRange);
+    long estimateMatchingRowsCount(Expression expression);
 
     Iterator<Pair<ByteComparable.Preencoded, List<MemoryIndex.PkWithFrequency>>> iterator(DecoratedKey min, DecoratedKey max);
 

--- a/src/java/org/apache/cassandra/index/sai/memory/TrieMemoryIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/TrieMemoryIndex.java
@@ -718,7 +718,7 @@ public class TrieMemoryIndex extends MemoryIndex
     }
 
     @Override
-    public long estimateMatchingRowsCount(Expression expression, AbstractBounds<PartitionPosition> keyRange)
+    public long estimateMatchingRowsCount(Expression expression)
     {
         switch (expression.getOp())
         {

--- a/src/java/org/apache/cassandra/index/sai/memory/TrieMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/TrieMemtableIndex.java
@@ -365,57 +365,54 @@ public class TrieMemtableIndex extends AbstractMemtableIndex
     }
 
     /**
-     * Estimates the number of matching rows by extrapolating from the first shard only.
-     * This method provides a fast approximation by calculating the matching row count for the first
-     * shard in the key range and then multiplying by the total number of shards involved.
-     *
-     * <p>This approach assumes that data is uniformly distributed across shards, which may not
+     * Estimates the number of rows matching the given query predicate.
+     * <p>
+     * This method provides a fast approximation by calculating the matching row count from a subset of shards.
+     * The number of shards taken for the computation is determined dynamically depending on the number of indexed
+     * and matching rows – the more rows found in the shard, the fewer shards are needed to get a reliable estimate.
+     * <p>
+     * This approach assumes that data is uniformly distributed across shards, which may not
      * always be accurate but provides a quick estimate with minimal computational overhead.
      * The estimate is particularly useful for query planning and optimization decisions where
      * speed is more important than precision.</p>
      *
      * @param expression the search expression/predicate to match against indexed terms
-     * @param keyRange   the partition key range to search within, used to determine which shards to consider
-     * @return an estimated number of matching rows extrapolated from the first shard;
-     * @see #estimateMatchingRowsCountUsingAllShards(Expression, AbstractBounds) for a more accurate but slower alternative
+     * @return an estimated number of matching rows extrapolated from the first few shards;
      */
     @Override
-    public long estimateMatchingRowsCountUsingFirstShard(Expression expression, AbstractBounds<PartitionPosition> keyRange)
+    public long estimateMatchingRowsCount(Expression expression)
     {
-        int startShard = boundaries.getShardForToken(keyRange.left.getToken());
-        int endShard = getEndShardForBounds(keyRange);
-        return rangeIndexes[startShard].estimateMatchingRowsCount(expression, keyRange) * (endShard - startShard + 1);
-    }
+        // Control how many shards are taken for estimating the number of keys matching the query expression.
+        // Shards are taken until we reach at least MIN_MATCHING_ROWS matching rows
+        // or the total number of indexed rows in all the shards we considered reaches MIN_INDEXED_ROWS.
+        // Those constants do not affect query correctness, and can be safely to set to any value.
+        // They navigate the tradeoff between the cardinality estimation speed and accuracy. The higher the values are,
+        // the more shards will be considered for the estimation, which will increase accuracy but also
+        // increase the time it takes to estimate.
+        // If set to MAX_VALUE, all shards will be considered.
+        // If set to 0, only the first shard will be considered.
+        final int MIN_MATCHING_ROWS = 100;
+        final int MIN_INDEXED_ROWS = 100000;
 
-    /**
-     * Estimates the number of matching rows by querying all relevant shards individually.
-     * This method provides a more accurate estimate compared to the first-shard extrapolation
-     * approach by actually calculating the matching row count for each shard that intersects
-     * with the given key range and summing the results.
-     *
-     * <p>This approach accounts for non-uniform data distribution across shards and provides
-     * a more precise estimate at the cost of increased computational overhead. Each shard's
-     * memory index is consulted to determine how many rows would match the given expression
-     * within the specified key range.</p>
-     *
-     * @param expression the search expression/predicate to match against indexed terms
-     * @param keyRange the partition key range to search within, used to determine which shards to query
-     * @return the sum of estimated matching rows from all relevant shards;
-     *
-     * @see #estimateMatchingRowsCountUsingFirstShard(Expression, AbstractBounds) for a faster but less accurate alternative
-     */
-    @Override
-    public long estimateMatchingRowsCountUsingAllShards(Expression expression, AbstractBounds<PartitionPosition> keyRange)
-    {
-        int startShard = boundaries.getShardForToken(keyRange.left.getToken());
-        int endShard = getEndShardForBounds(keyRange);
-        long count = 0;
-        for (int shard = startShard; shard <= endShard; ++shard)
+        long matchingRows = 0;
+        long indexedRows = 0;
+        int processedShards = 0;
+
+        for (int shard = 0; shard < shardCount(); ++shard)
         {
             assert rangeIndexes[shard] != null;
-            count += rangeIndexes[shard].estimateMatchingRowsCount(expression, keyRange);
+            matchingRows += rangeIndexes[shard].estimateMatchingRowsCount(expression);
+            indexedRows += rangeIndexes[shard].indexedRows();
+            processedShards++;
+
+            if (matchingRows >= MIN_MATCHING_ROWS)
+                break;
+            if (indexedRows >= MIN_INDEXED_ROWS)
+                break;
         }
-        return count;
+
+        assert processedShards >= 1 : "Must process at least one shard for estimating matching rows count";
+        return Math.round(matchingRows * (double) (shardCount()) / processedShards);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/index/sai/plan/Plan.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Plan.java
@@ -19,6 +19,7 @@
 package org.apache.cassandra.index.sai.plan;
 
 import java.util.*;
+import java.util.function.Consumer;
 import java.util.function.DoubleSupplier;
 import java.util.function.Function;
 import javax.annotation.Nonnull;
@@ -363,14 +364,23 @@ abstract public class Plan
     }
 
     /**
-     * Returns the index context if the plan node uses one.
-     * Need to be overridden by nodes that use an index.
-     * Non-recursive.
+     * Traverses the tree recursively and calls the consumer for each index used in the plan.
      */
-    protected @Nullable IndexContext getIndexContext()
+    public final void visitIndexesRecursive(Consumer<IndexContext> consumer)
+    {
+        forEach(node -> {
+            node.visitIndexes(consumer);
+            return Plan.ControlFlow.Continue;
+        });
+    }
+
+    /**
+     * Non-recursive auxiliary method for {@link #visitIndexesRecursive(Consumer)}
+     * that calls the consumer for the index(es) in the current node.
+     */
+    protected void visitIndexes(Consumer<IndexContext> consumer)
     {
         // By default, a node does not contain an index.
-        return null;
     }
 
     /**
@@ -958,10 +968,10 @@ abstract public class Plan
         }
 
         @Override
-        final protected IndexContext getIndexContext()
+        final protected void visitIndexes(Consumer<IndexContext> consumer)
         {
             assert predicate != null || ordering != null;
-            return predicate != null ? predicate.context : ordering.context;
+            consumer.accept(predicate != null ? predicate.context : ordering.context);
         }
     }
     /**
@@ -1009,11 +1019,14 @@ abstract public class Plan
     static final class Union extends KeysIteration
     {
         private final LazyTransform<List<KeysIteration>> subplansSupplier;
+        private final boolean disjoint;
 
-        Union(Factory factory, int id, List<KeysIteration> subplans, Access access)
+        Union(Factory factory, int id, List<KeysIteration> subplans, boolean disjoint, Access access)
         {
             super(factory, id, access);
             Preconditions.checkArgument(!subplans.isEmpty(), "Subplans must not be empty");
+
+            this.disjoint = disjoint;
 
             // We propagate Access lazily just before we need the subplans.
             // This is because there may be several requests to change the access pattern from the top,
@@ -1049,14 +1062,25 @@ abstract public class Plan
         @Override
         protected double estimateSelectivity()
         {
-            // Assume independence (lack of correlation) of subplans.
-            // We multiply the probabilities of *not* selecting a key.
-            // Because selectivity is usage-independent, we can use the original subplans,
-            // to avoid forcing pushdown of Access information down.
-            double inverseSelectivity = 1.0;
-            for (KeysIteration plan : subplansSupplier.orig)
-                inverseSelectivity *= (1.0 - plan.selectivity());
-            return 1.0 - inverseSelectivity;
+            if (disjoint)
+            {
+                // If we know the subplans are disjoint, we can just sum their selectivities.
+                double selectivity = 0.0;
+                for (KeysIteration plan : subplansSupplier.orig)
+                    selectivity += plan.selectivity();
+                return Math.min(1.0, selectivity);
+            }
+            else
+            {
+                // Assume independence (lack of correlation) of subplans.
+                // We multiply the probabilities of *not* selecting a key.
+                // Because selectivity is usage-independent, we can use the original subplans,
+                // to avoid forcing pushdown of Access information down.
+                double inverseSelectivity = 1.0;
+                for (KeysIteration plan : subplansSupplier.orig)
+                    inverseSelectivity *= (1.0 - plan.selectivity());
+                return 1.0 - inverseSelectivity;
+            }
         }
 
         @Override
@@ -1080,7 +1104,7 @@ abstract public class Plan
 
             return newSubplans.equals(subplans)
                    ? this
-                   : factory.union(newSubplans, id).withAccess(access);
+                   : factory.union(newSubplans, disjoint, id).withAccess(access);
         }
 
         @Override
@@ -1088,7 +1112,7 @@ abstract public class Plan
         {
             return Objects.equals(access, this.access)
                    ? this
-                   : new Union(factory, id, subplansSupplier.orig, access);
+                   : new Union(factory, id, subplansSupplier.orig, disjoint, access);
         }
 
         @Override
@@ -1427,6 +1451,12 @@ abstract public class Plan
         {
             return source.usesIncludedIndex();
         }
+
+        @Override
+        protected String description()
+        {
+            return ordering.toString();
+        }
     }
 
     /**
@@ -1506,11 +1536,16 @@ abstract public class Plan
                    : new AnnIndexScan(factory, id, access, ordering);
         }
 
-        @Nullable
         @Override
-        protected IndexContext getIndexContext()
+        protected void visitIndexes(Consumer<IndexContext> consumer)
         {
-            return ordering.context;
+            consumer.accept(ordering.context);
+        }
+
+        @Override
+        protected String description()
+        {
+            return ordering.toString();
         }
     }
 
@@ -1548,9 +1583,9 @@ abstract public class Plan
         }
 
         @Override
-        protected IndexContext getIndexContext()
+        protected void visitIndexes(Consumer<IndexContext> consumer)
         {
-            return ordering.context;
+            consumer.accept(ordering.context);
         }
     }
 
@@ -1580,7 +1615,8 @@ abstract public class Plan
             return cost().costPerRow();
         }
 
-        final double expectedRows()
+        @VisibleForTesting
+        public final double expectedRows()
         {
             return cost().expectedRows;
         }
@@ -1900,14 +1936,27 @@ abstract public class Plan
 
         /**
          * Constructs a plan node representing a union of two key sets.
+         * Key sets are assumed to be non-correlated and may overlap.
          * @param subplans a list of subplans for unioned key sets
          */
         public KeysIteration union(List<KeysIteration> subplans)
         {
-            return union(subplans, nextId++);
+            return union(subplans, false, nextId++);
         }
 
-        private KeysIteration union(List<KeysIteration> subplans, int id)
+        /**
+         * Constructs a plan node representing a union of two key sets.
+         *
+         * @param subplans a list of subplans for unioned key sets
+         * @param disjoint hint to the planner that the subplans are disjoint; used for better row count estimation
+         */
+        public KeysIteration union(List<KeysIteration> subplans, boolean disjoint)
+        {
+            return union(subplans, disjoint, nextId++);
+        }
+
+
+        private KeysIteration union(List<KeysIteration> subplans, boolean disjoint, int id)
         {
             if (subplans.contains(everything))
                 return everything;
@@ -1918,7 +1967,7 @@ abstract public class Plan
             if (subplans.isEmpty())
                 return nothing;
 
-            return new Union(this, id, subplans, defaultAccess);
+            return new Union(this, id, subplans, disjoint, defaultAccess);
         }
 
         /**

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -188,9 +188,7 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
         this.tableQueryMetrics = tableQueryMetrics;
         this.indexFeatureSet = indexFeatureSet;
         this.ranges = dataRanges(command);
-        DataRange first = ranges.get(0);
-        DataRange last = ranges.get(ranges.size() - 1);
-        this.mergeRange = ranges.size() == 1 ? first.keyRange() : first.keyRange().withNewRight(last.keyRange().right);
+        this.mergeRange = merge(ranges);
 
         this.keyFactory = PrimaryKey.factory(cfs.metadata().comparator, indexFeatureSet);
         this.firstPrimaryKey = keyFactory.createTokenOnly(mergeRange.left.getToken());
@@ -382,21 +380,18 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
     private void updateIndexMetricsQueriesCount(Plan plan)
     {
         HashSet<IndexContext> queriedIndexesContexts = new HashSet<>();
-        plan.forEach(node -> {
-            IndexContext indexContext = node.getIndexContext();
-            if (indexContext != null)
-                queriedIndexesContexts.add(indexContext);
-            return Plan.ControlFlow.Continue;
-        });
-        queriedIndexesContexts.forEach(indexContext -> indexContext.getIndexMetrics()
-                .ifPresent(m -> m.queriesCount.inc()));
+        plan.visitIndexesRecursive(queriedIndexesContexts::add);
+        queriedIndexesContexts.forEach(indexContext ->
+                                       indexContext.getIndexMetrics()
+                                                   .ifPresent(m -> m.queriesCount.inc()));
     }
 
     Plan buildPlan()
     {
         Plan.KeysIteration keysIterationPlan = buildKeysIterationPlan();
         Plan.RowsIteration rowsIteration = planFactory.fetch(keysIterationPlan);
-        rowsIteration = planFactory.recheckFilter(command.rowFilter(), rowsIteration);
+
+        rowsIteration = planFactory.recheckFilter(command.rowFilter().withoutOrderingExpressions(), rowsIteration);
         rowsIteration = planFactory.limit(rowsIteration, command.limits().rows());
 
         // Limit the number of intersected clauses before optimizing so we reduce the size of the
@@ -417,7 +412,8 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
         plan = plan.limitIntersectedClauses(intersectionClauseLimit);
 
         if (plan.contains(node -> node instanceof Plan.Filter)
-            && plan.contains(node -> node instanceof Plan.IndexScan && ((Plan.IndexScan) node).ordering != null))
+            && plan.contains(node -> node instanceof Plan.IndexScan && ((Plan.IndexScan) node).ordering != null ||
+                                          node instanceof Plan.ScoredIndexScan))
             queryContext.setFilterSortOrder(QueryContext.FilterSortOrder.SCAN_THEN_FILTER);
         if (plan.contains(node -> node instanceof Plan.KeysSort))
             queryContext.setFilterSortOrder(QueryContext.FilterSortOrder.SEARCH_THEN_ORDER);
@@ -559,7 +555,7 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
         {
             Plan.KeysIteration left = buildHalfRangeFromInequality(predicate, Operator.LT);
             Plan.KeysIteration right = buildHalfRangeFromInequality(predicate, Operator.GT);
-            return planFactory.union(new ArrayList<>(Arrays.asList(left, right)));
+            return planFactory.union(new ArrayList<>(Arrays.asList(left, right)), true);
         }
     }
 
@@ -730,7 +726,7 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
                     orderer.bm25stats.add(index.getRowCount(),
                                           index.getApproximateTermCount(),
                                           termAndExpressions,
-                                          termExpression -> index.estimateMatchingRowsCountUsingAllShards(termExpression, mergeRange));
+                                          termExpression -> index.estimateMatchingRowsCount(termExpression));
                 for (SSTableIndex index : view.sstableIndexes)
                     orderer.bm25stats.add(index.getRowCount(),
                                           index.getApproximateTermCount(),
@@ -953,12 +949,12 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
 
     /**
      * Returns the total count of rows in the sstables which overlap with any of the given ranges
-     * and all live memtables.
+     * and the rows in the memtables restricted to the queried token ranges. Token ranges are
+     * approximated to full shards, according to the way how TrieMemtableIndex shards the indexes.
      */
     private long estimateTotalAvailableRows(List<DataRange> ranges)
     {
         long rows = 0;
-
         for (Memtable memtable : cfs.getAllMemtables())
             rows += Memtable.estimateRowCount(memtable);
 
@@ -968,6 +964,13 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
                     rows += sstable.getTotalRows();
 
         return rows;
+    }
+
+    private static AbstractBounds<PartitionPosition> merge(List<DataRange> ranges)
+    {
+        DataRange first = ranges.get(0);
+        DataRange last = ranges.get(ranges.size() - 1);
+        return ranges.size() == 1 ? first.keyRange() : first.keyRange().withNewRight(last.keyRange().right);
     }
 
     /**
@@ -1006,10 +1009,10 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
 
         long rowCount = 0;
         for (MemtableIndex index : queryView.memtableIndexes)
-            rowCount += index.estimateMatchingRowsCountUsingFirstShard(predicate, mergeRange);
+            rowCount += index.estimateMatchingRowsCount(predicate);
 
         for (SSTableIndex index : queryView.sstableIndexes)
-            rowCount += index.estimateMatchingRowsCount(predicate, mergeRange);
+            rowCount += index.estimateMatchingRowsCount(predicate);
 
         return rowCount;
     }

--- a/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
@@ -30,7 +30,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.PriorityQueue;
 import java.util.Queue;
-import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -131,33 +130,20 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
         return queryContext;
     }
 
+    /**
+     * Builds a Plan and stops. Leaves the controller in aborted state, and the Plan cannot be used to
+     * execute the query as all its iterators will be closed. This is only useful for testing purposes.
+     */
     @VisibleForTesting
-    public final Set<String> plannedIndexes()
+    public Plan.RowsIteration buildPlan()
     {
-        try
-        {
-            Plan plan = controller.buildPlan();
-            Set<String> indexes = new HashSet<>();
-            plan.forEach(node -> {
-                if (node instanceof Plan.IndexScan)
-                {
-                    Plan.IndexScan indexScan = (Plan.IndexScan) node;
-                    indexes.add(indexScan.getIndexName());
-                }
-                if (node instanceof Plan.ScoredIndexScan)
-                {
-                    Plan.ScoredIndexScan indexScan = (Plan.ScoredIndexScan) node;
-                    indexes.add(indexScan.getIndexName());
-                }
-                return Plan.ControlFlow.Continue;
-            });
-            return indexes;
-        }
-        finally
-        {
-            // we need to call this to clean up the resources opened by the plan
-            controller.abort();
-        }
+        return (Plan.RowsIteration) controller.buildPlan();
+    }
+
+    @VisibleForTesting
+    public void abort()
+    {
+        controller.abort();
     }
 
     @Override

--- a/src/java/org/apache/cassandra/index/sai/utils/RangeUtil.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/RangeUtil.java
@@ -18,7 +18,10 @@
 
 package org.apache.cassandra.index.sai.utils;
 
+import java.util.List;
+
 import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.db.DataRange;
 import org.apache.cassandra.db.PartitionPosition;
 import org.apache.cassandra.dht.AbstractBounds;
 import org.apache.cassandra.dht.Range;
@@ -66,5 +69,27 @@ public class RangeUtil
         cmp = keyRange.left.compareTo(maxKeyBound);
         // if left bound is bigger than maxKeyBound, no intersection
         return (keyRange.isStartInclusive() || cmp != 0) && cmp <= 0;
+    }
+
+
+    public static double getRingFraction(AbstractBounds<PartitionPosition> keyRange)
+    {
+        return keyRange.left.getToken().size(keyRange.right.getToken().nextValidToken());
+    }
+
+    public static double getRingFraction(DataRange dataRange)
+    {
+        return getRingFraction(dataRange.keyRange());
+    }
+
+    public static double getRingFraction(List<DataRange> dataRanges)
+    {
+        double fraction = 0.0;
+        for (DataRange range : dataRanges)
+        {
+            fraction += getRingFraction(range);
+        }
+        fraction = Math.min(1.0, fraction);  // rounding errors could cause exceeding 1.0
+        return fraction;
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/SAITester.java
+++ b/test/unit/org/apache/cassandra/index/sai/SAITester.java
@@ -82,6 +82,7 @@ import org.apache.cassandra.index.sai.disk.format.IndexComponentType;
 import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
 import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.index.sai.disk.v1.SegmentBuilder;
+import org.apache.cassandra.index.sai.plan.Plan;
 import org.apache.cassandra.index.sai.plan.QueryController;
 import org.apache.cassandra.index.sai.plan.StorageAttachedIndexQueryPlan;
 import org.apache.cassandra.index.sai.plan.StorageAttachedIndexSearcher;
@@ -96,6 +97,7 @@ import org.apache.cassandra.io.sstable.format.SSTableFormat;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.sstable.format.TOCComponent;
 import org.apache.cassandra.io.util.File;
+
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.schema.IndexMetadata;
 import org.apache.cassandra.schema.MockSchema;
@@ -1091,33 +1093,51 @@ public class SAITester extends CQLTester
         List<String> warnings = ClientWarn.instance.getWarnings();
         ClientWarn.instance.resetWarnings();
 
-        // Then get the indexes used by the plan
-        Set<String> plannedIndexes = plannedIndexes(query);
-        return new PlanSelectionAssertion(plannedIndexes, warnings);
-    }
-
-    private Set<String> plannedIndexes(String query)
-    {
         ReadCommand command = parseReadCommand(query);
         Index.QueryPlan queryPlan = command.indexQueryPlan();
         if (queryPlan == null)
-            return Collections.emptySet();
+            return new PlanSelectionAssertion(null, warnings);
 
         StorageAttachedIndexQueryPlan saiQueryPlan = (StorageAttachedIndexQueryPlan) queryPlan;
         Assertions.assertThat(saiQueryPlan).isNotNull();
-        StorageAttachedIndexSearcher searcher = (StorageAttachedIndexSearcher) saiQueryPlan.searcherFor(command);
-        return searcher.plannedIndexes();
+
+        StorageAttachedIndexSearcher searcher = saiQueryPlan.searcherFor(command);
+        try
+        {
+            return new PlanSelectionAssertion(searcher.buildPlan(), warnings);
+        }
+        finally
+        {
+            searcher.abort();
+        }
     }
 
     protected static class PlanSelectionAssertion
     {
+        private final double expectedRows;
         private final Set<String> selectedIndexes;
         private final List<String> warnings;
 
-        public PlanSelectionAssertion(Set<String> selectedIndexes, @Nullable List<String> warnings)
+        public PlanSelectionAssertion(@Nullable Plan.RowsIteration plan, @Nullable List<String> warnings)
         {
-            this.selectedIndexes = selectedIndexes;
+            this.expectedRows = plan != null ? plan.expectedRows() : -1.0;
+            this.selectedIndexes = plan != null ? plannedIndexes(plan) : Set.of();
             this.warnings = warnings;
+        }
+
+        private Set<String> plannedIndexes(Plan plan)
+        {
+            Set<String> indexes = new HashSet<>();
+            plan.visitIndexesRecursive(i -> indexes.add(i.getIndexName()));
+            return indexes;
+        }
+
+        public PlanSelectionAssertion hasEstimatedRowsCountBetween(double minRows, double maxRows)
+        {
+            Assertions.assertThat(expectedRows)
+                      .as("Expected rows to be between %s and %s, but got: %s", minRows, maxRows, expectedRows)
+                      .isBetween(minRows, maxRows);
+            return this;
         }
 
         public PlanSelectionAssertion uses(String... indexes)

--- a/test/unit/org/apache/cassandra/index/sai/cql/EstimatedRowCountTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/EstimatedRowCountTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.cql;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.memtable.TrieMemtable;
+import org.apache.cassandra.index.sai.SAITester;
+
+/// This is a regression test for CNDB-16363.
+/// It verifies that estimated row counts returned by the query planner are not zero even when the number
+/// of shards is large and shards contain little data.
+/// To some degree this test duplicates SingleRestrictionEstimatedRowCountTest, however this one is parameterized
+/// differently and explores different ranges of shard/partition counts, so both tests are needed.
+@RunWith(Parameterized.class)
+public class EstimatedRowCountTest extends SAITester
+{
+    @Parameterized.Parameter(0)
+    public int numShards;
+
+    @Parameterized.Parameter(1)
+    public int numPartitions;
+
+    @Parameters(name = "numShards={0}, numPartitions={1}")
+    public static Collection<Object[]> data()
+    {
+        return Arrays.asList(new Object[][] {
+            { 1, 0 },
+            { 8, 0 },
+            { 64, 0 },
+            { 1, 11 },
+            { 2, 11 },
+            { 4, 11 },
+            { 8, 11 },
+            { 16, 11 },
+            { 64, 11 },
+            { 1, 1000 },
+            { 8, 1000 },
+            { 64, 10000 }
+        });
+    }
+
+    @Test
+    public void testReturnedRowsEstimates() throws Throwable
+    {
+        TrieMemtable.SHARD_COUNT = numShards;
+        createTable("CREATE TABLE %s (k int, c int, n int, PRIMARY KEY(k, c))");
+        createIndex("CREATE CUSTOM INDEX n_idx ON %s (n) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX c_idx ON %s (c) USING 'StorageAttachedIndex'");
+
+        int numRowsPerPartition = 13;
+        int numRows = numPartitions * numRowsPerPartition;
+
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.unsafeRunWithoutFlushing(() -> {
+             for (int k = 0; k < numPartitions; k++)
+                 for (int c = 0; c < numRowsPerPartition; c++)
+                     execute("INSERT INTO %s (k, c, n) VALUES (?, ?, 1)", k, c);
+         });
+
+        beforeAndAfterFlush(() -> {
+            assertThatPlanFor("SELECT k, c FROM %s WHERE n = 0", 0)
+                .hasEstimatedRowsCountBetween(0.0, 0.0);
+            assertThatPlanFor("SELECT k, c FROM %s WHERE n = 1", numRows)
+                .hasEstimatedRowsCountBetween((double) numRows / 2, numRows * 2);
+            assertThatPlanFor("SELECT k, c FROM %s WHERE n < 5", numRows)
+                .hasEstimatedRowsCountBetween((double) numRows / 2, numRows * 2);
+            assertThatPlanFor("SELECT k, c FROM %s WHERE c = 1", numPartitions)
+                .hasEstimatedRowsCountBetween((double) numPartitions / 2, numPartitions * 2);
+            assertThatPlanFor("SELECT k, c FROM %s WHERE c >= 1 AND c <= 10", numPartitions * 10)
+                .hasEstimatedRowsCountBetween((double) numPartitions * 5, numPartitions * 20);
+            assertThatPlanFor("SELECT k, c FROM %s WHERE n = 1 AND c = 1", numPartitions)
+                .hasEstimatedRowsCountBetween((double) numPartitions / 2, numPartitions * 2);;
+        });
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/NonNumericTermsDistributionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/NonNumericTermsDistributionTest.java
@@ -424,7 +424,7 @@ public class NonNumericTermsDistributionTest extends SAITester
         var wholeRange = DataRange.allData(index.getIndexContext().getPartitioner()).keyRange();
         for (var memtableIndex : memtableIndexes)
             for (var memoryIndex : ((TrieMemtableIndex) memtableIndex).getRangeIndexes())
-                memoryCount += memoryIndex.estimateMatchingRowsCount(expression, wholeRange);
+                memoryCount += memoryIndex.estimateMatchingRowsCount(expression);
 
         assertEstimateCorrect(expectedCount, uncertainty, memoryCount);
     }
@@ -444,11 +444,10 @@ public class NonNumericTermsDistributionTest extends SAITester
     private long estimateSSTableRowCount(StorageAttachedIndex index, Operator op, String value)
     {
         var expression = buildExpression(index, op, value);
-        var wholeRange = DataRange.allData(index.getIndexContext().getPartitioner()).keyRange();
         var view = index.getIndexContext().getView();
         var onDiskCount = 0L;
         for (var sstableIndex : view.getIndexes())
-            onDiskCount += sstableIndex.estimateMatchingRowsCount(expression, wholeRange);
+            onDiskCount += sstableIndex.estimateMatchingRowsCount(expression);
         return onDiskCount;
     }
 

--- a/test/unit/org/apache/cassandra/index/sai/cql/NumericTermsDistributionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/NumericTermsDistributionTest.java
@@ -28,7 +28,7 @@ import org.junit.runners.Parameterized;
 
 import org.apache.cassandra.cql3.CQL3Type;
 import org.apache.cassandra.cql3.Operator;
-import org.apache.cassandra.db.DataRange;
+
 import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.db.marshal.NumberType;
 import org.apache.cassandra.index.sai.SAITester;
@@ -230,10 +230,9 @@ public class NumericTermsDistributionTest extends SAITester
                                    .values();
         var expression = buildExpression(index, op, value);
         var memoryCount = 0L;
-        var wholeRange = DataRange.allData(index.getIndexContext().getPartitioner()).keyRange();
         for (var memtableIndex : memtableIndexes)
             for (var memoryIndex : ((TrieMemtableIndex) memtableIndex).getRangeIndexes())
-                memoryCount += memoryIndex.estimateMatchingRowsCount(expression, wholeRange);
+                memoryCount += memoryIndex.estimateMatchingRowsCount(expression);
 
         assertEstimateCorrect(expectedCount, roundingValue, uncertainty, memoryCount);
     }
@@ -246,11 +245,10 @@ public class NumericTermsDistributionTest extends SAITester
     private void assertSSTableEstimateCount(StorageAttachedIndex index, Operator op, String value, long expectedCount, long roundingValue, long uncertainty)
     {
         var expression = buildExpression(index, op, value);
-        var wholeRange = DataRange.allData(index.getIndexContext().getPartitioner()).keyRange();
         var view = index.getIndexContext().getView();
         var onDiskCount = 0L;
         for (var sstableIndex : view.getIndexes())
-            onDiskCount += sstableIndex.estimateMatchingRowsCount(expression, wholeRange);
+            onDiskCount += sstableIndex.estimateMatchingRowsCount(expression);
 
         assertEstimateCorrect(expectedCount, roundingValue, uncertainty, onDiskCount);
     }

--- a/test/unit/org/apache/cassandra/index/sai/metrics/QueryMetricsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/metrics/QueryMetricsTest.java
@@ -68,6 +68,7 @@ public class QueryMetricsTest extends AbstractMetricsTest
     @Rule
     public ExpectedException exception = ExpectedException.none();
 
+
     @Test
     public void testSameIndexNameAcrossKeyspaces()
     {
@@ -521,23 +522,31 @@ public class QueryMetricsTest extends AbstractMetricsTest
         rows = execute("SELECT k, c FROM %s WHERE k = 0 AND n = 1");
         assertEquals(numRowsPerPartition, rows.size());
 
-        // hybrid query, postfiltering (goes to the general, hybrid and range query metrics)
+        // hybrid query doing filtering after the sorted index scan (goes to the general, hybrid and range query metrics)
         rows = execute("SELECT k, c FROM %s WHERE n = 1 ORDER BY v ANN OF [1, 1] LIMIT 1000");
         assertEquals(numRows, rows.size());
 
-        // hybrid query, single partition (goes to the general, hybrid and range query metrics)
+        // hybrid query doing filtering after the sorted index scan, single partition (goes to the general, hybrid and range query metrics)
         rows = execute("SELECT k, c FROM %s WHERE k = 0 AND n = 1 ORDER BY v ANN OF [1, 1] LIMIT 1000");
         assertEquals(numRowsPerPartition, rows.size());
 
+        // hybrid query doing search first (goes to the general, hybrid and range query metrics)
+        rows = execute("SELECT k, c FROM %s WHERE n = 2 ORDER BY v ANN OF [1, 1] LIMIT 1000");
+        assertEquals(0, rows.size());
+
+        // hybrid query doing search first, single partition (goes to the general, hybrid and range query metrics)
+        rows = execute("SELECT k, c FROM %s WHERE k = 0 AND n = 2 ORDER BY v ANN OF [1, 1] LIMIT 1000");
+        assertEquals(0, rows.size());
+
         // Verify metrics for total queries completed.
         String name = "TotalQueriesCompleted";
-        waitForEquals(objectName(name, TABLE_QUERY_METRIC_TYPE), 6);
+        waitForEquals(objectName(name, TABLE_QUERY_METRIC_TYPE), 8);
         waitForEqualsIfExists(perTable, objectName(name, TABLE_SP_FILTER_QUERY_METRIC_TYPE), 1);
         waitForEqualsIfExists(perTable, objectName(name, TABLE_MP_FILTER_QUERY_METRIC_TYPE), 1);
         waitForEqualsIfExists(perTable, objectName(name, TABLE_SP_TOPK_QUERY_METRIC_TYPE), 1);
         waitForEqualsIfExists(perTable, objectName(name, TABLE_MP_TOPK_QUERY_METRIC_TYPE), 1);
-        waitForEqualsIfExists(perTable, objectName(name, TABLE_SP_HYBRID_QUERY_METRIC_TYPE), 1);
-        waitForEqualsIfExists(perTable, objectName(name, TABLE_MP_HYBRID_QUERY_METRIC_TYPE), 1);
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_SP_HYBRID_QUERY_METRIC_TYPE), 2);
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_MP_HYBRID_QUERY_METRIC_TYPE), 2);
 
         // Verify counters for total keys fetched.
         name = "TotalKeysFetched";
@@ -624,9 +633,9 @@ public class QueryMetricsTest extends AbstractMetricsTest
         // We have no support for forcing the different order of operations in the query engine, so we cannot
         // directly test sort-then-filter queries.
         name = "SortThenFilterQueriesCompleted";
-        waitForEquals(objectName(name, TABLE_QUERY_METRIC_TYPE), 0);
-        waitForEqualsIfExists(perTable, objectName(name, TABLE_SP_HYBRID_QUERY_METRIC_TYPE), 0);
-        waitForEqualsIfExists(perTable, objectName(name, TABLE_MP_HYBRID_QUERY_METRIC_TYPE), 0);
+        waitForEquals(objectName(name, TABLE_QUERY_METRIC_TYPE), 2);
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_SP_HYBRID_QUERY_METRIC_TYPE), 1);
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_MP_HYBRID_QUERY_METRIC_TYPE), 1);
 
         // Verify counters for filter-then-sort hybrid queries.
         name = "FilterThenSortQueriesCompleted";
@@ -646,13 +655,13 @@ public class QueryMetricsTest extends AbstractMetricsTest
 
     private void verifyHistogramCount(String name, boolean hasPerQueryKindMetrics)
     {
-        waitForHistogramCountEquals(objectName(name, PER_QUERY_METRIC_TYPE), 6);
+        waitForHistogramCountEquals(objectName(name, PER_QUERY_METRIC_TYPE), 8);
         waitForHistogramCountEqualsIfExists(hasPerQueryKindMetrics, objectName(name, PER_SP_FILTER_QUERY_METRIC_TYPE), 1);
         waitForHistogramCountEqualsIfExists(hasPerQueryKindMetrics, objectName(name, PER_MP_FILTER_QUERY_METRIC_TYPE), 1);
         waitForHistogramCountEqualsIfExists(hasPerQueryKindMetrics, objectName(name, PER_SP_TOPK_QUERY_METRIC_TYPE), 1);
         waitForHistogramCountEqualsIfExists(hasPerQueryKindMetrics, objectName(name, PER_MP_TOPK_QUERY_METRIC_TYPE), 1);
-        waitForHistogramCountEqualsIfExists(hasPerQueryKindMetrics, objectName(name, PER_SP_HYBRID_QUERY_METRIC_TYPE), 1);
-        waitForHistogramCountEqualsIfExists(hasPerQueryKindMetrics, objectName(name, PER_MP_HYBRID_QUERY_METRIC_TYPE), 1);
+        waitForHistogramCountEqualsIfExists(hasPerQueryKindMetrics, objectName(name, PER_SP_HYBRID_QUERY_METRIC_TYPE), 2);
+        waitForHistogramCountEqualsIfExists(hasPerQueryKindMetrics, objectName(name, PER_MP_HYBRID_QUERY_METRIC_TYPE), 2);
     }
 
     private ObjectName objectName(String name, String type)

--- a/test/unit/org/apache/cassandra/index/sai/plan/PlanTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/plan/PlanTest.java
@@ -36,6 +36,7 @@ import org.junit.Test;
 import org.apache.cassandra.cql3.Operator;
 import org.apache.cassandra.db.filter.IndexHints;
 import org.apache.cassandra.db.filter.RowFilter;
+
 import org.apache.cassandra.index.sai.disk.vector.VectorMemtableIndex;
 import org.apache.cassandra.index.sai.iterators.KeyRangeIterator;
 import org.apache.cassandra.index.sai.iterators.LongIterator;
@@ -67,6 +68,7 @@ public class PlanTest
     {
         Orderer orderer = Mockito.mock(Orderer.class);
         Mockito.when(orderer.isANN()).thenReturn(true);
+        Mockito.when(orderer.toString()).thenReturn("ORDER BY v ANN OF [...]");
         return orderer;
     }
 
@@ -567,6 +569,7 @@ public class PlanTest
                               " └─ Filter pred1 < %s AND pred2 < %<s AND pred4 < %<s (sel: 1.000000000) (rows: 3.0, cost/row: 3895.8, cost: 44171.3..55858.7)\n" +
                               "     └─ Fetch (rows: 3.0, cost/row: 3895.8, cost: 44171.3..55858.7)\n" +
                               "         └─ KeysSort (keys: 3.0, cost/key: 3792.4, cost: 44171.3..55548.4)\n" +
+                              "            ORDER BY v ANN OF [...]\n" +
                               "             └─ Union (keys: 1999.0, cost/key: 14.8, cost: 13500.0..43001.3)\n" +
                               "                 ├─ Intersection (keys: 1000.0, cost/key: 29.4, cost: 9000.0..38401.3)\n" +
                               "                 │   ├─ NumericIndexScan of pred2_idx (sel: 0.002000000, step: 1.0) (keys: 2000.0, cost/key: 0.1, cost: 4500.0..4700.0)\n" +

--- a/test/unit/org/apache/cassandra/index/sai/plan/SingleRestrictionEstimatedRowCountTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/plan/SingleRestrictionEstimatedRowCountTest.java
@@ -31,14 +31,17 @@ import org.apache.cassandra.cql3.CQL3Type;
 import org.apache.cassandra.cql3.Operator;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.ReadCommand;
+import org.apache.cassandra.db.memtable.TrieMemtable;
 import org.apache.cassandra.index.sai.QueryContext;
 import org.apache.cassandra.index.sai.SAITester;
 import org.apache.cassandra.index.sai.SAIUtil;
 import org.apache.cassandra.index.sai.disk.format.Version;
 
+
 import static org.apache.cassandra.cql3.CQL3Type.Native.DECIMAL;
 import static org.apache.cassandra.cql3.CQL3Type.Native.INT;
 import static org.apache.cassandra.cql3.CQL3Type.Native.VARINT;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
@@ -72,35 +75,47 @@ public class SingleRestrictionEstimatedRowCountTest extends SAITester
     @Test
     public void testMemtablesSAI()
     {
+        // Use fixed number of shards to make the test predictable; without it, the default is
+        // to use the processors count, which may vary depending on the environment where tests are run.
+        TrieMemtable.SHARD_COUNT = 8;
+
         createTables();
 
-        RowCountTest test = new RowCountTest(Operator.NEQ, 25);
-        test.doTest(Version.DB, INT, 97.0);
-        test.doTest(Version.EB, INT, 97.0);
-        // Truncated numeric types planned differently
-        test.doTest(Version.DB, DECIMAL, 97.0);
-        test.doTest(Version.EB, DECIMAL, 97.0);
-        test.doTest(Version.EB, VARINT, 97.0);
+        // Estimates are just estimates, they are expected to have some inaccuracy, therefore we don't check
+        // them for equality. Common sources of estimate inaccuracy are:
+        // - estimating number of memtable rows based on memtable live size and average row size
+        // - finite resolution of histograms (applies to newer histogram based estimation in E* formats and later)
+        // - taking a subset of shards for estimation for better speed
+        // - running search on some shards lazily
 
-        test = new RowCountTest(Operator.LT, 50);
-        test.doTest(Version.DB, INT, 48);
-        test.doTest(Version.EB, INT, 48);
-        test.doTest(Version.DB, DECIMAL, 48);
-        test.doTest(Version.EB, DECIMAL, 48);
+        for (Version version : versions)
+        {
+            RowCountTest test = new RowCountTest(Operator.NEQ, 25);
+            test.doTest(version, INT, 95, 100);
+            test.doTest(version, DECIMAL, 95, version.onOrAfter(Version.EB) ? 99 : 100);
+            test.doTest(version, VARINT, 95, 99);
 
-        test = new RowCountTest(Operator.LT, 150);
-        test.doTest(Version.DB, INT, 97);
-        test.doTest(Version.EB, INT, 97);
-        test.doTest(Version.DB, DECIMAL, 97);
-        test.doTest(Version.EB, DECIMAL, 97);
+            test = new RowCountTest(Operator.LT, 50);
+            test.doTest(version, INT, 40, 60);
+            test.doTest(version, DECIMAL, 40, 60);
+            test.doTest(version, VARINT, 40, 60);
 
-        test = new RowCountTest(Operator.EQ, 31);
-        test.doTest(Version.DB, INT, 15);
-        test.doTest(Version.EB, INT, 0);
-        test.doTest(Version.DB, DECIMAL, 15);
-        test.doTest(Version.EB, DECIMAL, 0);
+            test = new RowCountTest(Operator.LT, 150);
+            test.doTest(version, INT, 95, 100);
+            test.doTest(version, DECIMAL, 95, 100);
+            test.doTest(version, VARINT, 95, 100);
+
+            test = new RowCountTest(Operator.EQ, 31);
+            // For older on-disk formats we expect less accurate estimates due to lack of per-index stats and due to
+            // lazy search on the first shard only; in this scenario each shard iterator will report at least one row,
+            // even if none are matching. We could have run the search on all shards to get more accurate estimates,
+            // but search is expensive, so we accept less accurate estimates for older formats.
+            int maxExpectedRows = version.onOrAfter(Version.EB) ? 1 : TrieMemtable.SHARD_COUNT;
+            test.doTest(version, INT, 1, maxExpectedRows);
+            test.doTest(version, DECIMAL, 1, maxExpectedRows);
+            test.doTest(version, VARINT, 1, maxExpectedRows);
+        }
     }
-
 
     void createTables()
     {
@@ -143,7 +158,7 @@ public class SingleRestrictionEstimatedRowCountTest extends SAITester
             this.filterValue = filterValue;
         }
 
-        void doTest(Version version, CQL3Type.Native type, double expectedRows)
+        void doTest(Version version, CQL3Type.Native type, double minExpectedRows, double maxExpectedRows)
         {
             ColumnFamilyStore cfs = tables.get(new AbstractMap.SimpleEntry<>(version, type));
             Object filter = getFilterValue(type, filterValue);
@@ -166,9 +181,12 @@ public class SingleRestrictionEstimatedRowCountTest extends SAITester
             Plan.KeysIteration planNode = root.firstNodeOfType(Plan.KeysIteration.class);
             assertNotNull(planNode);
 
-            assertEquals(expectedRows, root.expectedRows(), 0.1);
-            assertEquals(expectedRows, planNode.expectedKeys(), 0.1);
-            assertEquals(expectedRows / totalRows, planNode.selectivity(), 0.01);
+            double minSelectivity = minExpectedRows / totalRows;
+            double maxSelectivity = maxExpectedRows / totalRows;
+
+            assertThat(root.expectedRows()).isBetween(minExpectedRows, maxExpectedRows);
+            assertThat(planNode.expectedKeys()).isBetween(minExpectedRows, maxExpectedRows);
+            assertThat(planNode.selectivity()).isBetween(minSelectivity, maxSelectivity);
         }
     }
 }


### PR DESCRIPTION
When a memory index contains very few rows and is split into many shards, we can expect a lot of variance in the number of rows between the shards. Hence, if we took only one
shard to estimate the number of matched rows, and
extrapolate that on all shards to compute the estimated matching rows from the whole index, we risk making a huge estimation error.

This commit changes the algorithm to take as many shards as needed to collect enough returned or indexed rows. For very tiny datasets is it's likely to use all shards for estimation. For big datasets, one shard will likely be enough, speeding up estimation.

This change also allows to remove one estimation method. We no longer need to manually choose between the estimation from the first shard and from all shards.

Additionally, the accuracy of estimating of NOT_EQ rows has been improved by letting the planner know the union generated by NOT_EQ is disjoint so the result set cardinality is the sum of cardinalities of the subplans.

The commit contains also a fix for a bug that caused some non-hybrid queries be counted as hybrid by the query metrics.

Unused keyRange parameters have been removed from the methods for estimating row counts in the index classes.
