### PR TITLE
CNDB-16762 use the index name constant and validate it

### DIFF
--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateIndexStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateIndexStatement.java
@@ -161,7 +161,7 @@ public final class CreateIndexStatement extends AlterSchemaStatement
         if (isDseIndexCreateStatement())
         {
             // DSE indexes are not supported. The index is not created, the attempt is ignored (doesn't cause error),
-            // a meaningfull warning is returned instead.
+            // a meaningful warning is returned instead.
             return schema;
         }
 
@@ -359,8 +359,8 @@ public final class CreateIndexStatement extends AlterSchemaStatement
     {
         assert keyspace.name.equals(keyspaceName);
         String baseName = targets.size() == 1
-                        ? IndexMetadata.generateDefaultIndexName(keyspaceName, tableName, targets.get(0).column)
-                        : IndexMetadata.generateDefaultIndexName(keyspaceName, tableName, null);
+                          ? IndexMetadata.generateDefaultIndexName(tableName, targets.get(0).column)
+                          : IndexMetadata.generateDefaultIndexName(tableName, null);
         return keyspace.findAvailableIndexName(baseName);
     }
 

--- a/src/java/org/apache/cassandra/index/sai/disk/format/Version.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/Version.java
@@ -23,6 +23,7 @@ import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Objects;
 import com.google.common.collect.Lists;
 
@@ -128,7 +129,10 @@ public class Version implements Comparable<Version>
      * Calculates the maximum allowed length for SAI index names to ensure generated filenames
      * do not exceed the system's filename length limit (defined in {@link SchemaConstants#FILENAME_LENGTH}).
      * This accounts for all additional components in the filename.
+     * It is only used to validate that {@link SchemaConstants#INDEX_NAME_LENGTH}
+     * is not bigger than the actual acceptable length.
      */
+    @VisibleForTesting
     public static int calculateIndexNameAllowedLength(String keyspace)
     {
         int addedLength = getAddedLengthFromDescriptorAndVersion(keyspace);
@@ -151,7 +155,7 @@ public class Version implements Comparable<Version>
         int addedLength = SAI_DESCRIPTOR.length()
                           + versionNameLength
                           + generationLength
-                          + IndexComponentType.PRIMARY_KEY_BLOCK_OFFSETS.representation.length()
+                          + calculateMaxComponentRepresentationLength()
                           + SAI_SEPARATOR.length() * 3
                           + EXTENSION.length();
 
@@ -164,6 +168,14 @@ public class Version implements Comparable<Version>
                        + tableIdLength
                        + separatorLength * 3;
         return addedLength;
+    }
+
+    private static int calculateMaxComponentRepresentationLength()
+    {
+        int maxLength = 0;
+        for (IndexComponentType component : IndexComponentType.values())
+            maxLength = Math.max(maxLength, component.representation.length());
+        return maxLength;
     }
 
     @Override

--- a/src/java/org/apache/cassandra/schema/IndexMetadata.java
+++ b/src/java/org/apache/cassandra/schema/IndexMetadata.java
@@ -46,7 +46,6 @@ import org.apache.cassandra.exceptions.UnknownIndexException;
 import org.apache.cassandra.index.Index;
 import org.apache.cassandra.index.internal.CassandraIndex;
 import org.apache.cassandra.index.sai.StorageAttachedIndex;
-import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.io.util.DataInputPlus;
 import org.apache.cassandra.io.util.DataOutputPlus;
 import org.apache.cassandra.utils.FBUtilities;
@@ -122,12 +121,11 @@ public final class IndexMetadata
      * Characters other than alphanumeric and underscore are removed.
      * Long index names are truncated to fit the length allowing constructing filenames.
      *
-     * @param keyspace the keyspace name
      * @param table  the table name
      * @param column the column identifier. Can be null if the index is not column specific.
      * @return the generated index name
      */
-    public static String generateDefaultIndexName(String keyspace, String table, @Nullable ColumnIdentifier column)
+    public static String generateDefaultIndexName(String table, @Nullable ColumnIdentifier column)
     {
         String indexNameUncleaned = table;
         if (column != null)
@@ -135,7 +133,7 @@ public final class IndexMetadata
         String indexNameUntrimmed = PATTERN_NON_WORD_CHAR.matcher(indexNameUncleaned).replaceAll("");
         String indexNameTrimmed = indexNameUntrimmed
                                   .substring(0,
-                                             Math.min(calculateGeneratedIndexNameMaxLength(keyspace),
+                                             Math.min(calculateGeneratedIndexNameMaxLength(),
                                                       indexNameUntrimmed.length()));
         return indexNameTrimmed + INDEX_POSTFIX;
     }
@@ -143,23 +141,20 @@ public final class IndexMetadata
     /**
      * Calculates the maximum length of the generated index name to fit file names.
      * It includes the generated suffixes in account.
-     * The calculation depends on how index implements file names construciton from index names.
+     * The calculation depends on how an index implements file names construciton from index names.
      * This needs to be addressed, see CNDB-13240.
      *
      * @return the allowed length of the generated index name
      */
-    private static int calculateGeneratedIndexNameMaxLength(String keyspace)
+    private static int calculateGeneratedIndexNameMaxLength()
     {
         // Speculative assumption that uniqueness breaker will fit into 999.
         // The value is used for trimming the index name if needed.
         // Introducing validation of index name length is TODO for CNDB-13198.
         int uniquenessSuffixLength = 4;
         int indexNameAddition = uniquenessSuffixLength + INDEX_POSTFIX.length();
-        int allowedIndexNameLength = Version.calculateIndexNameAllowedLength(keyspace);
 
-        assert allowedIndexNameLength >= indexNameAddition : "cannot happen with current implementation as allowedIndexNameLength is approximately 255 - ~76. However, allowedIndexNameLength was " + allowedIndexNameLength + " and  indexNameAddition was " + indexNameAddition;
-
-        return allowedIndexNameLength - indexNameAddition;
+        return SchemaConstants.INDEX_NAME_LENGTH - indexNameAddition;
     }
 
     public void validate(TableMetadata table)

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/IndexAvailabilityTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/IndexAvailabilityTest.java
@@ -292,7 +292,7 @@ public class IndexAvailabilityTest extends TestBaseImpl
 
             // get index name base on node id to have different non-queryable index on different nodes.
             Function<Integer, String> nodeIdToColumn = nodeId -> "v" + (nodeId % 2 + 1);
-            IntFunction<String> nodeIdToIndex = nodeId -> IndexMetadata.generateDefaultIndexName(KEYSPACE, table, ColumnIdentifier.getInterned(nodeIdToColumn.apply(nodeId), false));
+            IntFunction<String> nodeIdToIndex = nodeId -> IndexMetadata.generateDefaultIndexName(table, ColumnIdentifier.getInterned(nodeIdToColumn.apply(nodeId), false));
 
             for (List<Integer> nonQueryableNodes : nonQueryableNodesList)
             {

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/NativeIndexDDLTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/NativeIndexDDLTest.java
@@ -253,7 +253,7 @@ public class NativeIndexDDLTest extends TestBaseImpl
             {
                 ColumnIdentifier columnID = ColumnIdentifier.getInterned(column, true);
                 ColumnFamilyStore cfs = Keyspace.open(KEYSPACE).getColumnFamilyStore(table);
-                String indexName = IndexMetadata.generateDefaultIndexName(KEYSPACE, table, columnID);
+                String indexName = IndexMetadata.generateDefaultIndexName(table, columnID);
                 StorageAttachedIndex index = (StorageAttachedIndex) cfs.indexManager.getIndexByName(indexName);
                 return index.getIndexContext().getCellCount();
             }

--- a/test/unit/org/apache/cassandra/cql3/CQLTester.java
+++ b/test/unit/org/apache/cassandra/cql3/CQLTester.java
@@ -1397,8 +1397,8 @@ public abstract class CQLTester
             isQuotedGeneratedIndexName = ParseUtils.isQuoted(column, '\"');
 
             String baseName = Strings.isNullOrEmpty(column)
-                              ? IndexMetadata.generateDefaultIndexName(keyspace, table, null)
-                              : IndexMetadata.generateDefaultIndexName(keyspace, table, new ColumnIdentifier(column, true));
+                              ? IndexMetadata.generateDefaultIndexName(table, null)
+                              : IndexMetadata.generateDefaultIndexName(table, new ColumnIdentifier(column, true));
 
             KeyspaceMetadata ks = Schema.instance.getKeyspaceMetadata(keyspace);
             assertNotNull(ks);

--- a/test/unit/org/apache/cassandra/index/sai/cql/NativeIndexDDLTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/NativeIndexDDLTest.java
@@ -849,8 +849,8 @@ public class NativeIndexDDLTest extends SAITester
         waitForAssert(this::verifyNoIndexFiles);
 
         // verify index-view-manager has been cleaned up
-        verifySSTableIndexes(IndexMetadata.generateDefaultIndexName(KEYSPACE, currentTable(), V1_COLUMN_IDENTIFIER), 0);
-        verifySSTableIndexes(IndexMetadata.generateDefaultIndexName(KEYSPACE, currentTable(), V2_COLUMN_IDENTIFIER), 0);
+        verifySSTableIndexes(IndexMetadata.generateDefaultIndexName(currentTable(), V1_COLUMN_IDENTIFIER), 0);
+        verifySSTableIndexes(IndexMetadata.generateDefaultIndexName(currentTable(), V2_COLUMN_IDENTIFIER), 0);
 
         assertEquals("Segment memory limiter should revert to zero after truncate.", 0L, getSegmentBufferUsedBytes());
         assertEquals("There should be no segment builders in progress.", 0L, getColumnIndexBuildsInProgress());
@@ -1406,8 +1406,8 @@ public class NativeIndexDDLTest extends SAITester
         IndexContext literalIndexContext = createIndexContext(createIndex(String.format(CREATE_INDEX_TEMPLATE, "v2")), UTF8Type.instance);
 
         populateData.run();
-        verifySSTableIndexes(IndexMetadata.generateDefaultIndexName(KEYSPACE, currentTable(), V1_COLUMN_IDENTIFIER), 2, 2);
-        verifySSTableIndexes(IndexMetadata.generateDefaultIndexName(KEYSPACE, currentTable(), V2_COLUMN_IDENTIFIER), 2, 2);
+        verifySSTableIndexes(IndexMetadata.generateDefaultIndexName(currentTable(), V1_COLUMN_IDENTIFIER), 2, 2);
+        verifySSTableIndexes(IndexMetadata.generateDefaultIndexName(currentTable(), V2_COLUMN_IDENTIFIER), 2, 2);
         verifyIndexFiles(numericIndexContext, literalIndexContext, 2, 0, 0, 2, 2);
 
         ResultSet rows = executeNet("SELECT id1 FROM %s WHERE v1>=0");
@@ -1417,8 +1417,8 @@ public class NativeIndexDDLTest extends SAITester
 
         // compact empty index
         compact();
-        verifySSTableIndexes(IndexMetadata.generateDefaultIndexName(KEYSPACE, currentTable(), V1_COLUMN_IDENTIFIER), 1, 1);
-        verifySSTableIndexes(IndexMetadata.generateDefaultIndexName(KEYSPACE, currentTable(), V2_COLUMN_IDENTIFIER), 1, 1);
+        verifySSTableIndexes(IndexMetadata.generateDefaultIndexName(currentTable(), V1_COLUMN_IDENTIFIER), 1, 1);
+        verifySSTableIndexes(IndexMetadata.generateDefaultIndexName(currentTable(), V2_COLUMN_IDENTIFIER), 1, 1);
         waitForAssert(() -> verifyIndexFiles(numericIndexContext, literalIndexContext, 1, 0, 0, 1, 1));
 
         rows = executeNet("SELECT id1 FROM %s WHERE v1>=0");

--- a/test/unit/org/apache/cassandra/index/sai/functional/CompactionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/functional/CompactionTest.java
@@ -326,8 +326,8 @@ public class CompactionTest extends AbstractMetricsTest
 
         assertNumRows(num, "SELECT id1 FROM %%s WHERE v1>=0");
         assertNumRows(num, "SELECT id1 FROM %%s WHERE v2='0'");
-        verifySSTableIndexes(IndexMetadata.generateDefaultIndexName(KEYSPACE, currentTable(), V1_COLUMN_IDENTIFIER), sstables);
-        verifySSTableIndexes(IndexMetadata.generateDefaultIndexName(KEYSPACE, currentTable(), V2_COLUMN_IDENTIFIER), sstables);
+        verifySSTableIndexes(IndexMetadata.generateDefaultIndexName(currentTable(), V1_COLUMN_IDENTIFIER), sstables);
+        verifySSTableIndexes(IndexMetadata.generateDefaultIndexName(currentTable(), V2_COLUMN_IDENTIFIER), sstables);
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/schema/IndexMetadataTest.java
+++ b/test/unit/org/apache/cassandra/schema/IndexMetadataTest.java
@@ -30,8 +30,7 @@ public class IndexMetadataTest
     @Test
     public void testGetDefaultIndexName()
     {
-        String keyspace = "ks";
-        Assert.assertEquals("aB4__idx", IndexMetadata.generateDefaultIndexName(keyspace, "a B-4@!_+", null));
-        Assert.assertEquals("34_Ddd_F6_idx", IndexMetadata.generateDefaultIndexName(keyspace, "34_()Ddd", new ColumnIdentifier("#F%6*", true)));
+        Assert.assertEquals("aB4__idx", IndexMetadata.generateDefaultIndexName("a B-4@!_+", null));
+        Assert.assertEquals("34_Ddd_F6_idx", IndexMetadata.generateDefaultIndexName("34_()Ddd", new ColumnIdentifier("#F%6*", true)));
     }
 }


### PR DESCRIPTION
### What is the issue

Index name length is controlled through INDEX_NAME_LENGTH constant, however, the generated index name uses calculateIndexNameAllowedLength, which will give different result if components are changing. Also calculateIndexNameAllowedLength uses a particular longest component, which might become not longest.

### What does this PR fix and why was it fixed

Fixes calculateGeneratedIndexNameMaxLength to use the index length constant and validates the constant to fit the maximum file name length even with the longest component name representation.
