### PR TITLE
CNDB-17728: Fix coordinator warning setup in CQLTester

### DIFF
--- a/test/unit/org/apache/cassandra/cql3/CQLTester.java
+++ b/test/unit/org/apache/cassandra/cql3/CQLTester.java
@@ -181,6 +181,7 @@ import org.apache.cassandra.serializers.TypeSerializer;
 import org.apache.cassandra.service.ClientState;
 import org.apache.cassandra.service.QueryState;
 import org.apache.cassandra.service.StorageService;
+import org.apache.cassandra.service.reads.thresholds.CoordinatorWarnings;
 import org.apache.cassandra.transport.Event;
 import org.apache.cassandra.transport.Message;
 import org.apache.cassandra.transport.ProtocolVersion;
@@ -1912,46 +1913,59 @@ public abstract class CQLTester
     private UntypedResultSet executeFormattedQuery(String query, boolean useCoordinator, Object... values)
     {
         if (useCoordinator)
+        {
             requireNetworkWithoutDriver();
+            CoordinatorWarnings.init();
+        }
 
         UntypedResultSet rs;
-        if (usePrepared)
+        try
         {
-            if (logger.isTraceEnabled())
-                logger.trace("Executing: {} with values {}", query, formatAllValues(values));
-
-            Object[] transformedValues = transformValues(values);
-
-            if (reusePrepared)
+            if (usePrepared)
             {
-                rs = useCoordinator
-                     ? QueryProcessor.execute(query, ConsistencyLevel.ONE, transformedValues)
-                     : QueryProcessor.executeInternal(query, transformedValues);
+                if (logger.isTraceEnabled())
+                    logger.trace("Executing: {} with values {}", query, formatAllValues(values));
 
-                // If a test uses a "USE ...", then presumably its statements use relative table. In that case, a USE
-                // change the meaning of the current keyspace, so we don't want a following statement to reuse a previously
-                // prepared statement at this wouldn't use the right keyspace. To avoid that, we drop the previously
-                // prepared statement.
-                if (query.startsWith("USE"))
-                    QueryProcessor.clearInternalStatementsCache();
+                Object[] transformedValues = transformValues(values);
+
+                if (reusePrepared)
+                {
+                    rs = useCoordinator
+                         ? QueryProcessor.execute(query, ConsistencyLevel.ONE, transformedValues)
+                         : QueryProcessor.executeInternal(query, transformedValues);
+
+                    // If a test uses a "USE ...", then presumably its statements use relative table. In that case, a USE
+                    // change the meaning of the current keyspace, so we don't want a following statement to reuse a previously
+                    // prepared statement at this wouldn't use the right keyspace. To avoid that, we drop the previously
+                    // prepared statement.
+                    if (query.startsWith("USE"))
+                        QueryProcessor.clearInternalStatementsCache();
+                }
+                else
+                {
+                    rs = useCoordinator
+                         ? QueryProcessor.executeOnce(query, ConsistencyLevel.ONE, transformedValues)
+                         : QueryProcessor.executeOnceInternal(query, transformedValues);
+                }
             }
             else
             {
+                query = replaceValues(query, values);
+
+                if (logger.isTraceEnabled())
+                    logger.trace("Executing: {}", query);
+
                 rs = useCoordinator
-                     ? QueryProcessor.executeOnce(query, ConsistencyLevel.ONE, transformedValues)
-                     : QueryProcessor.executeOnceInternal(query, transformedValues);
+                     ? QueryProcessor.executeOnce(query, ConsistencyLevel.ONE)
+                     : QueryProcessor.executeOnceInternal(query);
             }
+            if (useCoordinator)
+                CoordinatorWarnings.done();
         }
-        else
+        finally
         {
-            query = replaceValues(query, values);
-
-            if (logger.isTraceEnabled())
-                logger.trace("Executing: {}", query);
-
-            rs = useCoordinator
-                 ? QueryProcessor.executeOnce(query, ConsistencyLevel.ONE)
-                 : QueryProcessor.executeOnceInternal(query);
+            if (useCoordinator)
+                CoordinatorWarnings.reset();
         }
         if (rs != null)
         {

--- a/test/unit/org/apache/cassandra/index/sai/cql/EstimatedRowCountTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/EstimatedRowCountTest.java
@@ -24,6 +24,8 @@ import org.junit.runners.Parameterized.Parameters;
 import java.util.Arrays;
 import java.util.Collection;
 
+import org.apache.cassandra.config.DataStorageSpec.LongBytesBound;
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.memtable.TrieMemtable;
 import org.apache.cassandra.index.sai.SAITester;
@@ -64,34 +66,47 @@ public class EstimatedRowCountTest extends SAITester
     @Test
     public void testReturnedRowsEstimates() throws Throwable
     {
-        TrieMemtable.SHARD_COUNT = numShards;
-        createTable("CREATE TABLE %s (k int, c int, n int, PRIMARY KEY(k, c))");
-        createIndex("CREATE CUSTOM INDEX n_idx ON %s (n) USING 'StorageAttachedIndex'");
-        createIndex("CREATE CUSTOM INDEX c_idx ON %s (c) USING 'StorageAttachedIndex'");
+        LongBytesBound oldLocalReadSizeWarnThreshold = DatabaseDescriptor.getLocalReadSizeWarnThreshold();
+        LongBytesBound oldLocalReadSizeFailThreshold = DatabaseDescriptor.getLocalReadSizeFailThreshold();
+        try
+        {
+            DatabaseDescriptor.setLocalReadSizeWarnThreshold(null);
+            DatabaseDescriptor.setLocalReadSizeFailThreshold(null);
 
-        int numRowsPerPartition = 13;
-        int numRows = numPartitions * numRowsPerPartition;
+            TrieMemtable.SHARD_COUNT = numShards;
+            createTable("CREATE TABLE %s (k int, c int, n int, PRIMARY KEY(k, c))");
+            createIndex("CREATE CUSTOM INDEX n_idx ON %s (n) USING 'StorageAttachedIndex'");
+            createIndex("CREATE CUSTOM INDEX c_idx ON %s (c) USING 'StorageAttachedIndex'");
 
-        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
-        cfs.unsafeRunWithoutFlushing(() -> {
-             for (int k = 0; k < numPartitions; k++)
-                 for (int c = 0; c < numRowsPerPartition; c++)
-                     execute("INSERT INTO %s (k, c, n) VALUES (?, ?, 1)", k, c);
-         });
+            int numRowsPerPartition = 13;
+            int numRows = numPartitions * numRowsPerPartition;
 
-        beforeAndAfterFlush(() -> {
-            assertThatPlanFor("SELECT k, c FROM %s WHERE n = 0", 0)
-                .hasEstimatedRowsCountBetween(0.0, 0.0);
-            assertThatPlanFor("SELECT k, c FROM %s WHERE n = 1", numRows)
-                .hasEstimatedRowsCountBetween((double) numRows / 2, numRows * 2);
-            assertThatPlanFor("SELECT k, c FROM %s WHERE n < 5", numRows)
-                .hasEstimatedRowsCountBetween((double) numRows / 2, numRows * 2);
-            assertThatPlanFor("SELECT k, c FROM %s WHERE c = 1", numPartitions)
-                .hasEstimatedRowsCountBetween((double) numPartitions / 2, numPartitions * 2);
-            assertThatPlanFor("SELECT k, c FROM %s WHERE c >= 1 AND c <= 10", numPartitions * 10)
-                .hasEstimatedRowsCountBetween((double) numPartitions * 5, numPartitions * 20);
-            assertThatPlanFor("SELECT k, c FROM %s WHERE n = 1 AND c = 1", numPartitions)
-                .hasEstimatedRowsCountBetween((double) numPartitions / 2, numPartitions * 2);;
-        });
+            ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+            cfs.unsafeRunWithoutFlushing(() -> {
+                 for (int k = 0; k < numPartitions; k++)
+                     for (int c = 0; c < numRowsPerPartition; c++)
+                         execute("INSERT INTO %s (k, c, n) VALUES (?, ?, 1)", k, c);
+             });
+
+            beforeAndAfterFlush(() -> {
+                assertThatPlanFor("SELECT k, c FROM %s WHERE n = 0", 0)
+                    .hasEstimatedRowsCountBetween(0.0, 0.0);
+                assertThatPlanFor("SELECT k, c FROM %s WHERE n = 1", numRows)
+                    .hasEstimatedRowsCountBetween((double) numRows / 2, numRows * 2);
+                assertThatPlanFor("SELECT k, c FROM %s WHERE n < 5", numRows)
+                    .hasEstimatedRowsCountBetween((double) numRows / 2, numRows * 2);
+                assertThatPlanFor("SELECT k, c FROM %s WHERE c = 1", numPartitions)
+                    .hasEstimatedRowsCountBetween((double) numPartitions / 2, numPartitions * 2);
+                assertThatPlanFor("SELECT k, c FROM %s WHERE c >= 1 AND c <= 10", numPartitions * 10)
+                    .hasEstimatedRowsCountBetween((double) numPartitions * 5, numPartitions * 20);
+                assertThatPlanFor("SELECT k, c FROM %s WHERE n = 1 AND c = 1", numPartitions)
+                    .hasEstimatedRowsCountBetween((double) numPartitions / 2, numPartitions * 2);;
+            });
+        }
+        finally
+        {
+            DatabaseDescriptor.setLocalReadSizeWarnThreshold(oldLocalReadSizeWarnThreshold);
+            DatabaseDescriptor.setLocalReadSizeFailThreshold(oldLocalReadSizeFailThreshold);
+        }
     }
 }


### PR DESCRIPTION
### What is the issue
SAITester enabled coordinator execution for CQLTester.execute(), so test queries go through the same coordinator read path as real client queries, where coordinator warnings are used. 

### What does this PR fix and why was it fixed
Initialize and reset CoordinatorWarnings around coordinator execution in CQLTester, disable thresholds during EstimatedRowCountTest to allow large test reads
