### PR TITLE
HCD-335 Update Netty to 4.1.132.Final

### DIFF
--- a/.build/parent-pom-template.xml
+++ b/.build/parent-pom-template.xml
@@ -755,7 +755,7 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-all</artifactId>
-        <version>4.1.130.Final</version>
+        <version>4.1.132.Final</version>
         <exclusions>
           <exclusion>
             <groupId>io.netty</groupId>
@@ -768,10 +768,6 @@
           <exclusion>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec-http2</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-codec-http</artifactId>
           </exclusion>
           <exclusion>
             <groupId>io.netty</groupId>


### PR DESCRIPTION
This patch also removes the explicit excludes on netty-codec-http as the library and its dependencies are needed when HCD is used with Management API. Bringing netty-codec-http back into the fold means Netty has to be upgraded to 4.1.132.Final to address CVE-2026-33870.

### What is the issue
`netty-codec-http` is excluded

### What does this PR fix and why was it fixed
Adds back `netty-codec-http` and updates the Netty version
