### PR TITLE
CNDB-15926: Count compressed vector memory consumption in CassandraDiskAnn

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraDiskAnn.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraDiskAnn.java
@@ -186,7 +186,15 @@ public class CassandraDiskAnn
 
     public long ramBytesUsed()
     {
-        return graph.ramBytesUsed();
+        return graph.ramBytesUsed() + compressedVectorBytes();
+    }
+
+    private long compressedVectorBytes()
+    {
+        // compressedVectors counts the pq internally, so only count pq if compressedVectors is null.
+        return compressedVectors == null
+               ? pq == null ? 0 : pq.ramBytesUsed()
+               : compressedVectors.ramBytesUsed();
     }
 
     public int size()

--- a/test/unit/org/apache/cassandra/index/sai/SAITester.java
+++ b/test/unit/org/apache/cassandra/index/sai/SAITester.java
@@ -493,6 +493,11 @@ public class SAITester extends CQLTester
         assertEquals(expected, actual);
     }
 
+    protected boolean isMetricPresent(ObjectName objectName) throws IOException
+    {
+        return jmxConnection.isRegistered(objectName);
+    }
+
     protected Object getMBeanAttribute(ObjectName name, String attribute) throws Exception
     {
         return jmxConnection.getAttribute(name, attribute);

--- a/test/unit/org/apache/cassandra/index/sai/metrics/IndexMetricsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/metrics/IndexMetricsTest.java
@@ -24,6 +24,8 @@ import org.junit.Test;
 
 import com.datastax.driver.core.ResultSet;
 import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.index.sai.disk.vector.CassandraOnHeapGraph;
+import org.apache.cassandra.index.sai.disk.vector.VectorSourceModel;
 import org.apache.cassandra.io.compress.BufferType;
 import org.apache.cassandra.utils.Throwables;
 import org.assertj.core.api.Assertions;
@@ -396,5 +398,56 @@ public class IndexMetricsTest extends AbstractMetricsTest
 
         // Verify compaction count was also incremented
         assertEquals(1L, getMetricValue(objectName("CompactionCount", KEYSPACE, table, index, "IndexMetrics")));
+    }
+
+    @Test
+    public void testIndexFileCacheBytesIncludesAllComponents() throws Throwable
+    {
+        // Create a table with a vector index to ensure we have pq and compressedVectors
+        String table = createTable("CREATE TABLE %s (id INT PRIMARY KEY, v1 VECTOR<FLOAT, 1536>)");
+        String index = createIndex("CREATE CUSTOM INDEX ON %s (v1) USING 'StorageAttachedIndex'");
+
+        // Disable compaction so we can manually control it
+        disableCompaction();
+
+        // Insert some data to populate the index
+        int rowCount = CassandraOnHeapGraph.MIN_PQ_ROWS + 1;
+
+        // Create 4 sstables that do not individually have enough vectors for a PQ, but will together
+        for (int i = 0; i < rowCount; i++)
+        {
+            if (i % (rowCount / 4) == 0)
+                flush();
+            execute("INSERT INTO %s (id, v1) VALUES (?, ?)", i, randomVectorBoxed(1536));
+        }
+
+        // Wait for the index to be queryable
+        waitForTableIndexesQueryable();
+
+        // Verify that IndexFileCacheBytes metric exists and is greater than zero
+        // This metric should now include graph.ramBytesUsed() + pq.ramBytesUsed() + compressedVectors.ramBytesUsed()
+        ObjectName metricName = objectName("IndexFileCacheBytes", KEYSPACE, currentTable(), index, "IndexMetrics");
+
+        int bytesPerVector = VectorSourceModel.OTHER.compressionProvider.apply(1536).getCompressedSize();
+        long minPQBytesExpected = bytesPerVector * (long) rowCount;
+
+        // Because we flush half way, we don't have enough vectors for a PQ in either segment
+        long bytesAfterFlush = (long) getMetricValue(metricName);
+        assertTrue("Expected fewer than " + minPQBytesExpected + " bytes but got " + bytesAfterFlush,
+                   minPQBytesExpected >= bytesAfterFlush);
+
+        compact();
+        waitForIndexCompaction(KEYSPACE, table, index);
+
+        // Verify that the bytes contains the compression size. Note that the PQ vectors dominates the memory
+        // consumption significatly, which is what makes this test valid. The test fails if we remove the
+        // compressed vector accounting logic from the CassandraDiskAnn.ramBytesUsed() method.
+        long bytesAfterCompaction = (long) getMetricValue(objectName("IndexFileCacheBytes", KEYSPACE, currentTable(), index, "IndexMetrics"));
+        assertTrue("Expected at least " + minPQBytesExpected + " bytes but got " + bytesAfterCompaction,
+                   bytesAfterCompaction >= minPQBytesExpected);
+
+        // Drop the index and confirm the metric is no longer reported.
+        dropIndex("DROP INDEX %s." + index);
+        assertFalse(isMetricPresent(objectName("IndexFileCacheBytes", KEYSPACE, currentTable(), index, "IndexMetrics")));
     }
 }


### PR DESCRIPTION
### What is the issue
Fixes: https://github.com/riptano/cndb/issues/15926 CNDB Test PR: https://github.com/riptano/cndb/pull/16685

### What does this PR fix and why was it fixed

We do not count the compressed vectors bytes in the `CassandraDiskAnn#ramBytesUsed()` method, which leads to significantly under reported utilization on the metrics. This change fixes the logic and adds a test that fails without the new logic. Notably, the test fails with `Expected at least 196608 bytes but got 76` without the `compressedVectorBytes()` method in place, which just goes to show how significant of a miss this is.

When we merge #2042, the added test will need to be modified to account for the reduced memory consumption, but the test is valid for now.
