### PR TITLE
CNDB-17044: Use no spam logger for 'Assuming current protocol version for' log

### DIFF
--- a/src/java/org/apache/cassandra/net/EndpointMessagingVersions.java
+++ b/src/java/org/apache/cassandra/net/EndpointMessagingVersions.java
@@ -20,6 +20,7 @@ package org.apache.cassandra.net;
 import java.net.UnknownHostException;
 import java.util.Collections;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
 
 import org.cliffc.high_scale_lib.NonBlockingHashMap;
 
@@ -27,6 +28,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.locator.InetAddressAndPort;
+import org.apache.cassandra.utils.NoSpamLogger;
 
 /**
  * Map of hosts to their known current messaging versions.
@@ -35,6 +37,7 @@ public class EndpointMessagingVersions
 {
     public volatile int minClusterVersion = MessagingService.current_version;
     private static final Logger logger = LoggerFactory.getLogger(EndpointMessagingVersions.class);
+    private static final NoSpamLogger noSpamLogger = NoSpamLogger.getLogger(logger, 60L, TimeUnit.SECONDS);
 
     // protocol versions of the other nodes in the cluster
     private final ConcurrentMap<InetAddressAndPort, Integer> versions = new NonBlockingHashMap<>();
@@ -78,7 +81,7 @@ public class EndpointMessagingVersions
         if (v == null)
         {
             // we don't know the version. assume current. we'll know soon enough if that was incorrect.
-            logger.debug("Assuming current protocol version for {}", endpoint);
+            noSpamLogger.debug("Assuming current protocol version for {}", endpoint);
             return MessagingService.current_version;
         }
         else


### PR DESCRIPTION
### What is the issue

Fixes https://github.com/riptano/cndb/issues/17044

### What does this PR fix and why was it fixed

We were seeing this log line too many times. As a first measure, I propose putting it behind a no spam logger. The alternative solution is to make it `trace` level. Since I am unfamiliar with the utility of this log, I am not willing to unilaterally put it at trace level. No spam level allows us to have the insight without the excessive noise.
