### PR TITLE
CNDB-16484: handle brute force edge case selecting zero vectors

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
@@ -271,6 +271,9 @@ public class V2VectorIndexSearcher extends IndexSearcher
 
     private CloseableIterator<RowIdWithScore> orderByBruteForce(VectorFloat<?> queryVector, SegmentRowIdOrdinalPairs segmentOrdinalPairs, int limit, int rerankK) throws IOException
     {
+        if (segmentOrdinalPairs.size() == 0)
+            return CloseableIterator.emptyIterator();
+
         // We allow for negative rerankK, but for our cost calculations, it only makes sense to use 0 here.
         rerankK = Math.max(0, rerankK);
         // If we use compressed vectors, we still have to order rerankK results using full resolution similarity

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorTypeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorTypeTest.java
@@ -905,6 +905,26 @@ public class VectorTypeTest extends VectorTester.VersionedWithChecksums
         assertRowCount(execute("SELECT * FROM %s ORDER BY vec ANN OF [1,2] LIMIT 1"), 1);
     }
 
+    @Test
+    public void testCompactionWithEnoughRowsForPQAndARowWithAMissingVector() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, vec vector<float, 2>, PRIMARY KEY(pk))");
+        createIndex("CREATE CUSTOM INDEX ON %s(vec) USING 'StorageAttachedIndex'");
+
+        disableCompaction();
+
+        // Insert a row without a vector mapping. This row will be in the middle of the segment.
+        execute("INSERT INTO %s (pk) VALUES (?)", 0);
+
+        // Insert enough rows so that we hit the CompactionGraph during compaction.
+        for (int i = 1; i <= CassandraOnHeapGraph.MIN_PQ_ROWS + 1; i++)
+            execute("INSERT INTO %s (pk, vec) VALUES (?, ?)", i, vectorOf(i, i + 1));
+
+        runThenFlushThenCompact(() -> {
+            assertRows(execute("SELECT * FROM %s WHERE pk = 0 ORDER BY vec ANN OF [1,2] LIMIT 1"));
+        });
+    }
+
     /**
      * Tests a filter-then-sort query with a concurrent vector deletion. See CNDB-10536 for details.
      */


### PR DESCRIPTION
### What is the issue
Fixes: https://github.com/riptano/cndb/issues/16484

### What does this PR fix and why was it fixed

When a partition restriction filters down to rows without vectors, we can get a list of 0 rows, and then we attempt to create a bounded heap of size 0, which is invalid. The added test catches this error. The solution is to exit the method early in the event of a zero length `SegmentRowIdOrdinalPairs` object.

```
java.lang.IllegalArgumentException: initialSize must be > 0 and < 2147483630; got: 0
	at io.github.jbellis.jvector.util.AbstractLongHeap.<init>(AbstractLongHeap.java:52)
	at io.github.jbellis.jvector.util.BoundedLongHeap.<init>(BoundedLongHeap.java:47)
	at io.github.jbellis.jvector.util.BoundedLongHeap.<init>(BoundedLongHeap.java:43)
	at org.apache.cassandra.index.sai.disk.v2.V2VectorIndexSearcher.orderByBruteForce(V2VectorIndexSearcher.java:328)
	at org.apache.cassandra.index.sai.disk.v2.V2VectorIndexSearcher.orderByBruteForce(V2VectorIndexSearcher.java:283)
	at org.apache.cassandra.index.sai.disk.v2.V2VectorIndexSearcher.searchInternal(V2VectorIndexSearcher.java:246)
	at org.apache.cassandra.index.sai.disk.v2.V2VectorIndexSearcher.orderBy(V2VectorIndexSearcher.java:172)
	at org.apache.cassandra.index.sai.disk.v1.Segment.orderBy(Segment.java:160)
```

