### PR TITLE
[WIP] CNDB-17606: Enable FusedPQ, parallel graph writes and FA

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -399,7 +399,7 @@ public enum CassandraRelevantProperties
     MONITORING_EXECUTION_INFO_ENABLED("cassandra.monitoring_execution_info_enabled", "true"),
 
     /** The current version of the SAI on-disk index format. */
-    SAI_CURRENT_VERSION("cassandra.sai.latest.version", "ec"),
+    SAI_CURRENT_VERSION("cassandra.sai.latest.version", "fa"),
 
     /** The class to use for selecting the current version of the SAI on-disk index format on a per-keyspace basis. */
     SAI_VERSION_SELECTOR_CLASS("cassandra.sai.version.selector.class", ""),
@@ -453,7 +453,7 @@ public enum CassandraRelevantProperties
     SAI_VECTOR_FLUSH_PERIOD_IN_MILLIS("cassandra.sai.vector_flush_period_in_millis", "-1"),
     // Whether compaction should build vector indexes using a fused graph, aka a graph where the quantized vectors
     // are stored inline with a graph node. Feature is still experimental, so defaults to false.
-    SAI_VECTOR_ENABLE_FUSED("cassandra.sai.vector.enable_fused", "false"),
+    SAI_VECTOR_ENABLE_FUSED("cassandra.sai.vector.enable_fused", "true"),
     // Use nvq when building graphs in compaction. Disabled by default for now. Enabling will reduce recall slightly
     // while also reducing the storage footprint.
     SAI_VECTOR_ENABLE_NVQ("cassandra.sai.vector.enable_nvq", "false"),
@@ -466,14 +466,14 @@ public enum CassandraRelevantProperties
     SAI_VECTOR_ORDINAL_HOLE_DENSITY_LIMIT("cassandra.sai.vector.ordinal_hole_density_limit", "0.01"),
     // When building a compaction graph, encode layer 0 nodes in parallel and subsequently use async io for writes.
     // This feature is experimental, so defaults to false.
-    SAI_ENCODE_AND_WRITE_VECTOR_GRAPH_IN_PARALLEL_ENABLED("cassandra.sai.vector.encode_and_write_graph_in_parallel.enabled", "false"),
+    SAI_ENCODE_AND_WRITE_VECTOR_GRAPH_IN_PARALLEL_ENABLED("cassandra.sai.vector.encode_and_write_graph_in_parallel.enabled", "true"),
     // When parallel graph encoding is enabled, the number of threads to use for encoding. Defaults to 0, meaning
     // use all available processors as reported by the JVM.
     SAI_ENCODE_AND_WRITE_VECTOR_GRAPH_IN_PARALLEL_NUM_THREADS("cassandra.sai.vector.encode_and_write_graph_in_parallel.num_threads", "0"),
     // When parallel graph encoding is enabled, whether to use director buffers. Defaults to false, meaning heap
     // buffers are used. A buffer will be allocated per encoding thread. The size of each buffer is the size
     // of the encoded graph node at layer 0, which varies based on graph feature settings.
-    SAI_ENCODE_AND_WRITE_VECTOR_GRAPH_IN_PARALLEL_USE_DIRECT_BUFFERS("cassandra.sai.vector.encode_and_write_graph_in_parallel.use_direct_buffers", "false"),
+    SAI_ENCODE_AND_WRITE_VECTOR_GRAPH_IN_PARALLEL_USE_DIRECT_BUFFERS("cassandra.sai.vector.encode_and_write_graph_in_parallel.use_direct_buffers", "true"),
 
     /**
      * Whether to disable auto-compaction

--- a/src/java/org/apache/cassandra/db/filter/ColumnFilter.java
+++ b/src/java/org/apache/cassandra/db/filter/ColumnFilter.java
@@ -947,6 +947,11 @@ public abstract class ColumnFilter
             while (columns.hasNext())
             {
                 ColumnMetadata column = columns.next();
+                
+                // Skip synthetic columns in CQL representation as they are internal implementation details
+                if (cql && column.isSynthetic())
+                    continue;
+                
                 String columnName = cql ? column.name.toCQLString() : String.valueOf(column.name);
 
                 SortedSet<ColumnSubselection> s = subSelections != null

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorCompactionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorCompactionTest.java
@@ -408,6 +408,13 @@ abstract public class VectorCompactionTest extends VectorTester
                                 // reasonable for now.
                                 assertEquals(1.0f, quantizedSim, 0.01f);
                             }
+                            else if (numRows >= MIN_PQ_ROWS)
+                            {
+                                // With FA + fused PQ, PQ metadata is present and used by the graph, but there is no
+                                // standalone CompressedVectors instance to validate against.
+                                assertEquals("Expected fused PQ path only for FA+", Version.FA, version);
+                                assertNotNull("Expected PQ metadata for FA fused PQ", searcher.getPQ());
+                            }
                             else
                             {
                                 // We should only hit this case when we don't have enough rows to build a PQ.

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorMetricsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorMetricsTest.java
@@ -18,20 +18,23 @@
 
 package org.apache.cassandra.index.sai.cql;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.index.sai.SAIUtil;
 import org.apache.cassandra.index.sai.StorageAttachedIndex;
 import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.index.sai.disk.vector.CassandraOnHeapGraph;
+import org.apache.cassandra.index.sai.disk.vector.JVectorVersionUtil;
 import org.apache.cassandra.index.sai.metrics.ColumnQueryMetrics;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -44,10 +47,23 @@ public class VectorMetricsTest extends VectorTester
     @Parameterized.Parameter
     public Version version;
 
-    @Parameterized.Parameters(name = "{0}")
+    @Parameterized.Parameter(1)
+    public boolean fusedPQ;
+
+    @Parameterized.Parameters(name = "version={0} fusedPQ={1}")
     public static Collection<Object[]> data()
     {
-        return Stream.of(Version.CA, Version.DC).map(v -> new Object[]{ v}).collect(Collectors.toList());
+        // Test all versions except AA and BA
+        return Version.ALL.stream()
+                          .filter(v -> v != Version.AA && v != Version.BA)
+                          .flatMap(v -> {
+                              // FusedPQ is only relevant for FA
+                              Boolean[] enableFusedPQ = JVectorVersionUtil.versionSupportsFused(v)
+                                                        ? new Boolean[]{ true, false }
+                                                        : new Boolean[]{ false };
+                              return Arrays.stream(enableFusedPQ).map(b -> new Object[]{ v, b });
+                          })
+                          .collect(Collectors.toList());
     }
 
     @BeforeClass
@@ -62,6 +78,14 @@ public class VectorMetricsTest extends VectorTester
     {
         super.setup();
         SAIUtil.setCurrentVersion(version);
+        JVectorVersionUtil.ENABLE_FUSED = fusedPQ;
+    }
+
+    @After
+    public void tearDown()
+    {
+        // Reset FusedPQ to default after each test (we may add more tests in the future)
+        JVectorVersionUtil.ENABLE_FUSED = CassandraRelevantProperties.SAI_VECTOR_ENABLE_FUSED.getBoolean();
     }
 
     @Test
@@ -92,22 +116,28 @@ public class VectorMetricsTest extends VectorTester
         assertEquals(0, vectorMetrics.onDiskGraphVectorsCount.sum());
         assertEquals(0, vectorMetrics.annGraphSearchLatency.getCount());
 
-        // Insert 10 rows to simplify some of the assertions
         for (int i = 0; i < CassandraOnHeapGraph.MIN_PQ_ROWS; i++)
             execute("INSERT INTO %s (pk, val) VALUES (?, ?)", i, vector(1 + i, 2 + i, 3 + i));
         flush();
 
-        assertTrue(vectorMetrics.quantizationMemoryBytes.sum() > 0);
-        assertEquals(0, vectorMetrics.ordinalsMapMemoryBytes.sum()); // unique vectors means no cache required
-        assertEquals(1, vectorMetrics.onDiskGraphsCount.sum());
-        assertEquals( CassandraOnHeapGraph.MIN_PQ_ROWS, vectorMetrics.onDiskGraphVectorsCount.sum());
+        long pqMemoryAfterFlush = vectorMetrics.quantizationMemoryBytes.sum();
 
-        // Compaction should not impact metrics
-        compact();
-        assertTrue(vectorMetrics.quantizationMemoryBytes.sum() > 0);
+        assertEquals("Version " + version + " (FusedPQ: " + fusedPQ + ") PQ memory after flush",
+                    fusedPQ ? 0L : 1L, fusedPQ ? pqMemoryAfterFlush : (pqMemoryAfterFlush > 0 ? 1L : 0L));
+        
         assertEquals(0, vectorMetrics.ordinalsMapMemoryBytes.sum()); // unique vectors means no cache required
         assertEquals(1, vectorMetrics.onDiskGraphsCount.sum());
-        assertEquals( CassandraOnHeapGraph.MIN_PQ_ROWS, vectorMetrics.onDiskGraphVectorsCount.sum());
+        assertEquals(CassandraOnHeapGraph.MIN_PQ_ROWS, vectorMetrics.onDiskGraphVectorsCount.sum());
+
+        compact();
+        long pqMemoryAfterCompaction = vectorMetrics.quantizationMemoryBytes.sum();
+
+        assertEquals("Version " + version + " (FusedPQ: " + fusedPQ + ") PQ memory after compaction",
+                    fusedPQ ? 0L : 1L, fusedPQ ? pqMemoryAfterCompaction : (pqMemoryAfterCompaction > 0 ? 1L : 0L));
+        
+        assertEquals(0, vectorMetrics.ordinalsMapMemoryBytes.sum()); // unique vectors means no cache required
+        assertEquals(1, vectorMetrics.onDiskGraphsCount.sum());
+        assertEquals(CassandraOnHeapGraph.MIN_PQ_ROWS, vectorMetrics.onDiskGraphVectorsCount.sum());
 
         // Now run a pure ann query and verify we hit the ann graph
         var result = execute("SELECT pk FROM %s ORDER BY val ANN OF [2.5, 3.5, 4.5] LIMIT 2");

--- a/test/unit/org/apache/cassandra/index/sai/disk/vector/BruteForceRowIdIteratorTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/vector/BruteForceRowIdIteratorTest.java
@@ -19,7 +19,6 @@
 package org.apache.cassandra.index.sai.disk.vector;
 
 import java.util.NoSuchElementException;
-import java.util.function.Function;
 
 import org.junit.Test;
 
@@ -99,7 +98,7 @@ public class BruteForceRowIdIteratorTest
         @Override
         public void processNeighbors(int i, int i1, ScoreFunction scoreFunction, ImmutableGraphIndex.IntMarker intMarker, ImmutableGraphIndex.NeighborProcessor neighborProcessor)
         {
-
+            throw new UnsupportedOperationException();
         }
 
         @Override

--- a/test/unit/org/apache/cassandra/index/sai/metrics/IndexMetricsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/metrics/IndexMetricsTest.java
@@ -20,6 +20,9 @@ package org.apache.cassandra.index.sai.metrics;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.index.sai.disk.format.Version;
+import org.apache.cassandra.index.sai.disk.vector.JVectorVersionUtil;
+
 import org.junit.Test;
 
 import com.datastax.driver.core.ResultSet;
@@ -360,10 +363,18 @@ public class IndexMetricsTest extends AbstractMetricsTest
         compact();
         waitForIndexCompaction(KEYSPACE, table, index);
 
-        // Verify that the bytes contains the compression size. Note that the PQ vectors dominates the memory
-        // consumption significatly, which is what makes this test valid. The test fails if we remove the
-        // compressed vector accounting logic from the CassandraDiskAnn.ramBytesUsed() method.
+        // Verify that the bytes includes the compression size. Note that for this test configuration,
+        // the graph memory dominates (~87%), but the PQ vectors still contribute significantly (~12%).
+        // The test fails if we remove the compressed vector accounting logic from the
+        // CassandraDiskAnn.ramBytesUsed() method, proving the fix works correctly.
         long bytesAfterCompaction = (long) getMetricValue(objectName("IndexFileCacheBytes", KEYSPACE, currentTable(), index, "IndexMetrics"));
+        System.out.println("KATE: ===== Memory Breakdown =====");
+        System.out.println("KATE: bytesAfterCompaction=" + bytesAfterCompaction + ", minPQBytesExpected=" + minPQBytesExpected);
+        System.out.println("KATE: ENABLE_FUSED=" + JVectorVersionUtil.ENABLE_FUSED);
+        System.out.println("KATE: Version.LATEST=" + Version.LATEST);
+        System.out.println("KATE: Difference (graph + PQ codebook vs expected PQ vectors): " + (bytesAfterCompaction - minPQBytesExpected));
+        System.out.println("KATE: Graph memory is dominating: " + (bytesAfterCompaction > minPQBytesExpected));
+        System.out.println("KATE: ==============================");
         assertTrue("Expected at least " + minPQBytesExpected + " bytes but got " + bytesAfterCompaction,
                    bytesAfterCompaction >= minPQBytesExpected);
 


### PR DESCRIPTION
### What is the issue
...
This is WIP, I wanted to see the current tests, whether something fails in CI already when we enable things

Also, updated VectorMetricsTest and added some preliminary investigation comments on why `testIndexFileCacheBytesIncludesAllComponents` is not failing after enabling `FusedPQ`, despite the comment was saying it should. 
### What does this PR fix and why was it fixed
...
