### PR TITLE
CNDB-17487 require IBM copyright on new files

### DIFF
--- a/.github/workflows/pr_checklist.md
+++ b/.github/workflows/pr_checklist.md
@@ -9,4 +9,4 @@
 - [ ] Each commit has a meaningful description
 - [ ] Each commit is not very long and contains related changes
 - [ ] Renames, moves and reformatting are in distinct commits
-- [ ] All new files should contain the DataStax copyright header instead of the Apache License one
+- [ ] All new files should contain the IBM copyright header instead of the Apache License one (no DataStax copyright any longer)


### PR DESCRIPTION

### What is the issue
IBM copyright policy requires to use IBM copyright on new materials, including new files, in open source projects.

### What does this PR fix and why was it fixed
Implements https://github.com/riptano/cndb/issues/17487

Changing from DataStax to IBM copyright in the PR checklist.
