### PR TITLE
CNDB-15527: Upgrade jvector to 4.0.0-rc.8; make FusedPQ configurable

### DIFF
--- a/.build/parent-pom-template.xml
+++ b/.build/parent-pom-template.xml
@@ -1254,7 +1254,7 @@
       <dependency>
         <groupId>io.github.jbellis</groupId>
         <artifactId>jvector</artifactId>
-        <version>4.0.0-rc.5</version>
+        <version>4.0.0-rc.8</version>
       </dependency>
       <dependency>
         <groupId>com.carrotsearch.randomizedtesting</groupId>

--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -741,6 +741,16 @@ public enum CassandraRelevantProperties
     SAI_ENABLE_JVECTOR_DELETES("cassandra.sai.enable_jvector_deletes", "true"),
     SAI_ENABLE_LTM_CONSTRUCTION("cassandra.sai.ltm_construction", "true"),
     SAI_ENABLE_RERANK_FLOOR("cassandra.sai.rerank_floor", "true"),
+    // When building a compaction graph, encode layer 0 nodes in parallel and subsequently use async io for writes.
+    // This feature is experimental, so defaults to false.
+    SAI_ENCODE_AND_WRITE_VECTOR_GRAPH_IN_PARALLEL_ENABLED("cassandra.sai.vector.encode_and_write_graph_in_parallel.enabled", "false"),
+    // When parallel graph encoding is enabled, the number of threads to use for encoding. Defaults to 0, meaning
+    // use all available processors as reported by the JVM.
+    SAI_ENCODE_AND_WRITE_VECTOR_GRAPH_IN_PARALLEL_NUM_THREADS("cassandra.sai.vector.encode_and_write_graph_in_parallel.num_threads", "0"),
+    // When parallel graph encoding is enabled, whether to use director buffers. Defaults to false, meaning heap
+    // buffers are used. A buffer will be allocated per encoding thread. The size of each buffer is the size
+    // of the encoded graph node at layer 0, which varies based on graph feature settings.
+    SAI_ENCODE_AND_WRITE_VECTOR_GRAPH_IN_PARALLEL_USE_DIRECT_BUFFERS("cassandra.sai.vector.encode_and_write_graph_in_parallel.use_direct_buffers", "false"),
 
     /** Controls the hnsw vector cache size, in bytes, per index segment. 0 to disable */
     SAI_HNSW_VECTOR_CACHE_BYTES("cassandra.sai.vector_search.vector_cache_bytes", String.valueOf(4 * 1024 * 1024)),
@@ -827,6 +837,10 @@ public enum CassandraRelevantProperties
 
     /** Whether to validate terms that will be SAI indexed at the coordinator */
     SAI_VALIDATE_TERMS_AT_COORDINATOR("cassandra.sai.validate_terms_at_coordinator", "true"),
+
+    // Whether compaction should build vector indexes using a fused graph, aka a graph where the quantized vectors
+    // are stored inline with a graph node. Feature is still experimental, so defaults to false.
+    SAI_VECTOR_ENABLE_FUSED("cassandra.sai.vector.enable_fused", "false"),
 
     // Use nvq when building graphs in compaction. Disabled by default for now. Enabling will reduce recall slightly
     // while also reducing the storage footprint.

--- a/src/java/org/apache/cassandra/index/sai/disk/format/Version.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/Version.java
@@ -39,6 +39,7 @@ import org.apache.cassandra.index.sai.disk.v4.V4OnDiskFormat;
 import org.apache.cassandra.index.sai.disk.v5.V5OnDiskFormat;
 import org.apache.cassandra.index.sai.disk.v6.V6OnDiskFormat;
 import org.apache.cassandra.index.sai.disk.v7.V7OnDiskFormat;
+import org.apache.cassandra.index.sai.disk.v8.V8OnDiskFormat;
 import org.apache.cassandra.index.sai.utils.TypeUtil;
 import org.apache.cassandra.io.sstable.format.bti.BtiFormat;
 import org.apache.cassandra.schema.SchemaConstants;
@@ -75,10 +76,12 @@ public class Version implements Comparable<Version>
     public static final Version EC = new Version("ec", V7OnDiskFormat.instance, (c, i, g) -> stargazerFileNameFormat(c, i, g, "ec"));
     // total terms count serialization in index metadata, enables ANN_USE_SYNTHETIC_SCORE by default
     public static final Version ED = new Version("ed", V7OnDiskFormat.instance, (c, i, g) -> stargazerFileNameFormat(c, i, g, "ed"));
+    // jvector file format version 6 (skipped 5)
+    public static final Version FA = new Version("fa", V8OnDiskFormat.instance, (c, i, g) -> stargazerFileNameFormat(c, i, g, "fa"));
 
     // These are in reverse-chronological order so that the latest version is first. Version matching tests
     // are more likely to match the latest version, so we want to test that one first.
-    public static final List<Version> ALL = Lists.newArrayList(ED, EC, EB, DC, DB, CA, BA, AA);
+    public static final List<Version> ALL = Lists.newArrayList(FA, ED, EC, EB, DC, DB, CA, BA, AA);
 
     public static final Version EARLIEST = AA;
     public static final Version VECTOR_EARLIEST = BA;

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/V2VectorIndexSearcher.java
@@ -99,7 +99,8 @@ public class V2VectorIndexSearcher extends IndexSearcher
     @VisibleForTesting
     public static double BRUTE_FORCE_EXPENSE_FACTOR = DatabaseDescriptor.getAnnBruteForceExpenseFactor();
 
-    protected final CassandraDiskAnn graph;
+    @VisibleForTesting
+    public final CassandraDiskAnn graph;
     private final PrimaryKey.Factory keyFactory;
     private final PairedSlidingWindowReservoir expectedActualNodesVisited = new PairedSlidingWindowReservoir(20);
     private final ThreadLocal<SparseBits> cachedBits;

--- a/src/java/org/apache/cassandra/index/sai/disk/v8/V8OnDiskFormat.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v8/V8OnDiskFormat.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.disk.v8;
+
+import org.apache.cassandra.index.sai.disk.v7.V7OnDiskFormat;
+
+public class V8OnDiskFormat extends V7OnDiskFormat
+{
+   public static final V8OnDiskFormat instance = new V8OnDiskFormat();
+
+   @Override
+   public int jvectorFileFormatVersion()
+   {
+       return 6;
+   }
+}

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraDiskAnn.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraDiskAnn.java
@@ -96,7 +96,7 @@ public class CassandraDiskAnn
 
         SegmentMetadata.ComponentMetadata termsMetadata = this.componentMetadatas.get(IndexComponentType.TERMS_DATA);
         graphHandle = indexFiles.termsData();
-        var rawGraph = OnDiskGraphIndex.load(graphHandle::createReader, termsMetadata.offset);
+        var rawGraph = OnDiskGraphIndex.load(graphHandle::createReader, termsMetadata.offset, false);
         features = rawGraph.getFeatureSet();
         graph = rawGraph;
         usesNVQ = features.contains(FeatureId.NVQ_VECTORS);
@@ -124,7 +124,7 @@ public class CassandraDiskAnn
             }
 
             VectorCompression.CompressionType compressionType = VectorCompression.CompressionType.values()[reader.readByte()];
-            if (features.contains(FeatureId.FUSED_ADC))
+            if (features.contains(FeatureId.FUSED_PQ))
             {
                 assert compressionType == VectorCompression.CompressionType.PRODUCT_QUANTIZATION;
                 compressedVectors = null;
@@ -240,9 +240,7 @@ public class CassandraDiskAnn
         {
             var view = (ImmutableGraphIndex.ScoringView) searcher.getView();
             SearchScoreProvider ssp;
-            // FusedADC can no longer be written due to jvector upgrade. However, it's possible these index files
-            // still exist, so we have to support them.
-            if (features.contains(FeatureId.FUSED_ADC))
+            if (features.contains(FeatureId.FUSED_PQ))
             {
                 var asf = view.approximateScoreFunctionFor(queryVector, similarityFunction);
                 var rr = isRerankless ? null : view.rerankerFor(queryVector, similarityFunction);

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraOnHeapGraph.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraOnHeapGraph.java
@@ -25,12 +25,14 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.EnumMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
+import java.util.function.IntFunction;
 import java.util.function.IntUnaryOperator;
 import java.util.function.ToIntFunction;
 
@@ -41,16 +43,19 @@ import org.slf4j.LoggerFactory;
 
 import io.github.jbellis.jvector.graph.GraphIndexBuilder;
 import io.github.jbellis.jvector.graph.GraphSearcher;
+import io.github.jbellis.jvector.graph.ImmutableGraphIndex;
 import io.github.jbellis.jvector.graph.RandomAccessVectorValues;
 import io.github.jbellis.jvector.graph.SearchResult;
 import io.github.jbellis.jvector.graph.disk.OnDiskGraphIndexWriter;
 import io.github.jbellis.jvector.graph.disk.OrdinalMapper;
 import io.github.jbellis.jvector.graph.disk.feature.Feature;
 import io.github.jbellis.jvector.graph.disk.feature.FeatureId;
+import io.github.jbellis.jvector.graph.disk.feature.FusedPQ;
 import io.github.jbellis.jvector.graph.disk.feature.InlineVectors;
 import io.github.jbellis.jvector.graph.disk.feature.NVQ;
 import io.github.jbellis.jvector.graph.similarity.DefaultSearchScoreProvider;
 import io.github.jbellis.jvector.quantization.CompressedVectors;
+import io.github.jbellis.jvector.quantization.PQVectors;
 import io.github.jbellis.jvector.quantization.NVQuantization;
 import io.github.jbellis.jvector.quantization.ProductQuantization;
 import io.github.jbellis.jvector.quantization.VectorCompressor;
@@ -87,6 +92,7 @@ import org.apache.cassandra.index.sai.disk.vector.VectorCompression.CompressionT
 import org.apache.cassandra.index.sai.metrics.ColumnQueryMetrics;
 import org.apache.cassandra.index.sai.utils.PrimaryKeyWithSortKey;
 import org.apache.cassandra.index.sai.utils.SAICodecUtils;
+import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.SequentialWriter;
 import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.tracing.Tracing;
@@ -95,7 +101,7 @@ import org.apache.cassandra.utils.CloseableIterator;
 import org.apache.lucene.util.StringHelper;
 
 import static org.apache.cassandra.utils.Clock.Global.nanoTime;
-import static org.apache.cassandra.index.sai.disk.vector.NVQUtil.NUM_SUB_VECTORS;
+import static org.apache.cassandra.index.sai.disk.vector.JVectorVersionUtil.NUM_SUB_VECTORS;
 
 public class CassandraOnHeapGraph<T> implements Accountable
 {
@@ -166,7 +172,7 @@ public class CassandraOnHeapGraph<T> implements Accountable
         allVectorsAreUnitLength = true;
 
         // NVQ is only written during compaction to save on compute costs
-        writeNvq = NVQUtil.shouldWriteNVQ(dimension, context.version()) && !forSearching;
+        writeNvq = JVectorVersionUtil.shouldWriteNVQ(dimension, context.version()) && !forSearching;
 
         // This is only a warning since it's not a fatal error to write without hierarchy
         if (indexConfig.isHierarchyEnabled() && jvectorVersion < 4)
@@ -448,36 +454,24 @@ public class CassandraOnHeapGraph<T> implements Accountable
 
         OrdinalMapper ordinalMapper = remappedPostings.ordinalMapper;
 
-        // Write the NVQ feature. We could compute this at insert time, but because the graph allows for parallel
-        // insertions, it would be a bit more complicated. All vectors are in memory, so the computation to build the
-        // mean vector should be pretty fast, and this path is only used when we don't have an existing
-        // ProductQuantization.
-        NVQuantization nvq = writeNvq ? NVQuantization.compute(vectorValues, NUM_SUB_VECTORS) : null;
-
         IndexComponent.ForWrite termsDataComponent = perIndexComponents.addOrGet(IndexComponentType.TERMS_DATA);
         var indexFile = termsDataComponent.file();
         long termsOffset = SAICodecUtils.headerSize();
         if (indexFile.exists())
             termsOffset += indexFile.length();
         try (var pqOutput = perIndexComponents.addOrGet(IndexComponentType.PQ).openOutput(true);
-             var postingsOutput = perIndexComponents.addOrGet(IndexComponentType.POSTING_LISTS).openOutput(true);
-             var indexWriter = new OnDiskGraphIndexWriter.Builder(builder.getGraph(), indexFile.toPath())
-                               .withStartOffset(termsOffset)
-                               .withVersion(perIndexComponents.version().onDiskFormat().jvectorFileFormatVersion())
-                               .withMapper(ordinalMapper)
-                               .with(nvq != null ? new NVQ(nvq) : new InlineVectors(vectorValues.dimension()))
-                               .build())
+             var postingsOutput = perIndexComponents.addOrGet(IndexComponentType.POSTING_LISTS).openOutput(true))
         {
             SAICodecUtils.writeHeader(pqOutput);
             SAICodecUtils.writeHeader(postingsOutput);
-            indexWriter.getOutput().seek(indexFile.length()); // position at the end of the previous segment before writing our own header
-            SAICodecUtils.writeHeader(SAICodecUtils.toLuceneOutput(indexWriter.getOutput()), perIndexComponents.version());
-            assert indexWriter.getOutput().position() == termsOffset : "termsOffset " + termsOffset + " != " + indexWriter.getOutput().position();
+
+            // Write fused unless we don't meet some criteria (will be determined in the writePQ method)
+            boolean writeFusedPQ = JVectorVersionUtil.shouldWriteFused(perIndexComponents.version());
 
             // compute and write PQ
             long pqOffset = pqOutput.getFilePointer();
-            long pqPosition = writePQ(pqOutput.asSequentialWriter(), remappedPostings, perIndexComponents.context());
-            long pqLength = pqPosition - pqOffset;
+            var compressor = writePQ(pqOutput.asSequentialWriter(), remappedPostings, perIndexComponents.context(), writeFusedPQ);
+            long pqLength = pqOutput.getFilePointer() - pqOffset;
 
             // write postings
             long postingsOffset = postingsOutput.getFilePointer();
@@ -496,23 +490,48 @@ public class CassandraOnHeapGraph<T> implements Accountable
             }
             long postingsLength = postingsPosition - postingsOffset;
 
-            // write the graph
-            var start = nanoTime();
-            var supplier = nvq != null
-                            ? Feature.singleStateFactory(FeatureId.NVQ_VECTORS, nodeId -> new NVQ.State(nvq.encode(vectorValues.getVector(nodeId))))
-                            : Feature.singleStateFactory(FeatureId.INLINE_VECTORS, nodeId -> new InlineVectors.State(vectorValues.getVector(nodeId)));
-            indexWriter.write(supplier);
-            SAICodecUtils.writeFooter(indexWriter.getOutput(), indexWriter.checksum());
-            logger.info("Writing graph took {}ms", (nanoTime() - start) / 1_000_000);
-            long termsLength = indexWriter.getOutput().position() - termsOffset;
+            // Write the NVQ feature. We could compute this at insert time, but because the graph allows for parallel
+            // insertions, it would be a bit more complicated. All vectors are in memory, so the computation to build the
+            // mean vector should be pretty fast, and this path is only used when we don't have an existing
+            // ProductQuantization.
+            NVQuantization nvq = writeNvq ? NVQuantization.compute(vectorValues, NUM_SUB_VECTORS) : null;
 
-            // write remaining footers/checksums
-            SAICodecUtils.writeFooter(pqOutput);
-            SAICodecUtils.writeFooter(postingsOutput);
+            try (var indexWriter = createIndexWriter(indexFile, termsOffset, perIndexComponents.context(), ordinalMapper, compressor, nvq);
+                 var view = builder.getGraph().getView())
+            {
+                indexWriter.getOutput().seek(indexFile.length()); // position at the end of the previous segment before writing our own header
+                SAICodecUtils.writeHeader(SAICodecUtils.toLuceneOutput(indexWriter.getOutput()), perIndexComponents.version());
+                assert indexWriter.getOutput().position() == termsOffset : "termsOffset " + termsOffset + " != " + indexWriter.getOutput().position();
 
-            // add components to the metadata map
-            return createMetadataMap(termsOffset, termsLength, postingsOffset, postingsLength, pqOffset, pqLength);
+                // write the graph
+                var start = nanoTime();
+                indexWriter.write(suppliers(view, compressor, nvq, writeFusedPQ));
+                SAICodecUtils.writeFooter(indexWriter.getOutput(), indexWriter.checksum());
+                logger.info("Writing graph took {}ms", (nanoTime() - start) / 1_000_000);
+                long termsLength = indexWriter.getOutput().position() - termsOffset;
+
+                // write remaining footers/checksums
+                SAICodecUtils.writeFooter(pqOutput);
+                SAICodecUtils.writeFooter(postingsOutput);
+
+                // add components to the metadata map
+                return createMetadataMap(termsOffset, termsLength, postingsOffset, postingsLength, pqOffset, pqLength);
+            }
         }
+    }
+
+    private OnDiskGraphIndexWriter createIndexWriter(File indexFile, long termsOffset, IndexContext context, OrdinalMapper ordinalMapper, VectorCompressor<?> compressor, NVQuantization nvq) throws IOException
+    {
+        var indexWriterBuilder = new OnDiskGraphIndexWriter.Builder(builder.getGraph(), indexFile.toPath())
+            .withStartOffset(termsOffset)
+            .withVersion(context.version().onDiskFormat().jvectorFileFormatVersion())
+            .withMapper(ordinalMapper)
+            .with(nvq != null ? new NVQ(nvq) : new InlineVectors(vectorValues.dimension()));
+
+        if (compressor instanceof ProductQuantization && JVectorVersionUtil.shouldWriteFused(context.version()))
+            indexWriterBuilder.with(new FusedPQ(context.getIndexWriterConfig().getAnnMaxDegree(), (ProductQuantization) compressor));
+
+        return indexWriterBuilder.build();
     }
 
     static SegmentMetadata.ComponentMetadataMap createMetadataMap(long termsOffset, long termsLength, long postingsOffset, long postingsLength, long pqOffset, long pqLength)
@@ -523,6 +542,35 @@ public class CassandraOnHeapGraph<T> implements Accountable
         Map<String, String> vectorConfigs = Map.of("SEGMENT_ID", ByteBufferUtil.bytesToHex(ByteBuffer.wrap(StringHelper.randomId())));
         metadataMap.put(IndexComponentType.PQ, -1, pqOffset, pqLength, vectorConfigs);
         return metadataMap;
+    }
+
+    private EnumMap<FeatureId, IntFunction<Feature.State>> suppliers(ImmutableGraphIndex.View view, VectorCompressor<?> compressor, NVQuantization nvq, boolean writeFusedPQ)
+    {
+        var features = new EnumMap<FeatureId, IntFunction<Feature.State>>(FeatureId.class);
+
+        // We either write NVQ or inline (full precision) vectors in the graph. nvq is null when it is not enabled.
+        if (nvq != null)
+            features.put(FeatureId.NVQ_VECTORS, nodeId -> new NVQ.State(nvq.encode(vectorValues.getVector(nodeId))));
+        else
+            features.put(FeatureId.INLINE_VECTORS, nodeId -> new InlineVectors.State(vectorValues.getVector(nodeId)));
+
+        if (compressor instanceof ProductQuantization && writeFusedPQ)
+        {
+            // This block is an extension of an already present design that limits the PQ computation and encoding
+            // to one index at a time -- goal during flush is to evict from memory ASAP so better to do the PQ build
+            // (in parallel) one at a time. We have https://github.com/riptano/cndb/issues/12110 to encode the
+            // PQ iteratively, but since that isn't implemented, we keep the same, fairly brittle pattern.
+            final PQVectors pqVectors;
+            synchronized (CassandraOnHeapGraph.class)
+            {
+                // Note: the features implementation expects the pqVectors to be addressable on their old ordinal
+                // index, so we use the original vectorValues as the source without performing any remapping.
+                pqVectors = (PQVectors) compressor.encodeAll(vectorValues);
+            }
+            features.put(FeatureId.FUSED_PQ, nodeId -> new FusedPQ.State(view, pqVectors::get, nodeId));
+        }
+
+        return features;
     }
 
     /**
@@ -577,7 +625,7 @@ public class CassandraOnHeapGraph<T> implements Accountable
         }
     }
 
-    private long writePQ(SequentialWriter writer, V5VectorPostingsWriter.RemappedPostings remapped, IndexContext indexContext) throws IOException
+    private VectorCompressor<?> writePQ(SequentialWriter writer, V5VectorPostingsWriter.RemappedPostings remapped, IndexContext indexContext, boolean writeFusedPQ) throws IOException
     {
         var preferredCompression = sourceModel.compressionProvider.apply(vectorValues.dimension());
 
@@ -596,18 +644,24 @@ public class CassandraOnHeapGraph<T> implements Accountable
             }
             assert !vectorValues.isValueShared();
             // encode (compress) the vectors to save
-            if (compressor != null)
+            if (compressor != null && !writeFusedPQ)
                 cv = compressor.encodeAll(new RemappedVectorValues(remapped, remapped.maxNewOrdinal, vectorValues));
         }
 
         var actualType = compressor == null ? CompressionType.NONE : preferredCompression.type;
         writePqHeader(writer, allVectorsAreUnitLength, actualType, indexContext.version());
         if (actualType == CompressionType.NONE)
-            return writer.position();
+            return null;
+
+        if (writeFusedPQ)
+        {
+            compressor.write(writer, indexContext.version().onDiskFormat().jvectorFileFormatVersion());
+            return compressor;
+        }
 
         // save (outside the synchronized block, this is io-bound not CPU)
         cv.write(writer, indexContext.version().onDiskFormat().jvectorFileFormatVersion());
-        return writer.position();
+        return null; // Don't need compressor in this case
     }
 
     static void writePqHeader(DataOutput writer, boolean unitVectors, CompressionType type, Version version)

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/CompactionGraph.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/CompactionGraph.java
@@ -38,12 +38,14 @@ import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.github.jbellis.jvector.disk.BufferedRandomAccessWriter;
 import io.github.jbellis.jvector.graph.GraphIndexBuilder;
 import io.github.jbellis.jvector.graph.ListRandomAccessVectorValues;
 import io.github.jbellis.jvector.graph.RandomAccessVectorValues;
+import io.github.jbellis.jvector.graph.disk.OnDiskParallelGraphIndexWriter;
+import io.github.jbellis.jvector.graph.disk.RandomAccessOnDiskGraphIndexWriter;
 import io.github.jbellis.jvector.graph.disk.feature.Feature;
 import io.github.jbellis.jvector.graph.disk.feature.FeatureId;
+import io.github.jbellis.jvector.graph.disk.feature.FusedPQ;
 import io.github.jbellis.jvector.graph.disk.feature.InlineVectors;
 import io.github.jbellis.jvector.graph.disk.OnDiskGraphIndexWriter;
 import io.github.jbellis.jvector.graph.disk.OrdinalMapper;
@@ -56,7 +58,6 @@ import io.github.jbellis.jvector.quantization.PQVectors;
 import io.github.jbellis.jvector.quantization.ProductQuantization;
 import io.github.jbellis.jvector.quantization.VectorCompressor;
 import io.github.jbellis.jvector.util.Accountable;
-import io.github.jbellis.jvector.util.ExplicitThreadLocal;
 import io.github.jbellis.jvector.util.RamUsageEstimator;
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
 import io.github.jbellis.jvector.vector.VectorUtil;
@@ -72,6 +73,7 @@ import net.openhft.chronicle.map.ChronicleMap;
 import net.openhft.chronicle.map.ChronicleMapBuilder;
 import org.apache.cassandra.concurrent.ExecutorFactory;
 import org.agrona.collections.Int2ObjectHashMap;
+import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.db.marshal.VectorType;
 import org.apache.cassandra.exceptions.InvalidRequestException;
@@ -90,7 +92,6 @@ import org.apache.cassandra.index.sai.utils.LowPriorityThreadFactory;
 import org.apache.cassandra.index.sai.utils.SAICodecUtils;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileUtils;
-import org.apache.cassandra.io.util.RandomAccessReader;
 import org.apache.cassandra.service.StorageService;
 
 import static org.apache.cassandra.utils.Clock.Global.nanoTime;
@@ -117,6 +118,10 @@ public class CompactionGraph implements Closeable, Accountable
     @VisibleForTesting
     public static int PQ_TRAINING_SIZE = ProductQuantization.MAX_PQ_TRAINING_SET_SIZE;
 
+    private static boolean PARALLEL_ENCODING_WRITING = CassandraRelevantProperties.SAI_ENCODE_AND_WRITE_VECTOR_GRAPH_IN_PARALLEL_ENABLED.getBoolean();
+    private static int PARALLEL_ENCODING_WRITING_NUM_THREADS = CassandraRelevantProperties.SAI_ENCODE_AND_WRITE_VECTOR_GRAPH_IN_PARALLEL_NUM_THREADS.getInt();
+    private static boolean PARALLEL_ENCODING_WRITING_USE_DIRECT_BUFFERS = CassandraRelevantProperties.SAI_ENCODE_AND_WRITE_VECTOR_GRAPH_IN_PARALLEL_USE_DIRECT_BUFFERS.getBoolean();
+
     private final VectorType.VectorSerializer serializer;
     private final VectorSimilarityFunction similarityFunction;
     private final ChronicleMap<VectorFloat<?>, CompactionVectorPostings> postingsMap;
@@ -126,7 +131,7 @@ public class CompactionGraph implements Closeable, Accountable
     private final int postingsEntriesAllocated;
     private final File postingsFile;
     private final File vectorsByOrdinalTmpFile;
-    private final BufferedRandomAccessWriter vectorsByOrdinalBufferedWriter;
+    private final OnDiskVectorValuesWriter onDiskVectorValuesWriter;
     private final File termsFile;
     private final int dimension;
     private Structure postingsStructure;
@@ -196,7 +201,7 @@ public class CompactionGraph implements Closeable, Accountable
 
         // Formatted so that the full resolution vector is written at the ordinal * vector dimension offset
         vectorsByOrdinalTmpFile = perIndexComponents.tmpFileFor("vectors_by_ordinal");
-        vectorsByOrdinalBufferedWriter = new BufferedRandomAccessWriter(vectorsByOrdinalTmpFile.toPath());
+        onDiskVectorValuesWriter = new OnDiskVectorValuesWriter(vectorsByOrdinalTmpFile, dimension);
 
         BuildScoreProvider bsp;
         if (compressor instanceof ProductQuantization)
@@ -228,19 +233,29 @@ public class CompactionGraph implements Closeable, Accountable
         termsOffset = (termsFile.exists() ? termsFile.length() : 0)
                       + SAICodecUtils.headerSize();
 
-        globalMean = NVQUtil.shouldWriteNVQ(dimension, context.version()) ? vts.createFloatVector(new float[dimension])
-                                                                          : null;
+        globalMean = JVectorVersionUtil.shouldWriteNVQ(dimension, context.version()) ? vts.createFloatVector(new float[dimension])
+                                                                                     : null;
     }
 
-    private OnDiskGraphIndexWriter createTermsWriter(OrdinalMapper ordinalMapper, NVQuantization nvq) throws IOException
+    private RandomAccessOnDiskGraphIndexWriter createTermsWriter(OrdinalMapper ordinalMapper, NVQuantization nvq) throws IOException
     {
-        var feature = nvq != null ? new NVQ(nvq) : new InlineVectors(dimension);
-        return new OnDiskGraphIndexWriter.Builder(builder.getGraph(), termsFile.toPath())
-               .withStartOffset(termsOffset)
-               .with(feature)
-               .withVersion(context.version().onDiskFormat().jvectorFileFormatVersion())
-               .withMapper(ordinalMapper)
-               .build();
+        // We call termsFile.toJavaIOFile().toPath() to get a local file.
+        var path = termsFile.toJavaIOFile().toPath();
+        var graph = builder.getGraph();
+
+        var writerBuilder = PARALLEL_ENCODING_WRITING
+                            ? new OnDiskParallelGraphIndexWriter.Builder(graph, path)
+                              .withStartOffset(termsOffset)
+                              .withParallelWorkerThreads(PARALLEL_ENCODING_WRITING_NUM_THREADS)
+                              .withParallelDirectBuffers(PARALLEL_ENCODING_WRITING_USE_DIRECT_BUFFERS)
+                            : new OnDiskGraphIndexWriter.Builder(graph, path).withStartOffset(termsOffset);
+
+        writerBuilder.with(nvq != null ? new NVQ(nvq) : new InlineVectors(dimension))
+                     .withVersion(context.version().onDiskFormat().jvectorFileFormatVersion())
+                     .withMapper(ordinalMapper);
+        if (compressor instanceof ProductQuantization && JVectorVersionUtil.shouldWriteFused(context.version()))
+            writerBuilder.with(new FusedPQ(context.getIndexWriterConfig().getAnnMaxDegree(), (ProductQuantization) compressor));
+        return writerBuilder.build();
     }
 
     @Override
@@ -248,7 +263,7 @@ public class CompactionGraph implements Closeable, Accountable
     {
         // this gets called in `finally` blocks, so use closeQuietly to avoid generating additional exceptions
         FileUtils.closeQuietly(postingsMap);
-        FileUtils.closeQuietly(vectorsByOrdinalBufferedWriter);
+        FileUtils.closeQuietly(onDiskVectorValuesWriter);
         Files.delete(postingsFile.toJavaIOFile().toPath());
         Files.delete(vectorsByOrdinalTmpFile.toJavaIOFile().toPath());
     }
@@ -370,14 +385,9 @@ public class CompactionGraph implements Closeable, Accountable
                 if (globalMean != null)
                     VectorUtil.addInPlace(globalMean, vector);
 
-                // Skip to the correct position (ensuring that we only skip forward). Note that if the ordinal
-                // is the segmentRowId and there are duplicates, we will skip some positions. This works in conjunction
-                // with the posting list logic.
-                long targetPosition = ordinal * Float.BYTES * (long) dimension;
-                assert vectorsByOrdinalBufferedWriter.position() <= targetPosition : "vectorsByOrdinalBufferedWriter.position()=" + vectorsByOrdinalBufferedWriter.position() + " > targetPosition=" + targetPosition;
-                vectorsByOrdinalBufferedWriter.seek(targetPosition);
-                for (int i = 0; i < dimension; i++)
-                    vectorsByOrdinalBufferedWriter.writeFloat(vector.get(i));
+                // Store the vector on disk in a mapping from ordinal -> vector for fast retrieval later. This mapping
+                // is only needed during index build. It is a temp file.
+                onDiskVectorValuesWriter.write(ordinal, vector);
 
                 // Track the bytes used as a result of this operation
                 long compressedVectorsBytesUsed = compressedVectors.ramBytesUsed();
@@ -424,7 +434,7 @@ public class CompactionGraph implements Closeable, Accountable
     public SegmentMetadata.ComponentMetadataMap flush() throws IOException
     {
         // Close the temporary file so the reader will know it is the end of the file.
-        vectorsByOrdinalBufferedWriter.close();
+        onDiskVectorValuesWriter.close();
 
         int nInProgress = builder.insertsInProgress();
         assert nInProgress == 0 : String.format("Attempting to write graph while %d inserts are in progress", nInProgress);
@@ -500,23 +510,34 @@ public class CompactionGraph implements Closeable, Accountable
             {
                 writer.getOutput().seek(termsFile.length()); // position at the end of the previous segment before writing our own header
                 SAICodecUtils.writeHeader(SAICodecUtils.toLuceneOutput(writer.getOutput()), perIndexComponents.version());
-                // Use thread local readers as we do not control which thread jvector uses
-                try (var threadLocalReaders = ExplicitThreadLocal.withInitial(() -> new OnDiskVectorValues(vectorsByOrdinalTmpFile, dimension)))
+                // OnDiskVectorValues is thread safe, making it safe to close over it.
+                try (var vectorValues = new OnDiskVectorValues(vectorsByOrdinalTmpFile, dimension))
                 {
                     EnumMap<FeatureId, IntFunction<Feature.State>> supplier;
                     if (nvq != null)
                     {
                         supplier = Feature.singleStateFactory(FeatureId.NVQ_VECTORS, ordinal -> {
-                            return new NVQ.State(nvq.encode(threadLocalReaders.get().getVector(ordinal)));
+                            return new NVQ.State(nvq.encode(vectorValues.getVector(ordinal)));
                         });
                     }
                     else
                     {
                         supplier = Feature.singleStateFactory(FeatureId.INLINE_VECTORS, ordinal -> {
-                            return new InlineVectors.State(threadLocalReaders.get().getVector(ordinal));
+                            return new InlineVectors.State(vectorValues.getVector(ordinal));
                         });
                     }
-                    writer.write(supplier);
+                    if (writer.getFeatureSet().contains(FeatureId.FUSED_PQ))
+                    {
+                        try (var view = builder.getGraph().getView())
+                        {
+                            supplier.put(FeatureId.FUSED_PQ, ordinal -> new FusedPQ.State(view, (PQVectors) compressedVectors, ordinal));
+                            writer.write(supplier);
+                        }
+                    }
+                    else
+                    {
+                        writer.write(supplier);
+                    }
                 }
                 catch (Exception e)
                 {
@@ -548,7 +569,7 @@ public class CompactionGraph implements Closeable, Accountable
             return null;
         // Scale in place then create the NVQ
         VectorUtil.scale(globalMean, 1.0f / compressedVectors.count());
-        return NVQuantization.create(globalMean, NVQUtil.NUM_SUB_VECTORS);
+        return NVQuantization.create(globalMean, JVectorVersionUtil.NUM_SUB_VECTORS);
     }
 
     private long writePostings(Version version, V5VectorPostingsWriter.RemappedPostings rp, IndexOutputWriter postingsOutput,
@@ -636,63 +657,4 @@ public class CompactionGraph implements Closeable, Accountable
         }
     }
 
-    private static class OnDiskVectorValues implements RandomAccessVectorValues, AutoCloseable
-    {
-        private final RandomAccessReader reader;
-        private final int dimension;
-        private final long vectorSize;
-
-        public OnDiskVectorValues(File vectorsByOrdinalTmpFile, int dimension)
-        {
-            this.reader = RandomAccessReader.open(vectorsByOrdinalTmpFile);
-            this.dimension = dimension;
-            this.vectorSize = (long) dimension * Float.BYTES;
-        }
-
-        @Override
-        public int size()
-        {
-            return (int) (reader.length() / vectorSize);
-        }
-
-        @Override
-        public int dimension()
-        {
-            return dimension;
-        }
-
-        @Override
-        public VectorFloat<?> getVector(int i)
-        {
-            try
-            {
-                reader.seek(i * vectorSize);
-                var vector = new float[dimension];
-                reader.readFully(vector);
-                return vts.createFloatVector(vector);
-            }
-            catch (IOException e)
-            {
-                throw new RuntimeException(e);
-            }
-        }
-
-        @Override
-        public boolean isValueShared()
-        {
-            return false;
-        }
-
-        @Override
-        public RandomAccessVectorValues copy()
-        {
-            return new OnDiskVectorValues(reader.getFile(), dimension);
-        }
-
-        @Override
-        public void close()
-        {
-            FileUtils.closeQuietly(reader);
-        }
-    }
 }

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/JVectorVersionUtil.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/JVectorVersionUtil.java
@@ -19,8 +19,10 @@ package org.apache.cassandra.index.sai.disk.vector;
 import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.index.sai.disk.format.Version;
 
-public class NVQUtil
+public class JVectorVersionUtil
 {
+    /** Whether to fuse quantized vectors into the graph when writing indexes, assuming all other conditions are met */
+    public static final boolean ENABLE_FUSED = CassandraRelevantProperties.SAI_VECTOR_ENABLE_FUSED.getBoolean();
     public static final boolean ENABLE_NVQ = CassandraRelevantProperties.SAI_VECTOR_ENABLE_NVQ.getBoolean();
     public static final int NUM_SUB_VECTORS = CassandraRelevantProperties.SAI_VECTOR_NVQ_NUM_SUB_VECTORS.getInt();
 
@@ -40,5 +42,22 @@ public class NVQUtil
     public static boolean versionSupportsNVQ(Version version)
     {
         return version.onDiskFormat().jvectorFileFormatVersion() >= 4;
+    }
+
+    /**
+     * Decide whether to attempt to write the quantized vectors as fused parts of the graph. Note that this method
+     * does not take into account whether the graph has enough information to build a quantization, as that depends on
+     * external factors.
+     * @param version the SAI on disk format to use when writing to disk
+     * @return true if conditions are met, false otherwise
+     */
+    public static boolean shouldWriteFused(Version version)
+    {
+        return ENABLE_FUSED && versionSupportsFused(version);
+    }
+
+    public static boolean versionSupportsFused(Version version)
+    {
+        return version.onDiskFormat().jvectorFileFormatVersion() >= 6;
     }
 }

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/OnDiskVectorValues.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/OnDiskVectorValues.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.disk.vector;
+
+import java.io.IOException;
+
+import io.github.jbellis.jvector.graph.RandomAccessVectorValues;
+import io.github.jbellis.jvector.util.ExplicitThreadLocal;
+import io.github.jbellis.jvector.vector.VectorizationProvider;
+import io.github.jbellis.jvector.vector.types.VectorFloat;
+import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
+import org.apache.cassandra.io.util.File;
+import org.apache.cassandra.io.util.FileUtils;
+import org.apache.cassandra.io.util.RandomAccessReader;
+
+/**
+ * Reads vectors from a file indexed by ordinal position.
+ * <p>
+ * This class provides random access to vectors stored on disk by ordinal.
+ * Vectors are expected to be stored at positions calculated as: ordinal * dimension * Float.BYTES.
+ * <p>
+ * The reader supports:
+ * - Random access by ordinal via getVector(int)
+ * - Determining the total number of vectors in the file
+ * - Creating independent copies for concurrent access
+ * <p>
+ * This class is thread-safe.
+ * It should only be used within the vector index package.
+ */
+public class OnDiskVectorValues implements RandomAccessVectorValues, AutoCloseable
+{
+    private static final VectorTypeSupport vts = VectorizationProvider.getInstance().getVectorTypeSupport();
+
+    // Because of the way RandomAccessVectorValues are used within jvector, this is the safest solution
+    // at the moment. See https://github.com/datastax/jvector/issues/635.
+    private final ExplicitThreadLocal<RandomAccessReader> threadLocalRandomAccessReader;
+    private final int dimension;
+    private final long vectorSize;
+
+    /**
+     * Creates a new reader for vectors of the specified dimension.
+     *
+     * @param file the file containing vectors written by VectorByOrdinalWriter
+     * @param dimension the dimension of vectors in the file
+     */
+    public OnDiskVectorValues(File file, int dimension)
+    {
+        this.threadLocalRandomAccessReader = ExplicitThreadLocal.withInitial(() -> RandomAccessReader.open(file));
+        this.dimension = dimension;
+        this.vectorSize = (long) dimension * Float.BYTES;
+    }
+
+    /**
+     * Returns the total number of vectors in the file.
+     * This is calculated based on the file size and vector dimension.
+     */
+    @Override
+    public int size()
+    {
+        return (int) (threadLocalRandomAccessReader.get().length() / vectorSize);
+    }
+
+    /**
+     * Returns the dimension of vectors in this file.
+     */
+    @Override
+    public int dimension()
+    {
+        return dimension;
+    }
+
+    /**
+     * Reads and returns the vector at the specified ordinal position.
+     *
+     * @param ordinal the ordinal position to read from
+     * @return the vector at the specified position
+     * @throws RuntimeException if an I/O error occurs
+     */
+    @Override
+    public VectorFloat<?> getVector(int ordinal)
+    {
+        try
+        {
+            var reader = threadLocalRandomAccessReader.get();
+            reader.seek(ordinal * vectorSize);
+            return vts.readFloatVector(reader, dimension);
+        }
+        catch (IOException e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Returns false, indicating that vectors are not shared between calls to getVector.
+     */
+    @Override
+    public boolean isValueShared()
+    {
+        return false;
+    }
+
+    /**
+     * Returns an instance of self since the implementation is completely thread safe.
+     *
+     * @return self
+     */
+    @Override
+    public RandomAccessVectorValues copy()
+    {
+        // The only shared state are thread local readers only used within this class, so it is safe to share them
+        return this;
+    }
+
+    /**
+     * Returns the underlying file being read.
+     */
+    File getFile()
+    {
+        return threadLocalRandomAccessReader.get().getFile();
+    }
+
+    /**
+     * Returns the size in bytes of each vector in the file.
+     */
+    long getVectorSize()
+    {
+        return vectorSize;
+    }
+
+    @Override
+    public void close()
+    {
+        // Safely closes all readers, which is important because jvector doesn't handle closing them correctly
+        // at the moment.
+        FileUtils.closeQuietly(threadLocalRandomAccessReader);
+    }
+}

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/OnDiskVectorValuesWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/OnDiskVectorValuesWriter.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.disk.vector;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+import io.github.jbellis.jvector.disk.BufferedRandomAccessWriter;
+import io.github.jbellis.jvector.vector.types.VectorFloat;
+import org.apache.cassandra.io.util.File;
+
+/**
+ * Writes vectors to a file indexed by ordinal position.
+ * <p>
+ * This class provides efficient sequential and sparse writing of vectors to disk.
+ * Vectors are stored at positions calculated as: ordinal * dimension * Float.BYTES.
+ * This allows for direct random access reading by ordinal.
+ * <p>
+ * The writer supports:
+ * - Sequential writes (ordinal increases by 1 each time)
+ * - Sparse writes (ordinals can have gaps, which are left as zeros)
+ * - Efficient buffering via BufferedRandomAccessWriter
+ * This class is not thread-safe and should only be used within the vector index package.
+ */
+public class OnDiskVectorValuesWriter implements Closeable
+{
+    private final int dimension;
+    private final BufferedRandomAccessWriter bufferedWriter;
+    private int lastOrdinal;
+
+    /**
+     * Creates a new writer for vectors of the specified dimension.
+     *
+     * @param file the file to write vectors to
+     * @param dimension the dimension of vectors to be written
+     * @throws IOException if an I/O error occurs
+     */
+    public OnDiskVectorValuesWriter(File file, int dimension) throws IOException
+    {
+        this.bufferedWriter = new BufferedRandomAccessWriter(file.toPath());
+        this.dimension = dimension;
+        this.lastOrdinal = -1;
+    }
+
+    /**
+     * Writes a vector at the specified ordinal position.
+     * <p>
+     * Ordinals must be written in increasing order. If there are gaps between ordinals,
+     * the file will contain zeros at those positions.
+     *
+     * @param ordinal the ordinal position for this vector (must be greater than the last written ordinal)
+     * @param vector the vector to write (must have the same dimension as specified in constructor)
+     * @throws IOException if an I/O error occurs
+     * @throws AssertionError if ordinal is not greater than the last written ordinal, or if seeking backwards
+     */
+    public void write(int ordinal, VectorFloat<?> vector) throws IOException
+    {
+        assert ordinal > lastOrdinal : "Unexpected ordinal " + ordinal + " must be greater than " + lastOrdinal;
+        assert vector != null : "Vector is null";
+        assert vector.length() == dimension : "Incorrect vector dimension " + vector.length() + " != " + dimension;
+
+        // We are careful to only skip or call position() when necessary because the BufferedRandomAccessWriter always
+        // flushes the buffer for each of those operations. See https://github.com/datastax/jvector/issues/562.
+        if (ordinal != lastOrdinal + 1)
+        {
+            // Skip to the correct position (ensuring that we only skip forward). Note that if the ordinal
+            // is the segmentRowId and there are duplicates, we will skip some positions. This works in conjunction
+            // with the posting list logic.
+            long targetPosition = ordinal * Float.BYTES * (long) dimension;
+            assert bufferedWriter.position() <= targetPosition : "bufferedWriter.position()=" + bufferedWriter.position() + " > targetPosition=" + targetPosition;
+            bufferedWriter.seek(targetPosition);
+        }
+
+        // Update the last ordinal
+        lastOrdinal = ordinal;
+
+        // Write the vector data
+        vector.writeTo(bufferedWriter);
+    }
+
+    /**
+     * Returns the dimension of vectors being written.
+     */
+    int getDimension()
+    {
+        return dimension;
+    }
+
+    /**
+     * Returns the last ordinal that was written, or -1 if no vectors have been written yet.
+     */
+    public int getLastOrdinal()
+    {
+        return lastOrdinal;
+    }
+
+    /**
+     * Returns the current position in the file.
+     */
+    long position() throws IOException
+    {
+        return bufferedWriter.position();
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+        bufferedWriter.close();
+    }
+}

--- a/src/java/org/apache/cassandra/io/util/SequentialWriter.java
+++ b/src/java/org/apache/cassandra/io/util/SequentialWriter.java
@@ -23,6 +23,7 @@ import java.nio.channels.FileChannel;
 import java.nio.file.StandardOpenOption;
 import java.util.function.LongConsumer;
 
+import io.github.jbellis.jvector.disk.IndexWriter;
 import org.apache.cassandra.io.FSReadError;
 import org.apache.cassandra.io.FSWriteError;
 import org.apache.cassandra.utils.SyncUtil;
@@ -34,7 +35,7 @@ import static org.apache.cassandra.utils.Throwables.merge;
  * Adds buffering, mark, and fsyncing to OutputStream.  We always fsync on close; we may also
  * fsync incrementally if Config.trickle_fsync is enabled.
  */
-public class SequentialWriter extends BufferedDataOutputStreamPlus implements Transactional
+public class SequentialWriter extends BufferedDataOutputStreamPlus implements Transactional, IndexWriter
 {
     // absolute path to the given file
     protected final File file;

--- a/test/microbench/org/apache/cassandra/test/microbench/index/sai/disk/vector/OnDiskVectorValuesBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/index/sai/disk/vector/OnDiskVectorValuesBench.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.test.microbench.index.sai.disk.vector;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+import io.github.jbellis.jvector.vector.VectorizationProvider;
+import io.github.jbellis.jvector.vector.types.VectorFloat;
+import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.db.commitlog.CommitLog;
+import org.apache.cassandra.index.sai.SAITester;
+import org.apache.cassandra.index.sai.disk.vector.OnDiskVectorValues;
+import org.apache.cassandra.index.sai.disk.vector.OnDiskVectorValuesWriter;
+import org.apache.cassandra.io.util.File;
+import org.apache.cassandra.io.util.FileUtils;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * Benchmark to verify read and write performance of OnDiskVectorValues and OnDiskVectorValuesWriter.
+ * Tests writing 128k vectors and measuring the time to iterate through them.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 3, time = 3, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 5, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 1)
+@Threads(1)
+@State(Scope.Benchmark)
+public class OnDiskVectorValuesBench extends SAITester
+{
+    private static final VectorTypeSupport vts = VectorizationProvider.getInstance().getVectorTypeSupport();
+    private static final int NUM_VECTORS = 128_000; // 128k vectors is the number of vectors used to create a PQ
+
+    // Cover small and large vectors
+    @Param({ "384", "1536" })
+    public int dimension;
+
+    private File vectorFile;
+    private OnDiskVectorValues reader;
+    private VectorFloat<?>[] testVectors;
+
+    @Setup(Level.Trial)
+    public void setup() throws IOException
+    {
+        CQLTester.setUpClass();
+
+        // Create temporary file for vectors
+        vectorFile = FileUtils.createTempFile("vectors", ".bin");
+
+        // Generate random test vectors
+        testVectors = new VectorFloat<?>[NUM_VECTORS];
+        for (int i = 0; i < NUM_VECTORS; i++)
+        {
+            float[] vector = new float[dimension];
+            for (int j = 0; j < dimension; j++)
+            {
+                vector[j] = ThreadLocalRandom.current().nextFloat();
+            }
+            testVectors[i] = vts.createFloatVector(vector);
+        }
+
+        // Write vectors to disk
+        writeVectors();
+
+        // Create reader for read benchmarks
+        reader = new OnDiskVectorValues(vectorFile, dimension);
+    }
+
+    @TearDown(Level.Trial)
+    public void teardown() throws IOException, ExecutionException, InterruptedException
+    {
+        CommitLog.instance.shutdownBlocking();
+        CQLTester.cleanup();
+    }
+
+    private void writeVectors() throws IOException
+    {
+        try (OnDiskVectorValuesWriter writer = new OnDiskVectorValuesWriter(vectorFile, dimension))
+        {
+            for (int ordinal = 0; ordinal < NUM_VECTORS; ordinal++)
+            {
+                writer.write(ordinal, testVectors[ordinal]);
+            }
+        }
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDown()
+    {
+        if (reader != null)
+        {
+            reader.close();
+        }
+        if (vectorFile != null && vectorFile.exists())
+        {
+            vectorFile.delete();
+        }
+    }
+
+    /**
+     * Benchmark writing 128k vectors to disk.
+     */
+    @Benchmark
+    public void writeVectorsToDisk(Blackhole bh) throws IOException
+    {
+        File tempFile = FileUtils.createTempFile("vectors-write", ".bin");
+        try (OnDiskVectorValuesWriter writer = new OnDiskVectorValuesWriter(tempFile, dimension))
+        {
+            for (int ordinal = 0; ordinal < NUM_VECTORS; ordinal++)
+            {
+                writer.write(ordinal, testVectors[ordinal]);
+            }
+            bh.consume(writer.getLastOrdinal());
+        }
+        finally
+        {
+            tempFile.delete();
+        }
+    }
+
+    /**
+     * Benchmark sequential reading of all vectors using getVector().
+     */
+    @Benchmark
+    public void readAllVectorsSequential(Blackhole bh)
+    {
+        for (int ordinal = 0; ordinal < NUM_VECTORS; ordinal++)
+        {
+            VectorFloat<?> vector = reader.getVector(ordinal);
+            bh.consume(vector);
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/SAIUtil.java
+++ b/test/unit/org/apache/cassandra/index/sai/SAIUtil.java
@@ -29,7 +29,7 @@ import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.index.Index;
 import org.apache.cassandra.index.SecondaryIndexManager;
 import org.apache.cassandra.index.sai.disk.format.Version;
-import org.apache.cassandra.index.sai.disk.vector.NVQUtil;
+import org.apache.cassandra.index.sai.disk.vector.JVectorVersionUtil;
 import org.apache.cassandra.schema.Schema;
 import org.apache.cassandra.utils.ReflectionUtils;
 
@@ -105,7 +105,7 @@ public class SAIUtil
         try
         {
             CassandraRelevantProperties.SAI_VECTOR_ENABLE_NVQ.setBoolean(enableNVQ);
-            Field field = NVQUtil.class.getDeclaredField("ENABLE_NVQ");
+            Field field = JVectorVersionUtil.class.getDeclaredField("ENABLE_NVQ");
             field.setAccessible(true);
             Field modifiersField = ReflectionUtils.getField(Field.class, "modifiers");
             modifiersField.setAccessible(true);
@@ -116,7 +116,24 @@ public class SAIUtil
         {
             throw new RuntimeException(e);
         }
+    }
 
+    public static void setEnableFused(boolean enableFused)
+    {
+        try
+        {
+            CassandraRelevantProperties.SAI_VECTOR_ENABLE_FUSED.setBoolean(enableFused);
+            Field field = JVectorVersionUtil.class.getDeclaredField("ENABLE_FUSED");
+            field.setAccessible(true);
+            Field modifiersField = ReflectionUtils.getField(Field.class, "modifiers");
+            modifiersField.setAccessible(true);
+            modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+            field.set(null, enableFused);
+        }
+        catch (Exception e)
+        {
+            throw new RuntimeException(e);
+        }
     }
 
     public static class CustomVersionSelector implements Version.Selector

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorCompactionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorCompactionTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.cassandra.index.sai.cql;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -31,22 +32,35 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import io.github.jbellis.jvector.vector.VectorSimilarityFunction;
+import io.github.jbellis.jvector.vector.VectorizationProvider;
+import io.github.jbellis.jvector.vector.types.VectorFloat;
+import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
 import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.db.RegularAndStaticColumns;
+import org.apache.cassandra.db.Slices;
+import org.apache.cassandra.db.filter.ColumnFilter;
 import org.apache.cassandra.db.marshal.FloatType;
+import org.apache.cassandra.db.marshal.VectorType;
+import org.apache.cassandra.db.rows.Row;
 import org.apache.cassandra.index.sai.SAIUtil;
 import org.apache.cassandra.index.sai.StorageAttachedIndex;
 import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.index.sai.disk.v2.V2VectorIndexSearcher;
+import org.apache.cassandra.index.sai.disk.v5.V5OnDiskFormat;
 import org.apache.cassandra.index.sai.disk.v5.V5VectorPostingsWriter;
+import org.apache.cassandra.io.sstable.SSTableReadsListener;
 
 import static org.apache.cassandra.index.sai.disk.vector.CassandraOnHeapGraph.MIN_PQ_ROWS;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 @Ignore
 @RunWith(Parameterized.class)
 abstract public class VectorCompactionTest extends VectorTester
 {
+    private static final VectorTypeSupport vts = VectorizationProvider.getInstance().getVectorTypeSupport();
+
     // Subclasses must implement this to cover different dimensions
     abstract public int dimension();
 
@@ -172,7 +186,7 @@ abstract public class VectorCompactionTest extends VectorTester
     // Exercise the one-to-many path in compaction
     public void testOneToManyCompactionInternal(int vectorsPerSstable, int sstables)
     {
-        createTable();
+        var index = createTableAndReturnIndexName();
 
         disableCompaction();
 
@@ -182,6 +196,12 @@ abstract public class VectorCompactionTest extends VectorTester
         validateQueries();
         compact();
         validateQueries();
+
+        // ONE_TO_MANY is version dependent, so we need to branch based on which version we're writing
+        var expectedStructure = V5OnDiskFormat.writeV5VectorPostings(version)
+                                ? V5VectorPostingsWriter.Structure.ONE_TO_MANY
+                                : V5VectorPostingsWriter.Structure.ZERO_OR_ONE_TO_MANY;
+        validatePostingsStructureAndOrdinalToVectorMapping(index, expectedStructure, vectorsPerSstable * sstables);
     }
 
     @Test
@@ -216,7 +236,7 @@ abstract public class VectorCompactionTest extends VectorTester
         compact();
         validateQueries();
 
-        validatePostingsStructure(indexName, V5VectorPostingsWriter.Structure.ONE_TO_ONE);
+        validatePostingsStructureAndOrdinalToVectorMapping(indexName, V5VectorPostingsWriter.Structure.ONE_TO_ONE, vectorsPerSstable * sstables);
     }
 
     @Test
@@ -231,7 +251,7 @@ abstract public class VectorCompactionTest extends VectorTester
 
     public void testZeroOrOneToManyCompactionInternal(int vectorsPerSstable, int sstables)
     {
-        createTable();
+        var indexName = createTableAndReturnIndexName();
         disableCompaction();
 
         insertZeroOrOneToManyRows(vectorsPerSstable, sstables);
@@ -239,6 +259,8 @@ abstract public class VectorCompactionTest extends VectorTester
         validateQueries();
         compact();
         validateQueries();
+
+        validatePostingsStructureAndOrdinalToVectorMapping(indexName, V5VectorPostingsWriter.Structure.ZERO_OR_ONE_TO_MANY, vectorsPerSstable * sstables);
     }
 
     private void insertZeroOrOneToManyRows(int vectorsPerSstable, int sstables)
@@ -247,7 +269,7 @@ abstract public class VectorCompactionTest extends VectorTester
         double duplicateChance = R.nextDouble() * 0.2;
         int j = 0;
         boolean nullInserted = false;
-        
+
         for (int i = 0; i < sstables; i++)
         {
             var vectorsInserted = new ArrayList<Vector<Float>>();
@@ -302,7 +324,7 @@ abstract public class VectorCompactionTest extends VectorTester
             compact();
             validateQueries();
 
-            validatePostingsStructure(indexName, V5VectorPostingsWriter.Structure.ZERO_OR_ONE_TO_MANY);
+            validatePostingsStructureAndOrdinalToVectorMapping(indexName, V5VectorPostingsWriter.Structure.ZERO_OR_ONE_TO_MANY, vectorsPerSstable * sstables);
         }
         finally
         {
@@ -310,17 +332,118 @@ abstract public class VectorCompactionTest extends VectorTester
         }
     }
 
-    private void validatePostingsStructure(String indexName, V5VectorPostingsWriter.Structure expectedStructure)
+    private void validatePostingsStructureAndOrdinalToVectorMapping(String indexName, V5VectorPostingsWriter.Structure expectedStructure, int numRows)
     {
         // Validate that we have the expected structure for all the sstables-segment indexes.
         var sai = (StorageAttachedIndex) Keyspace.open(KEYSPACE).getColumnFamilyStore(currentTable()).getIndexManager().getIndexByName(indexName);
         var indexes = sai.getIndexContext().getView().getIndexes();
+        var columnMetadata = sai.getIndexContext().getDefinition();
+        var columnFilter = ColumnFilter.selection(RegularAndStaticColumns.of(columnMetadata));
         for (var index : indexes)
         {
-            for (var segment : index.getSegments())
+            boolean isMissingRows = index.getRowCount() < index.getSSTable().getTotalRows();
+
+            // We don't have enough rows to get segments, the assertions are simplified if we know the sstable has
+            // just one segment.
+            assertEquals(1, index.getSegments().size());
+            var segment = index.getSegments().get(0);
+
+            var searcher = (V2VectorIndexSearcher) segment.getIndexSearcher();
+
+            // We track nulls so that we can verify the postring structure matches.
+            boolean nullValueObserved = false;
+
+            // Validate that the vectors in the sstable row correctly match the vectors in the graph by grabbing
+            // the vector, creating a score function for the vector, converting its row id into an ordinal, and
+            // then assert that the sstable's vector is similar to the graph's vector within an epsilon.
+            assertNotNull(segment.sstableContext);
+            assertNotNull(segment.sstableContext.primaryKeyMapFactory());
+            try (var view = searcher.graph.getView();
+                 var ordinalsView = searcher.graph.getOrdinalsView();
+                 var pkm = segment.sstableContext.primaryKeyMapFactory().newPerSSTablePrimaryKeyMap())
             {
-                var searcher = (V2VectorIndexSearcher) segment.getIndexSearcher();
-                assertEquals(expectedStructure, searcher.getPostingsStructure());
+                assertNotNull(segment.metadata);
+                var vectorsSet = new HashSet<VectorFloat<?>>();
+                boolean hasUniqueVectors = true;
+                for (long i = segment.metadata.minSSTableRowId; i <= segment.metadata.maxSSTableRowId; i++)
+                {
+                    var primaryKey = pkm.primaryKeyFromRowId(i);
+                    assertTrue("The subsequent logic assumes that we have no clustering columns", primaryKey.hasEmptyClustering());
+                    try (var sstableIter = segment.sstableContext
+                                           .sstable()
+                                           .rowIterator(primaryKey.partitionKey(), Slices.ALL, columnFilter, false, SSTableReadsListener.NOOP_LISTENER))
+                    {
+                        int rowId = Math.toIntExact(i - segment.metadata.segmentRowIdOffset);
+                        assertTrue(sstableIter.hasNext());
+                        var next = (Row) sstableIter.next();
+                        var vectorData = next.getCell(columnMetadata);
+                        float[] vector = vectorData == null || vectorData.isTombstone() || vectorData.valueSize() == 0
+                                         ? null
+                                         : ((VectorType<?>) columnMetadata.type).composeAsFloat(vectorData.buffer());
+                        if (vector == null)
+                        {
+                            nullValueObserved = true;
+                            assertEquals(V5VectorPostingsWriter.Structure.ZERO_OR_ONE_TO_MANY, searcher.getPostingsStructure());
+                            int ordinal = ordinalsView.getOrdinalForRowId(rowId);
+                            assertTrue("Got " + ordinal, ordinal < 0);
+                        }
+                        else
+                        {
+                            VectorFloat<?> vectorFloat = vts.createFloatVector(vector);
+                            hasUniqueVectors &= vectorsSet.add(vectorFloat);
+                            int ordinal = ordinalsView.getOrdinalForRowId(rowId);
+                            // Compare using cosine to ignore magnitude
+                            float sim = view.rerankerFor(vectorFloat, VectorSimilarityFunction.COSINE).similarityTo(ordinal);
+                            assertEquals(1.0f, sim, 0.001f);
+
+                            if (searcher.graph.getCompressedVectors() != null)
+                            {
+                                // Compare using cosine to ignore magnitude
+                                float quantizedSim = searcher.graph.getCompressedVectors()
+                                                                   .scoreFunctionFor(vectorFloat, VectorSimilarityFunction.COSINE)
+                                                                   .similarityTo(ordinal);
+                                // Note that this tolerance failed at 0.001f, but passes at 0.01f. Assuming this is
+                                // reasonable for now.
+                                assertEquals(1.0f, quantizedSim, 0.01f);
+                            }
+                            else
+                            {
+                                // We should only hit this case when we don't have enough rows to build a PQ.
+                                assertTrue("Found " + numRows + " but no PQ", MIN_PQ_ROWS > numRows);
+                            }
+                        }
+                    }
+                }
+
+                assertEquals(vectorsSet.size(), searcher.graph.size());
+
+                // When we have a row with a null vector, it is valid for the missing row vector(s) to be at the
+                // start or end of the sstable, and in that case, we actually skip them within the segment.
+                var postingsStructure = searcher.getPostingsStructure();
+                if (!nullValueObserved
+                    && isMissingRows
+                    && expectedStructure != V5VectorPostingsWriter.Structure.ZERO_OR_ONE_TO_MANY)
+                {
+                    var struct = hasUniqueVectors
+                                 ? V5VectorPostingsWriter.Structure.ONE_TO_ONE
+                                 : V5VectorPostingsWriter.tooManyOrdinalMappingHoles(searcher.graph.size(), numRows)
+                                   ? V5VectorPostingsWriter.Structure.ZERO_OR_ONE_TO_MANY
+                                   : V5VectorPostingsWriter.Structure.ONE_TO_MANY;
+                    assertEquals(struct, postingsStructure);
+                }
+                else if (!nullValueObserved && expectedStructure == V5VectorPostingsWriter.Structure.ZERO_OR_ONE_TO_MANY)
+                {
+                    assertTrue(postingsStructure == V5VectorPostingsWriter.Structure.ZERO_OR_ONE_TO_MANY
+                               || postingsStructure == V5VectorPostingsWriter.Structure.ONE_TO_MANY);
+                }
+                else
+                {
+                    assertEquals(expectedStructure, postingsStructure);
+                }
+            }
+            catch (IOException e)
+            {
+                throw new RuntimeException(e);
             }
         }
     }

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorSiftSmallTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorSiftSmallTest.java
@@ -39,7 +39,7 @@ import org.apache.cassandra.index.sai.StorageAttachedIndex;
 import org.apache.cassandra.index.sai.disk.v1.SegmentBuilder;
 import org.apache.cassandra.index.sai.disk.v2.V2VectorIndexSearcher;
 import org.apache.cassandra.index.sai.disk.vector.CompactionGraph;
-import org.apache.cassandra.index.sai.disk.vector.NVQUtil;
+import org.apache.cassandra.index.sai.disk.vector.JVectorVersionUtil;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -159,7 +159,7 @@ public class VectorSiftSmallTest extends VectorTester.Versioned
         }
 
         // When NVQ is enabled, we expect worse recall
-        float postCompactionRecall = NVQUtil.ENABLE_NVQ ? 0.9499f : 0.975f;
+        float postCompactionRecall = JVectorVersionUtil.ENABLE_NVQ ? 0.9499f : 0.975f;
 
         // Take the CassandraOnHeapGraph code path.
         compact();
@@ -341,7 +341,7 @@ public class VectorSiftSmallTest extends VectorTester.Versioned
     private void createIndex()
     {
         // we need a long timeout because we are adding many vectors
-        String index = createIndexAsync("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
+        String index = createIndexAsync("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean', 'enable_hierarchy': 'true'}");
         waitForIndexQueryable(KEYSPACE, index, 5, TimeUnit.MINUTES);
     }
 

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorTester.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorTester.java
@@ -46,7 +46,7 @@ import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.index.sai.disk.v2.V2VectorIndexSearcher;
 import org.apache.cassandra.index.sai.disk.v5.V5VectorPostingsWriter;
 import org.apache.cassandra.index.sai.disk.vector.ConcurrentVectorValues;
-import org.apache.cassandra.index.sai.disk.vector.NVQUtil;
+import org.apache.cassandra.index.sai.disk.vector.JVectorVersionUtil;
 import org.apache.cassandra.index.sai.disk.vector.VectorMemtableIndex;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -191,19 +191,26 @@ public class VectorTester extends SAITester
         @Parameterized.Parameter(1)
         public boolean ENABLE_NVQ;
 
-        @Parameterized.Parameters(name = "{0} {1}")
+        @Parameterized.Parameter(2)
+        public boolean ENABLE_FUSED;
+
+        @Parameterized.Parameters(name = "{0} {1} {2}")
         public static Collection<Object[]> data()
         {
             // See Version file for explanation of changes associated with each version
             return Version.ALL.stream()
                               .filter(v -> v.onOrAfter(Version.JVECTOR_EARLIEST))
                               .flatMap(v -> {
-                                  var enableNVQ = NVQUtil.versionSupportsNVQ(v)
-                                              ? new Boolean[]{ true, false }
-                                              : new Boolean[]{ false };
-                                  return Arrays.stream(enableNVQ).map(b -> new Object[]{ v, b });
-                              })
-                              .collect(Collectors.toList());
+                                  var enableNVQ = JVectorVersionUtil.versionSupportsNVQ(v)
+                                                  ? new Boolean[]{ true, false }
+                                                  : new Boolean[]{ false };
+                                  var enableFused = JVectorVersionUtil.versionSupportsFused(v)
+                                                    ? new Boolean[]{ true, false }
+                                                    : new Boolean[]{ false };
+                                  return Arrays.stream(enableNVQ).flatMap(nvq ->
+                                      Arrays.stream(enableFused).map(fused -> new Object[]{ v, nvq, fused })
+                                  );
+                              }).collect(Collectors.toList());
         }
 
         @Before
@@ -216,6 +223,12 @@ public class VectorTester extends SAITester
         public void setEnableNVQ()
         {
             SAIUtil.setEnableNVQ(ENABLE_NVQ);
+        }
+
+        @Before
+        public void setEnableFused()
+        {
+            SAIUtil.setEnableFused(ENABLE_FUSED);
         }
     }
 

--- a/test/unit/org/apache/cassandra/index/sai/disk/vector/BruteForceRowIdIteratorTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/vector/BruteForceRowIdIteratorTest.java
@@ -96,6 +96,12 @@ public class BruteForceRowIdIteratorTest
         }
 
         @Override
+        public void processNeighbors(int i, int i1, ScoreFunction scoreFunction, ImmutableGraphIndex.IntMarker intMarker, ImmutableGraphIndex.NeighborProcessor neighborProcessor)
+        {
+
+        }
+
+        @Override
         public int size()
         {
             throw new UnsupportedOperationException();

--- a/test/unit/org/apache/cassandra/index/sai/disk/vector/OnDiskVectorValuesTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/vector/OnDiskVectorValuesTest.java
@@ -1,0 +1,491 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.disk.vector;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.github.jbellis.jvector.graph.RandomAccessVectorValues;
+import io.github.jbellis.jvector.vector.VectorizationProvider;
+import io.github.jbellis.jvector.vector.types.VectorFloat;
+import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
+import org.apache.cassandra.index.sai.SAITester;
+import org.apache.cassandra.io.util.File;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+
+public class OnDiskVectorValuesTest extends SAITester
+{
+    private static final VectorTypeSupport vts = VectorizationProvider.getInstance().getVectorTypeSupport();
+    private File tempFile;
+
+    @Before
+    public void setUp() throws IOException
+    {
+        // Need network stack to initialize buffers
+        requireNetwork();
+        tempFile = new File(Files.createTempFile("on-disk-vector-values-test", ".tmp"));
+    }
+
+    @After
+    public void tearDown()
+    {
+        if (tempFile != null && tempFile.exists())
+            tempFile.delete();
+    }
+
+    @Test
+    public void testReadSingleVector() throws IOException
+    {
+        int dimension = 3;
+        float[] data = {1.0f, 2.0f, 3.0f};
+
+        // Write vector
+        try (OnDiskVectorValuesWriter writer = new OnDiskVectorValuesWriter(tempFile, dimension))
+        {
+            writer.write(0, vts.createFloatVector(data));
+        }
+
+        // Read vector
+        try (OnDiskVectorValues reader = new OnDiskVectorValues(tempFile, dimension))
+        {
+            assertEquals(1, reader.size());
+            assertEquals(dimension, reader.dimension());
+            
+            VectorFloat<?> vector = reader.getVector(0);
+            assertVectorEquals(data, vector);
+        }
+    }
+
+    @Test
+    public void testReadMultipleVectors() throws IOException
+    {
+        int dimension = 4;
+        int numVectors = 10;
+        float[][] vectors = new float[numVectors][dimension];
+
+        // Write vectors
+        try (OnDiskVectorValuesWriter writer = new OnDiskVectorValuesWriter(tempFile, dimension))
+        {
+            for (int i = 0; i < numVectors; i++)
+            {
+                for (int j = 0; j < dimension; j++)
+                    vectors[i][j] = i * dimension + j;
+                writer.write(i, vts.createFloatVector(vectors[i]));
+            }
+        }
+
+        // Read vectors
+        try (OnDiskVectorValues reader = new OnDiskVectorValues(tempFile, dimension))
+        {
+            assertEquals(numVectors, reader.size());
+            assertEquals(dimension, reader.dimension());
+            
+            for (int i = 0; i < numVectors; i++)
+            {
+                VectorFloat<?> vector = reader.getVector(i);
+                assertVectorEquals(vectors[i], vector);
+            }
+        }
+    }
+
+    @Test
+    public void testReadSparseVectors() throws IOException
+    {
+        int dimension = 3;
+        int[] ordinals = {0, 2, 5};
+        float[][] vectors = {
+            {1.0f, 2.0f, 3.0f},
+            {4.0f, 5.0f, 6.0f},
+            {7.0f, 8.0f, 9.0f}
+        };
+
+        // Write sparse vectors
+        try (OnDiskVectorValuesWriter writer = new OnDiskVectorValuesWriter(tempFile, dimension))
+        {
+            for (int i = 0; i < ordinals.length; i++)
+                writer.write(ordinals[i], vts.createFloatVector(vectors[i]));
+        }
+
+        // Read vectors
+        try (OnDiskVectorValues reader = new OnDiskVectorValues(tempFile, dimension))
+        {
+            assertEquals(6, reader.size()); // 0-5 inclusive
+            
+            // Check written vectors
+            for (int i = 0; i < ordinals.length; i++)
+            {
+                VectorFloat<?> vector = reader.getVector(ordinals[i]);
+                assertVectorEquals(vectors[i], vector);
+            }
+            
+            // Check gaps are zeros
+            assertVectorEquals(new float[]{0.0f, 0.0f, 0.0f}, reader.getVector(1));
+            assertVectorEquals(new float[]{0.0f, 0.0f, 0.0f}, reader.getVector(3));
+            assertVectorEquals(new float[]{0.0f, 0.0f, 0.0f}, reader.getVector(4));
+        }
+    }
+
+    @Test
+    public void testReadLargeVectors() throws IOException
+    {
+        int dimension = 1536;
+        float[] data = new float[dimension];
+        for (int i = 0; i < dimension; i++)
+            data[i] = (float) Math.sin(i * 0.1);
+
+        // Write vector
+        try (OnDiskVectorValuesWriter writer = new OnDiskVectorValuesWriter(tempFile, dimension))
+        {
+            writer.write(0, vts.createFloatVector(data));
+        }
+
+        // Read vector
+        try (OnDiskVectorValues reader = new OnDiskVectorValues(tempFile, dimension))
+        {
+            VectorFloat<?> vector = reader.getVector(0);
+            assertVectorEquals(data, vector);
+        }
+    }
+
+    @Test
+    public void testRandomAccess() throws IOException
+    {
+        int dimension = 3;
+        int numVectors = 20;
+        float[][] vectors = new float[numVectors][dimension];
+
+        // Write vectors
+        try (OnDiskVectorValuesWriter writer = new OnDiskVectorValuesWriter(tempFile, dimension))
+        {
+            for (int i = 0; i < numVectors; i++)
+            {
+                for (int j = 0; j < dimension; j++)
+                    vectors[i][j] = i * 10 + j;
+                writer.write(i, vts.createFloatVector(vectors[i]));
+            }
+        }
+
+        // Read in random order
+        try (OnDiskVectorValues reader = new OnDiskVectorValues(tempFile, dimension))
+        {
+            int[] readOrder = {15, 3, 19, 0, 7, 12, 5, 18, 1, 10};
+            for (int ordinal : readOrder)
+            {
+                VectorFloat<?> vector = reader.getVector(ordinal);
+                assertVectorEquals(vectors[ordinal], vector);
+            }
+        }
+    }
+
+    @Test
+    public void testIsValueShared()
+    {
+        try (OnDiskVectorValues reader = new OnDiskVectorValues(tempFile, 3))
+        {
+            assertFalse("Vectors should be shared", reader.isValueShared());
+        }
+    }
+
+    @Test
+    public void testCopy() throws Exception
+    {
+        int dimension = 4;
+        float[] data = {1.0f, 2.0f, 3.0f, 4.0f};
+
+        // Write vector
+        try (OnDiskVectorValuesWriter writer = new OnDiskVectorValuesWriter(tempFile, dimension))
+        {
+            writer.write(0, vts.createFloatVector(data));
+        }
+
+        // Create reader and copy
+        try (OnDiskVectorValues reader = new OnDiskVectorValues(tempFile, dimension))
+        {
+            RandomAccessVectorValues copy = reader.copy();
+            assertNotNull(copy);
+            assertSame("Copy should be the same instance instance", reader, copy);
+            
+            // Both should read the same data
+            assertVectorEquals(data, reader.getVector(0));
+            assertVectorEquals(data, copy.getVector(0));
+        }
+    }
+
+    @Test
+    public void testConcurrentReads() throws Exception
+    {
+        int dimension = 5;
+        int numVectors = 100;
+        float[][] vectors = new float[numVectors][dimension];
+
+        // Write vectors
+        try (OnDiskVectorValuesWriter writer = new OnDiskVectorValuesWriter(tempFile, dimension))
+        {
+            for (int i = 0; i < numVectors; i++)
+            {
+                for (int j = 0; j < dimension; j++)
+                    vectors[i][j] = i + j * 0.1f;
+                writer.write(i, vts.createFloatVector(vectors[i]));
+            }
+        }
+
+        // Concurrent reads using copies
+        int numThreads = 10;
+        ExecutorService executor = Executors.newFixedThreadPool(numThreads);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        AtomicInteger errorCount = new AtomicInteger(0);
+        List<Future<?>> futures = new ArrayList<>();
+
+        try (OnDiskVectorValues reader = new OnDiskVectorValues(tempFile, dimension))
+        {
+            for (int t = 0; t < numThreads; t++)
+            {
+                futures.add(executor.submit(() -> {
+                    try
+                    {
+                        startLatch.await();
+                        
+                        // Each thread reads all vectors
+                        for (int i = 0; i < numVectors; i++)
+                        {
+                            VectorFloat<?> vector = reader.getVector(i);
+                            for (int j = 0; j < dimension; j++)
+                            {
+                                float expected = i + j * 0.1f;
+                                if (Math.abs(vector.get(j) - expected) > 0.0001f)
+                                    errorCount.incrementAndGet();
+                            }
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        errorCount.incrementAndGet();
+                        throw new RuntimeException(e);
+                    }
+                }));
+            }
+
+            startLatch.countDown(); // Start all threads
+            
+            for (Future<?> future : futures)
+                future.get(10, TimeUnit.SECONDS);
+        }
+        finally
+        {
+            executor.shutdown();
+        }
+
+        assertEquals("No errors should occur during concurrent reads", 0, errorCount.get());
+    }
+
+    @Test
+    public void testGetFile() throws IOException
+    {
+        try (OnDiskVectorValues reader = new OnDiskVectorValues(tempFile, 3))
+        {
+            assertEquals(tempFile, reader.getFile());
+        }
+    }
+
+    @Test
+    public void testGetVectorSize()
+    {
+        int dimension = 128;
+        try (OnDiskVectorValues reader = new OnDiskVectorValues(tempFile, dimension))
+        {
+            long expectedSize = dimension * Float.BYTES;
+            assertEquals(expectedSize, reader.getVectorSize());
+        }
+    }
+
+    @Test
+    public void testSizeCalculation() throws IOException
+    {
+        int dimension = 4;
+        int numVectors = 50;
+
+        // Write vectors
+        try (OnDiskVectorValuesWriter writer = new OnDiskVectorValuesWriter(tempFile, dimension))
+        {
+            for (int i = 0; i < numVectors; i++)
+            {
+                float[] data = new float[dimension];
+                for (int j = 0; j < dimension; j++)
+                    data[j] = i + j;
+                writer.write(i, vts.createFloatVector(data));
+            }
+        }
+
+        // Verify size calculation
+        try (OnDiskVectorValues reader = new OnDiskVectorValues(tempFile, dimension))
+        {
+            assertEquals(numVectors, reader.size());
+            
+            long fileSize = tempFile.length();
+            long vectorSize = reader.getVectorSize();
+            assertEquals(numVectors, fileSize / vectorSize);
+        }
+    }
+
+    @Test
+    public void testEmptyFile()
+    {
+        // Create empty file
+        try (OnDiskVectorValuesWriter writer = new OnDiskVectorValuesWriter(tempFile, 3))
+        {
+            // Don't write anything
+        }
+        catch (IOException e)
+        {
+            throw new RuntimeException(e);
+        }
+
+        // Read from empty file
+        try (OnDiskVectorValues reader = new OnDiskVectorValues(tempFile, 3))
+        {
+            assertEquals(0, reader.size());
+        }
+    }
+
+    @Test
+    public void testCloseIsIdempotent() throws IOException
+    {
+        int dimension = 3;
+        
+        // Write a vector
+        try (OnDiskVectorValuesWriter writer = new OnDiskVectorValuesWriter(tempFile, dimension))
+        {
+            writer.write(0, vts.createFloatVector(new float[]{1.0f, 2.0f, 3.0f}));
+        }
+
+        OnDiskVectorValues reader = new OnDiskVectorValues(tempFile, dimension);
+        reader.getVector(0); // Read something
+        reader.close();
+        reader.close(); // Should not throw
+    }
+
+    @Test
+    public void testMultipleCopiesIndependent() throws Exception
+    {
+        int dimension = 3;
+        int numVectors = 10;
+
+        // Write vectors
+        try (OnDiskVectorValuesWriter writer = new OnDiskVectorValuesWriter(tempFile, dimension))
+        {
+            for (int i = 0; i < numVectors; i++)
+            {
+                float[] data = {i, i + 1, i + 2};
+                writer.write(i, vts.createFloatVector(data));
+            }
+        }
+
+        // Create multiple copies and verify they work independently
+        try (OnDiskVectorValues reader = new OnDiskVectorValues(tempFile, dimension))
+        {
+            RandomAccessVectorValues copy1 = reader.copy();
+            RandomAccessVectorValues copy2 = reader.copy();
+
+            try
+            {
+                // Read different vectors from each
+                VectorFloat<?> v1 = copy1.getVector(0);
+                VectorFloat<?> v2 = copy2.getVector(5);
+                VectorFloat<?> v3 = reader.getVector(9);
+
+                assertVectorEquals(new float[]{0, 1, 2}, v1);
+                assertVectorEquals(new float[]{5, 6, 7}, v2);
+                assertVectorEquals(new float[]{9, 10, 11}, v3);
+
+                // Verify they can still read independently
+                v1 = copy1.getVector(3);
+                v2 = copy2.getVector(7);
+                
+                assertVectorEquals(new float[]{3, 4, 5}, v1);
+                assertVectorEquals(new float[]{7, 8, 9}, v2);
+            }
+            finally
+            {
+                if (copy1 instanceof AutoCloseable)
+                    ((AutoCloseable) copy1).close();
+                if (copy2 instanceof AutoCloseable)
+                    ((AutoCloseable) copy2).close();
+            }
+        }
+    }
+
+    @Test
+    public void testReadBoundaryVectors() throws IOException
+    {
+        int dimension = 4;
+        int numVectors = 100;
+
+        // Write vectors
+        try (OnDiskVectorValuesWriter writer = new OnDiskVectorValuesWriter(tempFile, dimension))
+        {
+            for (int i = 0; i < numVectors; i++)
+            {
+                float[] data = new float[dimension];
+                for (int j = 0; j < dimension; j++)
+                    data[j] = i * dimension + j;
+                writer.write(i, vts.createFloatVector(data));
+            }
+        }
+
+        // Read boundary vectors
+        try (OnDiskVectorValues reader = new OnDiskVectorValues(tempFile, dimension))
+        {
+            // First vector
+            VectorFloat<?> first = reader.getVector(0);
+            assertVectorEquals(new float[]{0, 1, 2, 3}, first);
+
+            // Last vector
+            VectorFloat<?> last = reader.getVector(numVectors - 1);
+            float[] expectedLast = new float[dimension];
+            for (int j = 0; j < dimension; j++)
+                expectedLast[j] = (numVectors - 1) * dimension + j;
+            assertVectorEquals(expectedLast, last);
+        }
+    }
+
+    private void assertVectorEquals(float[] expected, VectorFloat<?> actual)
+    {
+        assertEquals("Vector dimension mismatch", expected.length, actual.length());
+        for (int i = 0; i < expected.length; i++)
+        {
+            assertEquals("Mismatch at index " + i, expected[i], actual.get(i), 0.0001f);
+        }
+    }
+}
+
+// Made with Bob

--- a/test/unit/org/apache/cassandra/index/sai/disk/vector/OnDiskVectorValuesWriterTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/vector/OnDiskVectorValuesWriterTest.java
@@ -1,0 +1,366 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.disk.vector;
+
+import java.io.IOException;
+import java.nio.file.Files;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.github.jbellis.jvector.vector.ArrayVectorFloat;
+import io.github.jbellis.jvector.vector.VectorizationProvider;
+import io.github.jbellis.jvector.vector.types.VectorFloat;
+import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
+import org.apache.cassandra.index.sai.SAITester;
+import org.apache.cassandra.io.util.File;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class OnDiskVectorValuesWriterTest extends SAITester
+{
+    private static final VectorTypeSupport vts = VectorizationProvider.getInstance().getVectorTypeSupport();
+    private File tempFile;
+
+    @Before
+    public void setUp() throws IOException
+    {
+        // Need network for the buffer initialization, not for actual network.
+        requireNetwork();
+        tempFile = new File(Files.createTempFile("vector-by-ordinal-test", ".tmp"));
+    }
+
+    @After
+    public void tearDown()
+    {
+        if (tempFile != null && tempFile.exists())
+            tempFile.delete();
+    }
+
+    @Test
+    public void testWriteSingleVector() throws IOException
+    {
+        int dimension = 3;
+        float[] data = { 1.0f, 2.0f, 3.0f };
+        VectorFloat<?> vector = vts.createFloatVector(data);
+
+        try (OnDiskVectorValuesWriter writer = new OnDiskVectorValuesWriter(tempFile, dimension))
+        {
+            writer.write(0, vector);
+            assertEquals(0, writer.getLastOrdinal());
+            assertEquals(dimension, writer.getDimension());
+        }
+
+        // Verify file size
+        long expectedSize = dimension * Float.BYTES;
+        assertEquals(expectedSize, tempFile.length());
+
+        // Verify content
+        try (OnDiskVectorValues reader = new OnDiskVectorValues(tempFile, dimension))
+        {
+            assertEquals(1, reader.size());
+            VectorFloat<?> readVector = reader.getVector(0);
+            assertVectorEquals(data, readVector);
+        }
+    }
+
+    @Test
+    public void testWriteSequentialVectors() throws IOException
+    {
+        int dimension = 4;
+        int numVectors = 5;
+
+        try (OnDiskVectorValuesWriter writer = new OnDiskVectorValuesWriter(tempFile, dimension))
+        {
+            for (int i = 0; i < numVectors; i++)
+            {
+                float[] data = new float[dimension];
+                for (int j = 0; j < dimension; j++)
+                    data[j] = i * dimension + j;
+
+                VectorFloat<?> vector = vts.createFloatVector(data);
+                writer.write(i, vector);
+                assertEquals(i, writer.getLastOrdinal());
+            }
+        }
+
+        // Verify all vectors
+        try (OnDiskVectorValues reader = new OnDiskVectorValues(tempFile, dimension))
+        {
+            assertEquals(numVectors, reader.size());
+            for (int i = 0; i < numVectors; i++)
+            {
+                float[] expected = new float[dimension];
+                for (int j = 0; j < dimension; j++)
+                    expected[j] = i * dimension + j;
+
+                VectorFloat<?> readVector = reader.getVector(i);
+                assertVectorEquals(expected, readVector);
+            }
+        }
+    }
+
+    @Test
+    public void testWriteSparseVectors() throws IOException
+    {
+        int dimension = 3;
+        int[] ordinals = { 0, 2, 5, 10 };
+        float[][] vectors = {
+        { 1.0f, 2.0f, 3.0f },
+        { 4.0f, 5.0f, 6.0f },
+        { 7.0f, 8.0f, 9.0f },
+        { 10.0f, 11.0f, 12.0f }
+        };
+
+        try (OnDiskVectorValuesWriter writer = new OnDiskVectorValuesWriter(tempFile, dimension))
+        {
+            for (int i = 0; i < ordinals.length; i++)
+            {
+                VectorFloat<?> vector = vts.createFloatVector(vectors[i]);
+                writer.write(ordinals[i], vector);
+            }
+            assertEquals(ordinals[ordinals.length - 1], writer.getLastOrdinal());
+        }
+
+        // Verify written vectors and gaps
+        try (OnDiskVectorValues reader = new OnDiskVectorValues(tempFile, dimension))
+        {
+            // Size should be based on the highest ordinal + 1
+            assertEquals(11, reader.size());
+
+            // Check written vectors
+            for (int i = 0; i < ordinals.length; i++)
+            {
+                VectorFloat<?> readVector = reader.getVector(ordinals[i]);
+                assertVectorEquals(vectors[i], readVector);
+            }
+
+            // Check gaps are zeros
+            VectorFloat<?> gapVector = reader.getVector(1);
+            assertVectorEquals(new float[]{ 0.0f, 0.0f, 0.0f }, gapVector);
+
+            gapVector = reader.getVector(3);
+            assertVectorEquals(new float[]{ 0.0f, 0.0f, 0.0f }, gapVector);
+        }
+    }
+
+    @Test
+    public void testWriteArrayVectorFloat() throws IOException
+    {
+        int dimension = 5;
+        float[] data = { 1.5f, 2.5f, 3.5f, 4.5f, 5.5f };
+        ArrayVectorFloat vector = (ArrayVectorFloat) vts.createFloatVector(data);
+
+        try (OnDiskVectorValuesWriter writer = new OnDiskVectorValuesWriter(tempFile, dimension))
+        {
+            writer.write(0, vector);
+        }
+
+        // Verify
+        try (OnDiskVectorValues reader = new OnDiskVectorValues(tempFile, dimension))
+        {
+            VectorFloat<?> readVector = reader.getVector(0);
+            assertVectorEquals(data, readVector);
+        }
+    }
+
+    @Test
+    public void testWriteLargeVectors() throws IOException
+    {
+        int dimension = 1536; // Common embedding dimension
+        float[] data = new float[dimension];
+        for (int i = 0; i < dimension; i++)
+            data[i] = (float) Math.sin(i * 0.1);
+
+        try (OnDiskVectorValuesWriter writer = new OnDiskVectorValuesWriter(tempFile, dimension))
+        {
+            writer.write(0, vts.createFloatVector(data));
+        }
+
+        // Verify
+        try (OnDiskVectorValues reader = new OnDiskVectorValues(tempFile, dimension))
+        {
+            VectorFloat<?> readVector = reader.getVector(0);
+            assertVectorEquals(data, readVector);
+        }
+    }
+
+    @Test
+    public void testWriteMultipleLargeVectors() throws IOException
+    {
+        int dimension = 768;
+        int numVectors = 100;
+
+        try (OnDiskVectorValuesWriter writer = new OnDiskVectorValuesWriter(tempFile, dimension))
+        {
+            for (int i = 0; i < numVectors; i++)
+            {
+                float[] data = new float[dimension];
+                for (int j = 0; j < dimension; j++)
+                    data[j] = (float) (i + Math.cos(j * 0.1));
+
+                writer.write(i, vts.createFloatVector(data));
+            }
+        }
+
+        // Verify file size
+        long expectedSize = (long) numVectors * dimension * Float.BYTES;
+        assertEquals(expectedSize, tempFile.length());
+
+        // Spot check a few vectors
+        try (OnDiskVectorValues reader = new OnDiskVectorValues(tempFile, dimension))
+        {
+            assertEquals(numVectors, reader.size());
+
+            // Check first vector
+            float[] expected = new float[dimension];
+            for (int j = 0; j < dimension; j++)
+                expected[j] = (float) Math.cos(j * 0.1);
+            assertVectorEquals(expected, reader.getVector(0));
+
+            // Check last vector
+            expected = new float[dimension];
+            for (int j = 0; j < dimension; j++)
+                expected[j] = (float) (numVectors - 1 + Math.cos(j * 0.1));
+            assertVectorEquals(expected, reader.getVector(numVectors - 1));
+        }
+    }
+
+    @Test
+    public void testWriteWithLargeGaps() throws IOException
+    {
+        int dimension = 3;
+
+        try (OnDiskVectorValuesWriter writer = new OnDiskVectorValuesWriter(tempFile, dimension))
+        {
+            writer.write(0, vts.createFloatVector(new float[]{ 1.0f, 2.0f, 3.0f }));
+            writer.write(1000, vts.createFloatVector(new float[]{ 4.0f, 5.0f, 6.0f }));
+        }
+
+        // Verify file size accounts for the gap
+        long expectedSize = 1001L * dimension * Float.BYTES;
+        assertEquals(expectedSize, tempFile.length());
+
+        try (OnDiskVectorValues reader = new OnDiskVectorValues(tempFile, dimension))
+        {
+            assertEquals(1001, reader.size());
+            assertVectorEquals(new float[]{ 1.0f, 2.0f, 3.0f }, reader.getVector(0));
+            assertVectorEquals(new float[]{ 4.0f, 5.0f, 6.0f }, reader.getVector(1000));
+            assertVectorEquals(new float[]{ 0.0f, 0.0f, 0.0f }, reader.getVector(500));
+        }
+    }
+
+    @Test
+    public void testGetDimension() throws IOException
+    {
+        int dimension = 128;
+        try (OnDiskVectorValuesWriter writer = new OnDiskVectorValuesWriter(tempFile, dimension))
+        {
+            assertEquals(dimension, writer.getDimension());
+        }
+    }
+
+    @Test
+    public void testGetLastOrdinalInitialState() throws IOException
+    {
+        try (OnDiskVectorValuesWriter writer = new OnDiskVectorValuesWriter(tempFile, 3))
+        {
+            assertEquals(-1, writer.getLastOrdinal());
+        }
+    }
+
+    @Test
+    public void testPosition() throws IOException
+    {
+        int dimension = 4;
+
+        try (OnDiskVectorValuesWriter writer = new OnDiskVectorValuesWriter(tempFile, dimension))
+        {
+            assertEquals(0, writer.position());
+
+            writer.write(0, vts.createFloatVector(new float[]{ 1.0f, 2.0f, 3.0f, 4.0f }));
+            long expectedPosition = dimension * Float.BYTES;
+            assertEquals(expectedPosition, writer.position());
+
+            writer.write(1, vts.createFloatVector(new float[]{ 5.0f, 6.0f, 7.0f, 8.0f }));
+            expectedPosition = 2L * dimension * Float.BYTES;
+            assertEquals(expectedPosition, writer.position());
+        }
+    }
+
+    @Test(expected = AssertionError.class)
+    public void testWriteNonIncreasingOrdinalFails() throws IOException
+    {
+        int dimension = 3;
+
+        try (OnDiskVectorValuesWriter writer = new OnDiskVectorValuesWriter(tempFile, dimension))
+        {
+            writer.write(5, vts.createFloatVector(new float[]{ 1.0f, 2.0f, 3.0f }));
+            // This should fail - ordinal must be greater than last
+            writer.write(5, vts.createFloatVector(new float[]{ 4.0f, 5.0f, 6.0f }));
+        }
+    }
+
+    @Test(expected = AssertionError.class)
+    public void testWriteDecreasingOrdinalFails() throws IOException
+    {
+        int dimension = 3;
+
+        try (OnDiskVectorValuesWriter writer = new OnDiskVectorValuesWriter(tempFile, dimension))
+        {
+            writer.write(5, vts.createFloatVector(new float[]{ 1.0f, 2.0f, 3.0f }));
+            // This should fail - ordinal must be greater than last
+            writer.write(3, vts.createFloatVector(new float[]{ 4.0f, 5.0f, 6.0f }));
+        }
+    }
+
+    @Test
+    public void testCloseIsIdempotent() throws IOException
+    {
+        OnDiskVectorValuesWriter writer = new OnDiskVectorValuesWriter(tempFile, 3);
+        writer.write(0, vts.createFloatVector(new float[]{ 1.0f, 2.0f, 3.0f }));
+        writer.close();
+        writer.close(); // Should not throw
+    }
+
+    @Test
+    public void testEmptyFile() throws IOException
+    {
+        // Create and immediately close without writing
+        try (OnDiskVectorValuesWriter writer = new OnDiskVectorValuesWriter(tempFile, 3))
+        {
+            assertEquals(-1, writer.getLastOrdinal());
+        }
+
+        // File should exist but be empty
+        assertTrue(tempFile.exists());
+        assertEquals(0, tempFile.length());
+    }
+
+    private void assertVectorEquals(float[] expected, VectorFloat<?> actual)
+    {
+        assertEquals("Vector dimension mismatch", expected.length, actual.length());
+        for (int i = 0; i < expected.length; i++)
+        {
+            assertEquals("Mismatch at index " + i, expected[i], actual.get(i), 0.0001f);
+        }
+    }
+}
+
+// Made with Bob


### PR DESCRIPTION
### What is the issue

Fixes: https://github.com/riptano/cndb/issues/15527
CNDB test PR: https://github.com/riptano/cndb/pull/16797

### What does this PR fix and why was it fixed

This PR upgrades jvector, which brings several improvements. Here are the git commits brought in:

```
8b3e93cf (tag: 4.0.0-rc.8) chore: update changelog for 4.0.0-rc.8 (#627)
9d0488e5 release 4.0.0-rc.8 (#626)
570bd118 Refactor parallel writer (#608)
20c348ec Move buffer position in ByteBufferIndexWriter#writeFloats (#607)
d9ddce51 Ensure extractTrainingVectors return a list of at most MAX_PQ_TRAINING_SET_SIZE (#610)
d663b4f7 add config options for regression testing (#609)
7e493eee On-disk index cache for the Grid benchmark harness (#612)
e263cc80 Improved dataset loading; fixes, safeties, diagnostics, and better feedback (#613)
6b235ce7 bump to next SNAPSHOT (#605)
84bf5708 (tag: 4.0.0-rc.7) chore: update changelog for 4.0.0-rc.7 (#604)
fceeb885 release 4.0.0-rc.7 (#603)
51807cba add protection against bad ordinal mappings (#602)
6ca3b5e2 adding memory and disk usage stats to bench tests (#591)
a66fd914 Fix OnDiskGraphIndex#ramBytesUsed NPE (#588)
0ca5a392 Move float bulk-write into IndexWriter to enforce endianness (#577)
a6c6c09b Add diversityScoreFunctionFor to avoid creation of wrapper object (#592)
977c21d4 Relax the threshold of a flaky test related to an experimental feature (#598)
fa808d69 adding average nodes visited to benchmark tests (#552)
3bd15e70 Virtualize and Modularize DataSetLoader logic (#593)
42259e9f Speed up ivec reads by buffering (#584)
f967f1c9 virtualize DataSet (#589)
55f902f4 turn off parallel writes in grid (#582)
019a241d Parallelize graph writes (#542)
02fea879 Save allocation of a large array in PQVectors.encodeAndBuild (#574)
32a51821 javadoc for base [graph] (#548)
4eb607f8 javadoc for base [disk,exceptions] (#547)
30e8932c Enable the fused graph index  (#561)
d8848fc6 Start development on 4.0.0-rc.7-SNAPSHOT (#573)
c57f3a62 (tag: 4.0.0-rc.6) chore: update changelog for 4.0.0-rc.6 (#572)
214b7c20 release 4.0.0-rc.6 (#571)
e3686999 fix javadoc error (#570)
88669887 Ignoring testIncrementalInsertionFromOnDiskIndex_withNonIdentityOrdinalMapping and adding a TODO in buildAndMergeNewNodes (#569)
29a943e1 Computation of reconstruction errors for vector compressors (#567)
d8e9cb16 Add NVQ paper in README (#560)
d5cbe658 Add ImmutableGraphIndex.isHierarchical (#563)
b484dae2 Harden tests for heap graph reconstruction (#543)
9471c57d Make the thresholds in TestLowCardinalityFiltering tighter (#559)
21e4a226 Begin development on 4.0.0-rc.6 (#558)
4f661d99 Revert "Start development on 4.0.0-rc.6-SNAPSHOT"
fdee5779 Start development on 4.0.0-rc.6-SNAPSHOT
```

### SAI Version Bump

Adds a new sai on disk version: `fa`

### Fused PQ

With this version, we are adding a new, experimental feature to write PQ vectors fused into the graph. In doing so, we are able to skip writing the PQ vectors to the PQ file, which results in significant memory savings since the PQ vectors in the `CassandraDiskAnn` graph searcher consumers `O(n)` memory based on the number of vectors and their quantized size. The fused pq vectors mostly fit within the page cache as we read the node and its neighbors from disk, so we see minimal latency reduction due to this change, though further testing is required to see the real impact.

In order to enable fused pq, the runtime needs
`cassandra.sai.latest.version=fa` or greater and
`cassandra.sai.vector.enable_fused=true`. Note that because this feature is still experimental, `cassandra.sai.vector.enable_fused` defaults to `false`.

Another experimental feature introduced in this commit via the jvector upgrade is parallel graph encoding and writing to disk. Writing the fused graph requires increased CPU time to encode the graph node and we write more bytes to disk, so this parallelism is likely necessary to keep vector index creation/compaction times down. The key configurations available with their associated defaults:

```java
    // When building a compaction graph, encode layer 0 nodes in parallel and subsequently use async io for writes.
    // This feature is experimental, so defaults to false.
    SAI_ENCODE_AND_WRITE_VECTOR_GRAPH_IN_PARALLEL_ENABLED("cassandra.sai.vector.encode_and_write_graph_in_parallel.enabled", "false"),
    // When parallel graph encoding is enabled, the number of threads to use for encoding. Defaults to 0, meaning
    // use all available processors as reported by the JVM.
    SAI_ENCODE_AND_WRITE_VECTOR_GRAPH_IN_PARALLEL_NUM_THREADS("cassandra.sai.vector.encode_and_write_graph_in_parallel.num_threads", "0"),
    // When parallel graph encoding is enabled, whether to use director buffers. Defaults to false, meaning heap
    // buffers are used. A buffer will be allocated per encoding thread. The size of each buffer is the size
    // of the encoded graph node at layer 0, which varies based on graph feature settings.
    SAI_ENCODE_AND_WRITE_VECTOR_GRAPH_IN_PARALLEL_USE_DIRECT_BUFFERS("cassandra.sai.vector.encode_and_write_graph_in_parallel.use_direct_buffers", "false"),
```

### OnDiskVectorValues and OnDiskVectorValuesWriter

`OnDiskVectorValues` is now in its own file and is now thread safe in order to account for some necessary implementation details within jvector. Added `OnDiskVectorValuesWriter` to improve test coverage and to abstract away the flush issues associated with
`BufferedRandomAccessWriter` as described in
https://github.com/datastax/jvector/issues/562.

### Verification

This PR also introduces new benchmarks as well as improved unit testing. The new benchmarks verify the performance of the `OnDiskVectorValues` and `OnDiskVectorValuesWriter` to confirm (at least directionally) the time associated with read and write operations.

New tests have been added to verify that when we iterate over an sstable's rows, we are able to assert that the sstable's vector value's similarity to the one stored in the vector graph is ~1. This testing is valuable in that it confirms the row id to ordinal mapping is correct at every node. Previously, we relied on recall results to verify this for us. This new pattern allows us to confirm _every_ node, which is more thorough and removes most edge cases that might have led to partially correct graphs that may have achieved acceptable recall.
