### PR TITLE
CNDB-16237: Add execution info to logs about aborted queries

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -592,7 +592,7 @@ public enum CassandraRelevantProperties
     MMAPPED_MAX_SEGMENT_SIZE_IN_MB("cassandra.mmapped_max_segment_size"),
     /**
      * Whether to log detailed execution info when logging slow non-SAI queries.
-     * For SAI queries, see {@link #SAI_SLOW_QUERY_LOG_EXECUTION_INFO_ENABLED}.
+     * For SAI queries, see {@link #SAI_MONITORING_EXECUTION_INFO_ENABLED}.
      */
     MONITORING_EXECUTION_INFO_ENABLED("cassandra.monitoring_execution_info_enabled", "true"),
     /** Defines the maximum number of unique timed out queries that will be reported in the logs. Use a negative number to remove any limit. */
@@ -769,6 +769,14 @@ public enum CassandraRelevantProperties
     SAI_MAX_FROZEN_TERM_SIZE("cassandra.sai.max_frozen_term_size_kb", "8"),
     SAI_MAX_STRING_TERM_SIZE("cassandra.sai.max_string_term_size_kb", "8"),
     SAI_MAX_VECTOR_TERM_SIZE("cassandra.sai.max_vector_term_size_kb", "16"),
+
+    /**
+     * Whether to log SAI-specific detailed execution info when logging slow SAI queries.
+     * This execution info includes the query metrics and the query plan of the slow queries.
+     * For non-SAI queries, see {@link #MONITORING_EXECUTION_INFO_ENABLED}.
+     */
+    SAI_MONITORING_EXECUTION_INFO_ENABLED("cassandra.sai.monitoring_execution_info_enabled", "true"),
+
     // Use non-positive value to disable it. Period in millis to trigger a flush for SAI non-vector memtable index.
     SAI_NON_VECTOR_FLUSH_PERIOD_IN_MILLIS("cassandra.sai.non_vector_flush_period_in_millis", "-1"),
     // Use non-positive value to disable it. When num of rows in SAI non-vector memtable index reaches the threshold, it triggers flush
@@ -794,13 +802,6 @@ public enum CassandraRelevantProperties
 
     SAI_QUERY_OPT_LEVEL("cassandra.sai.query.optimization.level", "1"),
     SAI_REDUCE_TOPK_ACROSS_SSTABLES("cassandra.sai.reduce_topk_across_sstables", "true"),
-
-    /**
-     * Whether to log SAI-specific detailed execution info when logging slow SAI queries.
-     * This execution info includes the query metrics and the query plan of the slow queries.
-     * For non-SAI queries, see {@link #MONITORING_EXECUTION_INFO_ENABLED}.
-     */
-    SAI_SLOW_QUERY_LOG_EXECUTION_INFO_ENABLED("cassandra.sai.slow_query_log.execution_info_enabled", "true"),
 
     /**
      * Whether to enable SAI table state metrics such as disk usage, queryable index count, and index build progress.

--- a/src/java/org/apache/cassandra/db/monitoring/MonitoringTask.java
+++ b/src/java/org/apache/cassandra/db/monitoring/MonitoringTask.java
@@ -328,6 +328,9 @@ public class MonitoringTask
          * this is set lazily as it takes time to build the query CQL */
         private String name;
 
+        /** Any specific execution info of the slowest operation among the aggregated operations. */
+        protected Monitorable.ExecutionInfo slowestOperationExecutionInfo;
+
         Operation(Monitorable operation, long nowNanos)
         {
             this.operation = operation;
@@ -335,6 +338,7 @@ public class MonitoringTask
             totalTimeNanos = nowNanos - operation.creationTimeNanos();
             minTime = totalTimeNanos;
             maxTime = totalTimeNanos;
+            slowestOperationExecutionInfo = operation.executionInfo();
         }
 
         public String name()
@@ -344,17 +348,24 @@ public class MonitoringTask
             return name;
         }
 
-        void add(Operation operation)
+        private void add(Operation operation)
         {
             numTimesReported++;
             totalTimeNanos += operation.totalTimeNanos;
+
+            if (operation.maxTime > maxTime)
+                slowestOperationExecutionInfo = operation.executionInfo();
+
             maxTime = Math.max(maxTime, operation.maxTime);
             minTime = Math.min(minTime, operation.minTime);
         }
 
         public abstract String getLogMessage();
 
-        protected abstract Monitorable.ExecutionInfo executionInfo();
+        protected Monitorable.ExecutionInfo executionInfo()
+        {
+            return slowestOperationExecutionInfo;
+        }
     }
 
     /**
@@ -370,26 +381,22 @@ public class MonitoringTask
         public String getLogMessage()
         {
             if (numTimesReported == 1)
-                return String.format("<%s>, total time %d msec, timeout %d %s",
+                return String.format("<%s>, total time %d msec, timeout %d %s%s",
                                      name(),
                                      NANOSECONDS.toMillis(totalTimeNanos),
                                      NANOSECONDS.toMillis(operation.timeoutNanos()),
-                                     operation.isCrossNode() ? "msec/cross-node" : "msec");
+                                     operation.isCrossNode() ? "msec/cross-node" : "msec",
+                                     slowestOperationExecutionInfo.toLogString(true));
             else
-                return String.format("<%s> timed out %d times, avg/min/max %d/%d/%d msec, timeout %d %s",
+                return String.format("<%s> timed out %d times, avg/min/max %d/%d/%d msec, timeout %d %s%s",
                                      name(),
                                      numTimesReported,
                                      NANOSECONDS.toMillis(totalTimeNanos / numTimesReported),
                                      NANOSECONDS.toMillis(minTime),
                                      NANOSECONDS.toMillis(maxTime),
                                      NANOSECONDS.toMillis(operation.timeoutNanos()),
-                                     operation.isCrossNode() ? "msec/cross-node" : "msec");
-        }
-
-        @Override
-        protected Monitorable.ExecutionInfo executionInfo()
-        {
-            return Monitorable.ExecutionInfo.EMPTY;
+                                     operation.isCrossNode() ? "msec/cross-node" : "msec",
+                                     slowestOperationExecutionInfo.toLogString(false));
         }
     }
 
@@ -399,14 +406,10 @@ public class MonitoringTask
     @VisibleForTesting
     public final static class SlowOperation extends Operation
     {
-        /** Any specific execution info of the slowest operation among the aggregated operations. */
-        private Monitorable.ExecutionInfo slowestOperationExecutionInfo;
-
         @VisibleForTesting
         public SlowOperation(Monitorable operation, long slowAtNanos)
         {
             super(operation, slowAtNanos);
-            slowestOperationExecutionInfo = operation.executionInfo();
         }
 
         public String getLogMessage()
@@ -428,21 +431,6 @@ public class MonitoringTask
                                      NANOSECONDS.toMillis(operation.slowTimeoutNanos()),
                                      operation.isCrossNode() ? "msec/cross-node" : "msec",
                                      slowestOperationExecutionInfo.toLogString(false));
-        }
-
-        @Override
-        protected Monitorable.ExecutionInfo executionInfo()
-        {
-            return slowestOperationExecutionInfo;
-        }
-
-        @Override
-        void add(Operation operation)
-        {
-            if (operation.maxTime > maxTime)
-                slowestOperationExecutionInfo = operation.executionInfo();
-
-            super.add(operation);
         }
     }
 }

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryMonitorableExecutionInfo.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryMonitorableExecutionInfo.java
@@ -52,7 +52,7 @@ public class QueryMonitorableExecutionInfo implements Monitorable.ExecutionInfo
      */
     public static Supplier<Monitorable.ExecutionInfo> supplier(QueryContext context, Plan plan)
     {
-        if (!CassandraRelevantProperties.SAI_SLOW_QUERY_LOG_EXECUTION_INFO_ENABLED.getBoolean())
+        if (!CassandraRelevantProperties.SAI_MONITORING_EXECUTION_INFO_ENABLED.getBoolean())
             return Monitorable.ExecutionInfo.EMPTY_SUPPLIER;
 
         String planAsString = toLogString(plan);

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/SlowSAIQueryLoggerTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/SlowSAIQueryLoggerTest.java
@@ -337,7 +337,7 @@ public class SlowSAIQueryLoggerTest extends TestBaseImpl
             node.runOnInstance(() -> BB.queryDelay.updateAndGet(x -> x / 4)); // restore the query delay
 
             // disable execution info logging and verify they are not logged
-            CassandraRelevantProperties.SAI_SLOW_QUERY_LOG_EXECUTION_INFO_ENABLED.setBoolean(false);
+            CassandraRelevantProperties.SAI_MONITORING_EXECUTION_INFO_ENABLED.setBoolean(false);
             mark = node.logs().mark();
             coordinator.execute(numericQuery, ConsistencyLevel.ONE);
             coordinator.execute(textQuery, ConsistencyLevel.ONE);
@@ -345,7 +345,7 @@ public class SlowSAIQueryLoggerTest extends TestBaseImpl
             coordinator.execute(hybridQuery, ConsistencyLevel.ONE);
             assertLogsContain(mark, node, "4 operations were slow");
             assertLogsDoNotContainSAIExecutionInfo(mark, node);
-            CassandraRelevantProperties.SAI_SLOW_QUERY_LOG_EXECUTION_INFO_ENABLED.setBoolean(true);
+            CassandraRelevantProperties.SAI_MONITORING_EXECUTION_INFO_ENABLED.setBoolean(true);
 
             // test with a legacy index, there should be no SAI execution info
             cluster.schemaChange(withKeyspace("CREATE INDEX legacy_idx ON %s.t (l)"));

--- a/test/microbench/org/apache/cassandra/test/microbench/index/sai/QueryMonitorableExecutionInfoBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/index/sai/QueryMonitorableExecutionInfoBench.java
@@ -81,7 +81,7 @@ public class QueryMonitorableExecutionInfoBench extends SAITester
     @Setup(Level.Trial)
     public void setup() throws Throwable
     {
-        CassandraRelevantProperties.SAI_SLOW_QUERY_LOG_EXECUTION_INFO_ENABLED.setBoolean(enabled);
+        CassandraRelevantProperties.SAI_MONITORING_EXECUTION_INFO_ENABLED.setBoolean(enabled);
         CQLTester.setUpClass();
         CQLTester.prepareServer();
         beforeTest();


### PR DESCRIPTION
Add execution information to the log reports for aborted queries.

The extension of the log messages is identical to what we did for slow successful queries in CNDB-15260 and CNDB-15260, but applied to aborted queries. For regular queries this information is the number of fetched/returned/deleted partitions and rows. For SAI queries, this information is the SAI query metrics and a tree view of the SAI query plan.

This also renames the CassandraRelevantProperties related to monitoring, to align them with ASF/CC5. The renames are:

SLOW_QUERY_LOG_MONITORING_REPORT_INTERVAL_IN_MS -> MONITORING_REPORT_INTERVAL_MS SLOW_QUERY_LOG_MONITORING_MAX_OPERATIONS -> MONITORING_MAX_OPERATIONS SLOW_QUERY_LOG_EXECUTION_INFO_ENABLED -> MONITORING_EXECUTION_INFO_ENABLED SAI_SLOW_QUERY_LOG_EXECUTION_INFO_ENABLED -> SAI_MONITORING_EXECUTION_INFO_ENABLED

Please note that the real underlying system properties are unchanged, and this only renames their enum names.

The feature is toggled with the cassandra.monitoring_execution_info_enabled system property for general queries, and cassandra.sai.monitoring_execution_info_enabled for SAI queries. The per-writer endpoints to enable/disable slow query logging are http://<HOST>:<PORT>/writer/api/v0/nodetool/cassandra_relevant_property?property=MONITORING_EXECUTION_INFO_ENABLED&new_value=<false|true> for general queries, and http://<HOST>:<PORT>/writer/api/v0/nodetool/cassandra_relevant_property?property=SAI_MONITORING_EXECUTION_INFO_ENABLED&new_value=<false|true> for SAI queries
