### PR TITLE
CNDB-17161-202604: fix SSTableContextManager#sstableDescriptors to handle different index sets to avoid returning IndexDescriptor for indexes that have not be loaded

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/SSTableContextManager.java
+++ b/src/java/org/apache/cassandra/index/sai/SSTableContextManager.java
@@ -209,12 +209,31 @@ public class SSTableContextManager
             context.close();
     }
 
+    /**
+     * Returns a descriptor for the given sstable and indexes, reusing a cached one when possible.
+     * <p>
+     * Note that during index initialization, index is added to {@link StorageAttachedIndexGroup} one by one but initialization
+     * tasks are executed concurrently, each task may have a different view of registered indexes. The cache must handle
+     * it and load indexes if they are not already loaded by the cached IndexDescriptor.
+     */
     IndexDescriptor getOrLoadIndexDescriptor(SSTableReader sstable, Set<StorageAttachedIndex> indices)
     {
-        // If we have a SSTableReader, it means the sstable exists, and so if we don't have a descriptor for it,
-        // then create one now. Since the sstable exists, it also means that we will get notified if/when it
-        // is removed (in `update`), so we shouldn't "leak" descriptors.
-        return sstableDescriptors.computeIfAbsent(sstable, __ -> IndexDescriptor.load(sstable, contexts(indices)));
+        Set<IndexContext> requested = contexts(indices);
+        return sstableDescriptors.compute(sstable, (k, existing) -> {
+            // load for the 1st time
+            if (existing == null)
+                return IndexDescriptor.load(sstable, requested);
+
+            // all requested indexes are loaded
+            if (existing.includedIndexes().containsAll(requested))
+                return existing;
+
+            logger.debug("Reloading existing IndexDescriptor for {} because included indexes {} do not include all indexes from {}", sstable.descriptor.id, existing.includedIndexes(), requested);
+            // Load indexes that are not included. Not creating a new IndexDescriptor because existing IndexDescriptor
+            // is already referenced in SSTableContext#perSSTableComponents
+            existing = existing.loadIfAbsent(sstable, requested);
+            return existing;
+        });
     }
 
     private static Set<IndexContext> contexts(Set<StorageAttachedIndex> indices)

--- a/src/java/org/apache/cassandra/index/sai/disk/format/IndexDescriptor.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/IndexDescriptor.java
@@ -29,13 +29,13 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 import javax.annotation.Nullable;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Maps;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -91,7 +91,7 @@ public class IndexDescriptor
     // The per-sstable components for this descriptor. This is never `null` in practice, but 1) it's a bit easier to
     // initialize it outsides of the ctor, and 2) it can actually change upon calls to `reload`.
     private IndexComponentsImpl perSSTable;
-    private final Map<IndexContext, IndexComponentsImpl> perIndexes = Maps.newHashMap();
+    private final Map<IndexContext, IndexComponentsImpl> perIndexes = new ConcurrentHashMap<>();
 
     private IndexDescriptor(Descriptor descriptor)
     {
@@ -243,6 +243,22 @@ public class IndexDescriptor
 
         // Then reload data.
         initialize(indices, discovered);
+        return this;
+    }
+
+    /**
+     * Loads per-index components for the provided indexes only when they are currently missing from this descriptor.
+     * <p>
+     * This method does not modify per-SSTable components and does not replace already tracked per-index groups.
+     * It is intended for incremental index discovery flows where callers only need to populate indexes that are
+     * not present yet without disturbing existing in-memory references.
+     */
+    public IndexDescriptor loadIfAbsent(SSTableReader sstable, Set<IndexContext> indices)
+    {
+        Preconditions.checkArgument(sstable.getDescriptor().equals(this.descriptor));
+        SSTableIndexComponentsState discovered = IndexComponentDiscovery.instance().discoverComponents(sstable);
+        for (var context : indices)
+            perIndexes.computeIfAbsent(context, k -> initializeGroup(context, discovered.perIndexBuild(context.getIndexName())));
         return this;
     }
 

--- a/test/unit/org/apache/cassandra/index/sai/SSTableContextManagerTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/SSTableContextManagerTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.google.common.collect.Iterables;
+import org.junit.Test;
+
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
+import org.apache.cassandra.io.sstable.format.SSTableReader;
+
+import static org.junit.Assert.*;
+
+public class SSTableContextManagerTest extends SAITester
+{
+    @Test
+    public void shouldRefreshDescriptorWhenRequestDifferentIndexes()
+    {
+        createTable("CREATE TABLE %s (id text PRIMARY KEY, v1 int, v2 int)");
+
+        String indexOnV1 = createIndex(String.format(CREATE_INDEX_TEMPLATE, "v1"));
+        String indexOnV2 = createIndex(String.format(CREATE_INDEX_TEMPLATE, "v2"));
+
+        execute("INSERT INTO %s (id, v1, v2) VALUES ('k1', 1, 2)");
+        flush();
+
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        StorageAttachedIndexGroup group = StorageAttachedIndexGroup.getIndexGroup(cfs);
+        assertNotNull(group);
+
+        SSTableReader sstable = Iterables.getOnlyElement(cfs.getLiveSSTables());
+
+        Map<String, StorageAttachedIndex> indexesByName = group.getIndexes()
+                                                             .stream()
+                                                             .collect(Collectors.toMap(i -> i.getIndexMetadata().name, i -> i));
+
+        StorageAttachedIndex v1 = indexesByName.get(indexOnV1);
+        StorageAttachedIndex v2 = indexesByName.get(indexOnV2);
+
+        assertNotNull(v1);
+        assertNotNull(v2);
+
+        assertTrue(IndexDescriptor.isIndexBuildCompleteOnDisk(sstable, v1.getIndexContext()));
+        assertTrue(IndexDescriptor.isIndexBuildCompleteOnDisk(sstable, v2.getIndexContext()));
+
+        // clear in-memory to simulate startup
+        SSTableContextManager manager = group.sstableContextManager();
+        manager.clear();
+
+        // initialization task after registering first index
+        manager.update(Set.of(), Set.of(sstable), false, Set.of(v1));
+        IndexDescriptor firstDescriptor = manager.getOrLoadIndexDescriptor(sstable, Set.of(v1));
+        assertTrue(firstDescriptor.perIndexComponents(v1.getIndexContext()).isComplete());
+        assertFalse(firstDescriptor.perIndexComponents(v2.getIndexContext()).isComplete());
+
+        SSTableContext firstContext = manager.getContext(sstable);
+        assertTrue(firstContext.usedPerSSTableComponents().indexDescriptor().perIndexComponents(v1.getIndexContext()).isComplete());
+        assertFalse(firstContext.usedPerSSTableComponents().indexDescriptor().perIndexComponents(v2.getIndexContext()).isComplete());
+
+        // initialization task after registering second index
+        manager.update(Set.of(), Set.of(sstable), false, Set.of(v1, v2));
+        IndexDescriptor secondDescriptor = manager.getOrLoadIndexDescriptor(sstable, Set.of(v1, v2));
+
+        assertSame(firstDescriptor, secondDescriptor);
+        assertTrue(secondDescriptor.perIndexComponents(v1.getIndexContext()).isComplete());
+        assertTrue(secondDescriptor.perIndexComponents(v2.getIndexContext()).isComplete());
+
+        // verify IndexDescriptor from SSTableContext has latest info
+        SSTableContext secondContext = manager.getContext(sstable);
+        assertSame(firstContext, secondContext);
+        assertTrue(secondContext.usedPerSSTableComponents().indexDescriptor().perIndexComponents(v1.getIndexContext()).isComplete());
+        assertTrue(secondContext.usedPerSSTableComponents().indexDescriptor().perIndexComponents(v2.getIndexContext()).isComplete());
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/disk/format/IndexDescriptorTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/format/IndexDescriptorTest.java
@@ -46,6 +46,7 @@ import org.mockito.Mockito;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -271,6 +272,40 @@ public class IndexDescriptorTest
         assertTrue(components.has(IndexComponentType.META));
         assertTrue(components.has(IndexComponentType.KD_TREE));
         assertTrue(components.has(IndexComponentType.KD_TREE_POSTING_LISTS));
+    }
+
+    @Test
+    public void testLoadIfAbsentLoadsOnlyMissingPerIndexComponents() throws Throwable
+    {
+        SAIUtil.setCurrentVersion(current);
+
+        IndexContext existing = SAITester.createIndexContext("existing_index", Int32Type.instance);
+        IndexContext missing = SAITester.createIndexContext("missing_index", UTF8Type.instance);
+
+        createFakeDataFile(descriptor);
+        createFakePerSSTableComponents(descriptor, current, 0);
+        createFakePerIndexComponents(descriptor, existing, current, 0);
+        createFakePerIndexComponents(descriptor, missing, current, 0);
+
+        IndexDescriptor indexDescriptor = loadDescriptor(existing);
+        IndexComponents.ForRead perSSTableBefore = indexDescriptor.perSSTableComponents();
+        IndexComponents.ForRead existingBefore = indexDescriptor.perIndexComponents(existing);
+        assertEquals(indexDescriptor.includedIndexes(), Set.of(existing));
+
+        SSTableReader sstable = Mockito.mock(SSTableReader.class);
+        Mockito.when(sstable.getDescriptor()).thenReturn(descriptor);
+        indexDescriptor.loadIfAbsent(sstable, Set.of(existing, missing));
+
+        assertSame(perSSTableBefore, indexDescriptor.perSSTableComponents());
+        assertSame(existingBefore, indexDescriptor.perIndexComponents(existing));
+
+        IndexComponents.ForRead missingComponents = indexDescriptor.perIndexComponents(missing);
+        assertTrue(missingComponents.isComplete());
+        assertTrue(missingComponents.has(IndexComponentType.COLUMN_COMPLETION_MARKER));
+        assertTrue(missingComponents.has(IndexComponentType.META));
+        assertTrue(missingComponents.has(IndexComponentType.TERMS_DATA));
+        assertTrue(missingComponents.has(IndexComponentType.POSTING_LISTS));
+        assertTrue(indexDescriptor.includedIndexes().containsAll(Set.of(existing, missing)));
     }
 
     private static void createEmptyFileOnDisk(Descriptor descriptor, String componentStr) throws IOException


### PR DESCRIPTION
- Use CHM for IndexDescriptor#perIndexes

- only load missing indexes
