### PR TITLE
CNDB-15508: Query planner metrics

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -801,6 +801,14 @@ public enum CassandraRelevantProperties
     SAI_QUERY_KIND_PER_TABLE_METRICS_ENABLED("cassandra.sai.metrics.query_kind.per_table.enabled", "true"),
 
     SAI_QUERY_OPT_LEVEL("cassandra.sai.query.optimization.level", "1"),
+
+    /**
+     * Whether to enable SAI query plan metrics such as the estimated cost, estimated number of rows,
+     * number of indexes used in the original and optimized query plan, etc.
+     * These metrics are counters and histograms.
+     */
+    SAI_QUERY_PLAN_METRICS_ENABLED("cassandra.sai.metrics.query_plan.enabled", "true"),
+
     SAI_REDUCE_TOPK_ACROSS_SSTABLES("cassandra.sai.reduce_topk_across_sstables", "true"),
 
     /**

--- a/src/java/org/apache/cassandra/index/sai/QueryContext.java
+++ b/src/java/org/apache/cassandra/index/sai/QueryContext.java
@@ -19,12 +19,15 @@
 package org.apache.cassandra.index.sai;
 
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
 import com.google.common.annotations.VisibleForTesting;
 
 import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.index.sai.plan.Plan;
 import org.apache.cassandra.index.sai.utils.AbortedOperationException;
 import org.apache.cassandra.utils.MonotonicClock;
 
@@ -94,6 +97,8 @@ public class QueryContext
     // Determines the order of using indexes for filtering and sorting.
     // Null means the query execution order hasn't been decided yet.
     private FilterSortOrder filterSortOrder = null;
+
+    private PlanInfo queryPlanInfo;
 
     @VisibleForTesting
     public QueryContext()
@@ -278,6 +283,12 @@ public class QueryContext
         SCAN_THEN_FILTER
     }
 
+    public void recordQueryPlan(Plan.RowsIteration originalPlan, Plan.RowsIteration optimizedPlan)
+    {
+        if (CassandraRelevantProperties.SAI_QUERY_PLAN_METRICS_ENABLED.getBoolean())
+            this.queryPlanInfo = new PlanInfo(originalPlan, optimizedPlan);
+    }
+
     public Snapshot snapshot()
     {
         checkThreadOwnership();
@@ -329,6 +340,9 @@ public class QueryContext
         public final long postFilteringReadLatency;
         public final FilterSortOrder filterSortOrder;
 
+        @Nullable
+        public final PlanInfo queryPlanInfo;
+
         /**
          * Creates a snapshot of all the metrics in the given {@link QueryContext}.
          *
@@ -357,6 +371,38 @@ public class QueryContext
             annGraphSearchLatency = context.annGraphSearchLatency;
             postFilteringReadLatency = context.postFilteringReadLatency;
             filterSortOrder = context.filterSortOrder;
+            queryPlanInfo = context.queryPlanInfo;
+        }
+    }
+
+    /**
+     * Captures relevant information about a query plan, both original and optimized.
+     */
+    public static class PlanInfo
+    {
+        public final boolean searchExecutedBeforeOrder;
+        public final boolean filterExecutedAfterOrderedScan;
+
+        public final long costEstimated;
+        public final long rowsToReturnEstimated;
+        public final long rowsToFetchEstimated;
+        public final long keysToIterateEstimated;
+        public final int logSelectivityEstimated;
+
+        public final int indexReferencesInQuery;
+        public final int indexReferencesInPlan;
+
+        public PlanInfo(@Nonnull Plan.RowsIteration originalPlan, @Nonnull Plan.RowsIteration optimizedPlan)
+        {
+            this.costEstimated = Math.round(optimizedPlan.fullCost());
+            this.rowsToReturnEstimated = Math.round(optimizedPlan.expectedRows());
+            this.rowsToFetchEstimated = Math.round(optimizedPlan.estimatedRowsToFetch());
+            this.keysToIterateEstimated = Math.round(optimizedPlan.estimatedKeysToIterate());
+            this.logSelectivityEstimated = Math.min(20, (int) Math.floor(-Math.log10(optimizedPlan.selectivity())));
+            this.indexReferencesInQuery = originalPlan.referencedIndexCount();
+            this.indexReferencesInPlan = optimizedPlan.referencedIndexCount();
+            this.searchExecutedBeforeOrder = optimizedPlan.isSearchThenOrderHybrid();
+            this.filterExecutedAfterOrderedScan = optimizedPlan.isOrderedScanThenFilterHybrid();
         }
     }
 }

--- a/src/java/org/apache/cassandra/index/sai/metrics/TableQueryMetrics.java
+++ b/src/java/org/apache/cassandra/index/sai/metrics/TableQueryMetrics.java
@@ -22,6 +22,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
+import javax.annotation.Nullable;
+
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Timer;
@@ -116,7 +118,7 @@ public class TableQueryMetrics
         {
             final long queryLatencyMicros = TimeUnit.NANOSECONDS.toMicros(snapshot.totalQueryTimeNs);
 
-            if (snapshot.filterSortOrder == QueryContext.FilterSortOrder.SEARCH_THEN_ORDER)
+            if (snapshot.queryPlanInfo != null && snapshot.queryPlanInfo.searchExecutedBeforeOrder)
             {
                 Tracing.trace("Index query accessed memtable indexes, {}, and {}, selected {} before ranking, " +
                               "post-filtered {} in {}, and took {} microseconds.",
@@ -200,8 +202,8 @@ public class TableQueryMetrics
         public final Counter totalRowTombstonesFetched;
         public final Counter totalQueriesCompleted;
 
-        public final Counter sortThenFilterQueriesCompleted;
-        public final Counter filterThenSortQueriesCompleted;
+        @Nullable
+        public final QueryPlanMetrics queryPlanMetrics;
 
         /**
          * @param table the table to measure metrics for
@@ -221,9 +223,9 @@ public class TableQueryMetrics
             totalRowTombstonesFetched = Metrics.counter(createMetricName("TotalRowTombstonesFetched"));
             totalQueriesCompleted = Metrics.counter(createMetricName("TotalQueriesCompleted"));
             totalQueryTimeouts = Metrics.counter(createMetricName("TotalQueryTimeouts"));
-
-            sortThenFilterQueriesCompleted = Metrics.counter(createMetricName("SortThenFilterQueriesCompleted"));
-            filterThenSortQueriesCompleted = Metrics.counter(createMetricName("FilterThenSortQueriesCompleted"));
+            queryPlanMetrics = (CassandraRelevantProperties.SAI_QUERY_PLAN_METRICS_ENABLED.getBoolean())
+                                 ? new QueryPlanMetrics()
+                                 : null;
         }
 
         @Override
@@ -244,10 +246,42 @@ public class TableQueryMetrics
             totalRowsReturned.inc(snapshot.rowsReturned);
             totalRowTombstonesFetched.inc(snapshot.rowTombstonesFetched);
 
-            if (snapshot.filterSortOrder == QueryContext.FilterSortOrder.SCAN_THEN_FILTER)
-                sortThenFilterQueriesCompleted.inc();
-            else if (snapshot.filterSortOrder == QueryContext.FilterSortOrder.SEARCH_THEN_ORDER)
-                filterThenSortQueriesCompleted.inc();
+            QueryContext.PlanInfo queryPlanInfo = snapshot.queryPlanInfo;
+            if (queryPlanInfo != null && queryPlanMetrics != null)
+            {
+                queryPlanMetrics.totalCostEstimated.inc(queryPlanInfo.costEstimated);
+                queryPlanMetrics.totalRowsToReturnEstimated.inc(queryPlanInfo.rowsToReturnEstimated);
+                queryPlanMetrics.totalRowsToFetchEstimated.inc(queryPlanInfo.rowsToFetchEstimated);
+                queryPlanMetrics.totalKeysToIterateEstimated.inc(queryPlanInfo.keysToIterateEstimated);
+
+                if (queryPlanInfo.filterExecutedAfterOrderedScan)
+                    queryPlanMetrics.sortThenFilterQueriesCompleted.inc();
+                if (queryPlanInfo.searchExecutedBeforeOrder)
+                    queryPlanMetrics.filterThenSortQueriesCompleted.inc();
+            }
+        }
+
+        public class QueryPlanMetrics
+        {
+            public final Counter totalRowsToReturnEstimated;
+            public final Counter totalRowsToFetchEstimated;
+            public final Counter totalKeysToIterateEstimated;
+            public final Counter totalCostEstimated;
+
+            public final Counter sortThenFilterQueriesCompleted;
+            public final Counter filterThenSortQueriesCompleted;
+
+
+            public QueryPlanMetrics()
+            {
+                totalRowsToReturnEstimated = Metrics.counter(createMetricName("TotalRowsToReturnEstimated"));
+                totalRowsToFetchEstimated = Metrics.counter(createMetricName("TotalRowsToFetchEstimated"));
+                totalKeysToIterateEstimated = Metrics.counter(createMetricName("TotalKeysToIterateEstimated"));
+                totalCostEstimated = Metrics.counter(createMetricName("TotalCostEstimated"));
+
+                sortThenFilterQueriesCompleted = Metrics.counter(createMetricName("SortThenFilterQueriesCompleted"));
+                filterThenSortQueriesCompleted = Metrics.counter(createMetricName("FilterThenSortQueriesCompleted"));
+            }
         }
     }
 
@@ -296,6 +330,9 @@ public class TableQueryMetrics
 
         public final Timer postFilteringReadLatency;
 
+        @Nullable
+        public final QueryPlanMetrics queryPlanMetrics;
+
         /**
          * @param table the table to measure metrics for
          * @param queryKind an identifier for the kind of query which metrics are being recorded for
@@ -327,6 +364,10 @@ public class TableQueryMetrics
             // Key vector metrics that translate to performance
             annGraphSearchLatency = Metrics.timer(createMetricName("ANNGraphSearchLatency"));
             postFilteringReadLatency = Metrics.timer(createMetricName("PostFilteringReadLatency"));
+
+            queryPlanMetrics = CassandraRelevantProperties.SAI_QUERY_PLAN_METRICS_ENABLED.getBoolean()
+                                 ? new QueryPlanMetrics()
+                                 : null;
         }
 
         @Override
@@ -367,6 +408,75 @@ public class TableQueryMetrics
                 annGraphSearchLatency.update(snapshot.annGraphSearchLatency, TimeUnit.NANOSECONDS);
             }
             postFilteringReadLatency.update(snapshot.postFilteringReadLatency, TimeUnit.NANOSECONDS);
+
+            QueryContext.PlanInfo queryPlanInfo = snapshot.queryPlanInfo;
+            if (queryPlanInfo != null && queryPlanMetrics != null)
+            {
+                queryPlanMetrics.costEstimated.update(queryPlanInfo.costEstimated);
+                queryPlanMetrics.rowsToReturnEstimated.update(queryPlanInfo.rowsToReturnEstimated);
+                queryPlanMetrics.rowsToFetchEstimated.update(queryPlanInfo.rowsToFetchEstimated);
+                queryPlanMetrics.keysToIterateEstimated.update(queryPlanInfo.keysToIterateEstimated);
+                queryPlanMetrics.logSelectivityEstimated.update(queryPlanInfo.logSelectivityEstimated);
+                queryPlanMetrics.indexReferencesInQuery.update(queryPlanInfo.indexReferencesInQuery);
+                queryPlanMetrics.indexReferencesInPlan.update(queryPlanInfo.indexReferencesInPlan);
+            }
         }
+
+        /// Metrics related to query planning.
+        /// Moved to separate class so they can be enabled/disabled as a group.
+        public class QueryPlanMetrics
+        {
+            /**
+             * Query execution cost as estimated by the planner
+             */
+            public final Histogram costEstimated;
+
+            /**
+             * Number of rows to be returned from the query as estimated by the planner
+             */
+            public final Histogram rowsToReturnEstimated;
+
+            /**
+             * Number of rows to be fetched by the query as estimated by the planner
+             */
+            public final Histogram rowsToFetchEstimated;
+
+            /**
+             * Number of keys to be iterated by the query as estimated by the planner
+             */
+            public final Histogram keysToIterateEstimated;
+
+            /**
+             * Negative decimal logarithm of selectivity of the query, before applying the LIMIT clause.
+             * We use logarithm because selectivity values can be very small (e.g. 10^-9).
+             */
+            public final Histogram logSelectivityEstimated;
+
+            /**
+             * Number of indexes referenced by the optimized query plan.
+             * The same index referenced from unrelated query clauses,
+             * leading to separate index searches, are counted separately.
+             */
+            public final Histogram indexReferencesInPlan;
+
+            /**
+             * Number of indexes referenced by the original query plan before optimization (as stated in the query text)
+             */
+            public final Histogram indexReferencesInQuery;
+
+            QueryPlanMetrics()
+            {
+                costEstimated = Metrics.histogram(createMetricName("CostEstimated"), false);
+                rowsToReturnEstimated = Metrics.histogram(createMetricName("RowsToReturnEstimated"), true);
+                rowsToFetchEstimated = Metrics.histogram(createMetricName("RowsToFetchEstimated"), true);
+                keysToIterateEstimated = Metrics.histogram(createMetricName("KeysToIterateEstimated"), true);
+                logSelectivityEstimated = Metrics.histogram(createMetricName("LogSelectivityEstimated"), true);
+                indexReferencesInPlan = Metrics.histogram(createMetricName("IndexReferencesInPlan"), true);
+                indexReferencesInQuery = Metrics.histogram(createMetricName("IndexReferencesInQuery"), false);
+            }
+        }
+
     }
+
+
 }

--- a/src/java/org/apache/cassandra/index/sai/plan/Plan.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Plan.java
@@ -28,6 +28,8 @@ import javax.annotation.concurrent.NotThreadSafe;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import org.apache.commons.lang3.mutable.MutableDouble;
+import org.apache.commons.lang3.mutable.MutableInt;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -216,7 +218,7 @@ abstract public class Plan
      * If node of given type is not found, returns null.
      */
     @SuppressWarnings("unchecked")
-    final <T extends Plan> @Nullable T firstNodeOfType(Class<T> nodeType)
+    public final <T extends Plan> @Nullable T firstNodeOfType(Class<T> nodeType)
     {
         Plan[] result = new Plan[] { null };
         forEach(node -> {
@@ -390,7 +392,7 @@ abstract public class Plan
      * and recomputes the nodes above it. Then it returns the best plan from candidates obtained that way.
      * The expected running time is proportional to the height of the plan tree multiplied by the number of the leaves.
      */
-    public final Plan optimize()
+    protected Plan optimize()
     {
         if (logger.isTraceEnabled())
             logger.trace("Optimizing plan:\n{}", toRedactedStringRecursive());
@@ -423,7 +425,7 @@ abstract public class Plan
      * Modifies all intersections to not intersect more clauses than the given limit.
      * Retains the most selective clauses.
      */
-    public final Plan limitIntersectedClauses(int clauseLimit)
+    protected Plan limitIntersectedClauses(int clauseLimit)
     {
         Plan result = this;
         if (result instanceof Intersection)
@@ -435,10 +437,34 @@ abstract public class Plan
     }
 
     /** Returns true if the plan contains a node matching the condition */
-    final boolean contains(Function<Plan, Boolean> condition)
+    public final boolean contains(Function<Plan, Boolean> condition)
     {
         ControlFlow res = forEach(node -> (condition.apply(node)) ? ControlFlow.Break : ControlFlow.Continue);
         return res == ControlFlow.Break;
+    }
+
+    /**
+     * Returns true if the plan represents a hybrid query that first selects the matching
+     * rows by index-based search and then orders the matching rows in memory. This order of execution
+     * is best when the query contains a predicate that matches only a very small number of rows.
+     * Returns false in other cases, including when the query is not a hybrid query.
+     */
+    public final boolean isSearchThenOrderHybrid()
+    {
+        return contains(node -> node instanceof KeysSort);
+    }
+
+    /**
+     * Returns true if the plan represents a hybrid query that first scans the index in
+     * the index term-order (sorted by the index terms) and then filters the matching rows in memory.
+     * This order of execution is best when the query contains a predicate with a poor selectivity.
+     * Returns false in other cases, including when the query is not a hybrid query.
+     */
+    public final boolean isOrderedScanThenFilterHybrid()
+    {
+        return (contains(node -> node instanceof Filter)
+                && contains(node -> node instanceof IndexScan && ((IndexScan) node).ordering != null
+                                      || node instanceof ScoredIndexScan));
     }
 
     /**
@@ -499,6 +525,44 @@ abstract public class Plan
             selectivity = estimateSelectivity();
         assert 0.0 <= selectivity && selectivity <= 1.0 : "Invalid selectivity: " + selectivity;
         return selectivity;
+    }
+
+    /**
+     * Returns the number of indexes referenced by this plan.
+     * The same index referenced from unrelated query clauses,
+     * leading to separate index searches, are counted separately.
+     */
+    public final int referencedIndexCount()
+    {
+        MutableInt count = new MutableInt(0);
+        visitIndexesRecursive(index -> count.increment());
+        return count.intValue();
+    }
+
+    /**
+     * Returns the estimated number of rows to be fetched from storage.
+     */
+    public final double estimatedRowsToFetch()
+    {
+        Fetch fetch = firstNodeOfType(Plan.Fetch.class);
+        return fetch != null ? fetch.expectedRows() : 0.0;
+    }
+
+    /**
+     * Returns the estimated number of primary keys to be iterated by all index iterators.
+     * This may be larger than the number of rows to fetch because of intersections.
+     */
+    public final double estimatedKeysToIterate()
+    {
+        MutableDouble total = new MutableDouble(0.0);
+        forEach(node -> {
+            if (node instanceof Leaf)
+            {
+                total.add(((Leaf) node).expectedKeys());
+            }
+            return ControlFlow.Continue;
+        });
+        return total.doubleValue();
     }
 
     protected interface Cost
@@ -676,6 +740,18 @@ abstract public class Plan
         final double costPerKey()
         {
             return cost().costPerKey();
+        }
+
+        @Override
+        public final KeysIteration optimize()
+        {
+            return (KeysIteration) super.optimize();
+        }
+
+        @Override
+        public final KeysIteration limitIntersectedClauses(int clauseLimit)
+        {
+            return (KeysIteration) super.limitIntersectedClauses(clauseLimit);
         }
 
         protected abstract boolean usesIncludedIndex();
@@ -1619,6 +1695,18 @@ abstract public class Plan
         public final double expectedRows()
         {
             return cost().expectedRows;
+        }
+
+        @Override
+        public final RowsIteration optimize()
+        {
+            return (RowsIteration) super.optimize();
+        }
+
+        @Override
+        public final RowsIteration limitIntersectedClauses(int clauseLimit)
+        {
+            return (RowsIteration) super.limitIntersectedClauses(clauseLimit);
         }
     }
 

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -404,20 +404,14 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
         // in which predicates it leaves in the plan and the probability of accidentally removing a good branch
         // here is even lower.
         int intersectionClauseLimit = CassandraRelevantProperties.SAI_INTERSECTION_CLAUSE_LIMIT.getInt();
-        Plan plan = rowsIteration.limitIntersectedClauses(intersectionClauseLimit * 3);
+        Plan.RowsIteration origPlan = rowsIteration.limitIntersectedClauses(intersectionClauseLimit * 3);
+        Plan.RowsIteration plan = origPlan;
 
         if (QUERY_OPT_LEVEL > 0)
-            plan = plan.optimize();
+            plan = origPlan.optimize();
 
         plan = plan.limitIntersectedClauses(intersectionClauseLimit);
-
-        if (plan.contains(node -> node instanceof Plan.Filter)
-            && plan.contains(node -> node instanceof Plan.IndexScan && ((Plan.IndexScan) node).ordering != null ||
-                                          node instanceof Plan.ScoredIndexScan))
-            queryContext.setFilterSortOrder(QueryContext.FilterSortOrder.SCAN_THEN_FILTER);
-        if (plan.contains(node -> node instanceof Plan.KeysSort))
-            queryContext.setFilterSortOrder(QueryContext.FilterSortOrder.SEARCH_THEN_ORDER);
-
+        queryContext.recordQueryPlan(origPlan, plan);
         updateIndexMetricsQueriesCount(plan);
 
         if (logger.isTraceEnabled())

--- a/test/unit/org/apache/cassandra/index/sai/SAITester.java
+++ b/test/unit/org/apache/cassandra/index/sai/SAITester.java
@@ -520,6 +520,18 @@ public class SAITester extends CQLTester
         return metricValue;
     }
 
+    protected double getHistogramMean(ObjectName metricObjectName)
+    {
+        try
+        {
+            return ((Number) getMBeanAttribute(metricObjectName, "Mean")).doubleValue();
+        }
+        catch (Exception e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+
     protected void assertMetricExists(ObjectName name)
     {
         Assertions.assertThatNoException().isThrownBy(() -> getMetricValue(name));

--- a/test/unit/org/apache/cassandra/index/sai/metrics/AbstractMetricsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/metrics/AbstractMetricsTest.java
@@ -20,9 +20,11 @@ package org.apache.cassandra.index.sai.metrics;
 import java.util.concurrent.TimeUnit;
 import javax.management.ObjectName;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 
+import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.index.sai.SAITester;
 import org.apache.cassandra.utils.Throwables;
 
@@ -32,6 +34,11 @@ import static org.junit.Assert.assertTrue;
 @Ignore
 public abstract class AbstractMetricsTest extends SAITester
 {
+    boolean indexMetricsEnabled;
+    boolean perQueryKindPerTableMetricsEnabled;
+    boolean perQueryKindPerQueryMetricsEnabled;
+    boolean queryPlanMetricsEnabled;
+
     @Before
     public void initializeTest() throws Throwable
     {
@@ -40,6 +47,20 @@ public abstract class AbstractMetricsTest extends SAITester
         startJMXServer();
 
         createMBeanServerConnection();
+
+        indexMetricsEnabled = CassandraRelevantProperties.SAI_INDEX_METRICS_ENABLED.getBoolean();
+        perQueryKindPerQueryMetricsEnabled = CassandraRelevantProperties.SAI_QUERY_KIND_PER_QUERY_METRICS_ENABLED.getBoolean();
+        perQueryKindPerTableMetricsEnabled = CassandraRelevantProperties.SAI_QUERY_KIND_PER_TABLE_METRICS_ENABLED.getBoolean();
+        queryPlanMetricsEnabled = CassandraRelevantProperties.SAI_QUERY_PLAN_METRICS_ENABLED.getBoolean();
+    }
+
+    @After
+    public void cleanupTest() throws Throwable
+    {
+        CassandraRelevantProperties.SAI_INDEX_METRICS_ENABLED.setBoolean(indexMetricsEnabled);
+        CassandraRelevantProperties.SAI_QUERY_KIND_PER_TABLE_METRICS_ENABLED.setBoolean(perQueryKindPerTableMetricsEnabled);
+        CassandraRelevantProperties.SAI_QUERY_KIND_PER_QUERY_METRICS_ENABLED.setBoolean(perQueryKindPerQueryMetricsEnabled);
+        CassandraRelevantProperties.SAI_QUERY_PLAN_METRICS_ENABLED.setBoolean(indexMetricsEnabled);
     }
 
     protected long getTableQueryMetrics(String keyspace, String table, String metricsName)
@@ -90,7 +111,6 @@ public abstract class AbstractMetricsTest extends SAITester
         }, 10, TimeUnit.SECONDS);
     }
 
-
     protected void waitForGreaterThanZero(ObjectName name)
     {
         waitForAssert(() -> {
@@ -103,5 +123,20 @@ public abstract class AbstractMetricsTest extends SAITester
                 throw Throwables.unchecked(ex);
             }
         }, 160, TimeUnit.SECONDS);
+    }
+
+    protected void waitForMetricValueBetween(ObjectName name, long min, long max)
+    {
+        waitForAssert(() -> {
+            try
+            {
+                double value = ((Number) getMetricValue(name)).longValue();
+                assertTrue("Metric value " + value + " is between " + min + " and " + max, value >= min && value <= max);
+            }
+            catch (Throwable ex)
+            {
+                throw Throwables.unchecked(ex);
+            }
+        }, 60, TimeUnit.SECONDS);
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/metrics/QueryMetricsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/metrics/QueryMetricsTest.java
@@ -664,6 +664,138 @@ public class QueryMetricsTest extends AbstractMetricsTest
         waitForHistogramCountEqualsIfExists(hasPerQueryKindMetrics, objectName(name, PER_MP_HYBRID_QUERY_METRIC_TYPE), 2);
     }
 
+    @Test
+    public void testQueryPlannerMetrics()
+    {
+        CassandraRelevantProperties.SAI_QUERY_PLAN_METRICS_ENABLED.setBoolean(true);
+
+        String table = createTable("CREATE TABLE %s (k int PRIMARY KEY, lc int, hc int)");
+        createIndex("CREATE CUSTOM INDEX ON %s(lc) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX ON %s(hc) USING 'StorageAttachedIndex'");
+
+        int numRows = 10000;
+        for (int i = 0; i < numRows; i++)
+        {
+            execute("INSERT INTO %s (k, lc, hc) VALUES (?, ?, ?)", i, i % 2, i);
+        }
+
+        flush();
+
+        UntypedResultSet rows = execute("SELECT k FROM %s WHERE lc = 0");
+        assertEquals(numRows / 2, rows.size());
+
+        final double ESTIMATION_TOLERANCE = 0.25;
+        final double LOWER_BOUND_MULTIPLIER = 1.0 - ESTIMATION_TOLERANCE;
+        final double UPPER_BOUND_MULTIPLIER = 1.0 + ESTIMATION_TOLERANCE;
+
+        var rowsToReturnEstimatedMetric = objectNameNoIndex("RowsToReturnEstimated", KEYSPACE, table, PER_QUERY_METRIC_TYPE);
+        waitForHistogramCountEquals(rowsToReturnEstimatedMetric, 1);
+        waitForHistogramMeanBetween(rowsToReturnEstimatedMetric, numRows / 2.0 * LOWER_BOUND_MULTIPLIER, numRows / 2.0 * UPPER_BOUND_MULTIPLIER);
+
+        var rowsToFetchEstimatedMetric = objectNameNoIndex("RowsToFetchEstimated", KEYSPACE, table, PER_QUERY_METRIC_TYPE);
+        waitForHistogramCountEquals(rowsToFetchEstimatedMetric, 1);
+        waitForHistogramMeanBetween(rowsToFetchEstimatedMetric, numRows / 2.0 * LOWER_BOUND_MULTIPLIER, numRows / 2.0 * UPPER_BOUND_MULTIPLIER);
+
+        var keysToIterateEstimatedMetric = objectNameNoIndex("KeysToIterateEstimated", KEYSPACE, table, PER_QUERY_METRIC_TYPE);
+        waitForHistogramCountEquals(keysToIterateEstimatedMetric, 1);
+        waitForHistogramMeanBetween(keysToIterateEstimatedMetric, numRows / 2.0 * LOWER_BOUND_MULTIPLIER, numRows / 2.0 * UPPER_BOUND_MULTIPLIER);
+
+        var objectName = objectNameNoIndex("CostEstimated", KEYSPACE, table, PER_QUERY_METRIC_TYPE);
+        waitForHistogramCountEquals(objectName, 1);
+        waitForHistogramMeanBetween(objectName, 1.0, Double.POSITIVE_INFINITY);
+
+        var logSelectivityEstimatedMetric = objectNameNoIndex("LogSelectivityEstimated", KEYSPACE, table, PER_QUERY_METRIC_TYPE);
+        waitForHistogramCountEquals(logSelectivityEstimatedMetric, 1);
+        waitForHistogramMeanBetween(logSelectivityEstimatedMetric, 0, 0);
+
+        var indexReferencesInQueryMetric = objectNameNoIndex("IndexReferencesInQuery", KEYSPACE, table, PER_QUERY_METRIC_TYPE);
+        waitForHistogramCountEquals(indexReferencesInQueryMetric, 1);
+        waitForHistogramMeanBetween(indexReferencesInQueryMetric, 1.0, 1.0);
+
+        var indexReferencesInPlan = objectNameNoIndex("IndexReferencesInPlan", KEYSPACE, table, PER_QUERY_METRIC_TYPE);
+        waitForHistogramCountEquals(indexReferencesInPlan, 1);
+        waitForHistogramMeanBetween(indexReferencesInPlan, 1.0, 1.0);
+
+        objectName = objectNameNoIndex("TotalRowsToReturnEstimated", KEYSPACE, table, TABLE_QUERY_METRIC_TYPE);
+        waitForMetricValueBetween(objectName, (long)(numRows / 2.0 * LOWER_BOUND_MULTIPLIER), (long)(numRows / 2.0 * UPPER_BOUND_MULTIPLIER));
+
+        objectName = objectNameNoIndex("TotalRowsToFetchEstimated", KEYSPACE, table, TABLE_QUERY_METRIC_TYPE);
+        waitForMetricValueBetween(objectName, (long)(numRows / 2.0 * LOWER_BOUND_MULTIPLIER), (long)(numRows / 2.0 * UPPER_BOUND_MULTIPLIER));
+
+        objectName = objectNameNoIndex("TotalKeysToIterateEstimated", KEYSPACE, table, TABLE_QUERY_METRIC_TYPE);
+        waitForMetricValueBetween(objectName, (long)(numRows / 2.0 * LOWER_BOUND_MULTIPLIER), (long)(numRows / 2.0 * UPPER_BOUND_MULTIPLIER));
+
+        objectName = objectNameNoIndex("TotalCostEstimated", KEYSPACE, table, TABLE_QUERY_METRIC_TYPE);
+        waitForMetricValueBetween(objectName, 1, Long.MAX_VALUE);
+
+        rows = execute("SELECT k FROM %s WHERE lc = 0 AND hc < 10");
+        assertEquals(5, rows.size());
+
+        waitForHistogramCountEquals(logSelectivityEstimatedMetric, 2);
+        waitForHistogramMeanBetween(logSelectivityEstimatedMetric, 1, 2);
+
+        waitForHistogramCountEquals(indexReferencesInQueryMetric, 2);
+        waitForHistogramMeanBetween(indexReferencesInQueryMetric, 1.4999, 1.5001);  // average of 2 indexes and 1 index
+
+        waitForHistogramCountEquals(indexReferencesInPlan, 2);
+        waitForHistogramMeanBetween(indexReferencesInPlan, 1.0, 1.0);  // low selectivity index eliminated by optimisation
+
+        // Check estimates are updated also for queries returning 0 rows
+        // 0 is special, log selectivity would be -infinity, so we need to check if there is no overflow
+        var oldRowsEstimated = getHistogramMean(rowsToFetchEstimatedMetric);
+        var oldLogSelectivityEstimated = getHistogramMean(logSelectivityEstimatedMetric);
+        rows = execute("SELECT k FROM %s WHERE lc = -1");
+        assertEquals(0, rows.size());
+        var newRowsEstimated = getHistogramMean(rowsToFetchEstimatedMetric);
+        assertTrue(newRowsEstimated < oldRowsEstimated);
+        var newLogSelectivityEstimated = getHistogramMean(logSelectivityEstimatedMetric);
+        assertTrue(Double.isFinite(newLogSelectivityEstimated));
+        assertTrue(newLogSelectivityEstimated > oldLogSelectivityEstimated);
+    }
+
+    @Test
+    public void testDisableQueryPlanMetrics()
+    {
+        CassandraRelevantProperties.SAI_QUERY_PLAN_METRICS_ENABLED.setBoolean(false);
+
+        String table = createTable("CREATE TABLE %s (k int PRIMARY KEY, lc int, hc int)");
+        createIndex("CREATE CUSTOM INDEX ON %s(lc) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX ON %s(hc) USING 'StorageAttachedIndex'");
+
+        int numRows = 10000;
+        for (int i = 0; i < numRows; i++)
+        {
+            execute("INSERT INTO %s (k, lc, hc) VALUES (?, ?, ?)", i, i % 2, i);
+        }
+
+        flush();
+
+        // Check if SAI queries still work correctly when plan metrics are disabled
+        UntypedResultSet rows;
+        rows = execute("SELECT k FROM %s WHERE lc = 0");
+        assertEquals(numRows / 2, rows.size());
+        rows = execute("SELECT k FROM %s WHERE lc = 0 AND hc < 10");
+        assertEquals(5, rows.size());
+        rows = execute("SELECT k FROM %s WHERE lc = 0 ORDER BY hc LIMIT 100");
+        assertEquals(100, rows.size());
+        rows = execute("SELECT k FROM %s WHERE k = 1 AND hc = 1");
+        assertEquals(1, rows.size());
+
+        assertMetricDoesNotExist(objectNameNoIndex("RowsToReturnEstimated", KEYSPACE, table, PER_QUERY_METRIC_TYPE));
+        assertMetricDoesNotExist(objectNameNoIndex("RowsToFetchEstimated", KEYSPACE, table, PER_QUERY_METRIC_TYPE));
+        assertMetricDoesNotExist(objectNameNoIndex("KeysToIterateEstimated", KEYSPACE, table, PER_QUERY_METRIC_TYPE));
+        assertMetricDoesNotExist(objectNameNoIndex("CostEstimated", KEYSPACE, table, PER_QUERY_METRIC_TYPE));
+        assertMetricDoesNotExist(objectNameNoIndex("LogSelectivityEstimated", KEYSPACE, table, PER_QUERY_METRIC_TYPE));
+        assertMetricDoesNotExist(objectNameNoIndex("IndexReferencesInQuery", KEYSPACE, table, PER_QUERY_METRIC_TYPE));
+        assertMetricDoesNotExist(objectNameNoIndex("IndexReferencesInPlan", KEYSPACE, table, PER_QUERY_METRIC_TYPE));
+        assertMetricDoesNotExist(objectNameNoIndex("TotalRowsToReturnEstimated", KEYSPACE, table, TABLE_QUERY_METRIC_TYPE));
+        assertMetricDoesNotExist(objectNameNoIndex("TotalRowsToFetchEstimated", KEYSPACE, table, TABLE_QUERY_METRIC_TYPE));
+        assertMetricDoesNotExist(objectNameNoIndex("TotalKeysToIterateEstimated", KEYSPACE, table, TABLE_QUERY_METRIC_TYPE));
+        assertMetricDoesNotExist(objectNameNoIndex("TotalCostEstimated", KEYSPACE, table, TABLE_QUERY_METRIC_TYPE));
+        assertMetricDoesNotExist(objectNameNoIndex("SortThenFilterQueriesCompleted", KEYSPACE, table, TABLE_QUERY_METRIC_TYPE));
+        assertMetricDoesNotExist(objectNameNoIndex("FilterThenSortQueriesCompleted", KEYSPACE, table, TABLE_QUERY_METRIC_TYPE));
+    }
+
     private ObjectName objectName(String name, String type)
     {
         return objectNameNoIndex(name, KEYSPACE, currentTable(), type);


### PR DESCRIPTION
This commit adds new metrics related to the operation of SAI query planner. The metrics should help checking if the query planner makes proper decisions by correlating them with the other metrics, e.g. the metrics of the actual query execution.

Per-query metrics (histograms):
- `RowsToReturnEstimated`: the estimated number of rows to be returned by the query
- `RowsToFetchEstimated`: the estimated number of rows the query is going to fetch from storage
- `KeysToIterateEstimated`: the estimated number of primary keys to read from the indexes when executing the query to completion
- `CostEstimated`: the abstract cost of query execution
- `LogSelectivityEstimated`: minus decimal logarithm of query selectivity,  before applying the query LIMIT (0 means the query selects all rows, 5 means it selects 10^(-5) = 0.00001 subset of rows)
- `IndexReferencesInQuery`: the number of index references in the unoptimized query execution plan (the same index may be referenced multiple times and counts separately)
- `IndexReferencesInPlan`: the number of index references in the optimized query execution plan (the same index may be referenced multiple times and counts separately)

Per-table:
- `TotalRowsToReturnEstimated`: the sum of all estimates of returned rows from all completed queries
- `TotalRowsToFetchEstimated`: the sum of all estimates of fetched rows from all completed queries
- `TotalKeysToIterateEstimated`: the sum of all estimates of iterated primary keys from all completed queries
- `TotalCostEstimated`: counts the sum of all cost estimates from all completed queries

### What is the issue
...

### What does this PR fix and why was it fixed
...
