### PR TITLE
CNDB-16583: Add new param to failure callback messages - verb name of the incoming message. 

### DIFF
--- a/src/java/org/apache/cassandra/net/InboundSink.java
+++ b/src/java/org/apache/cassandra/net/InboundSink.java
@@ -22,14 +22,14 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Predicate;
 
-import org.apache.cassandra.index.IndexBuildInProgressException;
-import org.apache.cassandra.index.sai.utils.AbortedOperationException;
 import org.slf4j.LoggerFactory;
 
 import net.openhft.chronicle.core.util.ThrowingConsumer;
 import org.apache.cassandra.db.filter.TombstoneOverwhelmingException;
 import org.apache.cassandra.exceptions.RequestFailureReason;
+import org.apache.cassandra.index.IndexBuildInProgressException;
 import org.apache.cassandra.index.IndexNotAvailableException;
+import org.apache.cassandra.index.sai.utils.AbortedOperationException;
 import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.utils.NoSpamLogger;
 
@@ -87,7 +87,8 @@ public class InboundSink implements InboundMessageHandlers.MessageConsumer
             InetAddressAndPort to = header.respondTo() != null ? header.respondTo() : header.from;
             Message<RequestFailureReason> response = Message.failureResponse(header.id,
                                                                              header.expiresAtNanos,
-                                                                             RequestFailureReason.forException(failure));
+                                                                             RequestFailureReason.forException(failure),
+                                                                             header.verb);
             messaging.send(response, to);
         }
     }

--- a/src/java/org/apache/cassandra/net/Message.java
+++ b/src/java/org/apache/cassandra/net/Message.java
@@ -323,12 +323,12 @@ public class Message<T>
     /** Builds a failure response Message with an explicit reason, and fields inferred from request Message */
     public Message<RequestFailureReason> failureResponse(RequestFailureReason reason)
     {
-        return failureResponse(id(), expiresAtNanos(), reason);
+        return failureResponse(id(), expiresAtNanos(), reason, verb());
     }
 
-    static Message<RequestFailureReason> failureResponse(long id, long expiresAtNanos, RequestFailureReason reason)
+    static Message<RequestFailureReason> failureResponse(long id, long expiresAtNanos, RequestFailureReason reason, Verb requestVerb)
     {
-        return outWithParam(id, Verb.FAILURE_RSP, expiresAtNanos, reason, null, null).build();
+        return outWithParam(id, Verb.FAILURE_RSP, expiresAtNanos, reason, ParamType.REQUEST_VERB_NAME, requestVerb.name()).build();
     }
 
     public <V> Message<V> withPayload(V newPayload)

--- a/src/java/org/apache/cassandra/net/MessageDelivery.java
+++ b/src/java/org/apache/cassandra/net/MessageDelivery.java
@@ -31,6 +31,6 @@ public interface MessageDelivery
     public <V> void respond(V response, Message<?> message);
     public default void respondWithFailure(RequestFailureReason reason, Message<?> message)
     {
-        send(Message.failureResponse(message.id(), message.expiresAtNanos(), reason), message.respondTo());
+        send(Message.failureResponse(message.id(), message.expiresAtNanos(), reason, message.verb()), message.respondTo());
     }
 }

--- a/src/java/org/apache/cassandra/net/ParamType.java
+++ b/src/java/org/apache/cassandra/net/ParamType.java
@@ -62,7 +62,11 @@ public enum ParamType
     /**
      * Messages with tracing sessions are decorated with the traced keyspace.
      */
-    TRACE_KEYSPACE                   (18, StringSerializer.serializer);
+    TRACE_KEYSPACE                   (18, StringSerializer.serializer),
+    /**
+     * Failure response messages contain verb name of the incoming message.
+     */
+    REQUEST_VERB_NAME                (19, StringSerializer.serializer);
 
     final int id;
     final IVersionedSerializer serializer;

--- a/test/unit/org/apache/cassandra/net/MessageTest.java
+++ b/test/unit/org/apache/cassandra/net/MessageTest.java
@@ -188,12 +188,29 @@ public class MessageTest
     public void testFailureResponse() throws IOException
     {
         long expiresAt = approxTime.now();
-        Message<RequestFailureReason> msg = Message.failureResponse(1, expiresAt, RequestFailureReason.INCOMPATIBLE_SCHEMA);
+        Message<RequestFailureReason> msg = Message.failureResponse(1, expiresAt, RequestFailureReason.INCOMPATIBLE_SCHEMA, Verb.MUTATION_REQ);
 
         assertEquals(1, msg.id());
         assertEquals(Verb.FAILURE_RSP, msg.verb());
         assertEquals(expiresAt, msg.expiresAtNanos());
         assertEquals(RequestFailureReason.INCOMPATIBLE_SCHEMA, msg.payload);
+        assertEquals(Verb.MUTATION_REQ.name(), msg.header.params().get(ParamType.REQUEST_VERB_NAME));
+        assertTrue(msg.isFailureResponse());
+
+        testCycle(msg);
+    }
+
+    @Test
+    public void testNonStaticFailureResponse() throws IOException
+    {
+        Message<String> incomingMessage = Message.builder(Verb.MUTATION_REQ, "some-payload").withId(1).build();
+        Message<RequestFailureReason> msg = incomingMessage.failureResponse(RequestFailureReason.INCOMPATIBLE_SCHEMA);
+
+        assertEquals(1, msg.id());
+        assertEquals(Verb.FAILURE_RSP, msg.verb());
+        assertEquals(incomingMessage.expiresAtNanos(), msg.expiresAtNanos());
+        assertEquals(RequestFailureReason.INCOMPATIBLE_SCHEMA, msg.payload);
+        assertEquals(Verb.MUTATION_REQ.name(), msg.header.params().get(ParamType.REQUEST_VERB_NAME));
         assertTrue(msg.isFailureResponse());
 
         testCycle(msg);


### PR DESCRIPTION
Added a new parameter to failure callback messages—the verb name of the incoming request. This parameter allows to differentiate failure responses based on the origin of the request.
