### PR TITLE
CNDB-16308: Add GLOBAL_HOLES_ALLOWED logic to CompactionGraph

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -832,6 +832,11 @@ public enum CassandraRelevantProperties
     // it as a global variable in case it's needed.
     SAI_VECTOR_NVQ_NUM_SUB_VECTORS("cassandra.sai.vector.nvq_num_sub_vectors", "2"),
 
+    // The allowed ratio of extra rows (that map to "holes" in the ordinal space) to total rows indexed in the graph
+    // Higher percentages will result in more memory utilized to store the extra postings mappings and larger graph
+    // file sizes to store the empty nodes.
+    SAI_VECTOR_ORDINAL_HOLE_DENSITY_LIMIT("cassandra.sai.vector.ordinal_hole_density_limit", "0.01"),
+
     /**
      * The maximum number of primary keys that a WHERE clause may materialize before the query planner switches
      * from a search-then-sort execution strategy to an order-by-then-filter strategy. Increasing this limit allows

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/CompactionGraph.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/CompactionGraph.java
@@ -464,8 +464,11 @@ public class CompactionGraph implements Closeable, Accountable
                 // similarly, if we've been using synthetic ordinals then we can't map to ONE_TO_MANY
                 // (ending up at ONE_TO_MANY when the source sstables were not is unusual, but possible,
                 // if a row with null vector in sstable A gets updated with a vector in sstable B)
+                // If there are too many holes, we leave the mapping on the disk.
                 if (postingsStructure == Structure.ONE_TO_MANY
-                    && (!V5OnDiskFormat.writeV5VectorPostings(version) || useSyntheticOrdinals))
+                    && (!V5OnDiskFormat.writeV5VectorPostings(version)
+                        || useSyntheticOrdinals
+                        || V5VectorPostingsWriter.tooManyOrdinalMappingHoles(postingsMap.size(), rowsAdded)))
                 {
                     postingsStructure = Structure.ZERO_OR_ONE_TO_MANY;
                 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorCompactionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorCompactionTest.java
@@ -31,10 +31,12 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
-
+import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.db.marshal.FloatType;
 import org.apache.cassandra.index.sai.SAIUtil;
+import org.apache.cassandra.index.sai.StorageAttachedIndex;
 import org.apache.cassandra.index.sai.disk.format.Version;
+import org.apache.cassandra.index.sai.disk.v2.V2VectorIndexSearcher;
 import org.apache.cassandra.index.sai.disk.v5.V5VectorPostingsWriter;
 
 import static org.apache.cassandra.index.sai.disk.vector.CassandraOnHeapGraph.MIN_PQ_ROWS;
@@ -191,6 +193,33 @@ abstract public class VectorCompactionTest extends VectorTester
     }
 
     @Test
+    public void testOneToOneCompaction()
+    {
+        for (int sstables = 2; sstables <= 3; sstables++)
+        {
+            testOneToOneCompactionInternal(10, sstables);
+            testOneToOneCompactionInternal(MIN_PQ_ROWS, sstables);
+        }
+    }
+
+    // Exercise the one-to-one path in compaction where each row has exactly one unique vector
+    public void testOneToOneCompactionInternal(int vectorsPerSstable, int sstables)
+    {
+        var indexName = createTableAndReturnIndexName();
+
+        disableCompaction();
+
+        insertOneToOneRows(vectorsPerSstable, sstables);
+
+        // queries should behave sanely before and after compaction
+        validateQueries();
+        compact();
+        validateQueries();
+
+        validatePostingsStructure(indexName, V5VectorPostingsWriter.Structure.ONE_TO_ONE);
+    }
+
+    @Test
     public void testZeroOrOneToManyCompaction()
     {
         for (int sstables = 2; sstables <= 3; sstables++)
@@ -255,20 +284,45 @@ abstract public class VectorCompactionTest extends VectorTester
 
     public void testOneToManyCompactionHolesInternal(int vectorsPerSstable, int sstables)
     {
-        createTable();
+        var indexName = createTableAndReturnIndexName();
 
         disableCompaction();
 
         insertOneToManyRows(vectorsPerSstable, sstables);
 
-        // this should be done after writing data so that we exercise the "we thought we were going to use the
-        // one-to-many-path but there were too many holes so we changed plans" code path
-        V5VectorPostingsWriter.GLOBAL_HOLES_ALLOWED = 0.0;
+        double originalGlobalHolesAllowed = V5VectorPostingsWriter.GLOBAL_HOLES_ALLOWED;
+        try
+        {
+            // this should be done after writing data so that we exercise the "we thought we were going to use the
+            // one-to-many-path but there were too many holes so we changed plans" code path
+            V5VectorPostingsWriter.GLOBAL_HOLES_ALLOWED = 0.0;
 
-        // queries should behave sanely before and after compaction
-        validateQueries();
-        compact();
-        validateQueries();
+            // queries should behave sanely before and after compaction
+            validateQueries();
+            compact();
+            validateQueries();
+
+            validatePostingsStructure(indexName, V5VectorPostingsWriter.Structure.ZERO_OR_ONE_TO_MANY);
+        }
+        finally
+        {
+            V5VectorPostingsWriter.GLOBAL_HOLES_ALLOWED = originalGlobalHolesAllowed;
+        }
+    }
+
+    private void validatePostingsStructure(String indexName, V5VectorPostingsWriter.Structure expectedStructure)
+    {
+        // Validate that we have the expected structure for all the sstables-segment indexes.
+        var sai = (StorageAttachedIndex) Keyspace.open(KEYSPACE).getColumnFamilyStore(currentTable()).getIndexManager().getIndexByName(indexName);
+        var indexes = sai.getIndexContext().getView().getIndexes();
+        for (var index : indexes)
+        {
+            for (var segment : index.getSegments())
+            {
+                var searcher = (V2VectorIndexSearcher) segment.getIndexSearcher();
+                assertEquals(expectedStructure, searcher.getPostingsStructure());
+            }
+        }
     }
 
     private void insertOneToManyRows(int vectorsPerSstable, int sstables)
@@ -300,10 +354,34 @@ abstract public class VectorCompactionTest extends VectorTester
         }
     }
 
+    private void insertOneToOneRows(int vectorsPerSstable, int sstables)
+    {
+        var vectors = new HashSet<Vector<Float>>();
+        int j = 0;
+        for (int i = 0; i < sstables; i++)
+        {
+            for (int k = 0; k < vectorsPerSstable; k++)
+            {
+                Vector<Float> v;
+                do
+                {
+                    v = randomVectorBoxed(dimension()); // ensure no duplicates
+                } while (!vectors.add(v));
+                execute("INSERT INTO %s (pk, v) VALUES (?, ?)", j++, v);
+            }
+            flush();
+        }
+    }
+
     private void createTable()
     {
+        createTableAndReturnIndexName();
+    }
+
+    private String createTableAndReturnIndexName()
+    {
         createTable("CREATE TABLE %s (pk int, v vector<float, " + dimension() + ">, PRIMARY KEY(pk))");
-        createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
+        return createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
     }
 
     private void validateQueries()

--- a/test/unit/org/apache/cassandra/index/sai/disk/v5/V5OnDiskOrdinalsMapTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v5/V5OnDiskOrdinalsMapTest.java
@@ -150,6 +150,71 @@ public class V5OnDiskOrdinalsMapTest extends VectorTester
         validate(Structure.ONE_TO_ONE, postingsMap, vv);
     }
 
+    @Test
+    public void testTooManyOrdinalMappingHoles_WithZeroHolesAllowed()
+    {
+        double originalValue = V5VectorPostingsWriter.GLOBAL_HOLES_ALLOWED;
+        try
+        {
+            V5VectorPostingsWriter.GLOBAL_HOLES_ALLOWED = 0.0;
+
+            // With 0% holes allowed, any holes should be too many
+            assertEquals(false, V5VectorPostingsWriter.tooManyOrdinalMappingHoles(10, 10)); // 0 holes
+            assertEquals(true, V5VectorPostingsWriter.tooManyOrdinalMappingHoles(10, 11));  // 1 hole
+            assertEquals(true, V5VectorPostingsWriter.tooManyOrdinalMappingHoles(10, 12));  // 2 holes
+        }
+        finally
+        {
+            V5VectorPostingsWriter.GLOBAL_HOLES_ALLOWED = originalValue;
+        }
+    }
+
+    @Test
+    public void testTooManyOrdinalMappingHoles_WithSmallNumberOfRows()
+    {
+        double originalValue = V5VectorPostingsWriter.GLOBAL_HOLES_ALLOWED;
+        try
+        {
+            V5VectorPostingsWriter.GLOBAL_HOLES_ALLOWED = 0.1; // 10% holes allowed
+
+            // With 2 rows and 1 vector, there is 1 hole (50% holes) - should be too many
+            assertEquals(true, V5VectorPostingsWriter.tooManyOrdinalMappingHoles(1, 2));
+
+            // With 10 rows and 9 vectors, there is 1 hole (10% holes) - exactly at threshold
+            assertEquals(false, V5VectorPostingsWriter.tooManyOrdinalMappingHoles(9, 10));
+
+            // With 10 rows and 8 vectors, there are 2 holes (20% holes) - over threshold
+            assertEquals(true, V5VectorPostingsWriter.tooManyOrdinalMappingHoles(8, 10));
+        }
+        finally
+        {
+            V5VectorPostingsWriter.GLOBAL_HOLES_ALLOWED = originalValue;
+        }
+    }
+
+    @Test
+    public void testTooManyOrdinalMappingHoles_StandardCases()
+    {
+        double originalValue = V5VectorPostingsWriter.GLOBAL_HOLES_ALLOWED;
+        try
+        {
+            V5VectorPostingsWriter.GLOBAL_HOLES_ALLOWED = 0.1; // 10% holes allowed
+
+            // 100 vectors, 110 rows = 10 holes = 10% holes (exactly at threshold)
+            assertEquals(false, V5VectorPostingsWriter.tooManyOrdinalMappingHoles(100, 110));
+
+            // 100 vectors, 111 rows = 11 holes = ~9.9% holes (rounds down due to truncation)
+            assertEquals(false, V5VectorPostingsWriter.tooManyOrdinalMappingHoles(100, 111));
+
+            // 100 vectors, 109 rows = 9 holes = 9% holes (under threshold)
+            assertEquals(false, V5VectorPostingsWriter.tooManyOrdinalMappingHoles(100, 109));
+        }
+        finally
+        {
+            V5VectorPostingsWriter.GLOBAL_HOLES_ALLOWED = originalValue;
+        }
+    }
+
     private static void computeRowIds(Map<VectorFloat<?>, VectorPostings<String>> postingsMap)
     {
         for (var p: postingsMap.entrySet())


### PR DESCRIPTION
### What is the issue
Fixes: https://github.com/riptano/cndb/issues/16308 CNDB PR: https://github.com/riptano/cndb/pull/16493

### What does this PR fix and why was it fixed
When we build with the compaction graph, we have to decide the kind of postings structure. Currently, we ignore the `GLOBAL_HOLES_ALLOWED` percentage after graph construction, which can lead to building very large `ONE_TO_MANY` postings lists (which leads to increased memory consumption and graph sizes). We need to instead look at the graph stats after construction and decide if they warrant choosing the `ZERO_OR_ONE_TO_MANY` structure, which will put everything on disk.

Because this change could push some graphs that previously built using `ONE_TO_MANY` to `ZERO_OR_ONE_TO_MANY`, we can expect that we might see reduced hybrid search performance due to the need to go to disk more. This is a necessary change though to prevent excessive memory utilization here. Because this is a trade off without an absolute right choice, this PR makes `GLOBAL_HOLES_ALLOWED` configurable as a `-D` system property named:
`cassandra.sai.vector.ordinal_hole_density_limit`.
