### PR TITLE
CNDB-17087: Make JVectorVersionUtil constants volatile, not final to prevent JIT optimization

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/vector/JVectorVersionUtil.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/JVectorVersionUtil.java
@@ -21,9 +21,13 @@ import org.apache.cassandra.index.sai.disk.format.Version;
 
 public class JVectorVersionUtil
 {
-    /** Whether to fuse quantized vectors into the graph when writing indexes, assuming all other conditions are met */
-    public static final boolean ENABLE_FUSED = CassandraRelevantProperties.SAI_VECTOR_ENABLE_FUSED.getBoolean();
-    public static final boolean ENABLE_NVQ = CassandraRelevantProperties.SAI_VECTOR_ENABLE_NVQ.getBoolean();
+    /**
+     * Whether to fuse quantized vectors into the graph when writing indexes, assuming all other conditions are met.
+     * Variables are volatile to allow for changing in unit tests. They are only accessed on flush, so their access
+     * is infrequent.
+     */
+    public static volatile boolean ENABLE_FUSED = CassandraRelevantProperties.SAI_VECTOR_ENABLE_FUSED.getBoolean();
+    public static volatile boolean ENABLE_NVQ = CassandraRelevantProperties.SAI_VECTOR_ENABLE_NVQ.getBoolean();
     public static final int NUM_SUB_VECTORS = CassandraRelevantProperties.SAI_VECTOR_NVQ_NUM_SUB_VECTORS.getInt();
 
     /**

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorTester.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorTester.java
@@ -194,7 +194,7 @@ public class VectorTester extends SAITester
         @Parameterized.Parameter(2)
         public boolean ENABLE_FUSED;
 
-        @Parameterized.Parameters(name = "{0} {1} {2}")
+        @Parameterized.Parameters(name = "version={0} enableNVQ={1} enableFused={2}")
         public static Collection<Object[]> data()
         {
             // See Version file for explanation of changes associated with each version


### PR DESCRIPTION
### What is the issue

Fixes: https://github.com/riptano/cndb/issues/17087

### What does this PR fix and why was it fixed

We have several tests that change the `ENABLE_FUSED` and `ENABLE_NVQ` variables. Because they are marked `final`, they are eligible for the JVM to JIT and do not have any memory propagation guarantees. As such, we need to make them `volatile` to ensure correct visibility. Since these are accessed infrequently, only on flush and compaction, this is a minor change that guarantees correctness without much cost to production environments. Note that we never change these values in normal runtime envs.
