### PR TITLE
CNDB-15608 homogenize hasClustering and hasEmptyClustering

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/PrimaryKeyMapIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/PrimaryKeyMapIterator.java
@@ -111,7 +111,7 @@ public final class PrimaryKeyMapIterator extends KeyRangeIterator
         while (currentRowId >= 0 && currentRowId < keys.count())
         {
             PrimaryKey key = keys.primaryKeyFromRowId(currentRowId++, getMinimum(), getMaximum());
-            if (filter == KeyFilter.KEYS_WITH_CLUSTERING && key.hasEmptyClustering())
+            if (filter == KeyFilter.KEYS_WITH_CLUSTERING && !key.hasClustering())
                 continue;
             return key;
         }

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/RowAwarePrimaryKeyFactory.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/RowAwarePrimaryKeyFactory.java
@@ -41,13 +41,13 @@ import org.apache.cassandra.utils.bytecomparable.ByteSource;
 public class RowAwarePrimaryKeyFactory implements PrimaryKey.Factory
 {
     private final ClusteringComparator clusteringComparator;
-    private final boolean hasEmptyClustering;
+    private final boolean hasClustering;
 
 
     public RowAwarePrimaryKeyFactory(ClusteringComparator clusteringComparator)
     {
         this.clusteringComparator = clusteringComparator;
-        this.hasEmptyClustering = clusteringComparator.size() == 0;
+        this.hasClustering = clusteringComparator.size() > 0;
     }
 
     @Override
@@ -183,7 +183,7 @@ public class RowAwarePrimaryKeyFactory implements PrimaryKey.Factory
             // clusterings then we can return the result of this without
             // needing to compare the clusterings
             cmp = partitionKey().compareTo(o.partitionKey());
-            if (cmp != 0 || hasEmptyClustering() || o.hasEmptyClustering())
+            if (cmp != 0 || !hasClustering() || !o.hasClustering())
                 return cmp;
             return clusteringComparator.compare(clustering(), o.clustering());
         }
@@ -191,9 +191,10 @@ public class RowAwarePrimaryKeyFactory implements PrimaryKey.Factory
         @Override
         public int hashCode()
         {
-            if (hasEmptyClustering)
+            if (hasClustering)
+                return Objects.hash(token, clustering());
+            else
                 return Objects.hash(token);
-            return Objects.hash(token, clustering());
         }
 
         @Override

--- a/src/java/org/apache/cassandra/index/sai/iterators/KeyRangeIntersectionIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/iterators/KeyRangeIntersectionIterator.java
@@ -107,7 +107,7 @@ public class KeyRangeIntersectionIterator extends KeyRangeIterator
                     // More specific keys should win over full partitions,
                     // because they match a single row instead of the whole partition.
                     // However, because this key matches with the earlier keys, we can continue the inner loop.
-                    if (!nextKey.hasEmptyClustering())
+                    if (nextKey.hasClustering())
                     {
                         highestKey = nextKey;
                         indexOfHighestKey = index;
@@ -118,13 +118,13 @@ public class KeyRangeIntersectionIterator extends KeyRangeIterator
 
             // Now we need to advance the iterators to avoid returning the same key again.
             // This is tricky because of empty clustering keys that match the whole partition.
-            // We must not advance ranges at keys with empty clustering because they
+            // We must not advance ranges at keys with no clustering because they
             // may still match the next keys returned by other iterators in the next cycles.
-            // However, if all ranges are at the same partition with empty clustering (highestKey.hasEmptyClustering()),
+            // However, if all ranges are at the same partition with no clustering (!highestKey.hasClustering()),
             // we must advance all of them, because we return the key for the whole partition and that partition is done.
             for (var range : ranges)
             {
-                if (highestKey.hasEmptyClustering() || !range.peek().hasEmptyClustering())
+                if (!highestKey.hasClustering() || range.peek().hasClustering())
                     range.next();
             }
 

--- a/src/java/org/apache/cassandra/index/sai/iterators/KeyRangeUnionIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/iterators/KeyRangeUnionIterator.java
@@ -84,7 +84,7 @@ public class KeyRangeUnionIterator extends KeyRangeIterator
                     // If we chose one of the specific keys with non-empty clustering (e.g. pick the first one we see),
                     // we may miss rows matched by the non-row-aware index, as well as the rows matched by
                     // the other row-aware indexes.
-                    if (range.peek().hasEmptyClustering() && !candidate.peek().hasEmptyClustering())
+                    if (!range.peek().hasClustering() && candidate.peek().hasClustering())
                         candidate = range;
                     else
                         range.next();   // truly equal by partition and clustering, so we can just get rid of one
@@ -105,7 +105,7 @@ public class KeyRangeUnionIterator extends KeyRangeIterator
         // advance all other ranges to the end of this partition to avoid duplicates.
         // We delay that to the next call to computeNext() though, because if we have a wide partition, it's better
         // to first let the caller consume all the rows from this partition - maybe they won't call again.
-        if (result.hasEmptyClustering())
+        if (!result.hasClustering())
             partitionToSkip = result.partitionKey();
 
         return result;

--- a/src/java/org/apache/cassandra/index/sai/memory/MemtableKeyRangeIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/MemtableKeyRangeIterator.java
@@ -108,7 +108,7 @@ public class MemtableKeyRangeIterator extends KeyRangeIterator
         if (partitionIterator.hasNext())
         {
             this.rowIterator = partitionIterator.next();
-            if (!nextKey.hasEmptyClustering() && rowIterator.partitionKey().equals(nextKey.partitionKey()))
+            if (nextKey.hasClustering() && rowIterator.partitionKey().equals(nextKey.partitionKey()))
             {
                 Slice slice = Slice.make(nextKey.clustering(), Clustering.EMPTY);
                 Slices slices = Slices.with(memtable.metadata().comparator, slice);

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -820,7 +820,7 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
      */
     public boolean selects(PrimaryKey key)
     {
-        return key.hasEmptyClustering() ||
+        return !key.hasClustering() ||
                command.clusteringIndexFilter(key.partitionKey()).selects(key.clustering());
     }
 
@@ -837,7 +837,7 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
     {
         ClusteringIndexFilter clusteringIndexFilter = command.clusteringIndexFilter(key.partitionKey());
 
-        if (!indexFeatureSet.isRowAware() || key.hasEmptyClustering())
+        if (!indexFeatureSet.isRowAware() || !key.hasClustering())
             return clusteringIndexFilter;
         else
             return new ClusteringIndexNamesFilter(FBUtilities.singleton(key.clustering(), cfs.metadata().comparator),
@@ -849,12 +849,12 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
         PrimaryKey firstKey = keys.get(0);
 
         assert !indexFeatureSet.isRowAware() ||
-               cfs.metadata().comparator.size() == 0 && firstKey.hasEmptyClustering() ||
-               cfs.metadata().comparator.size() > 0 && (!firstKey.hasEmptyClustering() || cfs.metadata().hasStaticColumns()):
+               cfs.metadata().comparator.size() == 0 && !firstKey.hasClustering() ||
+               cfs.metadata().comparator.size() > 0 && (firstKey.hasClustering() || cfs.metadata().hasStaticColumns()) :
         "PrimaryKey " + firstKey + " clustering does not match table. There should be a clustering of size " + cfs.metadata().comparator.size();
 
         ClusteringIndexFilter clusteringIndexFilter = command.clusteringIndexFilter(firstKey.partitionKey());
-        if (cfs.metadata().comparator.size() == 0 || firstKey.hasEmptyClustering())
+        if (cfs.metadata().comparator.size() == 0 || !firstKey.hasClustering())
         {
             return clusteringIndexFilter;
         }

--- a/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
@@ -383,7 +383,7 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
             // filtered and considered as a result multiple times).
             return lastKey != null &&
                    Objects.equals(lastKey.partitionKey(), key.partitionKey()) &&
-                   (lastKey.hasEmptyClustering() || key.hasEmptyClustering() || Objects.equals(lastKey.clustering(), key.clustering()));
+                   (!lastKey.hasClustering() || !key.hasClustering() || Objects.equals(lastKey.clustering(), key.clustering()));
         }
 
         private void fillNextSelectedKeysInPartition(DecoratedKey partitionKey, List<PrimaryKey> nextPrimaryKeys)

--- a/src/java/org/apache/cassandra/index/sai/utils/PrimaryKey.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/PrimaryKey.java
@@ -150,15 +150,12 @@ public interface PrimaryKey extends Comparable<PrimaryKey>, Accountable
     Clustering clustering();
 
     /**
-     * Return whether the primary key has an empty clustering or not.
-     * By default the clustering is empty if the internal clustering
-     * is null or is empty.
-     *
-     * @return {@code true} if the clustering is empty, otherwise {@code false}
+     * Return whether the primary key has a clustering, i.e., has non-static clustering column(s).
+     * This operation might require loading the primary key.
      */
-    default boolean hasEmptyClustering()
+    default boolean hasClustering()
     {
-        return clustering() == null || clustering().isEmpty();
+        return clustering() != null && !clustering().isEmpty();
     }
 
     /**

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorCompactionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorCompactionTest.java
@@ -371,7 +371,7 @@ abstract public class VectorCompactionTest extends VectorTester
                 for (long i = segment.metadata.minSSTableRowId; i <= segment.metadata.maxSSTableRowId; i++)
                 {
                     var primaryKey = pkm.primaryKeyFromRowId(i);
-                    assertTrue("The subsequent logic assumes that we have no clustering columns", primaryKey.hasEmptyClustering());
+                    assertTrue("The subsequent logic assumes that we have no clustering columns", !primaryKey.hasClustering());
                     try (var sstableIter = segment.sstableContext
                                            .sstable()
                                            .rowIterator(primaryKey.partitionKey(), Slices.ALL, columnFilter, false, SSTableReadsListener.NOOP_LISTENER))

--- a/test/unit/org/apache/cassandra/index/sai/iterators/AbstractKeyRangeIteratorTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/iterators/AbstractKeyRangeIteratorTest.java
@@ -274,10 +274,10 @@ public class AbstractKeyRangeIteratorTest extends SaiRandomizedTest
         Clustering<?> lastClustering = Clustering.EMPTY;
         for (PrimaryKey key : keys)
         {
-            if (key.hasEmptyClustering() && key.partitionKey().equals(lastPartitionKey))
+            if (!key.hasClustering() && key.partitionKey().equals(lastPartitionKey))
                 throw new AssertionError("A primary key with empty clustering follows a key in the same partition:\n" + key + "\nafter:\n" + lastPrimaryKey);
 
-            if (!key.hasEmptyClustering() && lastClustering.isEmpty() && key.partitionKey().equals(lastPartitionKey))
+            if (key.hasClustering() && lastClustering.isEmpty() && key.partitionKey().equals(lastPartitionKey))
                 throw new AssertionError("A primary key with non-empty clustering follows a key with empty clustering in the same partition:\n" + key + "\nafter:\n" + lastPrimaryKey);
 
             if (Objects.equals(key, lastPrimaryKey))
@@ -305,7 +305,7 @@ public class AbstractKeyRangeIteratorTest extends SaiRandomizedTest
         {
             for (PrimaryKey pk : keys)
             {
-                if (pk.hasEmptyClustering())
+                if (!pk.hasClustering())
                     partitions.add(pk.partitionKey());
                 else
                     rows.add(Pair.create(pk.partitionKey(), pk.clustering()));


### PR DESCRIPTION
There are methods and variables with names hasClustering and hasEmptyClustering.
[CNDB-15608](https://github.com/riptano/cndb/issues/15608) adds more hasClustering methods.

Changes hasEmptyClustering to hasClustering to homogenize to a single name. For my personal taste hasClustering is easier to understand.
