### PR TITLE
HCD-339 CQLSH Describe command failure

### DIFF
--- a/bin/cqlsh.py
+++ b/bin/cqlsh.py
@@ -1459,7 +1459,7 @@ class Shell(cmd.Cmd):
                     self.describe_element(result)
 
             except CQL_ERRORS as err:
-                err_msg = ensure_text(err.message if hasattr(err, 'message') else str(err))
+                err_msg = maybe_ensure_text(err.message if hasattr(err, 'message') else str(err))
                 self.printerr(err_msg.partition("message=")[2].strip('"'))
             except Exception:
                 import traceback


### PR DESCRIPTION
The Descrive cqlsh command would fail under some specific scenarios.

### What is the issue
On HCD-190 python was updated to later releases. That implied changing the code in a number of places but it was missed on an error condition.

### What does this PR fix and why was it fixed
The correct method is being called now instead.
