### PR TITLE
CNDB-17110: Fix possible deadlock if flush fails

### DIFF
--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -1455,18 +1455,25 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
             }
             catch (Throwable t)
             {
-                JVMStabilityInspector.inspectThrowable(t);
                 postFlush.flushFailure = t;
+                JVMStabilityInspector.inspectThrowable(t);
             }
+            finally
+            {
+                if (logger.isTraceEnabled())
+                    logger.trace("Flush task {}@{} signaling post flush task", hashCode(), name);
 
-            if (logger.isTraceEnabled())
-                logger.trace("Flush task {}@{} signaling post flush task", hashCode(), name);
+                // signal the post-flush we've done our work
+                postFlush.latch.decrement();
 
-            // signal the post-flush we've done our work
-            postFlush.latch.decrement();
-
-            if (logger.isTraceEnabled())
-                logger.trace("Flush task task {}@{} finished", hashCode(), name);
+                if (logger.isTraceEnabled())
+                {
+                    if (postFlush.flushFailure != null)
+                        logger.trace("Flush task task {}@{} failed", hashCode(), name);
+                    else
+                        logger.trace("Flush task task {}@{} finished successfully", hashCode(), name);
+                }
+            }
         }
 
         public Collection<SSTableReader> flushMemtable(ColumnFamilyStore cfs, Memtable memtable, boolean flushNonCf2i)


### PR DESCRIPTION
`JVMStabilityInspector.inspectThrowable(t)` can throw an exception. In that case the control flow never reaches
`postFlush.latch.decrement()` and threads waiting for flush to finish never unlock and never get a chance to propagate the exception up the call chain. This ends up in a bad lockup with no error logged anywhere, system appearing to be performing a pending flush, but no flush actually running. This scenario has been observed in tests when the system hit the limit of open files.

This commit moves `latch.decrement()` to a finally block so it can never be skipped.
