### PR TITLE
CNDB-17757: Fix flaky password rate limit test timing

### DIFF
--- a/test/unit/org/apache/cassandra/auth/CassandraRoleManagerTest.java
+++ b/test/unit/org/apache/cassandra/auth/CassandraRoleManagerTest.java
@@ -275,9 +275,6 @@ public class CassandraRoleManagerTest
             RoleOptions newOptions1 = getLoginRoleOptions("new_password1");
             roleManager.alterRole(AuthenticatedUser.ANONYMOUS_USER, role1, newOptions1);
 
-            RoleOptions newOptions2 = getLoginRoleOptions("new_password2");
-            roleManager.alterRole(AuthenticatedUser.ANONYMOUS_USER, role2, newOptions2);
-
             try
             {
                 RoleOptions newOptions1Again = getLoginRoleOptions("another_password1");
@@ -288,6 +285,9 @@ public class CassandraRoleManagerTest
             {
                 assertEquals("Password for role test_role_1 can only be changed every 100ms.", e.getMessage());
             }
+
+            RoleOptions newOptions2 = getLoginRoleOptions("new_password2");
+            roleManager.alterRole(AuthenticatedUser.ANONYMOUS_USER, role2, newOptions2);
 
             roleManager.dropRole(AuthenticatedUser.ANONYMOUS_USER, role1);
             roleManager.dropRole(AuthenticatedUser.ANONYMOUS_USER, role2);


### PR DESCRIPTION
### What is the issue
the test altered role2 between the first and second updates to role1. Password hashing can sometimes take longer than the 100ms interval, so by the time role1 was updated again, its rate-limit entry had expired. 

### What does this PR fix and why was it fixed
assert the second role1 update is rate-limited immediately after the first role1 update, then verify role2 can still be updated independently.
