### PR TITLE
CNDB-16350: Optimize ChronicleMap access, iteration to reduce serde cost

### DIFF
--- a/test/microbench/org/apache/cassandra/test/microbench/index/sai/VectorCompactionBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/index/sai/VectorCompactionBench.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.test.microbench.index.sai;
+
+import java.io.BufferedInputStream;
+import java.io.DataInputStream;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.db.commitlog.CommitLog;
+import org.apache.cassandra.index.sai.SAITester;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Benchmark for measuring vector index compaction performance using the SIFT dataset.
+ * This benchmark loads the siftsmall dataset and measures the time it takes to compact
+ * multiple SSTables containing vector data.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 3, time = 5, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 1)
+@Threads(1)
+@State(Scope.Benchmark)
+public class VectorCompactionBench extends SAITester
+{
+    private static final String DATASET = "siftsmall";
+
+    /**
+     * The percent of vectors to duplicate expressed as a decimal from 0 to 1. This covers several code paths related
+     * to different kinds of postings lists generated for no dupes, some dupes, and many dupes.
+     */
+    @Param({ "0", "0.009", "0.999", "10" })
+    public double dupeVectorFactor;
+
+    @Setup(Level.Trial)
+    public void setup() throws Throwable
+    {
+        CQLTester.setUpClass();
+        CQLTester.prepareServer();
+        beforeTest();
+
+        // Load the SIFT dataset
+        var baseVectors = readFvecs(String.format("test/data/%s/%s_base.fvecs", DATASET, DATASET));
+
+        // Create table and index
+        createTable("CREATE TABLE %s (pk int, val vector<float, 128>, PRIMARY KEY(pk))");
+        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
+
+        // Disable background compactions to avoid interference
+        disableCompaction();
+
+        // Select dupes by percent
+        int numDupes = (int) (baseVectors.size() * dupeVectorFactor);
+        for (int i = 0; i < numDupes; i++)
+            baseVectors.add(baseVectors.get(i));
+
+        IntStream.range(0, baseVectors.size()).parallel().forEach(i -> {
+            float[] arrayVector = baseVectors.get(i);
+            try {
+                execute("INSERT INTO %s (pk, val) VALUES (?, ?)", i, vector(arrayVector));
+            } catch (Throwable throwable) {
+                throw new RuntimeException(throwable);
+            }
+        });
+
+        // Flush since we only want to measure compaction performance
+        flush();
+    }
+
+
+    @TearDown(Level.Trial)
+    public void teardown() throws IOException, ExecutionException, InterruptedException
+    {
+        CommitLog.instance.shutdownBlocking();
+        CQLTester.cleanup();
+    }
+
+    /**
+     * Benchmark the compaction of vector indexes.
+     * This measures the time it takes to compact a single sstable, which currently builds the whole
+     * index from scratch each time.
+     */
+    @Benchmark
+    public void compactVectorIndex() throws Throwable
+    {
+        compact();
+    }
+
+    /**
+     * Read float vectors from a .fvecs file (SIFT dataset format).
+     */
+    private static ArrayList<float[]> readFvecs(String filePath) throws IOException
+    {
+        var vectors = new ArrayList<float[]>();
+        try (var dis = new DataInputStream(new BufferedInputStream(new FileInputStream(filePath))))
+        {
+            while (dis.available() > 0)
+            {
+                var dimension = Integer.reverseBytes(dis.readInt());
+                assert dimension > 0 : dimension;
+                var buffer = new byte[dimension * Float.BYTES];
+                dis.readFully(buffer);
+                var byteBuffer = ByteBuffer.wrap(buffer).order(ByteOrder.LITTLE_ENDIAN);
+
+                var vector = new float[dimension];
+                for (var i = 0; i < dimension; i++)
+                {
+                    vector[i] = byteBuffer.getFloat();
+                }
+                vectors.add(vector);
+            }
+        }
+        return vectors;
+    }
+}

--- a/test/microbench/org/apache/cassandra/test/microbench/index/sai/disk/v5/V5VectorPostingsWriterBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/index/sai/disk/v5/V5VectorPostingsWriterBench.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.test.microbench.index.sai.disk.v5;
+
+import java.io.File;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+
+import io.github.jbellis.jvector.util.RamUsageEstimator;
+import io.github.jbellis.jvector.vector.VectorizationProvider;
+import io.github.jbellis.jvector.vector.types.VectorFloat;
+import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
+import net.openhft.chronicle.hash.serialization.SizeMarshaller;
+import net.openhft.chronicle.map.ChronicleMap;
+import net.openhft.chronicle.map.ChronicleMapBuilder;
+import org.apache.cassandra.index.sai.disk.v5.V5VectorPostingsWriter;
+import org.apache.cassandra.index.sai.disk.vector.CompactionGraph;
+import org.apache.cassandra.index.sai.disk.vector.VectorPostings;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 3, time = 5, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 1)
+@Threads(1)
+@State(Scope.Benchmark)
+public class V5VectorPostingsWriterBench
+{
+    private static final VectorTypeSupport vts = VectorizationProvider.getInstance().getVectorTypeSupport();
+
+    private AtomicInteger maxRowId = new AtomicInteger(0);
+
+    @Param({ "768", "1536"})
+    public int dimension;
+
+    @Param({"100000", "1000000", "10000000"})
+    public int numVectors;
+
+    private File postingsFile;
+    private ChronicleMap<VectorFloat<?>, VectorPostings.CompactionVectorPostings> postingsMap;
+
+    @Setup(Level.Trial)
+    public void setup() throws Throwable
+    {
+        postingsFile = File.createTempFile("postings", ".map");
+        // Build a ChronicleMap
+        postingsMap = ChronicleMapBuilder.of((Class<VectorFloat<?>>) (Class) VectorFloat.class, (Class<VectorPostings.CompactionVectorPostings>) (Class) VectorPostings.CompactionVectorPostings.class)
+                                         .averageKeySize(dimension * Float.BYTES)
+                                         .keySizeMarshaller(SizeMarshaller.constant((long) dimension * Float.BYTES))
+                                         .averageValueSize(VectorPostings.emptyBytesUsed() + RamUsageEstimator.NUM_BYTES_OBJECT_REF + 2 * Integer.BYTES)
+                                         .keyMarshaller(new CompactionGraph.VectorFloatMarshaller(dimension))
+                                         .valueMarshaller(new VectorPostings.Marshaller())
+                                         .entries(numVectors)
+                                         .createPersistedTo(postingsFile);
+
+        var rowId = new AtomicInteger(0);
+        IntStream.range(0, numVectors)
+                 .parallel()
+                 .forEach(ordinal -> {
+                     float[] vector = new float[dimension];
+                     for (int j = 0; j < dimension; j++)
+                         vector[j] = ThreadLocalRandom.current().nextFloat();
+                     var floatVector = vts.createFloatVector(vector);
+                     var row = rowId.getAndIncrement();
+                     var postings = new VectorPostings.CompactionVectorPostings(ordinal, row);
+                     // Add a dupe every so often, shifting it to ensure unique row ids and to ensure that ordinals
+                     // still map to their respective row id and allow for the ONE_TO_MANY logic to work correctly.
+                     if (row % 100 == 0)
+                     {
+                         maxRowId.accumulateAndGet(row + numVectors, Integer::max);
+                         postings.add(row + numVectors);
+                     }
+                     postingsMap.put(floatVector, postings);
+                 });
+    }
+
+    @Benchmark
+    public void createGenericIdentityMapping()
+    {
+        V5VectorPostingsWriter.createGenericIdentityMapping(postingsMap, maxRowId.get(), numVectors - 1);
+    }
+
+    @Benchmark
+    public void describeForCompactionOneToMany()
+    {
+        V5VectorPostingsWriter.describeForCompaction(V5VectorPostingsWriter.Structure.ONE_TO_MANY, numVectors, maxRowId.get(), numVectors - 1, postingsMap);
+    }
+
+    @TearDown
+    public void tearDown() throws Throwable
+    {
+        postingsMap.close();
+        boolean success = postingsFile.delete();
+        if (!success)
+            throw new AssertionError("failed to delete " + postingsFile);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/disk/vector/VectorPostingsMarshallerTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/vector/VectorPostingsMarshallerTest.java
@@ -1,0 +1,328 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.disk.vector;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import net.openhft.chronicle.bytes.Bytes;
+import net.openhft.chronicle.core.io.IORuntimeException;
+import net.openhft.chronicle.map.ChronicleMap;
+import net.openhft.chronicle.map.ChronicleMapBuilder;
+import org.agrona.collections.Int2IntHashMap;
+import org.apache.cassandra.index.sai.disk.vector.VectorPostings.CompactionVectorPostings;
+import org.apache.cassandra.index.sai.disk.vector.VectorPostings.Marshaller;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class VectorPostingsMarshallerTest
+{
+    private final Marshaller marshaller = new Marshaller();
+
+    @Test
+    public void testWriteAndReadSinglePosting()
+    {
+        // Create a CompactionVectorPostings with a single posting
+        int ordinal = 42;
+        int rowId = 100;
+        CompactionVectorPostings postings = new CompactionVectorPostings(ordinal, rowId);
+
+        // Write to bytes
+        Bytes<?> bytes = Bytes.allocateElasticOnHeap();
+        marshaller.write(bytes, postings);
+
+        // Read back
+        bytes.readPosition(0);
+        CompactionVectorPostings read = marshaller.read(bytes, null);
+
+        // Verify
+        assertNotNull(read);
+        assertEquals(ordinal, read.getOrdinal());
+        assertEquals(1, read.size());
+        assertEquals(rowId, read.getPostings().get(0).intValue());
+        
+        bytes.releaseLast();
+    }
+
+    @Test
+    public void testWriteAndReadMultiplePostings()
+    {
+        // Create a CompactionVectorPostings with multiple postings
+        int ordinal = 10;
+        List<Integer> rowIds = List.of(5, 15, 25, 35);
+        CompactionVectorPostings postings = new CompactionVectorPostings(ordinal, rowIds);
+
+        // Write to bytes
+        Bytes<?> bytes = Bytes.allocateElasticOnHeap();
+        marshaller.write(bytes, postings);
+
+        // Read back
+        bytes.readPosition(0);
+        CompactionVectorPostings read = marshaller.read(bytes, null);
+
+        // Verify
+        assertNotNull(read);
+        assertEquals(ordinal, read.getOrdinal());
+        assertEquals(4, read.size());
+        assertEquals(rowIds, read.getPostings());
+        
+        bytes.releaseLast();
+    }
+
+    @Test
+    public void testWriteAndReadEmptyPostings()
+    {
+        // Create a CompactionVectorPostings with empty list
+        int ordinal = 7;
+        List<Integer> rowIds = List.of();
+        CompactionVectorPostings postings = new CompactionVectorPostings(ordinal, rowIds);
+
+        // Write to bytes
+        Bytes<?> bytes = Bytes.allocateElasticOnHeap();
+        marshaller.write(bytes, postings);
+
+        // Read back
+        bytes.readPosition(0);
+        CompactionVectorPostings read = marshaller.read(bytes, null);
+
+        // Verify
+        assertNotNull(read);
+        assertEquals(ordinal, read.getOrdinal());
+        assertEquals(0, read.size());
+        assertTrue(read.getPostings().isEmpty());
+        
+        bytes.releaseLast();
+    }
+
+    @Test
+    public void testWriteAndReadLargeOrdinalAndRowIds()
+    {
+        // Test with large values to ensure proper integer handling
+        int ordinal = Integer.MAX_VALUE - 1;
+        List<Integer> rowIds = List.of(Integer.MAX_VALUE - 10, Integer.MAX_VALUE - 5, Integer.MAX_VALUE - 1);
+        CompactionVectorPostings postings = new CompactionVectorPostings(ordinal, rowIds);
+
+        // Write to bytes
+        Bytes<?> bytes = Bytes.allocateElasticOnHeap();
+        marshaller.write(bytes, postings);
+
+        // Read back
+        bytes.readPosition(0);
+        CompactionVectorPostings read = marshaller.read(bytes, null);
+
+        // Verify
+        assertNotNull(read);
+        assertEquals(ordinal, read.getOrdinal());
+        assertEquals(3, read.size());
+        assertEquals(rowIds, read.getPostings());
+        
+        bytes.releaseLast();
+    }
+
+    @Test
+    public void testExtractOrdinalFromMapEntry() throws IORuntimeException
+    {
+        // Create a ChronicleMap to test extractOrdinal
+        try (ChronicleMap<Integer, CompactionVectorPostings> map = ChronicleMapBuilder
+                .of(Integer.class, CompactionVectorPostings.class)
+                .entries(10)
+                .averageValueSize(100)
+                .valueMarshaller(marshaller)
+                .create())
+        {
+            int key = 1;
+            int ordinal = 123;
+            int rowId = 456;
+            CompactionVectorPostings postings = new CompactionVectorPostings(ordinal, rowId);
+            
+            map.put(key, postings);
+
+            // Extract ordinal using the optimized method
+            map.forEachEntry(entry -> {
+                int extractedOrdinal = Marshaller.extractOrdinal(entry);
+                assertEquals(ordinal, extractedOrdinal);
+            });
+        }
+    }
+
+    @Test
+    public void testExtractOrdinalWithMultiplePostings() throws IORuntimeException
+    {
+        // Test extractOrdinal with multiple postings
+        try (ChronicleMap<Integer, CompactionVectorPostings> map = ChronicleMapBuilder
+                .of(Integer.class, CompactionVectorPostings.class)
+                .entries(10)
+                .averageValueSize(100)
+                .valueMarshaller(marshaller)
+                .create())
+        {
+            int key = 2;
+            int ordinal = 999;
+            List<Integer> rowIds = List.of(100, 200, 300);
+            CompactionVectorPostings postings = new CompactionVectorPostings(ordinal, rowIds);
+            
+            map.put(key, postings);
+
+            // Extract ordinal using the optimized method
+            map.forEachEntry(entry -> {
+                int extractedOrdinal = Marshaller.extractOrdinal(entry);
+                assertEquals(ordinal, extractedOrdinal);
+            });
+        }
+    }
+
+    @Test
+    public void testRecordExtraOrdinalsWithSinglePosting()
+    {
+        // Test recordExtraOrdinals with a single posting (should not add anything to extraOrdinals)
+        try (ChronicleMap<Integer, CompactionVectorPostings> map = ChronicleMapBuilder
+                .of(Integer.class, CompactionVectorPostings.class)
+                .entries(10)
+                .averageValueSize(100)
+                .valueMarshaller(marshaller)
+                .create())
+        {
+            int key = 1;
+            int ordinal = 50;
+            int rowId = 50; // First rowId must equal ordinal
+            CompactionVectorPostings postings = new CompactionVectorPostings(ordinal, rowId);
+            
+            map.put(key, postings);
+
+            Int2IntHashMap extraOrdinals = new Int2IntHashMap(-1);
+            
+            map.forEachEntry(entry -> {
+                Marshaller.recordExtraOrdinals(entry, extraOrdinals);
+            });
+
+            // With only one posting, no extra ordinals should be recorded
+            assertEquals(0, extraOrdinals.size());
+        }
+    }
+
+    @Test
+    public void testRecordExtraOrdinalsWithMultiplePostings()
+    {
+        // Test recordExtraOrdinals with multiple postings
+        try (ChronicleMap<Integer, CompactionVectorPostings> map = ChronicleMapBuilder
+                .of(Integer.class, CompactionVectorPostings.class)
+                .entries(10)
+                .averageValueSize(100)
+                .valueMarshaller(marshaller)
+                .create())
+        {
+            int key = 1;
+            int ordinal = 100;
+            // First rowId must equal ordinal for ONE_TO_MANY
+            List<Integer> rowIds = List.of(100, 200, 300, 400);
+            CompactionVectorPostings postings = new CompactionVectorPostings(ordinal, rowIds);
+            
+            map.put(key, postings);
+
+            Int2IntHashMap extraOrdinals = new Int2IntHashMap(-1);
+            
+            map.forEachEntry(entry -> {
+                Marshaller.recordExtraOrdinals(entry, extraOrdinals);
+            });
+
+            // Should have 3 extra ordinals (all except the first one)
+            assertEquals(3, extraOrdinals.size());
+            assertEquals(ordinal, extraOrdinals.get(200));
+            assertEquals(ordinal, extraOrdinals.get(300));
+            assertEquals(ordinal, extraOrdinals.get(400));
+        }
+    }
+
+    @Test
+    public void testRecordExtraOrdinalsWithMultipleEntries()
+    {
+        // Test recordExtraOrdinals with multiple map entries
+        try (ChronicleMap<Integer, CompactionVectorPostings> map = ChronicleMapBuilder
+                .of(Integer.class, CompactionVectorPostings.class)
+                .entries(10)
+                .averageValueSize(100)
+                .valueMarshaller(marshaller)
+                .create())
+        {
+            // Entry 1
+            int ordinal1 = 10;
+            List<Integer> rowIds1 = List.of(10, 20, 30);
+            map.put(1, new CompactionVectorPostings(ordinal1, rowIds1));
+
+            // Entry 2
+            int ordinal2 = 40;
+            List<Integer> rowIds2 = List.of(40, 50);
+            map.put(2, new CompactionVectorPostings(ordinal2, rowIds2));
+
+            Int2IntHashMap extraOrdinals = new Int2IntHashMap(-1);
+            
+            map.forEachEntry(entry -> {
+                Marshaller.recordExtraOrdinals(entry, extraOrdinals);
+            });
+
+            // Should have 3 extra ordinals total (2 from first entry, 1 from second)
+            assertEquals(3, extraOrdinals.size());
+            assertEquals(ordinal1, extraOrdinals.get(20));
+            assertEquals(ordinal1, extraOrdinals.get(30));
+            assertEquals(ordinal2, extraOrdinals.get(50));
+        }
+    }
+
+    @Test
+    public void testRoundTripWithZeroOrdinal()
+    {
+        // Test edge case with ordinal = 0
+        int ordinal = 0;
+        int rowId = 0;
+        CompactionVectorPostings postings = new CompactionVectorPostings(ordinal, rowId);
+
+        Bytes<?> bytes = Bytes.allocateElasticOnHeap();
+        marshaller.write(bytes, postings);
+
+        bytes.readPosition(0);
+        CompactionVectorPostings read = marshaller.read(bytes, null);
+
+        assertEquals(ordinal, read.getOrdinal());
+        assertEquals(1, read.size());
+        assertEquals(rowId, read.getPostings().get(0).intValue());
+        
+        bytes.releaseLast();
+    }
+
+    @Test
+    public void testSerializedSizeConsistency()
+    {
+        // Verify that the serialized size is consistent and predictable
+        int ordinal = 100;
+        List<Integer> rowIds = List.of(1, 2, 3, 4, 5);
+        CompactionVectorPostings postings = new CompactionVectorPostings(ordinal, rowIds);
+
+        Bytes<?> bytes = Bytes.allocateElasticOnHeap();
+        marshaller.write(bytes, postings);
+
+        // Expected size: 4 bytes (ordinal) + 4 bytes (size) + 5 * 4 bytes (row IDs) = 28 bytes
+        long expectedSize = 4 + 4 + (5 * 4);
+        assertEquals(expectedSize, bytes.writePosition());
+        
+        bytes.releaseLast();
+    }
+}
+
+// Made with Bob


### PR DESCRIPTION

### What is the issue
Fixes: https://github.com/riptano/cndb/issues/16350

### What does this PR fix and why was it fixed

ChronicleMap gives us several ways to use lower level APIs to avoid deserializing keys/values and the associated allocation that comes with them. The first key thing to mention is that iteration is very expensive as these maps get big, so we want to avoid it if possible. The second is that if we use the typical map iteration methods, they deserialize the key and the value eagerly. Since the key is typically a high dimensional vector, it is valuable to avoid such deserialization. This change:

* Removes unnecessary iteration leveraging the fact that compaction is additive
* Replaces `forEach` with `forEachEntry`, which gives better semantics
* Updates the `maybeAddVector` method to avoid serializing the vector key twice by using the `searchContext`. The `ChronicleMap#put` method uses this pattern internally

I added two sets of benchmarks, however the `VectorCompactionBench` doesn't seem to register the benefit of the ChronicleMap. I am leaving `VectorCompactionBench` in place since it is still useful. Likely, this is because ChronicleMap's cost isn't as expensive as graph construction.

Here are some of the benchmark results. They show between a 50x and 100x improvement. The improvement seems to increase as we build larger graphs.

benchmark results before change:

```
     [java] Benchmark                                                   (dimension)  (numVectors)  Mode  Cnt      Score     Error  Units
     [java] V5VectorPostingsWriterBench.createGenericIdentityMapping            768        100000  avgt    5    271.569 ±   3.473  ms/op
     [java] V5VectorPostingsWriterBench.createGenericIdentityMapping            768       1000000  avgt    5   5452.393 ± 227.905  ms/op
     [java] V5VectorPostingsWriterBench.createGenericIdentityMapping           1536        100000  avgt    5   1392.607 ±  30.388  ms/op
     [java] V5VectorPostingsWriterBench.createGenericIdentityMapping           1536       1000000  avgt    5  11496.696 ± 345.886  ms/op
     [java] V5VectorPostingsWriterBench.describeForCompactionOneToMany          768        100000  avgt    5    242.049 ±  20.708  ms/op
     [java] V5VectorPostingsWriterBench.describeForCompactionOneToMany          768       1000000  avgt    5   2365.691 ±  84.173  ms/op
     [java] V5VectorPostingsWriterBench.describeForCompactionOneToMany         1536        100000  avgt    5    265.395 ±   4.167  ms/op
     [java] V5VectorPostingsWriterBench.describeForCompactionOneToMany         1536       1000000  avgt    5   3641.557 ± 130.649  ms/op
```
after change:

```
     [java] Benchmark                                                   (dimension)  (numVectors)  Mode  Cnt    Score    Error  Units
     [java] V5VectorPostingsWriterBench.createGenericIdentityMapping            768        100000  avgt    5    5.721 ±  1.727  ms/op
     [java] V5VectorPostingsWriterBench.createGenericIdentityMapping            768       1000000  avgt    5  124.536 ± 22.464  ms/op
     [java] V5VectorPostingsWriterBench.createGenericIdentityMapping           1536        100000  avgt    5    5.662 ±  0.610  ms/op
     [java] V5VectorPostingsWriterBench.createGenericIdentityMapping           1536       1000000  avgt    5  122.671 ±  3.343  ms/op
     [java] V5VectorPostingsWriterBench.describeForCompactionOneToMany          768        100000  avgt    5    5.364 ±  1.194  ms/op
     [java] V5VectorPostingsWriterBench.describeForCompactionOneToMany          768       1000000  avgt    5  119.449 ±  4.809  ms/op
     [java] V5VectorPostingsWriterBench.describeForCompactionOneToMany         1536        100000  avgt    5    5.379 ±  0.552  ms/op
     [java] V5VectorPostingsWriterBench.describeForCompactionOneToMany         1536       1000000  avgt    5  121.293 ±  3.040  ms/op
```

### What is the issue
...

### What does this PR fix and why was it fixed
...
