### PR TITLE
CNDB-16693: Remove unused Binary Quantization logic from SAI (#2228)

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/VECTOR.md
+++ b/src/java/org/apache/cassandra/index/sai/VECTOR.md
@@ -85,7 +85,6 @@ Available models:
 | OTHER           | COSINE      | Auto-scaled PQ | Dynamic          | Generic configuration for unknown models |
 
 The `OTHER` model uses dimension-based heuristics to automatically determine appropriate compression settings and adjusts overquery based on compression ratio:
-- Binary quantization: 2.0x overquery
 - High compression (>16x): 1.5x overquery
 - Standard compression: 1.0x overquery
 

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/SSTableIndexWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/SSTableIndexWriter.java
@@ -31,11 +31,9 @@ import com.google.common.base.Stopwatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.github.jbellis.jvector.quantization.BinaryQuantization;
 import io.github.jbellis.jvector.quantization.ProductQuantization;
 import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.db.marshal.AbstractType;
-import org.apache.cassandra.db.marshal.VectorType;
 import org.apache.cassandra.db.rows.Row;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.SSTableIndex;
@@ -381,9 +379,6 @@ public class SSTableIndexWriter implements PerIndexWriter
 
         if (indexContext.isVector())
         {
-            int dimension = ((VectorType<?>) indexContext.getValidator()).dimension;
-            boolean bqPreferred = indexContext.getIndexWriterConfig().getSourceModel().compressionProvider.apply(dimension).type == CompressionType.BINARY_QUANTIZATION;
-
             // if we have a PQ instance available, we can use it to build a CompactionGraph;
             // otherwise, build on heap (which will create PQ for next time, if we have enough vectors)
             var pqi = CassandraOnHeapGraph.getPqIfPresent(indexContext, vc -> vc.type == CompressionType.PRODUCT_QUANTIZATION);
@@ -391,12 +386,10 @@ public class SSTableIndexWriter implements PerIndexWriter
             if (pqi == null && !segments.isEmpty())
                 pqi = maybeReadPqFromLastSegment();
 
-            if ((bqPreferred || pqi != null) && V3OnDiskFormat.ENABLE_LTM_CONSTRUCTION)
+            if (pqi != null && V3OnDiskFormat.ENABLE_LTM_CONSTRUCTION)
             {
-                var compressor = bqPreferred ? new BinaryQuantization(dimension) : pqi.pq;
-                var unitVectors = bqPreferred ? false : pqi.unitVectors;
                 var allRowsHaveVectors = allRowsHaveVectorsInWrittenSegments(indexContext);
-                builder = new SegmentBuilder.VectorOffHeapSegmentBuilder(perIndexComponents, rowIdOffset, keyCount, compressor, unitVectors, allRowsHaveVectors, limiter);
+                builder = new SegmentBuilder.VectorOffHeapSegmentBuilder(perIndexComponents, rowIdOffset, keyCount, pqi.pq, pqi.unitVectors, allRowsHaveVectors, limiter);
             }
             else
             {

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraDiskAnn.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraDiskAnn.java
@@ -33,7 +33,6 @@ import io.github.jbellis.jvector.graph.disk.feature.FeatureId;
 import io.github.jbellis.jvector.graph.disk.OnDiskGraphIndex;
 import io.github.jbellis.jvector.graph.similarity.DefaultSearchScoreProvider;
 import io.github.jbellis.jvector.graph.similarity.SearchScoreProvider;
-import io.github.jbellis.jvector.quantization.BQVectors;
 import io.github.jbellis.jvector.quantization.CompressedVectors;
 import io.github.jbellis.jvector.quantization.PQVectors;
 import io.github.jbellis.jvector.quantization.ProductQuantization;
@@ -141,14 +140,6 @@ public class CassandraDiskAnn
                 {
                     compressedVectors = PQVectors.load(reader, reader.getFilePointer());
                     pq = ((PQVectors) compressedVectors).getCompressor();
-                    compression = new VectorCompression(compressionType,
-                                                        compressedVectors.getOriginalSize(),
-                                                        compressedVectors.getCompressedSize());
-                }
-                else if (compressionType == VectorCompression.CompressionType.BINARY_QUANTIZATION)
-                {
-                    compressedVectors = BQVectors.load(reader, reader.getFilePointer());
-                    pq = null;
                     compression = new VectorCompression(compressionType,
                                                         compressedVectors.getOriginalSize(),
                                                         compressedVectors.getCompressedSize());

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraOnHeapGraph.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraOnHeapGraph.java
@@ -50,7 +50,6 @@ import io.github.jbellis.jvector.graph.disk.feature.FeatureId;
 import io.github.jbellis.jvector.graph.disk.feature.InlineVectors;
 import io.github.jbellis.jvector.graph.disk.feature.NVQ;
 import io.github.jbellis.jvector.graph.similarity.DefaultSearchScoreProvider;
-import io.github.jbellis.jvector.quantization.BinaryQuantization;
 import io.github.jbellis.jvector.quantization.CompressedVectors;
 import io.github.jbellis.jvector.quantization.NVQuantization;
 import io.github.jbellis.jvector.quantization.ProductQuantization;
@@ -452,7 +451,7 @@ public class CassandraOnHeapGraph<T> implements Accountable
         // Write the NVQ feature. We could compute this at insert time, but because the graph allows for parallel
         // insertions, it would be a bit more complicated. All vectors are in memory, so the computation to build the
         // mean vector should be pretty fast, and this path is only used when we don't have an existing
-        // ProductQuantization or when we're using BQ.
+        // ProductQuantization.
         NVQuantization nvq = writeNvq ? NVQuantization.compute(vectorValues, NUM_SUB_VECTORS) : null;
 
         IndexComponent.ForWrite termsDataComponent = perIndexComponents.addOrGet(IndexComponentType.TERMS_DATA);
@@ -583,22 +582,17 @@ public class CassandraOnHeapGraph<T> implements Accountable
         var preferredCompression = sourceModel.compressionProvider.apply(vectorValues.dimension());
 
         // Build encoder and compress vectors
-        VectorCompressor<?> compressor; // will be null if we can't compress
+        VectorCompressor<?> compressor = null; // will be null if we can't compress
         CompressedVectors cv = null;
         // limit the PQ computation and encoding to one index at a time -- goal during flush is to
         // evict from memory ASAP so better to do the PQ build (in parallel) one at a time
         synchronized (CassandraOnHeapGraph.class)
         {
-            // build encoder (expensive for PQ, cheaper for BQ)
+            // build encoder (expensive for PQ)
             if (preferredCompression.type == CompressionType.PRODUCT_QUANTIZATION)
             {
                 var pqi = getPqIfPresent(indexContext, preferredCompression::equals);
                 compressor = computeOrRefineFrom(pqi, preferredCompression);
-            }
-            else
-            {
-                assert preferredCompression.type == CompressionType.BINARY_QUANTIZATION : preferredCompression.type;
-                compressor = BinaryQuantization.compute(vectorValues);
             }
             assert !vectorValues.isValueShared();
             // encode (compress) the vectors to save

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/CompactionGraph.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/CompactionGraph.java
@@ -49,9 +49,6 @@ import io.github.jbellis.jvector.graph.disk.OnDiskGraphIndexWriter;
 import io.github.jbellis.jvector.graph.disk.OrdinalMapper;
 import io.github.jbellis.jvector.graph.disk.feature.NVQ;
 import io.github.jbellis.jvector.graph.similarity.BuildScoreProvider;
-import io.github.jbellis.jvector.quantization.BQVectors;
-import io.github.jbellis.jvector.quantization.BinaryQuantization;
-import io.github.jbellis.jvector.quantization.MutableBQVectors;
 import io.github.jbellis.jvector.quantization.MutableCompressedVectors;
 import io.github.jbellis.jvector.quantization.MutablePQVectors;
 import io.github.jbellis.jvector.quantization.NVQuantization;
@@ -201,18 +198,11 @@ public class CompactionGraph implements Closeable, Accountable
         vectorsByOrdinalTmpFile = perIndexComponents.tmpFileFor("vectors_by_ordinal");
         vectorsByOrdinalBufferedWriter = new BufferedRandomAccessWriter(vectorsByOrdinalTmpFile.toPath());
 
-        // VSTODO add LVQ
         BuildScoreProvider bsp;
         if (compressor instanceof ProductQuantization)
         {
             compressedVectors = new MutablePQVectors((ProductQuantization) compressor);
             bsp = BuildScoreProvider.pqBuildScoreProvider(similarityFunction, (PQVectors) compressedVectors);
-        }
-        else if (compressor instanceof BinaryQuantization)
-        {
-            var bq = new BinaryQuantization(dimension);
-            compressedVectors = new MutableBQVectors(bq);
-            bsp = BuildScoreProvider.bqBuildScoreProvider((BQVectors) compressedVectors);
         }
         else
         {

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/VectorCompression.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/VectorCompression.java
@@ -82,6 +82,5 @@ public class VectorCompression
     {
         NONE,
         PRODUCT_QUANTIZATION,
-        BINARY_QUANTIZATION
     }
 }

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/VectorSourceModel.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/VectorSourceModel.java
@@ -28,7 +28,6 @@ import static io.github.jbellis.jvector.vector.VectorSimilarityFunction.COSINE;
 import static io.github.jbellis.jvector.vector.VectorSimilarityFunction.DOT_PRODUCT;
 import static java.lang.Math.max;
 import static java.lang.Math.pow;
-import static org.apache.cassandra.index.sai.disk.vector.VectorCompression.CompressionType.BINARY_QUANTIZATION;
 import static org.apache.cassandra.index.sai.disk.vector.VectorCompression.CompressionType.NONE;
 import static org.apache.cassandra.index.sai.disk.vector.VectorCompression.CompressionType.PRODUCT_QUANTIZATION;
 public enum VectorSourceModel
@@ -143,9 +142,7 @@ public enum VectorSourceModel
     {
         assert vc != null;
         // we compress extra-large vectors more aggressively, so we need to bump up the limit for those.
-        if (vc.type == BINARY_QUANTIZATION)
-            return 2.0;
-        else if ((double) vc.getOriginalSize() / vc.getCompressedSize() > 16.0)
+        if ((double) vc.getOriginalSize() / vc.getCompressedSize() > 16.0)
             return 1.5;
         else
             return 1.0;

--- a/src/java/org/apache/cassandra/index/sai/plan/Plan.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Plan.java
@@ -2161,7 +2161,7 @@ abstract public class Plan
         /** Cost to get a scored key from DiskANN (~rerank cost). Affected by cache hit rate */
         public final static double ANN_SCORED_KEY_COST = 15;
 
-        /** Cost to perform a coarse (PQ or BQ) in-memory similarity computation */
+        /** Cost to perform a coarse (PQ) in-memory similarity computation */
         public final static double ANN_SIMILARITY_COST = 0.5;
 
         /** Cost to load the neighbor list for a DiskANN node. Affected by cache hit rate */


### PR DESCRIPTION
### What is the issue
Fixes: https://github.com/riptano/cndb/issues/16693 Test: https://github.com/riptano/cndb/pull/16694

### What does this PR fix and why was it fixed
Binary quantization was never used in production. We have a different quantization coming, but it is not ready yet. It simplifies some coming PRs to remove this logic eagerly, namely #2042.
