### PR TITLE
CNDB-17621 Fix CC 5.0 jackson-core 2.19.2 CVE (WS-2026-0003)

### DIFF
--- a/.build/parent-pom-template.xml
+++ b/.build/parent-pom-template.xml
@@ -421,17 +421,17 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
-        <version>2.19.2</version>
+        <version>2.21.2</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.19.2</version>
+        <version>2.21.2</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
-        <version>2.19.2</version>
+        <version>2.21</version>
       </dependency>
       <dependency>
         <groupId>com.googlecode.json-simple</groupId>
@@ -441,7 +441,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-jsr310</artifactId>
-        <version>2.19.2</version>
+        <version>2.21.2</version>
       </dependency>
       <dependency>
         <groupId>org.msgpack</groupId>
@@ -451,7 +451,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>
         <artifactId>jackson-dataformat-yaml</artifactId>
-        <version>2.19.2</version>
+        <version>2.21.2</version>
         <scope>test</scope>
         <!-- CASSANDRA-20848 2.19.x would bring snakeyaml 2.4 which is for now incompatible with rest of the codebase -->
         <exclusions>


### PR DESCRIPTION
### What is the issue
Fixes CNDB-17621

### What does this PR fix and why was it fixed
Bump jackson-core version to 2.21.2
