### PR TITLE
CNDB-17580: Apply missed update to VectorSiftSmallTest during cherry-pick of CNDB-16693

### DIFF
--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorSiftSmallTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorSiftSmallTest.java
@@ -38,7 +38,6 @@ import org.apache.cassandra.cql3.UntypedResultSet;
 import org.apache.cassandra.index.sai.StorageAttachedIndex;
 import org.apache.cassandra.index.sai.disk.v1.SegmentBuilder;
 import org.apache.cassandra.index.sai.disk.v2.V2VectorIndexSearcher;
-import org.apache.cassandra.index.sai.disk.vector.CompactionGraph;
 import org.apache.cassandra.index.sai.disk.vector.JVectorVersionUtil;
 
 import static org.junit.Assert.assertEquals;
@@ -225,7 +224,7 @@ public class VectorSiftSmallTest extends VectorTester.Versioned
 
         // Set force PQ training size to ensure we hit the refine code path and apply it to half the vectors.
         // TODO this test fails as of this commit due to recall issues. Will investigate further.
-        CompactionGraph.PQ_TRAINING_SIZE = baseVectors.size() / 2;
+        // CompactionGraph.PQ_TRAINING_SIZE = baseVectors.size() / 2;
 
         // Compact again to take the CompactionGraph code path that calls the refine logic
         compact();


### PR DESCRIPTION

### What is the issue
Fixes VectorSiftSmallTest.testCompaction

### What does this PR fix and why was it fixed
Add a missing update from the CNDB-17580 cherry-pick of main branch CNDB-16693 to VectorSiftSmallTest.testCompaction
