### PR TITLE
CNDB-16051: Include pq vectors in CompactionGraph bytesUsed calculation

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/vector/CompactionGraph.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/CompactionGraph.java
@@ -346,6 +346,7 @@ public class CompactionGraph implements Closeable, Accountable
                         compressor = ((ProductQuantization) compressor).refine(new ListRandomAccessVectorValues(trainingVectors, dimension));
                         trainingVectors.clear(); // don't need these anymore so let GC reclaim if it wants to
 
+                        long originalBytesUsed = compressedVectors.ramBytesUsed();
                         // re-encode the vectors added so far
                         int encodedVectorCount = compressedVectors.count();
                         compressedVectors = new MutablePQVectors((ProductQuantization) compressor);
@@ -360,6 +361,10 @@ public class CompactionGraph implements Closeable, Accountable
                                              compressedVectors.encodeAndSet(i, v);
                                      });
                         }).join();
+
+                        // Update bytes to account for new encoding. This isn't expected to change, but just
+                        // in case it does, we track it here.
+                        bytesUsed += (compressedVectors.ramBytesUsed() - originalBytesUsed);
 
                         // Keep the existing edges but recompute their scores
                         builder = GraphIndexBuilder.rescore(builder, BuildScoreProvider.pqBuildScoreProvider(similarityFunction, (PQVectors) compressedVectors));
@@ -384,12 +389,15 @@ public class CompactionGraph implements Closeable, Accountable
                 for (int i = 0; i < dimension; i++)
                     vectorsByOrdinalBufferedWriter.writeFloat(vector.get(i));
 
+                // Track the bytes used as a result of this operation
+                long compressedVectorsBytesUsed = compressedVectors.ramBytesUsed();
                 // Fill in any holes in the pqVectors (setZero has the side effect of increasing the count)
                 while (compressedVectors.count() < ordinal)
                     compressedVectors.setZero(compressedVectors.count());
                 compressedVectors.encodeAndSet(ordinal, vector);
 
                 bytesUsed += postings.ramBytesUsed();
+                bytesUsed += (compressedVectors.ramBytesUsed() - compressedVectorsBytesUsed);
                 return new InsertionResult(bytesUsed, ordinal, vector);
             }
 

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorSiftSmallTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorSiftSmallTest.java
@@ -38,6 +38,7 @@ import org.apache.cassandra.cql3.UntypedResultSet;
 import org.apache.cassandra.index.sai.StorageAttachedIndex;
 import org.apache.cassandra.index.sai.disk.v1.SegmentBuilder;
 import org.apache.cassandra.index.sai.disk.v2.V2VectorIndexSearcher;
+import org.apache.cassandra.index.sai.disk.vector.CompactionGraph;
 import org.apache.cassandra.index.sai.disk.vector.NVQUtil;
 
 import static org.junit.Assert.assertEquals;
@@ -174,6 +175,20 @@ public class VectorSiftSmallTest extends VectorTester.Versioned
         {
             var recall = testRecall(topK, queryVectors, groundTruth);
             assertTrue("Post-compaction recall is " + recall, recall > postCompactionRecall);
+        }
+
+        // Set force PQ training size to ensure we hit the refine code path and apply it to half the vectors.
+        // TODO this test fails as of this commit due to recall issues. Will investigate further.
+        CompactionGraph.PQ_TRAINING_SIZE = baseVectors.size() / 2;
+
+        // Compact again to take the CompactionGraph code path that calls the refine logic
+        compact();
+        for (int topK : List.of(1, 100))
+        {
+            var recall = testRecall(topK, queryVectors, groundTruth);
+            // This assertion will fail until we address the design the bug discussed
+            // in https://github.com/riptano/cndb/issues/16637.
+            // assertTrue("Post-compaction recall is " + recall, recall > postCompactionRecall);
         }
     }
 


### PR DESCRIPTION
### What is the issue
Fixes: https://github.com/riptano/cndb/issues/16051 CNDB PR: https://github.com/riptano/cndb/pull/16675

### What does this PR fix and why was it fixed

The SAI segment builder logic keeps track of bytes used by a segment builder to ensure proper flushing to prevent OOM. This change tracks the PQ and BQ vector byte utilization per insertion.
