### PR TITLE
CNDB-16269: throw exception and reduce log verbosity when compaction is rejected

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/SharedCompactionObserver.java
+++ b/src/java/org/apache/cassandra/db/compaction/SharedCompactionObserver.java
@@ -44,21 +44,23 @@ public class SharedCompactionObserver implements CompactionObserver
 {
     private static final Logger logger = LoggerFactory.getLogger(SharedCompactionObserver.class);
     private final AtomicInteger toReportOnComplete = new AtomicInteger(0);
-    private final AtomicReference<Throwable> onCompleteException = new AtomicReference(null);
+    private final AtomicReference<Throwable> onCompleteException = new AtomicReference<>(null);
     private final AtomicReference<CompactionProgress> inProgressReported = new AtomicReference<>(null);
 
     private final List<CompactionObserver> compObservers;
+    private final TimeUUID parentId;
 
-    public SharedCompactionObserver(CompactionObserver observer)
+    public SharedCompactionObserver(TimeUUID parentId, CompactionObserver observer)
     {
-        this(observer, null);
+        this(parentId, observer, null);
     }
 
-    public SharedCompactionObserver(CompactionObserver primary, @Nullable CompactionObserver secondary)
+    public SharedCompactionObserver(TimeUUID parentId, CompactionObserver primary, @Nullable CompactionObserver secondary)
     {
         if (primary == null)
             throw new IllegalArgumentException("Primary observer cannot be null");
 
+        this.parentId = parentId;
         this.compObservers = secondary != null ? ImmutableList.of(primary, secondary) : ImmutableList.of(primary);
     }
 
@@ -81,22 +83,27 @@ public class SharedCompactionObserver implements CompactionObserver
             Throwables.maybeFail(err);
         }
         else
+        {
             assert inProgressReported.get() == progress; // progress object must also be shared
+            assert progress.operationId().equals(parentId) : "progress.operationId() must match parentId";
+        }
     }
 
     @Override
     public void onCompleted(TimeUUID id, Throwable err)
     {
-        onCompleteException.compareAndSet(null, err); // acts like AND
+        if (err != null)
+            onCompleteException.compareAndSet(null, err);
+
         final int remainingToComplete = toReportOnComplete.decrementAndGet();
-        assert inProgressReported.get() != null : "onCompleted called before onInProgress";
         assert remainingToComplete >= 0 : "onCompleted called without corresponding registerExpectedSubtask";
-        // The individual operation ID given here may be different from the shared ID. Pass on the shared one.
+
         if (remainingToComplete == 0)
         {
             Throwable error = null;
+            Throwable finalErr = onCompleteException.get();
             for (CompactionObserver compObserver : compObservers)
-                error = Throwables.perform(error, () -> compObserver.onCompleted(inProgressReported.get().operationId(), onCompleteException.get()));
+                error = Throwables.perform(error, () -> compObserver.onCompleted(parentId, finalErr));
 
             Throwables.maybeFail(error);
         }

--- a/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.java
+++ b/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.java
@@ -734,7 +734,7 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
         ShardManager shardManager = getShardManager();
         CompositeLifecycleTransaction compositeTransaction = new CompositeLifecycleTransaction(transaction);
         SharedCompactionProgress sharedProgress = new SharedCompactionProgress(transaction.opId(), transaction.opType(), TableOperation.Unit.BYTES);
-        SharedCompactionObserver sharedObserver = new SharedCompactionObserver(this, additionalObserver);
+        SharedCompactionObserver sharedObserver = new SharedCompactionObserver(transaction.opId(), this, additionalObserver);
         SharedTableOperation sharedOperation = new SharedTableOperation(sharedProgress);
         List<UnifiedCompactionTask> tasks = shardManager.splitSSTablesInShardsLimited(
             sstables,

--- a/test/unit/org/apache/cassandra/db/compaction/SharedCompactionObserverTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/SharedCompactionObserverTest.java
@@ -51,8 +51,8 @@ public class SharedCompactionObserverTest
     public void setUp()
     {
         mockObserver = Mockito.mock(CompactionObserver.class);
-        sharedCompactionObserver = new SharedCompactionObserver(mockObserver);
         operationId = TimeUUID.Generator.nextTimeUUID();
+        sharedCompactionObserver = new SharedCompactionObserver(operationId, mockObserver);
         mockProgress = Mockito.mock(CompactionProgress.class);
         when(mockProgress.operationId()).thenReturn(operationId);
     }
@@ -168,14 +168,6 @@ public class SharedCompactionObserverTest
     }
 
     @Test
-    public void testErrorNoInProgress()
-    {
-        Util.assumeAssertsEnabled();
-        sharedCompactionObserver.registerExpectedSubtask();
-        Assert.assertThrows(AssertionError.class, () -> sharedCompactionObserver.onCompleted(operationId, null));
-    }
-
-    @Test
     public void testErrorWrongProgress()
     {
         Util.assumeAssertsEnabled();
@@ -192,7 +184,7 @@ public class SharedCompactionObserverTest
     {
         CompactionObserver mockObserver1 = Mockito.mock(CompactionObserver.class);
         CompactionObserver mockObserver2 = Mockito.mock(CompactionObserver.class);
-        SharedCompactionObserver sharedCompactionObserver = new SharedCompactionObserver(mockObserver1, mockObserver2);
+        SharedCompactionObserver sharedCompactionObserver = new SharedCompactionObserver(operationId, mockObserver1, mockObserver2);
 
         sharedCompactionObserver.registerExpectedSubtask();
         sharedCompactionObserver.onInProgress(mockProgress);
@@ -211,7 +203,7 @@ public class SharedCompactionObserverTest
         CompactionObserver mockObserver2 = Mockito.mock(CompactionObserver.class);
         Mockito.doThrow(new RuntimeException("Injected Exception")).when(mockObserver1).onInProgress(any());
 
-        SharedCompactionObserver sharedCompactionObserver = new SharedCompactionObserver(mockObserver1, mockObserver2);
+        SharedCompactionObserver sharedCompactionObserver = new SharedCompactionObserver(operationId, mockObserver1, mockObserver2);
 
         sharedCompactionObserver.registerExpectedSubtask();
         assertThatThrownBy(() -> sharedCompactionObserver.onInProgress(mockProgress)).isInstanceOf(RuntimeException.class);
@@ -228,7 +220,7 @@ public class SharedCompactionObserverTest
         CompactionObserver mockObserver2 = Mockito.mock(CompactionObserver.class);
         Mockito.doThrow(new RuntimeException("Injected Exception")).when(mockObserver1).onCompleted(any(), any());
 
-        SharedCompactionObserver sharedCompactionObserver = new SharedCompactionObserver(mockObserver1, mockObserver2);
+        SharedCompactionObserver sharedCompactionObserver = new SharedCompactionObserver(operationId, mockObserver1, mockObserver2);
 
         sharedCompactionObserver.registerExpectedSubtask();
         sharedCompactionObserver.onInProgress(mockProgress);
@@ -238,5 +230,39 @@ public class SharedCompactionObserverTest
         assertThatThrownBy(() -> sharedCompactionObserver.onCompleted(operationId, null)).isInstanceOf(RuntimeException.class);
         verify(mockObserver1, times(1)).onCompleted(operationId, null);
         verify(mockObserver2, times(1)).onCompleted(operationId, null);
+    }
+
+    @Test
+    public void testNullPrimaryObserver()
+    {
+        Assert.assertThrows(IllegalArgumentException.class,
+                            () -> new SharedCompactionObserver(operationId, null));
+    }
+
+    @Test
+    public void testErrorWrongProgressId()
+    {
+        Util.assumeAssertsEnabled();
+        sharedCompactionObserver.registerExpectedSubtask();
+        sharedCompactionObserver.registerExpectedSubtask();
+        sharedCompactionObserver.onInProgress(mockProgress);
+
+        when(mockProgress.operationId()).thenReturn(TimeUUID.Generator.nextTimeUUID());
+        Assert.assertThrows(AssertionError.class, () -> sharedCompactionObserver.onInProgress(mockProgress));
+    }
+
+    @Test
+    public void testFirstErrorWins()
+    {
+        sharedCompactionObserver.registerExpectedSubtask();
+        sharedCompactionObserver.registerExpectedSubtask();
+        sharedCompactionObserver.onInProgress(mockProgress);
+        sharedCompactionObserver.onInProgress(mockProgress);
+
+        Exception firstErr = new RuntimeException("first");
+        sharedCompactionObserver.onCompleted(operationId, firstErr);
+        sharedCompactionObserver.onCompleted(operationId, new RuntimeException("second"));
+
+        verify(mockObserver, times(1)).onCompleted(operationId, firstErr);
     }
 }

--- a/test/unit/org/apache/cassandra/db/compaction/unified/ParallelizedTasksTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/unified/ParallelizedTasksTest.java
@@ -103,7 +103,7 @@ public class ParallelizedTasksTest extends ShardingTestBase
         UnifiedCompactionStrategy mockStrategy = strategy;
         strategy.getCompactionLogger().enable();
         SharedCompactionProgress sharedProgress = new SharedCompactionProgress(transaction.opId(), transaction.opType(), TableOperation.Unit.BYTES);
-        SharedCompactionObserver sharedObserver = new SharedCompactionObserver(strategy);
+        SharedCompactionObserver sharedObserver = new SharedCompactionObserver(transaction.opId(), strategy);
         SharedTableOperation sharedOperation = new SharedTableOperation(sharedProgress);
 
         List<AbstractCompactionTask> tasks = shardManager.splitSSTablesInShards(


### PR DESCRIPTION

### What is the issue
(https://github.com/riptano/cndb/issues/16269)

### What does this PR fix and why was it fixed
 throw exception and reduce log verbosity when compaction task is rejected (#2215)
 Pass parentId explicitly to SharedCompactionObserver instead of deriving it from inProgressReported, fixing error propagation and removing the dependency on onInProgress being called before onCompleted.
