### PR TITLE
CNDB-15608 test row aware pimary key on all versions

### DIFF
--- a/test/unit/org/apache/cassandra/index/sai/disk/RowAwarePrimaryKeyTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/RowAwarePrimaryKeyTest.java
@@ -16,12 +16,17 @@
  * limitations under the License.
  */
 
-package org.apache.cassandra.index.sai.disk.v2;
+package org.apache.cassandra.index.sai.disk;
 
 import java.nio.ByteBuffer;
+import java.util.List;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import org.apache.cassandra.db.BufferDecoratedKey;
 import org.apache.cassandra.db.Clustering;
@@ -31,7 +36,9 @@ import org.apache.cassandra.db.marshal.Int32Type;
 import org.apache.cassandra.dht.Murmur3Partitioner;
 import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.index.sai.SAITester;
+import org.apache.cassandra.index.sai.SAIUtil;
 import org.apache.cassandra.index.sai.disk.format.Version;
+import org.apache.cassandra.index.sai.disk.v2.RowAwarePrimaryKeyFactory;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -39,12 +46,31 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
+@RunWith(Parameterized.class)
 public class RowAwarePrimaryKeyTest extends SAITester
 {
+    @Parameterized.Parameter
+    public Version version;
+
+    @Parameterized.Parameters(name = "version={0}")
+    public static List<Object[]> data()
+    {
+        return Version.ALL.stream()
+                          .filter(v -> v.onDiskFormat().indexFeatureSet().isRowAware())
+                          .map(v -> new Object[]{ v })
+                          .collect(Collectors.toList());
+    }
+
+    @Before
+    public void setup() throws Throwable
+    {
+        SAIUtil.setCurrentVersion(version);
+    }
+
     @Test
     public void testHashCodeForDeferredPrimaryKey()
     {
-        PrimaryKey.Factory factory = Version.BA.onDiskFormat().newPrimaryKeyFactory(EMPTY_COMPARATOR);
+        PrimaryKey.Factory factory = version.onDiskFormat().newPrimaryKeyFactory(EMPTY_COMPARATOR);
 
         // Test relies on this implementation detail
         assertTrue(factory instanceof RowAwarePrimaryKeyFactory);
@@ -71,7 +97,7 @@ public class RowAwarePrimaryKeyTest extends SAITester
     @Test
     public void testHashCodeForLoadedPrimaryKey()
     {
-        PrimaryKey.Factory factory = Version.BA.onDiskFormat().newPrimaryKeyFactory(EMPTY_COMPARATOR);
+        PrimaryKey.Factory factory = version.onDiskFormat().newPrimaryKeyFactory(EMPTY_COMPARATOR);
 
         // Test relies on this implementation detail
         assertTrue(factory instanceof RowAwarePrimaryKeyFactory);
@@ -93,7 +119,7 @@ public class RowAwarePrimaryKeyTest extends SAITester
     public void testHashCodeForDeferedPrimaryKeyWithClusteringColumns()
     {
         ClusteringComparator comparator = new ClusteringComparator(Int32Type.instance);
-        PrimaryKey.Factory factory = Version.BA.onDiskFormat().newPrimaryKeyFactory(comparator);
+        PrimaryKey.Factory factory = version.onDiskFormat().newPrimaryKeyFactory(comparator);
 
         // Test relies on this implementation detail
         assertTrue(factory instanceof RowAwarePrimaryKeyFactory);
@@ -114,7 +140,7 @@ public class RowAwarePrimaryKeyTest extends SAITester
     @Test
     public void testComparisonBetweenTokenOnlyAndFullKey()
     {
-        PrimaryKey.Factory factory = Version.BA.onDiskFormat().newPrimaryKeyFactory(EMPTY_COMPARATOR);
+        PrimaryKey.Factory factory = version.onDiskFormat().newPrimaryKeyFactory(EMPTY_COMPARATOR);
 
         // Test relies on this implementation detail
         assertTrue(factory instanceof RowAwarePrimaryKeyFactory);
@@ -139,7 +165,7 @@ public class RowAwarePrimaryKeyTest extends SAITester
     @Test
     public void testComparisonBetweenTokenOnlyKeysWithDifferentTokens()
     {
-        PrimaryKey.Factory factory = Version.BA.onDiskFormat().newPrimaryKeyFactory(EMPTY_COMPARATOR);
+        PrimaryKey.Factory factory = version.onDiskFormat().newPrimaryKeyFactory(EMPTY_COMPARATOR);
 
         // Test relies on this implementation detail
         assertTrue(factory instanceof RowAwarePrimaryKeyFactory);
@@ -163,7 +189,7 @@ public class RowAwarePrimaryKeyTest extends SAITester
     public void testComparisonWithClusteringColumns()
     {
         ClusteringComparator comparator = new ClusteringComparator(Int32Type.instance);
-        PrimaryKey.Factory factory = Version.BA.onDiskFormat().newPrimaryKeyFactory(comparator);
+        PrimaryKey.Factory factory = version.onDiskFormat().newPrimaryKeyFactory(comparator);
 
         // Test relies on this implementation detail
         assertTrue(factory instanceof RowAwarePrimaryKeyFactory);
@@ -184,7 +210,7 @@ public class RowAwarePrimaryKeyTest extends SAITester
     @Test
     public void testTokenOnlyKeyHashCode()
     {
-        PrimaryKey.Factory factory = Version.BA.onDiskFormat().newPrimaryKeyFactory(EMPTY_COMPARATOR);
+        PrimaryKey.Factory factory = version.onDiskFormat().newPrimaryKeyFactory(EMPTY_COMPARATOR);
 
         // Test relies on this implementation detail
         assertTrue(factory instanceof RowAwarePrimaryKeyFactory);

--- a/test/unit/org/apache/cassandra/index/sai/disk/RowAwareSkinnyPrimaryKeyMapTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/RowAwareSkinnyPrimaryKeyMapTest.java
@@ -14,12 +14,16 @@
  * limitations under the License.
  */
 
-package org.apache.cassandra.index.sai.disk.v2;
+package org.apache.cassandra.index.sai.disk;
 
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.marshal.Int32Type;
@@ -27,9 +31,10 @@ import org.apache.cassandra.db.marshal.UTF8Type;
 import org.apache.cassandra.dht.IPartitioner;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.SAITester;
-import org.apache.cassandra.index.sai.disk.PrimaryKeyMap;
+import org.apache.cassandra.index.sai.SAIUtil;
 import org.apache.cassandra.index.sai.disk.format.IndexComponents;
 import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
+import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 
@@ -37,8 +42,9 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * Skinny-table tests (no clustering columns) for
- * {@link RowAwarePrimaryKeyMap} using the row-aware on-disk format.
+ * {@link PrimaryKeyMap} using the row-aware on-disk format.
  */
+@RunWith(Parameterized.class)
 public class RowAwareSkinnyPrimaryKeyMapTest extends SAITester
 {
     private final IndexContext intContext = SAITester.createIndexContext("int_index", Int32Type.instance);
@@ -49,9 +55,23 @@ public class RowAwareSkinnyPrimaryKeyMapTest extends SAITester
     private PrimaryKey.Factory pkFactory;
     private IPartitioner partitioner;
 
+    @Parameterized.Parameter
+    public Version version;
+
+    @Parameterized.Parameters(name = "version={0}")
+    public static List<Object[]> data()
+    {
+        return Version.ALL.stream()
+                          .filter(v -> v.onDiskFormat().indexFeatureSet().isRowAware())
+                          .map(v -> new Object[]{ v })
+                          .collect(Collectors.toList());
+    }
+
     @Before
     public void setup() throws Throwable
     {
+        SAIUtil.setCurrentVersion(version);
+
         createTable("CREATE TABLE %s (pk int PRIMARY KEY, int_value int, text_value text)");
         execute("CREATE CUSTOM INDEX int_index ON %s(int_value) USING 'StorageAttachedIndex'");
         execute("CREATE CUSTOM INDEX text_index ON %s(text_value) USING 'StorageAttachedIndex'");

--- a/test/unit/org/apache/cassandra/index/sai/disk/RowAwareWidePrimaryKeyMapTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/RowAwareWidePrimaryKeyMapTest.java
@@ -1,13 +1,11 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Copyright DataStax, Inc.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,13 +14,17 @@
  * limitations under the License.
  */
 
-package org.apache.cassandra.index.sai.disk.v2;
+package org.apache.cassandra.index.sai.disk;
 
 import java.nio.ByteBuffer;
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import org.apache.cassandra.db.BufferDecoratedKey;
 import org.apache.cassandra.db.Clustering;
@@ -34,9 +36,10 @@ import org.apache.cassandra.dht.IPartitioner;
 import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.SAITester;
-import org.apache.cassandra.index.sai.disk.PrimaryKeyMap;
+import org.apache.cassandra.index.sai.SAIUtil;
 import org.apache.cassandra.index.sai.disk.format.IndexComponents;
 import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
+import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 
@@ -44,8 +47,9 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * Wide-table tests (with clustering columns) for
- * {@link RowAwarePrimaryKeyMap} using the row-aware on-disk format.
+ * {@link PrimaryKeyMap} using the row-aware on-disk format.
  */
+@RunWith(Parameterized.class)
 public class RowAwareWidePrimaryKeyMapTest extends SAITester
 {
     private final IndexContext intContext = SAITester.createIndexContext("int_index", Int32Type.instance);
@@ -56,10 +60,23 @@ public class RowAwareWidePrimaryKeyMapTest extends SAITester
     private IndexComponents.ForRead perSSTableComponents;
     private IPartitioner partitioner;
 
+    @Parameterized.Parameter
+    public Version version;
+
+    @Parameterized.Parameters(name = "version={0}")
+    public static List<Object[]> data()
+    {
+        return Version.ALL.stream()
+                          .filter(v -> v.onDiskFormat().indexFeatureSet().isRowAware())
+                          .map(v -> new Object[]{ v })
+                          .collect(Collectors.toList());
+    }
 
     @Before
     public void setup() throws Throwable
     {
+        SAIUtil.setCurrentVersion(version);
+
         createTable("CREATE TABLE %s (pk int, ck int, int_value int, text_value text, PRIMARY KEY (pk, ck)) WITH CLUSTERING ORDER BY (ck ASC)");
         execute("CREATE CUSTOM INDEX int_index ON %s(int_value) USING 'StorageAttachedIndex'");
         execute("CREATE CUSTOM INDEX text_index ON %s(text_value) USING 'StorageAttachedIndex'");


### PR DESCRIPTION
Parameterizes unit tests of row aware primary key factory and map on all applicable disk format versions, i.e., row aware versions. This allows to prevent regressions.

Fixes license header to DS instead of AFS as the test file was introduced recently in DS version only.
