### PR TITLE
CNDB-17459 CommitLog: allow to retrieve and recover optionally filtered segment files.

### DIFF
--- a/src/java/org/apache/cassandra/db/commitlog/CommitLog.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CommitLog.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.UUID;
@@ -180,9 +181,25 @@ public class CommitLog implements CommitLogMBean
 
     public File[] getUnmanagedFiles()
     {
-        File[] files = segmentManager.storageDirectory.tryList(unmanagedFilesFilter);
+        return getFilteredFiles(Optional.empty());
+    }
+
+    /**
+     * Returns segment files to replay according to the configured segment manager.
+     *
+     * @param filter An optional filter to apply to segment files returned by the segment manager.
+     * @return Segment files to replay, optionally filtered.
+     */
+    public File[] getFilteredFiles(Optional<BiPredicate<File, String>> filter)
+    {
+        BiPredicate<File, String> compositeFilter = (path, name) ->
+                                                    filter.orElse((ignored1, ignored2) -> true).test(path, name)
+                                                    && unmanagedFilesFilter.test(path, name);
+
+        File[] files = segmentManager.storageDirectory.tryList(compositeFilter);
         if (files == null)
             return new File[0];
+
         return files;
     }
 
@@ -201,7 +218,8 @@ public class CommitLog implements CommitLogMBean
     }
 
     /**
-     * Perform recovery on commit logs located in the directory specified by the config file.
+     * Perform recovery on commit logs located in the directory specified by the config file,
+     * performing archive and restore before.
      * The recovery is executed as a commit log read followed by a flush.
      *
      * @param flushReason the reason for flushing that fallows commit log reading, use
@@ -211,12 +229,9 @@ public class CommitLog implements CommitLogMBean
      * @return keyspaces and the corresponding number of partition updates
      * @throws IOException
      */
-    public Map<Keyspace, Integer> recoverSegmentsOnDisk(ColumnFamilyStore.FlushReason flushReason) throws IOException
+    public Map<Keyspace, Integer> recoverSegmentsOnDiskWithArchive(ColumnFamilyStore.FlushReason flushReason) throws IOException
     {
-        // submit all files for this segment manager for archiving prior to recovery - CASSANDRA-6904
-        // The files may have already been archived by normal CommitLog operation. This may cause errors in this
-        // archiving pass, which we should not treat as serious.
-        for (File file : getUnmanagedFiles())
+        for (File file : getFilteredFiles(Optional.empty()))
         {
             archiver.maybeArchive(file.path(), file.name());
             archiver.maybeWaitForArchiving(file.name());
@@ -226,7 +241,23 @@ public class CommitLog implements CommitLogMBean
         archiver.maybeRestoreArchive();
 
         // List the files again as archiver may have added segments.
-        File[] files = getUnmanagedFiles();
+        return recoverSegmentsOnDiskNoArchive(flushReason, getFilteredFiles(Optional.empty()));
+    }
+
+    /**
+     * Perform recovery on commit logs located in the directory specified by the config file, without archiving.
+     * The recovery is executed as a commit log read followed by a flush.
+     *
+     * @param flushReason the reason for flushing that fallows commit log reading, use
+     *                    {@link org.apache.cassandra.db.ColumnFamilyStore.FlushReason#STARTUP} when recovering on a
+     *                    node start. Use {@link org.apache.cassandra.db.ColumnFamilyStore.FlushReason#REMOTE_REPLAY}
+     *                    when replying commit logs to a remote storage.
+     * @param files THe segment files to recovery.
+     * @return keyspaces and the corresponding number of partition updates
+     * @throws IOException
+     */
+    public Map<Keyspace, Integer> recoverSegmentsOnDiskNoArchive(ColumnFamilyStore.FlushReason flushReason, File[] files) throws IOException
+    {
         Map<Keyspace, Integer> replayedKeyspaces = Collections.emptyMap();
         if (files.length == 0)
         {
@@ -631,7 +662,7 @@ public class CommitLog implements CommitLogMBean
     synchronized public Map<Keyspace, Integer> restartUnsafe() throws IOException
     {
         started = false;
-        return start().recoverSegmentsOnDisk(ColumnFamilyStore.FlushReason.STARTUP);
+        return start().recoverSegmentsOnDiskWithArchive(ColumnFamilyStore.FlushReason.STARTUP);
     }
 
     public static long freeDiskSpace()

--- a/src/java/org/apache/cassandra/service/CassandraDaemon.java
+++ b/src/java/org/apache/cassandra/service/CassandraDaemon.java
@@ -69,6 +69,7 @@ import org.apache.cassandra.security.ThreadAwareSecurityManager;
 import org.apache.cassandra.service.paxos.PaxosState;
 import org.apache.cassandra.streaming.StreamManager;
 import org.apache.cassandra.utils.FBUtilities;
+import org.apache.cassandra.utils.INativeLibrary;
 import org.apache.cassandra.utils.JMXServerUtils;
 import org.apache.cassandra.utils.JVMStabilityInspector;
 import org.apache.cassandra.utils.MBeanWrapper;
@@ -77,7 +78,6 @@ import org.apache.cassandra.utils.concurrent.Future;
 import org.apache.cassandra.utils.concurrent.FutureCombiner;
 import org.apache.cassandra.utils.logging.LoggingSupportFactory;
 import org.apache.cassandra.utils.logging.VirtualTableAppender;
-import org.apache.cassandra.utils.INativeLibrary;
 
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static org.apache.cassandra.config.CassandraRelevantProperties.CASSANDRA_FOREGROUND;
@@ -341,7 +341,7 @@ public class CassandraDaemon
         // replay the log if necessary
         try
         {
-            CommitLog.instance.recoverSegmentsOnDisk(ColumnFamilyStore.FlushReason.STARTUP);
+            CommitLog.instance.recoverSegmentsOnDiskWithArchive(ColumnFamilyStore.FlushReason.STARTUP);
         }
         catch (IOException e)
         {

--- a/test/distributed/org/apache/cassandra/distributed/impl/Instance.java
+++ b/test/distributed/org/apache/cassandra/distributed/impl/Instance.java
@@ -684,7 +684,7 @@ public class Instance extends IsolatedExecutor implements IInvokableInstance
                 // Replay any CommitLogSegments found on disk
                 try
                 {
-                    CommitLog.instance.recoverSegmentsOnDisk(ColumnFamilyStore.FlushReason.STARTUP);
+                    CommitLog.instance.recoverSegmentsOnDiskWithArchive(ColumnFamilyStore.FlushReason.STARTUP);
                 }
                 catch (IOException e)
                 {


### PR DESCRIPTION
This requires exposing a new getFilteredFiles() method, and splitting recoverSegmentsOnDisk() into recoverSegmentsOnDiskWithArchive() and recoverSegmentsOnDiskNoArchive(), with:
- recoverSegmentsOnDiskWithArchive() internally invoking getFilteredFiles() without any filtering, since archive restore might change the file list.
- recoverSegmentsOnDiskNoArchive() instead receiving the list of files to recover.
