### PR TITLE
CNDB-15670: Added deleteRequests metric to KeyspaceMetrics

### DIFF
--- a/src/java/org/apache/cassandra/metrics/KeyspaceMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/KeyspaceMetrics.java
@@ -164,6 +164,7 @@ public class KeyspaceMetrics
     public final Timer coordinatorCasWriteLatency;
     /** Time spent waiting for free memtable space, either on- or off-heap */
     public final Histogram waitingOnFreeMemtableSpace;
+    public final Counter deleteRequests;
 
     /*
      * Metrics for inconsistencies detected between repaired data sets across replicas. These
@@ -306,6 +307,7 @@ public class KeyspaceMetrics
         coordinatorWriteLatency = createKeyspaceTimer("CoordinatorWriteLatency");
         coordinatorCasWriteLatency = createKeyspaceTimer("CoordinatorCasWriteLatency");
         waitingOnFreeMemtableSpace = createKeyspaceHistogram("WaitingOnFreeMemtableSpace", false);
+        deleteRequests = createKeyspaceCounter("DeleteRequests", metric -> metric.deleteRequests.getCount());
 
         confirmedRepairedInconsistencies = createKeyspaceMeter("RepairedDataInconsistenciesConfirmed");
         unconfirmedRepairedInconsistencies = createKeyspaceMeter("RepairedDataInconsistenciesUnconfirmed");


### PR DESCRIPTION
### What is the issue
A new metric to track delete requests has been added as a table level metric in this [PR](https://github.com/datastax/cassandra/pull/2223) but not at the keyspace level

### What does this PR fix and why was it fixed
This PR adds the delete requests metric at the keyspace level as well.
