### PR TITLE
CNDB-14868 Add system property to always consider the remote peer supporting repair message timeouts.

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -689,6 +689,7 @@ public enum CassandraRelevantProperties
      * The factory for handler of the storage of sstables
      */
     REMOTE_STORAGE_HANDLER_FACTORY("cassandra.remote_storage_handler_factory"),
+    REPAIR_ALWAYS_CONSIDER_TIMEOUTS_SUPPORTED("cassandra.repair.always_consider_timeouts_supported", "false"),
     REPAIR_CLEANUP_INTERVAL_SECONDS("cassandra.repair_cleanup_interval_seconds", convertToString(Ints.checkedCast(TimeUnit.MINUTES.toSeconds(10)))),
     REPAIR_DELETE_TIMEOUT_SECONDS("cassandra.repair_delete_timeout_seconds", convertToString(Ints.checkedCast(TimeUnit.DAYS.toSeconds(1)))),
     REPAIR_FAIL_TIMEOUT_SECONDS("cassandra.repair_fail_timeout_seconds", convertToString(Ints.checkedCast(TimeUnit.DAYS.toSeconds(1)))),

--- a/src/java/org/apache/cassandra/repair/RepairJobDesc.java
+++ b/src/java/org/apache/cassandra/repair/RepairJobDesc.java
@@ -79,12 +79,14 @@ public class RepairJobDesc
     @Override
     public String toString()
     {
-        return "[repair #" + sessionId + " on " + keyspace + "/" + columnFamily + ", " + ranges + "]";
+        String parentSessionId = this.parentSessionId == null ? "" : " (parent session id: #" + this.parentSessionId + ")";
+        return "[repair #" + sessionId + parentSessionId + " on " + keyspace + "/" + columnFamily + ", " + ranges + "]";
     }
 
     public String toString(PreviewKind previewKind)
     {
-        return '[' + previewKind.logPrefix() + " #" + sessionId + " on " + keyspace + "/" + columnFamily + ", " + ranges + "]";
+        String parentSessionId = this.parentSessionId == null ? "" : " (parent session id: #" + this.parentSessionId + ")";
+        return '[' + previewKind.logPrefix() + " #" + sessionId + parentSessionId + " on " + keyspace + "/" + columnFamily + ", " + ranges + "]";
     }
 
     @Override

--- a/src/java/org/apache/cassandra/repair/RepairMessageVerbHandler.java
+++ b/src/java/org/apache/cassandra/repair/RepairMessageVerbHandler.java
@@ -302,8 +302,8 @@ public class RepairMessageVerbHandler implements IVerbHandler<RepairMessage>
             }
             else if (message.verb() == CLEANUP_MSG)
             {
-                logger.debug("cleaning up repair");
                 CleanupMessage cleanup = (CleanupMessage) message.payload;
+                logger.debug("Cleaning up parent repair session {}", cleanup.parentRepairSession);
                 ParticipateState state = ctx.repair().participate(cleanup.parentRepairSession);
                 if (state != null)
                     state.phase.success("Cleanup message recieved");

--- a/src/java/org/apache/cassandra/repair/messages/RepairMessage.java
+++ b/src/java/org/apache/cassandra/repair/messages/RepairMessage.java
@@ -52,6 +52,7 @@ import org.apache.cassandra.utils.NoSpamLogger;
 import org.apache.cassandra.utils.TimeUUID;
 import org.apache.cassandra.utils.concurrent.Future;
 
+import static org.apache.cassandra.config.CassandraRelevantProperties.REPAIR_ALWAYS_CONSIDER_TIMEOUTS_SUPPORTED;
 import static org.apache.cassandra.net.MessageFlag.CALL_BACK_ON_FAILURE;
 
 /**
@@ -61,7 +62,8 @@ import static org.apache.cassandra.net.MessageFlag.CALL_BACK_ON_FAILURE;
  */
 public abstract class RepairMessage
 {
-    private enum ErrorHandling { NONE, TIMEOUT, RETRY }
+    @VisibleForTesting
+    enum ErrorHandling { NONE, TIMEOUT, RETRY }
     @VisibleForTesting
     static final CassandraVersion SUPPORTS_RETRY = new CassandraVersion("5.0.0-alpha2.SNAPSHOT");
     private static final Map<Verb, CassandraVersion> VERB_TIMEOUT_VERSIONS;
@@ -277,7 +279,8 @@ public abstract class RepairMessage
         sendMessageWithRetries(ctx, allowRetry, request, verb, endpoint, callback);
     }
 
-    private static ErrorHandling errorHandlingSupported(SharedContext ctx, InetAddressAndPort from, Verb verb, TimeUUID parentSessionId)
+    @VisibleForTesting
+    static ErrorHandling errorHandlingSupported(SharedContext ctx, InetAddressAndPort from, Verb verb, TimeUUID parentSessionId)
     {
         if (SUPPORTS_RETRY_WITHOUT_VERSION_CHECK.contains(verb))
             return ErrorHandling.RETRY;
@@ -286,6 +289,14 @@ public abstract class RepairMessage
         CassandraVersion remoteVersion = Nodes.localOrPeerInfoOpt(from).map(INodeInfo::getReleaseVersion).orElse(null);
         if (remoteVersion == null)
         {
+            /*
+             * In CNDB, repair services won't be added to the Nodes.peers() map, so there's no clear way
+             * to check the version of the remote peer. This is the reason why a system property is introduced
+             * to skip the version check, in case it's known that the deployed C* version supports repair message
+             * timeouts.
+             */
+            if (areTimeoutsAlwaysSupported())
+                return ErrorHandling.RETRY;
             if (VERB_TIMEOUT_VERSIONS.containsKey(verb))
             {
                 logger.warn("[#{}] Not failing repair due to remote host {} not supporting repair message timeouts (version is unknown)", parentSessionId, from);
@@ -310,5 +321,10 @@ public abstract class RepairMessage
     public static void sendAck(SharedContext ctx, Message<? extends RepairMessage> message)
     {
         ctx.messaging().send(message.emptyResponse(), message.from());
+    }
+
+    private static boolean areTimeoutsAlwaysSupported()
+    {
+        return REPAIR_ALWAYS_CONSIDER_TIMEOUTS_SUPPORTED.getBoolean();
     }
 }

--- a/test/unit/org/apache/cassandra/repair/messages/RepairMessageTest.java
+++ b/test/unit/org/apache/cassandra/repair/messages/RepairMessageTest.java
@@ -23,7 +23,10 @@ import java.util.UUID;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.apache.cassandra.distributed.shared.WithProperties;
+
 import org.apache.cassandra.concurrent.ScheduledExecutorPlus;
+import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.exceptions.RequestFailureReason;
 import org.apache.cassandra.gms.Gossiper;
@@ -119,6 +122,34 @@ public class RepairMessageTest
             callback.onFailure(ADDRESS, RequestFailureReason.UNKNOWN);
             assertMetrics(maxAttempts, false, true);
         });
+    }
+
+    @Test
+    public void errorHandlingWithUnknownPeerReturnsNoneByDefault() throws Exception
+    {
+        InetAddressAndPort unknownPeer = InetAddressAndPort.getByName("127.0.0.3");
+        // VALIDATION_REQ has a timeout version, so with unknown peer version it returns NONE
+        RepairMessage.ErrorHandling result = RepairMessage.errorHandlingSupported(ctx(), unknownPeer, Verb.VALIDATION_REQ, SESSION);
+        Assertions.assertThat(result).isEqualTo(RepairMessage.ErrorHandling.NONE);
+    }
+
+    @Test
+    public void errorHandlingWithUnknownPeerReturnsRetryWhenPropertySet() throws Exception
+    {
+        try (WithProperties properties = new WithProperties().set(CassandraRelevantProperties.REPAIR_ALWAYS_CONSIDER_TIMEOUTS_SUPPORTED, true))
+        {
+            InetAddressAndPort unknownPeer = InetAddressAndPort.getByName("127.0.0.3");
+            RepairMessage.ErrorHandling result = RepairMessage.errorHandlingSupported(ctx(), unknownPeer, Verb.VALIDATION_REQ, SESSION);
+            Assertions.assertThat(result).isEqualTo(RepairMessage.ErrorHandling.RETRY);
+        }
+    }
+
+    @Test
+    public void errorHandlingWithKnownPeerIgnoresProperty() throws Exception
+    {
+        // ADDRESS is local and has a version >= SUPPORTS_RETRY, so should return RETRY regardless of property
+        RepairMessage.ErrorHandling result = RepairMessage.errorHandlingSupported(ctx(), ADDRESS, Verb.VALIDATION_REQ, SESSION);
+        Assertions.assertThat(result).isEqualTo(RepairMessage.ErrorHandling.RETRY);
     }
 
     private void assertNoRetries()


### PR DESCRIPTION

### What is the issue
A repair task in CNDB would hang forever if a timeout for validate or sync request is reached. This was happening because the repair initiator (the repair service in the primary region) would consider the peer repair service as not supporting timeouts, and therefore it would not fail the repair task, leaving it hanging. This behavior is due to the way C* used to detect if a peer supports repair timeouts, which is by checking the C* version of the peer in the `Nodes.peers()` table. In CNDB, though, the repair services (or external services in general) are not added to the peers as they are not handled by the ServiceTracker.

### What does this PR fix and why was it fixed
Add system property to always consider the remote peer supporting repair message timeouts.
Right now the peer's version is checked to figure out if timeouts are supported, but that doesn't work in CNDB, as repair services are not added to the Nodes.peers() table, so there's no clear way to check what version a remote peer is running on. The newly introduced system property allows to skip this version check and always consider timeouts supported by the remote peer. The default value of the property is `false` to provide backward compatibility.
