### PR TITLE
CNDB-10919: Add writeRequests counter to TableMetrics

### DIFF
--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -1708,6 +1708,7 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
 
     {
         long start = nanoTime();
+        metric.writeRequests.inc();
         OpOrder.Group opGroup = context.getGroup();
         CommitLogPosition commitLogPosition = context.getPosition();
         try

--- a/src/java/org/apache/cassandra/metrics/TableMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/TableMetrics.java
@@ -211,6 +211,8 @@ public class TableMetrics
     public final Counter readRequests;
     /** The number of range read requests, including those dropped due to timeouts */
     public final Counter rangeRequests;
+    /** The number of write requests in storage layer, including errors */
+    public final Counter writeRequests;
     /** Estimated number of tasks pending for this table */
     public final Counter pendingFlushes;
     /** Total number of bytes flushed since server [re]start */
@@ -833,6 +835,7 @@ public class TableMetrics
 
         readRequests = createTableCounter("ReadRequests");
         rangeRequests = createTableCounter("RangeRequests");
+        writeRequests = createTableCounter("WriteRequests");
 
         pendingFlushes = createTableCounter("PendingFlushes");
         bytesFlushed = createTableCounter("BytesFlushed");

--- a/test/unit/org/apache/cassandra/metrics/TableMetricsTest.java
+++ b/test/unit/org/apache/cassandra/metrics/TableMetricsTest.java
@@ -458,6 +458,50 @@ public class TableMetricsTest
     }
 
 
+    @Test
+    public void testWriteRequestsCounter()
+    {
+        ColumnFamilyStore cfs = recreateTable();
+        
+        // Verify initial state
+        assertEquals(0, cfs.metric.writeRequests.getCount());
+        assertEquals(0, cfs.metric.readRequests.getCount());
+        
+        int numOperations = 5;
+        
+        // Execute INSERT operations
+        for (int i = 0; i < numOperations; i++)
+            session.execute(String.format("INSERT INTO %s.%s (id, val1, val2) VALUES (%d, '%s', '%s')",
+                                        KEYSPACE, TABLE, i, "val" + i, "val" + i));
+        
+        // Verify writeRequests counter is incremented for inserts
+        assertEquals(numOperations, cfs.metric.writeRequests.getCount());
+        assertEquals(0, cfs.metric.readRequests.getCount());
+        
+        // Execute UPDATE operations
+        for (int i = 0; i < numOperations; i++)
+            session.execute(String.format("UPDATE %s.%s SET val2 = '%s' WHERE id = %d AND val1 = '%s'",
+                                        KEYSPACE, TABLE, "updated" + i, i, "val" + i));
+        
+        // Verify counter increments for updates
+        assertEquals(numOperations * 2, cfs.metric.writeRequests.getCount());
+        
+        // Execute DELETE operations
+        for (int i = 0; i < numOperations; i++)
+            session.execute(String.format("DELETE FROM %s.%s WHERE id = %d AND val1 = '%s'",
+                                        KEYSPACE, TABLE, i, "val" + i));
+        
+        // Verify counter increments for deletes
+        assertEquals(numOperations * 3, cfs.metric.writeRequests.getCount());
+        
+        // Execute a read to verify writeRequests doesn't increment on reads
+        session.execute(String.format("SELECT * FROM %s.%s WHERE id = 0 AND val1 = 'val0'", KEYSPACE, TABLE));
+        
+        // writeRequests should remain the same, readRequests should increment
+        assertEquals(numOperations * 3, cfs.metric.writeRequests.getCount());
+        assertEquals(1, cfs.metric.readRequests.getCount());
+    }
+
     @AfterClass
     public static void tearDown()
     {


### PR DESCRIPTION
### What is the issue
Add writeRequests counter to TableMetrics for tracking table-level write operations

### What does this PR fix and why was it fixed
Fixes https://github.com/riptano/cndb/issues/10919 partially by adding the write request metric to cassandra.
