### PR TITLE
CNDB-16634: Add counter for total terms indexed via compaction SAI

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/v1/SSTableIndexWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/SSTableIndexWriter.java
@@ -49,6 +49,7 @@ import org.apache.cassandra.index.sai.disk.v5.V5VectorPostingsWriter;
 import org.apache.cassandra.index.sai.disk.vector.CassandraDiskAnn;
 import org.apache.cassandra.index.sai.disk.vector.CassandraOnHeapGraph;
 import org.apache.cassandra.index.sai.disk.vector.VectorCompression.CompressionType;
+import org.apache.cassandra.index.sai.metrics.IndexMetrics;
 import org.apache.cassandra.index.sai.utils.NamedMemoryLimiter;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
 import org.apache.cassandra.index.sai.utils.TypeUtil;
@@ -68,6 +69,7 @@ public class SSTableIndexWriter implements PerIndexWriter
 
     private final IndexComponents.ForWrite perIndexComponents;
     private final IndexContext indexContext;
+    private final IndexMetrics indexMetrics;
     private final long nowInSec = FBUtilities.nowInSeconds();
     private final NamedMemoryLimiter limiter;
     private final BooleanSupplier isIndexDropped;
@@ -86,6 +88,7 @@ public class SSTableIndexWriter implements PerIndexWriter
         this.perIndexComponents = perIndexComponents;
         this.indexContext = perIndexComponents.context();
         Preconditions.checkNotNull(indexContext, "Provided components %s are the per-sstable ones, expected per-index ones", perIndexComponents);
+        this.indexMetrics = indexContext.getIndexMetrics().orElse(null);
         this.limiter = limiter;
         this.isIndexDropped = isIndexDropped;
         this.isIndexUnloaded = isIndexUnloaded;
@@ -275,7 +278,7 @@ public class SSTableIndexWriter implements PerIndexWriter
         if (term.remaining() == 0 && TypeUtil.skipsEmptyValue(indexContext.getValidator()))
             return false;
 
-        long allocated = currentBuilder.analyzeAndAdd(term, type, key, sstableRowId);
+        long allocated = currentBuilder.analyzeAndAdd(term, type, key, sstableRowId, indexMetrics);
         limiter.increment(allocated);
         return true;
     }

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/SegmentBuilder.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/SegmentBuilder.java
@@ -29,6 +29,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -54,6 +55,7 @@ import org.apache.cassandra.index.sai.disk.v1.kdtree.NumericIndexWriter;
 import org.apache.cassandra.index.sai.disk.v1.trie.InvertedIndexWriter;
 import org.apache.cassandra.index.sai.disk.vector.CassandraOnHeapGraph;
 import org.apache.cassandra.index.sai.disk.vector.CompactionGraph;
+import org.apache.cassandra.index.sai.metrics.IndexMetrics;
 import org.apache.cassandra.index.sai.utils.NamedMemoryLimiter;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
 import org.apache.cassandra.index.sai.utils.TypeUtil;
@@ -473,7 +475,11 @@ public abstract class SegmentBuilder
         return metadataBuilder.build();
     }
 
-    public long analyzeAndAdd(ByteBuffer rawTerm, AbstractType<?> type, PrimaryKey key, long sstableRowId)
+    public long analyzeAndAdd(ByteBuffer rawTerm,
+                              AbstractType<?> type,
+                              PrimaryKey key,
+                              long sstableRowId,
+                              @Nullable IndexMetrics indexMetrics)
     {
         long totalSize = 0;
         if (TypeUtil.isLiteral(type))
@@ -481,11 +487,15 @@ public abstract class SegmentBuilder
             var terms = ByteLimitedMaterializer.materializeTokens(analyzer, rawTerm, components.context(), key);
             totalSize += add(terms, key, sstableRowId);
             totalTermCount += terms.size();
+            if (indexMetrics != null)
+                indexMetrics.compactionTermsProcessedCount.inc(terms.size());
         }
         else
         {
             totalSize += add(List.of(rawTerm), key, sstableRowId);
             totalTermCount++;
+            if (indexMetrics != null)
+                indexMetrics.compactionTermsProcessedCount.inc();
         }
         return totalSize;
     }

--- a/src/java/org/apache/cassandra/index/sai/metrics/IndexMetrics.java
+++ b/src/java/org/apache/cassandra/index/sai/metrics/IndexMetrics.java
@@ -38,6 +38,7 @@ public class IndexMetrics extends AbstractMetrics
     
     public final Counter memtableIndexFlushCount;
     public final Counter compactionCount;
+    public final Counter compactionTermsProcessedCount;
     public final Counter memtableIndexFlushErrors;
     public final Counter segmentFlushErrors;
     public final Counter queriesCount;
@@ -59,6 +60,7 @@ public class IndexMetrics extends AbstractMetrics
         ssTableCellCount = Metrics.register(createMetricName("SSTableCellCount"), context::getCellCount);
         memtableIndexFlushCount = Metrics.counter(createMetricName("MemtableIndexFlushCount"));
         compactionCount = Metrics.counter(createMetricName("CompactionCount"));
+        compactionTermsProcessedCount = Metrics.counter(createMetricName("CompactionTermsProcessedCount"));
         memtableIndexFlushErrors = Metrics.counter(createMetricName("MemtableIndexFlushErrors"));
         segmentFlushErrors = Metrics.counter(createMetricName("CompactionSegmentFlushErrors"));
         queriesCount = Metrics.counter(createMetricName("QueriesCount"));

--- a/test/unit/org/apache/cassandra/index/sai/metrics/IndexMetricsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/metrics/IndexMetricsTest.java
@@ -187,6 +187,7 @@ public class IndexMetricsTest extends AbstractMetricsTest
             // Test all Counter metrics
             assertMetricExistsIfEnabled(metricsEnabled, "MemtableIndexFlushCount", table, index);
             assertMetricExistsIfEnabled(metricsEnabled, "CompactionCount", table, index);
+            assertMetricExistsIfEnabled(metricsEnabled, "CompactionTermsProcessedCount", table, index);
             assertMetricExistsIfEnabled(metricsEnabled, "MemtableIndexFlushErrors", table, index);
             assertMetricExistsIfEnabled(metricsEnabled, "CompactionSegmentFlushErrors", table, index);
             assertMetricExistsIfEnabled(metricsEnabled, "QueriesCount", table, index);
@@ -304,5 +305,96 @@ public class IndexMetricsTest extends AbstractMetricsTest
 
         // Verify the memtable index flush error metric is incremented
         assertEquals(1L, getMetricValue(objectName("MemtableIndexFlushErrors", KEYSPACE, table, index, "IndexMetrics")));
+    }
+
+    @Test
+    public void testCompactionTermsProcessedCount()
+    {
+        String table = createTable("CREATE TABLE %s (ID1 TEXT PRIMARY KEY, v1 INT, v2 TEXT) WITH compaction = " +
+                                   "{'class' : 'SizeTieredCompactionStrategy', 'enabled' : false }");
+        String index = createIndex("CREATE CUSTOM INDEX IF NOT EXISTS ON %s (v1) USING 'StorageAttachedIndex'");
+
+        // Initially, the counter should be 0
+        assertEquals(0L, getMetricValue(objectName("CompactionTermsProcessedCount", KEYSPACE, table, index, "IndexMetrics")));
+
+        // Insert rows and flush to create an SSTable
+        int rowCount = 10;
+        for (int i = 0; i < rowCount; i++)
+            execute("INSERT INTO %s (id1, v1, v2) VALUES (?, ?, '0')", Integer.toString(i), i);
+
+        flush(KEYSPACE, table);
+
+        // Counter should still be 0 after flush (no compaction yet)
+        assertEquals(0L, getMetricValue(objectName("CompactionTermsProcessedCount", KEYSPACE, table, index, "IndexMetrics")));
+
+        // Insert more rows and flush to create another SSTable
+        for (int i = rowCount; i < rowCount * 2; i++)
+            execute("INSERT INTO %s (id1, v1, v2) VALUES (?, ?, '0')", Integer.toString(i), i);
+
+        flush(KEYSPACE, table);
+
+        // Counter should still be 0 after the second flush (no compaction yet)
+        assertEquals(0L, getMetricValue(objectName("CompactionTermsProcessedCount", KEYSPACE, table, index, "IndexMetrics")));
+
+        // Trigger compaction
+        compact(KEYSPACE, table);
+
+        // Wait for index compaction to complete
+        waitForIndexCompaction(KEYSPACE, table, index);
+
+        // After compaction, the counter should reflect the number of terms processed
+        // Each row has one term (v1 value), so we expect rowCount * 2 terms
+        long termsProcessed = (Long) getMetricValue(objectName("CompactionTermsProcessedCount", KEYSPACE, table, index, "IndexMetrics"));
+        assertEquals(rowCount * 2, termsProcessed);
+
+        // Verify compaction count was also incremented
+        assertEquals(1L, getMetricValue(objectName("CompactionCount", KEYSPACE, table, index, "IndexMetrics")));
+    }
+
+    @Test
+    public void testCompactionTermsProcessedCountWithAnalyzer()
+    {
+        // Test with an analyzer that tokenizes text into multiple terms
+        String table = createTable("CREATE TABLE %s (ID1 TEXT PRIMARY KEY, v1 TEXT, v2 TEXT) WITH compaction = " +
+                                   "{'class' : 'SizeTieredCompactionStrategy', 'enabled' : false }");
+        String index = createIndex("CREATE CUSTOM INDEX IF NOT EXISTS ON %s (v1) USING 'StorageAttachedIndex' " +
+                                   "WITH OPTIONS = {'index_analyzer': 'standard'}");
+
+        // Initially, the counter should be 0
+        assertEquals(0L, getMetricValue(objectName("CompactionTermsProcessedCount", KEYSPACE, table, index, "IndexMetrics")));
+
+        // Insert rows with text that will be tokenized into multiple terms
+        // "apple orange banana" -> 3 terms
+        // "hello world" -> 2 terms
+        // "test data" -> 2 terms
+        execute("INSERT INTO %s (id1, v1, v2) VALUES ('1', 'apple orange banana', '0')");
+        execute("INSERT INTO %s (id1, v1, v2) VALUES ('2', 'hello world', '0')");
+        execute("INSERT INTO %s (id1, v1, v2) VALUES ('3', 'test data', '0')");
+
+        flush(KEYSPACE, table);
+
+        // Counter should still be 0 after flush (no compaction yet)
+        assertEquals(0L, getMetricValue(objectName("CompactionTermsProcessedCount", KEYSPACE, table, index, "IndexMetrics")));
+
+        // Insert more rows and flush to create another SSTable
+        execute("INSERT INTO %s (id1, v1, v2) VALUES ('4', 'quick brown fox', '0')");
+        execute("INSERT INTO %s (id1, v1, v2) VALUES ('5', 'lazy dog', '0')");
+
+        flush(KEYSPACE, table);
+
+        // Trigger compaction
+        compact(KEYSPACE, table);
+
+        // Wait for index compaction to complete
+        waitForIndexCompaction(KEYSPACE, table, index);
+
+        // After compaction, the counter should reflect all tokenized terms
+        // Expected: 3 + 2 + 2 + 3 + 2 = 12 terms
+        long termsProcessed = (Long) getMetricValue(objectName("CompactionTermsProcessedCount", KEYSPACE, table, index, "IndexMetrics"));
+        assertEquals("Expected terms processed to be 12 (tokenized terms) but was " + termsProcessed,
+                     12, termsProcessed);
+
+        // Verify compaction count was also incremented
+        assertEquals(1L, getMetricValue(objectName("CompactionCount", KEYSPACE, table, index, "IndexMetrics")));
     }
 }


### PR DESCRIPTION
### What is the issue
Fixes: https://github.com/riptano/cndb/issues/16634 CNDB pr: https://github.com/riptano/cndb/pull/16636

### What does this PR fix and why was it fixed

Adds a new metric named `CompactionTermsProcessedCount`. It is per `IndexMetrics` instance. It is incremented after a `term` is added to an index during compaction. It considers a term to be "an indexed thing". It follows that collections and analyzed text fields will increment the counter as many times as there were terms to be indexed and not simply once for the cell.

I chose a `Counter` to simplify the export of this metric and the aggregation in grafana. There are `Histograms` that seem similar, e.g. `compactionSegmentCellsPerSecond`, but rates do not aggregate correctly across metrics in grafana, and while compaction metrics are most useful in the single compaction context, there is a strong argument for getting higher levels of visibility aggregated at the node and even cluster level.

Note also that vector terms are inserted asynchronously, which means this metric might only approximate that insertion rate. However, because we have a blocking queue in the thread pool, back pressure will eventually propagate and show up as a decreased rate of processed terms. That back pressure would be indistinguishable from a slow down upstream of the `SSTableIndexWriter`, but I propose that we defer solving this problem for now. The main goal is to get a notion of in flight processing rates.

Special care is take to avoid allocations associated with lambda functions on this indexing path, given that this is performance sensitive code that will be called per term.
