### PR TITLE
HCD-293: Fix UCS compaction level reporting in debug logs 

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/BackgroundCompactions.java
+++ b/src/java/org/apache/cassandra/db/compaction/BackgroundCompactions.java
@@ -32,8 +32,8 @@ import org.slf4j.LoggerFactory;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.utils.ExpMovingAverage;
 import org.apache.cassandra.utils.MovingAverage;
-import org.apache.cassandra.utils.TimeUUID;
 import org.apache.cassandra.utils.Pair;
+import org.apache.cassandra.utils.TimeUUID;
 
 /**
  * A class for grouping the background compactions picked by a strategy, either pending or in progress.
@@ -318,6 +318,14 @@ public class BackgroundCompactions
     public Collection<CompactionPick> getCompactionsInProgress()
     {
         return Collections.unmodifiableCollection(compactions.values());
+    }
+
+    /**
+     * @return the compaction with the given id, if it is currently in progress
+     */
+    public CompactionPick getCompaction(TimeUUID id)
+    {
+        return compactions.get(id);
     }
 
     /**

--- a/src/java/org/apache/cassandra/db/compaction/CompactionStrategy.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionStrategy.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import org.apache.cassandra.db.SerializationHeader;
 import org.apache.cassandra.db.commitlog.CommitLogPosition;
 import org.apache.cassandra.db.commitlog.IntervalSet;
+import org.apache.cassandra.db.lifecycle.ILifecycleTransaction;
 import org.apache.cassandra.db.lifecycle.LifecycleNewTracker;
 import org.apache.cassandra.db.lifecycle.LifecycleTransaction;
 import org.apache.cassandra.dht.Range;
@@ -123,6 +124,14 @@ public interface CompactionStrategy extends CompactionObserver
      * @return the total number of background compactions, pending or in progress
      */
     int getTotalCompactions();
+
+    /**
+     * @return the level for the given transaction, if this strategy supports levels. Otherwise return -1.
+     */
+    default int getLevel(ILifecycleTransaction txn)
+    {
+        return -1;
+    }
 
     /**
      * Return the statistics. Not all strategies will provide non-empty statistics,

--- a/src/java/org/apache/cassandra/db/compaction/CompactionTask.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionTask.java
@@ -1201,14 +1201,18 @@ public class CompactionTask extends AbstractCompactionTask
         for (SSTableReader reader : newSStables)
             newSSTableNames.append(reader.descriptor.baseFileUri()).append(',');
         long durationInNano = TimeUnit.MILLISECONDS.toNanos(durationInMillis);
-        logger.debug("Compacted ({}{}) {} sstables to [{}] to level={}. {} to {} (~{}% of original) in {}ms. " +
+        int level = getLevel();
+        if (level == 0 && strategy != null)
+            level = strategy.getLevel(transaction);
+
+        logger.debug("Compacted ({}{}) {} sstables to [{}]{}. {} to {} (~{}% of original) in {}ms. " +
                      "Read Throughput = {}, Write Throughput = {}, Row Throughput = ~{}/s, Partition Throughput = ~{}/s." +
                      " {} total partitions merged to {}. Partition merge counts were {}.",
                      taskId,
                      tokenRange() != null ? " range " + tokenRange() : "",
                      transaction.originals().size(),
                      newSSTableNames,
-                     getLevel(),
+                     level >= 0 ? " in level=" + level : "",
                      prettyPrintMemory(progress.adjustedInputDiskSize()),
                      prettyPrintMemory(progress.outputDiskSize()),
                      (int) (progress.sizeRatio() * 100),
@@ -1234,8 +1238,7 @@ public class CompactionTask extends AbstractCompactionTask
         {
             ssTableLoggerMsg.append(sstr.getFilename());
             if (sstr.getSSTableLevel() != 0)
-                ssTableLoggerMsg.append(":level=")
-                                .append(sstr.getSSTableLevel());
+                ssTableLoggerMsg.append(":level=").append(sstr.getSSTableLevel());
             ssTableLoggerMsg.append(", ");
         }
         ssTableLoggerMsg.append(']');

--- a/src/java/org/apache/cassandra/db/compaction/LeveledCompactionStrategy.java
+++ b/src/java/org/apache/cassandra/db/compaction/LeveledCompactionStrategy.java
@@ -42,6 +42,7 @@ import com.google.common.primitives.Doubles;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.cassandra.db.lifecycle.ILifecycleTransaction;
 import org.apache.cassandra.db.lifecycle.LifecycleTransaction;
 import org.apache.cassandra.db.rows.UnfilteredRowIterator;
 import org.apache.cassandra.dht.Range;
@@ -349,6 +350,16 @@ public class LeveledCompactionStrategy extends LegacyAbstractCompactionStrategy.
     public void addSSTable(CompactionSSTable added)
     {
         manifest.addSSTables(Collections.singleton(added));
+    }
+
+    @Override
+    public int getLevel(ILifecycleTransaction txn)
+    {
+        CompactionPick pick = backgroundCompactions.getCompaction(txn.opId());
+        if (pick != null)
+            return (int) pick.parent();
+
+        return -1;
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/compaction/LeveledCompactionTask.java
+++ b/src/java/org/apache/cassandra/db/compaction/LeveledCompactionTask.java
@@ -102,9 +102,8 @@ public class LeveledCompactionTask extends CompactionTask
             // no point doing a L0 -> L{0,1} compaction if we have cancelled all L0 sstables
             if (largestL0SSTable != null && l0SSTableCount > 1)
             {
-                logger.info("Removing {} (level={}, size={}) from compaction {}",
+                logger.info("Removing {} (size={}) from compaction {}",
                             largestL0SSTable,
-                            largestL0SSTable.getSSTableLevel(),
                             largestL0SSTable.onDiskLength(),
                             transaction.opIdString());
                 transaction.cancel(largestL0SSTable);

--- a/src/java/org/apache/cassandra/db/compaction/LeveledManifest.java
+++ b/src/java/org/apache/cassandra/db/compaction/LeveledManifest.java
@@ -427,7 +427,7 @@ public class LeveledManifest
                         Range<PartitionPosition> r = new Range<>(sstable.getFirst(), sstable.getLast());
                         if (boundaries.contains(r) && !compacting.contains(sstable))
                         {
-                            logger.info("Adding high-level (L{}) {} to candidates", sstable.getSSTableLevel(), sstable);
+                            logger.info("Adding high-level {} to candidates", sstable);
                             withStarvedCandidate.add(sstable);
                             return withStarvedCandidate;
                         }

--- a/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.java
+++ b/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.java
@@ -1369,6 +1369,16 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
         return overlapsMap;
     }
 
+    @Override
+    public int getLevel(ILifecycleTransaction txn)
+    {
+        CompactionPick pick = backgroundCompactions.getCompaction(txn.opId());
+        if (pick != null)
+            return (int) pick.parent();
+
+        return -1;
+    }
+
     private static int levelOf(CompactionPick pick)
     {
         return (int) pick.parent();

--- a/test/unit/org/apache/cassandra/db/compaction/BaseCompactionStrategyTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/BaseCompactionStrategyTest.java
@@ -29,6 +29,7 @@ import java.util.stream.Stream;
 import org.apache.commons.math3.random.JDKRandomGenerator;
 import org.junit.Ignore;
 
+import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.BufferDecoratedKey;
 import org.apache.cassandra.db.DecoratedKey;
@@ -106,6 +107,10 @@ public class BaseCompactionStrategyTest
 
     protected static void setUpClass()
     {
+        String releaseVersion = CassandraRelevantProperties.RELEASE_VERSION.getString();
+        if (releaseVersion == null || FBUtilities.UNKNOWN_RELEASE_VERSION.equals(releaseVersion))
+            CassandraRelevantProperties.RELEASE_VERSION.setString("4.0");
+
         long seed = System.currentTimeMillis();
         random.setSeed(seed);
         System.out.println("Random seed: " + seed);

--- a/test/unit/org/apache/cassandra/db/compaction/LeveledCompactionStrategyTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/LeveledCompactionStrategyTest.java
@@ -49,6 +49,11 @@ import org.apache.cassandra.UpdateBuilder;
 import org.apache.cassandra.Util;
 import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.lifecycle.ILifecycleTransaction;
+import org.mockito.Mockito;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.db.lifecycle.LifecycleTransaction;
@@ -96,6 +101,10 @@ public class LeveledCompactionStrategyTest
     @BeforeClass
     public static void defineSchema() throws ConfigurationException
     {
+        String releaseVersion = CassandraRelevantProperties.RELEASE_VERSION.getString();
+        if (releaseVersion == null || FBUtilities.UNKNOWN_RELEASE_VERSION.equals(releaseVersion))
+            CassandraRelevantProperties.RELEASE_VERSION.setString("4.0");
+
         // Disable tombstone histogram rounding for tests
         CassandraRelevantProperties.STREAMING_HISTOGRAM_ROUND_SECONDS.setInt(1);
 
@@ -1055,6 +1064,43 @@ public class LeveledCompactionStrategyTest
             assertFalse(task.reduceScopeForLimitedSpace(Sets.newHashSet(sstables), 0));
             assertEquals(Sets.newHashSet(sstables), txn.originals());
         }
+    }
+
+    @Test
+    public void testGetLevelForTransaction()
+    {
+        CompactionStrategyFactory strategyFactory = Mockito.mock(CompactionStrategyFactory.class);
+        when(strategyFactory.getRealm()).thenReturn(cfs);
+        when(strategyFactory.getCompactionLogger()).thenReturn(Mockito.mock(CompactionLogger.class));
+
+        LeveledCompactionStrategy strategy = new LeveledCompactionStrategy(strategyFactory, Collections.<String, String>emptyMap());
+        BackgroundCompactions backgroundCompactions = strategy.getBackgroundCompactions();
+
+        // Test that getLevel returns -1 for unknown transactions
+        TimeUUID unknownTaskId = TimeUUID.Generator.nextTimeUUID();
+        ILifecycleTransaction unknownTxn = Mockito.mock(ILifecycleTransaction.class);
+        when(unknownTxn.opId()).thenReturn(unknownTaskId);
+
+        assertEquals(-1, strategy.getLevel(unknownTxn));
+
+        // Test that getLevel returns the correct level for a registered compaction
+        TimeUUID taskId = TimeUUID.Generator.nextTimeUUID();
+        ILifecycleTransaction txn = Mockito.mock(ILifecycleTransaction.class);
+        when(txn.opId()).thenReturn(taskId);
+
+        // Create a compaction pick at level 3
+        CompactionPick pick = Mockito.mock(CompactionPick.class);
+        when(pick.id()).thenReturn(taskId);
+        when(pick.parent()).thenReturn(3L);
+
+        CompactionAggregate aggregate = Mockito.mock(CompactionAggregate.class);
+        when(aggregate.getSelected()).thenReturn(pick);
+        when(aggregate.getMatching(any())).thenReturn(aggregate);
+        when(aggregate.containsSameInstance(any())).thenReturn(Pair.create(true, pick));
+
+        backgroundCompactions.setSubmitted(strategy, taskId, aggregate);
+
+        assertEquals(3, strategy.getLevel(txn));
     }
 
     private Pair<Set<SSTableReader>, Set<SSTableReader>> groupByLevel(Iterable<SSTableReader> sstables)

--- a/test/unit/org/apache/cassandra/db/compaction/UnifiedCompactionStrategyTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/UnifiedCompactionStrategyTest.java
@@ -57,6 +57,7 @@ import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.compaction.unified.Controller;
 import org.apache.cassandra.db.compaction.unified.Reservations;
 import org.apache.cassandra.db.compaction.unified.UnifiedCompactionTask;
+import org.apache.cassandra.db.lifecycle.ILifecycleTransaction;
 import org.apache.cassandra.db.lifecycle.LifecycleTransaction;
 import org.apache.cassandra.db.lifecycle.PartialLifecycleTransaction;
 import org.apache.cassandra.dht.Bounds;
@@ -2212,6 +2213,96 @@ public class UnifiedCompactionStrategyTest extends BaseCompactionStrategyTest
         assertEquals(1, level.index);
         assertEquals(0.25d, level.min, 0);
         assertEquals(0.5d, level.max, 0);
+    }
+
+    @Test
+    public void testGetLevelForTransaction()
+    {
+        // Test that getLevel returns -1 for unknown transactions
+        Controller controller = Mockito.mock(Controller.class);
+        BackgroundCompactions backgroundCompactions = new BackgroundCompactions(realm);
+        UnifiedCompactionStrategy strategy = new UnifiedCompactionStrategy(strategyFactory, backgroundCompactions, controller);
+
+        TimeUUID unknownTaskId = TimeUUID.Generator.nextTimeUUID();
+        ILifecycleTransaction unknownTxn = Mockito.mock(ILifecycleTransaction.class);
+        when(unknownTxn.opId()).thenReturn(unknownTaskId);
+
+        assertEquals(-1, strategy.getLevel(unknownTxn));
+
+        // Test that getLevel returns the correct level for a registered compaction
+        TimeUUID taskId = TimeUUID.Generator.nextTimeUUID();
+        ILifecycleTransaction txn = Mockito.mock(ILifecycleTransaction.class);
+        when(txn.opId()).thenReturn(taskId);
+
+        // Create a compaction pick at level 3
+        CompactionPick pick = Mockito.mock(CompactionPick.class);
+        when(pick.id()).thenReturn(taskId);
+        when(pick.parent()).thenReturn(3L);
+
+        CompactionAggregate aggregate = Mockito.mock(CompactionAggregate.class);
+        when(aggregate.getSelected()).thenReturn(pick);
+        when(aggregate.getMatching(any(TreeMap.class))).thenReturn(aggregate);
+        when(aggregate.containsSameInstance(any())).thenReturn(Pair.create(true, pick));
+
+        backgroundCompactions.setSubmitted(strategy, taskId, aggregate);
+
+        assertEquals(3, strategy.getLevel(txn));
+
+        // Test with a different level
+        TimeUUID taskId2 = TimeUUID.Generator.nextTimeUUID();
+        ILifecycleTransaction txn2 = Mockito.mock(ILifecycleTransaction.class);
+        when(txn2.opId()).thenReturn(taskId2);
+
+        CompactionPick pick2 = Mockito.mock(CompactionPick.class);
+        when(pick2.id()).thenReturn(taskId2);
+        when(pick2.parent()).thenReturn(7L);
+
+        CompactionAggregate aggregate2 = Mockito.mock(CompactionAggregate.class);
+        when(aggregate2.getSelected()).thenReturn(pick2);
+        when(aggregate2.getMatching(any(TreeMap.class))).thenReturn(aggregate2);
+        when(aggregate2.containsSameInstance(any())).thenReturn(Pair.create(true, pick2));
+
+        backgroundCompactions.setSubmitted(strategy, taskId2, aggregate2);
+
+        assertEquals(7, strategy.getLevel(txn2));
+
+        // Verify first transaction still returns correct level
+        assertEquals(3, strategy.getLevel(txn));
+    }
+
+    @Test
+    public void testGetSSTableLevelForUCS()
+    {
+        // For UCS, sstable.getSSTableLevel() is always 0 (misleading), 
+        // while strategy.getLevel(txn) provides the correct context.
+        Controller controller = Mockito.mock(Controller.class);
+        BackgroundCompactions backgroundCompactions = new BackgroundCompactions(realm);
+        UnifiedCompactionStrategy strategy = new UnifiedCompactionStrategy(strategyFactory, backgroundCompactions, controller);
+
+        CompactionSSTable sstable = Mockito.mock(CompactionSSTable.class);
+        when(sstable.getSSTableLevel()).thenReturn(0);
+
+        // Verify the "misleading" level is 0
+        assertEquals(0, sstable.getSSTableLevel());
+
+        // Verify that even if we had a task at level 5, the sstable itself still reports 0
+        TimeUUID taskId = TimeUUID.Generator.nextTimeUUID();
+        ILifecycleTransaction txn = Mockito.mock(ILifecycleTransaction.class);
+        when(txn.opId()).thenReturn(taskId);
+
+        CompactionPick pick = Mockito.mock(CompactionPick.class);
+        when(pick.id()).thenReturn(taskId);
+        when(pick.parent()).thenReturn(5L);
+
+        CompactionAggregate aggregate = Mockito.mock(CompactionAggregate.class);
+        when(aggregate.getSelected()).thenReturn(pick);
+        when(aggregate.getMatching(any(TreeMap.class))).thenReturn(aggregate);
+        when(aggregate.containsSameInstance(any())).thenReturn(Pair.create(true, pick));
+
+        backgroundCompactions.setSubmitted(strategy, taskId, aggregate);
+
+        assertEquals(5, strategy.getLevel(txn));
+        assertEquals(0, sstable.getSSTableLevel()); // Still 0
     }
 
     @Test


### PR DESCRIPTION
### What is the issue

Debug logs always report `level=0` for UCS (Unified Compaction Strategy) compactions, while `nodetool compactionstats -A` shows the correct levels. This happens because `CompactionTask.getLevel()` returns 0 by default, and only `LeveledCompactionTask` overrides it. See [HCD-293](https://datastax.jira.com/browse/HCD-293).

### What does this PR fix and why

This PR adds a `CompactionStrategy.getLevel(ILifecycleTransaction)` interface method that allows strategies to report their level dynamically. Both `UnifiedCompactionStrategy` and
`LeveledCompactionStrategy` now implement this by looking up the active compaction and returning its level. `CompactionTask.logCompletion()` now falls back to `strategy.getLevel(transaction)` when the task's `getLevel()` returns 0, ensuring debug logs show correct levels matching `nodetool compactionstats -A` output.

Also removes level logging for individual sstables.

### Testing

Added unit test `testGetLevelForTransaction()` that verifies `UnifiedCompactionStrategy.getLevel()` returns the correct level for registered compactions and -1 for unknown transactions.

[HCD-293]:
https://datastax.jira.com/browse/HCD-293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


[HCD-293]: https://datastax.jira.com/browse/HCD-293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HCD-293]: https://datastax.jira.com/browse/HCD-293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ