### PR TITLE
CNDB-16330: remove sync lock in PartialLifecycleTransaction::trackNewWritten

### DIFF
--- a/src/java/org/apache/cassandra/db/lifecycle/LifecycleNewTracker.java
+++ b/src/java/org/apache/cassandra/db/lifecycle/LifecycleNewTracker.java
@@ -34,7 +34,9 @@ public interface LifecycleNewTracker
     void trackNew(SSTable table);
 
     /**
-     * Called when a new sstable and its indexes bave been fully written
+     * Called when a new sstable and its indexes have been fully written.
+     * Implementation must be thread safe and not alter the state of the transaction.
+     *
      * @param table - the newly written sstable to be tracked
      */
     default void trackNewWritten(SSTable table)

--- a/src/java/org/apache/cassandra/db/lifecycle/PartialLifecycleTransaction.java
+++ b/src/java/org/apache/cassandra/db/lifecycle/PartialLifecycleTransaction.java
@@ -172,10 +172,8 @@ public class PartialLifecycleTransaction implements ILifecycleTransaction
     public void trackNewWritten(SSTable table)
     {
         throwIfCompositeAborted();
-        synchronized (mainTransaction)
-        {
-            mainTransaction.trackNewWritten(table);
-        }
+        // Beware: not synchronized. Thread safety shall be ensured in the main transaction trackNewWritten.
+        mainTransaction.trackNewWritten(table);
     }
 
     @Override


### PR DESCRIPTION
### What is the issue

https://github.com/riptano/cndb/issues/16330

### What does this PR fix and why was it fixed

This removes the lock in `PartialLifecycleTransaction::trackNewWritten` on the main transaction `trackNewWritten` as
`RemoteLogTransaction::trackNewWritten` performs the upload of SSTables to remote storage which takes a long time and thus it leads to contention and prevents parallel upload to remote storage.
