### PR TITLE
CNDB-15759: add unified_compaction.scaling_parameter_persistence flag

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -1081,6 +1081,7 @@ public enum CassandraRelevantProperties
     UCS_PARALLELIZE_OUTPUT_SHARDS("unified_compaction.parallelize_output_shards", "true"),
     UCS_RESERVATIONS_TYPE_OPTION("unified_compaction.reservations_type_option", Reservations.Type.LEVEL_OR_BELOW.name()),
     UCS_RESERVED_THREADS("reserved_threads", "max"),
+    UCS_SCALING_PARAMETER_PERSISTENCE("unified_compaction.scaling_parameter_persistence", "true"),
     UCS_SHARED_STORAGE("unified_compaction.shared_storage", "false"),
     UCS_SSTABLE_GROWTH("unified_compaction.sstable_growth", "0.333"),
     UCS_STATIC_SCALING_PARAMETERS("unified_compaction.scaling_parameters", "T4"),

--- a/src/java/org/apache/cassandra/db/compaction/unified/Controller.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/Controller.java
@@ -262,6 +262,14 @@ public abstract class Controller
     static final boolean DEFAULT_ALLOW_UNSAFE_AGGRESSIVE_SSTABLE_EXPIRATION = false;
 
     /**
+     * System property to control writing scaling parameters to JSON configuration file.
+     * When set to true (default), the controller will persist scaling parameters and flush size to disk.
+     * When set to false, persistence is disabled.
+     */
+    public static final String SCALING_PARAMETER_PERSISTENCE_PROPERTY = UCS_SCALING_PARAMETER_PERSISTENCE.getKey();
+    public static final boolean SCALING_PARAMETER_PERSISTENCE = UCS_SCALING_PARAMETER_PERSISTENCE.getBooleanWithLegacyFallback();
+
+    /**
      * This property allows seperate defaults for vector and non-vector tables.  If this property is set to true
      * and the table has a {@link VectorType}, the "vector" defaults are used over the regular defaults.  For instance,
      * "-Dunified_compaction.vector_sstable_growth" will be used over "-Dunified_compaction.sstable_growth".
@@ -436,6 +444,12 @@ public abstract class Controller
 
     public static void storeOptions(TableMetadata metadata, int[] scalingParameters, long flushSizeBytes)
     {
+        if (!SCALING_PARAMETER_PERSISTENCE)
+        {
+            logger.debug("Scaling parameter persistence is disabled via {}. Skipping write to disk.", SCALING_PARAMETER_PERSISTENCE_PROPERTY);
+            return;
+        }
+
         if (SchemaConstants.isSystemKeyspace(metadata.keyspace))
             return;
         File f = getControllerConfigPath(metadata);

--- a/test/unit/org/apache/cassandra/db/compaction/unified/ControllerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/unified/ControllerTest.java
@@ -16,6 +16,8 @@
 
 package org.apache.cassandra.db.compaction.unified;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -37,6 +39,7 @@ import org.apache.cassandra.db.DiskBoundaries;
 import org.apache.cassandra.db.compaction.CompactionStrategyOptions;
 import org.apache.cassandra.db.compaction.UnifiedCompactionStrategy;
 import org.apache.cassandra.exceptions.ConfigurationException;
+import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.locator.AbstractReplicationStrategy;
 import org.apache.cassandra.locator.ReplicationFactor;
 import org.apache.cassandra.metrics.TableMetrics;
@@ -44,6 +47,7 @@ import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.MovingAverage;
 import org.apache.cassandra.utils.Overlaps;
+import org.apache.cassandra.utils.ReflectionUtils;
 import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -915,5 +919,80 @@ public abstract class ControllerTest
         // Test negative values (should return first element)
         assertEquals(1, controller.getLargestFactorizedShardCount(-1.0));
         assertEquals(1, controller.getLargestFactorizedShardCount(-100.0));
+    }
+
+    @Test
+    public void testScalingParameterPersistence() throws Exception
+    {
+        // Verify that by default (SCALING_PARAMETER_PERSISTENCE = true), storeOptions creates a file
+        assertTrue("Scaling parameter persistence should be enabled by default", Controller.SCALING_PARAMETER_PERSISTENCE);
+
+        TableMetadata testMetadata = standardCFMD("test_ks", "test_table").build();
+        int[] scalingParameters = new int[] { 0, 2, 4 };
+        long flushSize = 100 << 20; // 100 MB
+
+        File configPath = Controller.getControllerConfigPath(testMetadata);
+        if (configPath.exists())
+            configPath.delete();
+
+        // Store the options - should create a file when persistence is enabled
+        Controller.storeOptions(testMetadata, scalingParameters, flushSize);
+
+        // Verify the file was created
+        assertTrue("Config file should exist when persistence is enabled", configPath.exists());
+
+        // Clean up
+        configPath.delete();
+    }
+
+    @Test
+    public void testScalingParameterPersistenceDisabled() throws Exception
+    {
+        TableMetadata testMetadata = standardCFMD("test_ks", "test_table_disabled").build();
+        int[] scalingParameters = new int[] { 0, 2, 4 };
+        long flushSize = 100 << 20; // 100 MB
+        File configPath = Controller.getControllerConfigPath(testMetadata);
+
+        if (configPath.exists())
+            configPath.delete();
+
+        try
+        {
+            setScalingParameterPersistenceForTest(false);
+            Controller.storeOptions(testMetadata, scalingParameters, flushSize);
+            assertFalse("Config file should not exist when persistence is disabled", configPath.exists());
+        }
+        finally
+        {
+            setScalingParameterPersistenceForTest(true);
+            if (configPath.exists())
+                configPath.delete();
+        }
+    }
+
+    private static void setScalingParameterPersistenceForTest(boolean enabled) throws Exception
+    {
+        Field field = Controller.class.getDeclaredField("SCALING_PARAMETER_PERSISTENCE");
+        field.setAccessible(true);
+        Field modifiersField = ReflectionUtils.getField(Field.class, "modifiers");
+        modifiersField.setAccessible(true);
+        modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+        field.set(null, enabled);
+    }
+
+    @Test
+    public void testScalingParameterPersistenceSystemKeyspace()
+    {
+        // Verify that system keyspaces never write config files regardless of persistence setting
+        TableMetadata systemMetadata = standardCFMD("system", "test_table").build();
+        int[] scalingParameters = new int[] { 0, 2, 4 };
+        long flushSize = 100 << 20; // 100 MB
+
+        // Store the options - should not create a file for system keyspace
+        Controller.storeOptions(systemMetadata, scalingParameters, flushSize);
+
+        // Verify the file was NOT created
+        File configPath = Controller.getControllerConfigPath(systemMetadata);
+        assertFalse("Config file should not exist for system keyspace", configPath.exists());
     }
 }


### PR DESCRIPTION
### What is the issue

Unified compaction write a json representation of the scaling parameters. There should be a way to disable this.

### What does this PR fix and why was it fixed

Adds a `unified_compaction.scaling_parameter_persistence` flag which defaults to true.
