### PR TITLE
Fix system UDT preservation during upgrade

### DIFF
--- a/src/java/org/apache/cassandra/schema/SchemaTransformations.java
+++ b/src/java/org/apache/cassandra/schema/SchemaTransformations.java
@@ -18,7 +18,10 @@
 
 package org.apache.cassandra.schema;
 
+import java.nio.ByteBuffer;
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -235,17 +238,31 @@ public class SchemaTransformations
 
                     if (curKeyspace.types != null)
                     {
-                        for (UserType currType : curKeyspace.types)
+                        Set<ByteBuffer> referencedTypes = new HashSet<>();
+                        for (TableMetadata table : updatedKeyspace.tables)
+                            referencedTypes.addAll(table.getReferencedUserTypes());
+
+                        boolean addedType;
+                        do
                         {
-                            UserType desiredType = updatedKeyspace.types.getNullable(currType.name);
-                            // if the type exist we keep the existing definition, otherwise we inherit the type
-                            // the motivation behind it is that there might be tables (inherited above) that depend on it
-                            if (desiredType == null)
+                            addedType = false;
+                            for (UserType currType : curKeyspace.types)
                             {
-                                logger.debug("Preserving type {} for keyspace {}", currType.getNameAsString(), curKeyspace.name);
-                                updatedKeyspace = updatedKeyspace.withSwapped(updatedKeyspace.types.with(currType));
+                                UserType desiredType = updatedKeyspace.types.getNullable(currType.name);
+                                // Preserve only missing types that are still referenced by preserved tables/columns.
+                                // This avoids changing schema digests by inheriting unrelated legacy system UDTs.
+                                if (desiredType == null && referencedTypes.contains(currType.name))
+                                {
+                                    logger.debug("Preserving type {} for keyspace {}", currType.getNameAsString(), curKeyspace.name);
+                                    updatedKeyspace = updatedKeyspace.withSwapped(updatedKeyspace.types.with(currType));
+                                    for (UserType type : curKeyspace.types)
+                                        if (currType.referencesUserType(type.name))
+                                            referencedTypes.add(type.name);
+                                    addedType = true;
+                                }
                             }
                         }
+                        while (addedType);
                     }
 
                 }

--- a/test/unit/org/apache/cassandra/schema/MigrationManagerTest.java
+++ b/test/unit/org/apache/cassandra/schema/MigrationManagerTest.java
@@ -645,13 +645,20 @@ public class MigrationManagerTest
     public void testInheritTypesFromPreviousKeyspace()
     {
         // given
-        TableMetadata table0 = addTestTable("ks2", "t", "");
         UserType udt = new UserType("ks2",
                                     bytes("PreviousType"),
                                     List.of(forUnquoted("a"), forUnquoted("b")),
                                     List.of(Int32Type.instance, Int32Type.instance),
                                     true);
-        KeyspaceMetadata previousKeyspace = KeyspaceMetadata.create("ks2", KeyspaceParams.simple(1), Tables.of(table0), Views.none(), Types.of(udt), UserFunctions.none());
+        UserType unreferencedUdt = new UserType("ks2",
+                                                bytes("UnreferencedType"),
+                                                List.of(forUnquoted("a")),
+                                                List.of(Int32Type.instance),
+                                                true);
+        TableMetadata table0 = addTestTable("ks2", "t", "").unbuild()
+                                                        .addRegularColumn("udt", udt)
+                                                        .build();
+        KeyspaceMetadata previousKeyspace = KeyspaceMetadata.create("ks2", KeyspaceParams.simple(1), Tables.of(table0), Views.none(), Types.of(udt, unreferencedUdt), UserFunctions.none());
         KeyspaceMetadata currentKeyspace = KeyspaceMetadata.create("ks2", KeyspaceParams.simple(1), Tables.of(table0));
 
         // when
@@ -665,6 +672,7 @@ public class MigrationManagerTest
         UserType inheritedUdt = keyspaceAfterTransformation.types.getNullable(udt.name);
         assertNotNull(inheritedUdt);
         assertEquals(udt, inheritedUdt);
+        assertNull(keyspaceAfterTransformation.types.getNullable(unreferencedUdt.name));
     }
 
     private TableMetadata addTestTable(String ks, String cf, String comment)


### PR DESCRIPTION
Preserve only missing UDTs that are still referenced by inherited system tables/columns.

### What is the issue
HCD-241 changed `SchemaTransformations.updateSystemKeyspace()` to preserve all UDTs from the previous keyspace, regardless of them being present in the new keyspace. These change the schema checksum which then causes a schema disagreement with OSS, and CC5 refuses schema pull across a messaging-version mismatch, which is the case during the rolling upgrade.

### What does this PR fix and why was it fixed
Keep the HCD-241 behavior of preserving missing UDTs during updateSystemKeyspace, but only preserve UDTs that are actually referenced by tables/columns.  Do not preserve unrelated UDTs.                                                                                                                                                         
