### PR TITLE
CNDB-17102: Break out VectorCompressionTest to reduce probability of timeouts

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/vector/VectorSourceModel.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/VectorSourceModel.java
@@ -187,7 +187,7 @@ public enum VectorSourceModel
     }
 
     @VisibleForTesting
-    static double tapered2x(int limit)
+    public static double tapered2x(int limit)
     {
         return max(1.0, 0.509 + 9.491 * pow(limit, -0.402)); // f(1) = 10.0, f(100) = 2.0, f(1000) = 1.1
     }

--- a/test/unit/org/apache/cassandra/index/sai/disk/vector/vectorcompression/AbstractVectorCompressionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/vector/vectorcompression/AbstractVectorCompressionTest.java
@@ -16,103 +16,33 @@
  * limitations under the License.
  */
 
-package org.apache.cassandra.index.sai.disk.vector;
+package org.apache.cassandra.index.sai.disk.vector.vectorcompression;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
-
-import org.junit.Test;
 
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.index.sai.StorageAttachedIndex;
 import org.apache.cassandra.index.sai.cql.VectorTester;
 import org.apache.cassandra.index.sai.disk.v2.V2VectorIndexSearcher;
+import org.apache.cassandra.index.sai.disk.vector.CassandraOnHeapGraph;
+import org.apache.cassandra.index.sai.disk.vector.VectorCompression;
+import org.apache.cassandra.index.sai.disk.vector.VectorSourceModel;
 import org.assertj.core.api.Assertions;
+import org.junit.Ignore;
 
 import static org.apache.cassandra.index.sai.disk.vector.VectorCompression.CompressionType.NONE;
 import static org.junit.Assert.assertEquals;
 
-public class VectorCompressionTest extends VectorTester
+@Ignore
+public abstract class AbstractVectorCompressionTest extends VectorTester
 {
-    @Test
-    public void testAda002() throws IOException
-    {
-        // ADA002 is always 1536
-        testOne(VectorSourceModel.ADA002, 1536, VectorSourceModel.ADA002.compressionProvider.apply(1536));
-    }
-
-    @Test
-    public void testGecko() throws IOException
-    {
-        // GECKO is always 768
-        testOne(VectorSourceModel.GECKO, 768, VectorSourceModel.GECKO.compressionProvider.apply(768));
-    }
-
-    @Test
-    public void testOpenAiV3Large() throws IOException
-    {
-        // V3_LARGE can be truncated
-        for (int i = 1; i < 3; i++)
-        {
-            int D = 3072 / i;
-            testOne(VectorSourceModel.OPENAI_V3_LARGE, D, VectorSourceModel.OPENAI_V3_LARGE.compressionProvider.apply(D));
-        }
-    }
-
-    @Test
-    public void testOpenAiV3Small() throws IOException
-    {
-        // V3_SMALL can be truncated
-        for (int i = 1; i < 3; i++)
-        {
-            int D = 1536 / i;
-            testOne(VectorSourceModel.OPENAI_V3_SMALL, D, VectorSourceModel.OPENAI_V3_SMALL.compressionProvider.apply(D));
-        }
-    }
-
-    @Test
-    public void testBert() throws IOException
-    {
-        // BERT is more of a family than a specific model
-        for (int dimension : List.of(128, 256, 512, 1024))
-        {
-            testOne(VectorSourceModel.BERT, dimension, VectorSourceModel.BERT.compressionProvider.apply(dimension));
-        }
-    }
-
-    @Test
-    public void testNV_QA_4() throws IOException
-    {
-        // NV_QA_4 is anecdotally 1024 based on reviewing https://build.nvidia.com/nvidia/embed-qa-4. Couldn't
-        // find supporting documentation for this number, though.
-        testOne(VectorSourceModel.NV_QA_4, 1024, VectorSourceModel.NV_QA_4.compressionProvider.apply(1024));
-    }
-
-    @Test
-    public void testOther() throws IOException
-    {
-        // 25..200 -> Glove dimensions
-        // 1536 -> Ada002
-        // 2000 -> something unknown and large
-        for (int dimension : List.of(25, 50, 100, 200, 1536, 2000))
-            testOne(VectorSourceModel.OTHER, dimension, VectorSourceModel.OTHER.compressionProvider.apply(dimension));
-    }
-
-    @Test
-    public void testFewRows() throws IOException
-    {
-        // with fewer than MIN_PQ_ROWS we expect to observe no compression no matter
-        // what the source model would prefer
-        testOne(1, VectorSourceModel.OTHER, 200, VectorCompression.NO_COMPRESSION);
-    }
-
-    private void testOne(VectorSourceModel model, int originalDimension, VectorCompression expectedCompression) throws IOException
+    protected void testOne(VectorSourceModel model, int originalDimension, VectorCompression expectedCompression) throws IOException
     {
         testOne(CassandraOnHeapGraph.MIN_PQ_ROWS, model, originalDimension, expectedCompression);
     }
 
-    private void testOne(int rows, VectorSourceModel model, int originalDimension, VectorCompression expectedCompression) throws IOException
+    protected void testOne(int rows, VectorSourceModel model, int originalDimension, VectorCompression expectedCompression) throws IOException
     {
         createTable(String.format("CREATE TABLE %%s (pk int, v vector<float, %d>, PRIMARY KEY(pk)) " +
                                   "WITH compaction = {'class': 'UnifiedCompactionStrategy', 'num_shards': 1, 'enabled': false}",

--- a/test/unit/org/apache/cassandra/index/sai/disk/vector/vectorcompression/VectorCompressionAda002Test.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/vector/vectorcompression/VectorCompressionAda002Test.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.disk.vector.vectorcompression;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import org.apache.cassandra.index.sai.disk.vector.VectorSourceModel;
+
+public class VectorCompressionAda002Test extends AbstractVectorCompressionTest
+{
+    @Test
+    public void testAda002() throws IOException
+    {
+        // ADA002 is always 1536
+        testOne(VectorSourceModel.ADA002, 1536, VectorSourceModel.ADA002.compressionProvider.apply(1536));
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/disk/vector/vectorcompression/VectorCompressionBertTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/vector/vectorcompression/VectorCompressionBertTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.disk.vector.vectorcompression;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.junit.Test;
+
+import org.apache.cassandra.index.sai.disk.vector.VectorSourceModel;
+
+public class VectorCompressionBertTest extends AbstractVectorCompressionTest
+{
+    @Test
+    public void testBert() throws IOException
+    {
+        // BERT is more of a family than a specific model
+        for (int dimension : List.of(128, 256, 512, 1024))
+        {
+            testOne(VectorSourceModel.BERT, dimension, VectorSourceModel.BERT.compressionProvider.apply(dimension));
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/disk/vector/vectorcompression/VectorCompressionFewRowsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/vector/vectorcompression/VectorCompressionFewRowsTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.disk.vector.vectorcompression;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import org.apache.cassandra.index.sai.disk.vector.VectorCompression;
+import org.apache.cassandra.index.sai.disk.vector.VectorSourceModel;
+
+public class VectorCompressionFewRowsTest extends AbstractVectorCompressionTest
+{
+    @Test
+    public void testFewRows() throws IOException
+    {
+        // with fewer than MIN_PQ_ROWS we expect to observe no compression no matter
+        // what the source model would prefer
+        testOne(1, VectorSourceModel.OTHER, 200, VectorCompression.NO_COMPRESSION);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/disk/vector/vectorcompression/VectorCompressionGeckoTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/vector/vectorcompression/VectorCompressionGeckoTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.disk.vector.vectorcompression;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import org.apache.cassandra.index.sai.disk.vector.VectorSourceModel;
+
+public class VectorCompressionGeckoTest extends AbstractVectorCompressionTest
+{
+    @Test
+    public void testGecko() throws IOException
+    {
+        // GECKO is always 768
+        testOne(VectorSourceModel.GECKO, 768, VectorSourceModel.GECKO.compressionProvider.apply(768));
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/disk/vector/vectorcompression/VectorCompressionNvQa4Test.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/vector/vectorcompression/VectorCompressionNvQa4Test.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.disk.vector.vectorcompression;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import org.apache.cassandra.index.sai.disk.vector.VectorSourceModel;
+
+public class VectorCompressionNvQa4Test extends AbstractVectorCompressionTest
+{
+    @Test
+    public void testNV_QA_4() throws IOException
+    {
+        // NV_QA_4 is anecdotally 1024 based on reviewing https://build.nvidia.com/nvidia/embed-qa-4. Couldn't
+        // find supporting documentation for this number, though.
+        testOne(VectorSourceModel.NV_QA_4, 1024, VectorSourceModel.NV_QA_4.compressionProvider.apply(1024));
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/disk/vector/vectorcompression/VectorCompressionOpenAiV3LargeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/vector/vectorcompression/VectorCompressionOpenAiV3LargeTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.disk.vector.vectorcompression;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import org.apache.cassandra.index.sai.disk.vector.VectorSourceModel;
+
+public class VectorCompressionOpenAiV3LargeTest extends AbstractVectorCompressionTest
+{
+    @Test
+    public void testOpenAiV3Large() throws IOException
+    {
+        // V3_LARGE can be truncated
+        for (int i = 1; i < 3; i++)
+        {
+            int D = 3072 / i;
+            testOne(VectorSourceModel.OPENAI_V3_LARGE, D, VectorSourceModel.OPENAI_V3_LARGE.compressionProvider.apply(D));
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/disk/vector/vectorcompression/VectorCompressionOpenAiV3SmallTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/vector/vectorcompression/VectorCompressionOpenAiV3SmallTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.disk.vector.vectorcompression;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import org.apache.cassandra.index.sai.disk.vector.VectorSourceModel;
+
+public class VectorCompressionOpenAiV3SmallTest extends AbstractVectorCompressionTest
+{
+    @Test
+    public void testOpenAiV3Small() throws IOException
+    {
+        // V3_SMALL can be truncated
+        for (int i = 1; i < 3; i++)
+        {
+            int D = 1536 / i;
+            testOne(VectorSourceModel.OPENAI_V3_SMALL, D, VectorSourceModel.OPENAI_V3_SMALL.compressionProvider.apply(D));
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/disk/vector/vectorcompression/VectorCompressionOtherTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/vector/vectorcompression/VectorCompressionOtherTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.disk.vector.vectorcompression;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.junit.Test;
+
+import org.apache.cassandra.index.sai.disk.vector.VectorSourceModel;
+
+public class VectorCompressionOtherTest extends AbstractVectorCompressionTest
+{
+    @Test
+    public void testOther() throws IOException
+    {
+        // 25..200 -> Glove dimensions
+        // 1536 -> Ada002
+        // 2000 -> something unknown and large
+        for (int dimension : List.of(25, 50, 100, 200, 1536, 2000))
+            testOne(VectorSourceModel.OTHER, dimension, VectorSourceModel.OTHER.compressionProvider.apply(dimension));
+    }
+}


### PR DESCRIPTION
### What is the issue

Fixes: https://github.com/riptano/cndb/issues/17102

### What does this PR fix and why was it fixed

This PR breaks the `VectorCompressionTest` into a test class per dataset to prevent the likelihood of timeouts.
