### PR TITLE
CNDB-12716: Metric for writes blocked on memory allocation

### DIFF
--- a/src/java/org/apache/cassandra/utils/memory/MemtableAllocator.java
+++ b/src/java/org/apache/cassandra/utils/memory/MemtableAllocator.java
@@ -189,7 +189,7 @@ public abstract class MemtableAllocator
                     allocated(size);
                     return;
                 }
-                WaitQueue.Signal signal = parent.hasRoom().register(parent.blockedTimerContext(), Timer.Context::stop);
+                WaitQueue.Signal signal = parent.hasRoom().register(parent.markMemoryBlockedOnAllocating(), Timer.Context::stop);
                 opGroup.notifyIfBlocking(signal);
                 boolean allocated = parent.tryAllocate(size);
                 if (allocated)

--- a/src/java/org/apache/cassandra/utils/memory/MemtablePool.java
+++ b/src/java/org/apache/cassandra/utils/memory/MemtablePool.java
@@ -25,6 +25,7 @@ import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 
+import com.codahale.metrics.Counter;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Timer;
 import org.apache.cassandra.metrics.CassandraMetricsRegistry;
@@ -48,6 +49,11 @@ public abstract class MemtablePool
     public final SubPool offHeap;
 
     public final Timer blockedOnAllocating;
+    /**
+     * Counter metric that registers blocked write immediately in contrast to Timer blockedOnAllocating that waits for
+     * allocation to register wait duration.
+     */
+    public final Counter blockedOnAllocatingCount;
     public final Gauge<Long> numPendingTasks;
 
     final WaitQueue hasRoom = newWaitQueue();
@@ -61,6 +67,7 @@ public abstract class MemtablePool
         this.cleaner = getCleaner(cleaner);
         DefaultNameFactory nameFactory = new DefaultNameFactory("MemtablePool");
         blockedOnAllocating = CassandraMetricsRegistry.Metrics.timer(nameFactory.createMetricName("BlockedOnAllocation"));
+        blockedOnAllocatingCount = CassandraMetricsRegistry.Metrics.counter(nameFactory.createMetricName("BlockedOnAllocationTotal"));
         numPendingTasks = CassandraMetricsRegistry.Metrics.register(nameFactory.createMetricName("PendingFlushTasks"),
                                                                     () -> (long) this.cleaner.numPendingTasks());
     }
@@ -249,8 +256,9 @@ public abstract class MemtablePool
             return hasRoom;
         }
 
-        public Timer.Context blockedTimerContext()
+        public Timer.Context markMemoryBlockedOnAllocating()
         {
+            blockedOnAllocatingCount.inc();
             return blockedOnAllocating.time();
         }
     }

--- a/test/unit/org/apache/cassandra/utils/memory/NativeAllocatorTest.java
+++ b/test/unit/org/apache/cassandra/utils/memory/NativeAllocatorTest.java
@@ -143,8 +143,10 @@ public class NativeAllocatorTest
 
             // allocate above limit, check we block until "marked blocking"
             exec.schedule(markBlocking, 10L, TimeUnit.MILLISECONDS);
+            Assert.assertEquals(0, pool.blockedOnAllocatingCount.getCount());
             allocator.allocate(30, group);
             Assert.assertNotNull(barrier.get());
+            Assert.assertEquals(1, pool.blockedOnAllocatingCount.getCount());
             verifyUsedReclaiming(110, 110);
 
             // release everything


### PR DESCRIPTION
Added counter metric for writes blocked on allocation to be able to see spikes of blocked allocations immediately.
