### PR TITLE
CNDB-17527: Bump messaging version to enable index hints

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -743,7 +743,7 @@ public enum CassandraRelevantProperties
      * or to force the node to use a specific version for testing purposes.
      */
     @Deprecated // remove when cndb no longer supports bdp/6.8-cndb
-    DS_CURRENT_MESSAGING_VERSION("ds.current_messaging_version", Integer.toString(MessagingService.VERSION_DS_11)),
+    DS_CURRENT_MESSAGING_VERSION("ds.current_messaging_version", Integer.toString(MessagingService.VERSION_DS_12)),
 
     /**
      * Which compression algorithm to use for SSTable compression when not specified explicitly in the sstable options.

--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -780,7 +780,7 @@ public enum CassandraRelevantProperties
      * or to force the node to use a specific version for testing purposes.
      */
     @Deprecated // remove when cndb no longer supports bdp/6.8-cndb
-    DS_CURRENT_MESSAGING_VERSION("ds.current_messaging_version", Integer.toString(MessagingService.VERSION_DS_11)),
+    DS_CURRENT_MESSAGING_VERSION("ds.current_messaging_version", Integer.toString(MessagingService.VERSION_DS_12)),
 
     /**
      * Fully-qualified class name of a {@link org.apache.cassandra.schema.CompressionParams.Selector} implementation

--- a/test/unit/org/apache/cassandra/db/filter/IndexHintsTest.java
+++ b/test/unit/org/apache/cassandra/db/filter/IndexHintsTest.java
@@ -73,8 +73,6 @@ public class IndexHintsTest extends CQLTester
     @BeforeClass
     public static void setUpClass()
     {
-        // Set the messaging version that adds support for the new index hints before starting the server
-        CassandraRelevantProperties.DS_CURRENT_MESSAGING_VERSION.setInt(MessagingService.VERSION_DS_12);
         CQLTester.setUpClass();
         CQLTester.enableCoordinatorExecution();
     }

--- a/test/unit/org/apache/cassandra/db/filter/IndexHintsTest.java
+++ b/test/unit/org/apache/cassandra/db/filter/IndexHintsTest.java
@@ -33,7 +33,6 @@ import org.apache.cassandra.index.sai.analyzer.AnalyzerEqOperatorSupport;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.cql3.CQLTester;
 import org.apache.cassandra.cql3.Operator;
 import org.apache.cassandra.cql3.restrictions.StatementRestrictions;
@@ -74,8 +73,6 @@ public class IndexHintsTest extends CQLTester
     @BeforeClass
     public static void setUpClass()
     {
-        // Set the messaging version that adds support for the new index hints before starting the server
-        CassandraRelevantProperties.DS_CURRENT_MESSAGING_VERSION.setInt(MessagingService.VERSION_DS_12);
         CQLTester.setUpClass();
         CQLTester.enableCoordinatorExecution();
     }

--- a/test/unit/org/apache/cassandra/index/SkipIndexOnFullPrimaryKeysTester.java
+++ b/test/unit/org/apache/cassandra/index/SkipIndexOnFullPrimaryKeysTester.java
@@ -30,7 +30,6 @@ import org.apache.cassandra.cql3.restrictions.StatementRestrictions;
 import org.apache.cassandra.db.ReadCommand;
 import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.index.sai.SAITester;
-import org.apache.cassandra.net.MessagingService;
 import org.assertj.core.api.Assertions;
 
 /**
@@ -61,8 +60,6 @@ public abstract class SkipIndexOnFullPrimaryKeysTester extends SAITester
     @BeforeClass
     public static void setUpClass()
     {
-        // Set the messaging version that adds support for the new index hints before starting the server
-        CassandraRelevantProperties.DS_CURRENT_MESSAGING_VERSION.setInt(MessagingService.VERSION_DS_12);
         CQLTester.setUpClass();
         CQLTester.enableCoordinatorExecution();
     }

--- a/test/unit/org/apache/cassandra/index/sai/cql/PlanWithIndexHintsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/PlanWithIndexHintsTest.java
@@ -18,9 +18,7 @@ package org.apache.cassandra.index.sai.cql;
 
 import java.util.Arrays;
 
-import org.apache.cassandra.net.MessagingService;
 import org.junit.Assume;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.cassandra.config.CassandraRelevantProperties;
@@ -52,13 +50,6 @@ import static java.lang.String.format;
  */
 public class PlanWithIndexHintsTest extends SAITester.Versioned
 {
-    @BeforeClass
-    public static void setUpClass()
-    {
-        CassandraRelevantProperties.DS_CURRENT_MESSAGING_VERSION.setInt(MessagingService.VERSION_DS_12);
-        SAITester.setUpClass();
-    }
-
     @Test
     public void testQueryPlanning() throws Throwable
     {


### PR DESCRIPTION
### What is the issue

https://github.com/riptano/cndb/issues/13129 added index hints. This is included in release 2026.6 (April 2026).
However, it isn't be possible to use this feature yet because the new messaging version that it introduced, VERSION_DS_12, is not yet the default.

We should bump the messaging version in one of the next releases so the feature becomes supported.

### What does this PR fix and why was it fixed

Bumps messaging version to VERSION_DS_12 enable index hints.

**DO NOT MERGE** until https://github.com/riptano/cndb/issues/14767 is merged.
