### PR TITLE
CNDB-17617 Fix CompactionTask.CompactionOperation to add subtasks before notifying listeners

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/CompactionTask.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionTask.java
@@ -444,8 +444,6 @@ public class CompactionTask extends AbstractCompactionTask
                 this.sstableRefs = Refs.ref(actuallyCompact);
                 this.op = initializeSource(tokenRange());
                 this.writer = getCompactionAwareWriter(realm, dirs, actuallyCompact);
-                if (null != opObserver)
-                    this.obsCloseable = opObserver.onOperationStart(op);
                 CompactionProgress progress = this;
                 var sharedProgress = sharedProgress();
                 if (sharedProgress != null)
@@ -454,6 +452,8 @@ public class CompactionTask extends AbstractCompactionTask
                     progress = sharedProgress;
                 }
 
+                if (null != opObserver)
+                    this.obsCloseable = opObserver.onOperationStart(op);
                 for (var obs : getCompObservers())
                     obs.onInProgress(progress);
             }


### PR DESCRIPTION
### What is the issue
Fixes https://github.com/riptano/cndb/issues/17617

### What does this PR fix and why was it fixed
Move opObserver.onOperationStart() to after sharedProgress.addSubtask() to ensure the sources list is populated before CompactionProgressListener callbacks are triggered.

This fixes a discrepancy between CC 5.0 and CC 4.0 introduced when porting CNDB-12431 (commit 7d89a0e83c). The execution order fix from CC 4.0 commit 1d7c4cbcf3 was lost during the rebase to CC 5.0.

Without this fix, listeners that call progress.metadata() receive null because SharedCompactionProgress.sources.isEmpty() is true, causing NullPointerException in implementations like CompactionTenant.

