### PR TITLE
CNDB-17275: Put SAI statistical estimation behind a feature flag

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -811,6 +811,14 @@ public enum CassandraRelevantProperties
      */
     SAI_QUERY_KIND_PER_TABLE_METRICS_ENABLED("cassandra.sai.metrics.query_kind.per_table.enabled", "true"),
 
+    /**
+     * If disabled, the query optimizer runs index search to estimate the number of matching keys.
+     * If enabled, the query optimizer uses, if present, the term statistics stored
+     * with the help of histograms in the metadata component of each SSTable index.
+     * Using terms statistics is significantly less costly but less precise.
+     */
+    SAI_QUERY_OPTIMIZATION_USE_TERM_STATISTICS("cassandra.sai.query_optimization.use_term_statistics", "false"),
+
     SAI_QUERY_OPT_LEVEL("cassandra.sai.query.optimization.level", "1"),
 
     /**

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -124,6 +124,8 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
     @VisibleForTesting
     public static int QUERY_OPT_LEVEL = SAI_QUERY_OPT_LEVEL.getInt();
 
+    public static volatile boolean QUERY_OPT_USE_TERM_STATS = CassandraRelevantProperties.SAI_QUERY_OPTIMIZATION_USE_TERM_STATISTICS.getBoolean();
+
     private final ColumnFamilyStore cfs;
     private final ReadCommand command;
     private final Orderer orderer;
@@ -984,7 +986,7 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
             case NOT_CONTAINS_KEY:
             case NOT_CONTAINS_VALUE:
             case RANGE:
-                return (indexFeatureSet.hasTermsHistogram())
+                return (indexFeatureSet.hasTermsHistogram() && QUERY_OPT_USE_TERM_STATS)
                        ? estimateMatchingRowCountUsingHistograms(predicate)
                        : estimateMatchingRowCountUsingIndex(predicate);
             default:

--- a/test/unit/org/apache/cassandra/index/sai/SAITester.java
+++ b/test/unit/org/apache/cassandra/index/sai/SAITester.java
@@ -241,6 +241,7 @@ public class SAITester extends CQLTester
     {
         // Enable the optimizer by default. If there are any tests that need to disable it, they can do so explicitly.
         QueryController.QUERY_OPT_LEVEL = 1;
+        QueryController.QUERY_OPT_USE_TERM_STATS = true;
 
     }
 

--- a/test/unit/org/apache/cassandra/index/sai/plan/SingleRestrictionEstimatedRowCountTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/plan/SingleRestrictionEstimatedRowCountTest.java
@@ -90,30 +90,38 @@ public class SingleRestrictionEstimatedRowCountTest extends SAITester
 
         for (Version version : versions)
         {
-            RowCountTest test = new RowCountTest(Operator.NEQ, 25);
-            test.doTest(version, INT, 95, 100);
-            test.doTest(version, DECIMAL, 95, version.onOrAfter(Version.EB) ? 99 : 100);
-            test.doTest(version, VARINT, 95, 99);
+            boolean[] useTermStatsTestedValues = new boolean[]{ false };
+            if (version.onOrAfter(Version.EB))
+                useTermStatsTestedValues = new boolean[]{ true, false };
+            for (boolean useTermStats : useTermStatsTestedValues)
+            {
+                QueryController.QUERY_OPT_USE_TERM_STATS = useTermStats;
 
-            test = new RowCountTest(Operator.LT, 50);
-            test.doTest(version, INT, 40, 60);
-            test.doTest(version, DECIMAL, 40, 60);
-            test.doTest(version, VARINT, 40, 60);
+                RowCountTest test = new RowCountTest(Operator.NEQ, 25);
+                test.doTest(version, INT, 95, 99);
+                test.doTest(version, DECIMAL, 95, 99);
+                test.doTest(version, VARINT, 95, 99);
 
-            test = new RowCountTest(Operator.LT, 150);
-            test.doTest(version, INT, 95, 100);
-            test.doTest(version, DECIMAL, 95, 100);
-            test.doTest(version, VARINT, 95, 100);
+                test = new RowCountTest(Operator.LT, 50);
+                test.doTest(version, INT, 40, 60);
+                test.doTest(version, DECIMAL, 40, 60);
+                test.doTest(version, VARINT, 40, 60);
 
-            test = new RowCountTest(Operator.EQ, 31);
-            // For older on-disk formats we expect less accurate estimates due to lack of per-index stats and due to
-            // lazy search on the first shard only; in this scenario each shard iterator will report at least one row,
-            // even if none are matching. We could have run the search on all shards to get more accurate estimates,
-            // but search is expensive, so we accept less accurate estimates for older formats.
-            int maxExpectedRows = version.onOrAfter(Version.EB) ? 1 : TrieMemtable.SHARD_COUNT;
-            test.doTest(version, INT, 1, maxExpectedRows);
-            test.doTest(version, DECIMAL, 1, maxExpectedRows);
-            test.doTest(version, VARINT, 1, maxExpectedRows);
+                test = new RowCountTest(Operator.LT, 150);
+                test.doTest(version, INT, 95, 100);
+                test.doTest(version, DECIMAL, 95, 100);
+                test.doTest(version, VARINT, 95, 100);
+
+                test = new RowCountTest(Operator.EQ, 31);
+                // For older on-disk formats we expect less accurate estimates due to lack of per-index stats and due to
+                // lazy search on the first shard only; in this scenario each shard iterator will report at least one row,
+                // even if none are matching. We could have run the search on all shards to get more accurate estimates,
+                // but search is expensive, so we accept less accurate estimates for older formats.
+                int maxExpectedRows = useTermStats ? 1 : TrieMemtable.SHARD_COUNT * 2;
+                test.doTest(version, INT, 1, maxExpectedRows);
+                test.doTest(version, DECIMAL, 1, maxExpectedRows);
+                test.doTest(version, VARINT, 1, maxExpectedRows);
+            }
         }
     }
 


### PR DESCRIPTION
PR #1253 switched query planner to use histograms for rows estimations. This can change query plans in existing databases leading to different performance. To avoid such change during upgrade, a flag, which controls using or not histograms, i.e., old vs new way of estimating rows, is introduced and set to FALSE by default.
