### PR TITLE
CNDB-17768:  Fix compaction history migration in HCD_1 mode

### DIFF
--- a/src/java/org/apache/cassandra/db/SystemKeyspaceMigrator41.java
+++ b/src/java/org/apache/cassandra/db/SystemKeyspaceMigrator41.java
@@ -168,6 +168,29 @@ public class SystemKeyspaceMigrator41
     @VisibleForTesting
     static void migrateCompactionHistory()
     {
+        if (DatabaseDescriptor.getStorageCompatibilityMode().isBefore(CassandraVersion.CASSANDRA_5_0.major))
+        {
+            migrateTable(false,
+                         SystemKeyspace.COMPACTION_HISTORY,
+                         SystemKeyspace.COMPACTION_HISTORY,
+                         new String[]{ "id",
+                                       "bytes_in",
+                                       "bytes_out",
+                                       "columnfamily_name",
+                                       "compacted_at",
+                                       "keyspace_name",
+                                       "rows_merged" },
+                         row -> Collections.singletonList(new Object[]{ row.getTimeUUID("id"),
+                                                                        row.has("bytes_in") ? row.getLong("bytes_in") : null,
+                                                                        row.has("bytes_out") ? row.getLong("bytes_out") : null,
+                                                                        row.has("columnfamily_name") ? row.getString("columnfamily_name") : null,
+                                                                        row.has("compacted_at") ? row.getTimestamp("compacted_at") : null,
+                                                                        row.has("keyspace_name") ? row.getString("keyspace_name") : null,
+                                                                        row.has("rows_merged") ? row.getMap("rows_merged", Int32Type.instance, LongType.instance) : null })
+            );
+            return;
+        }
+
         migrateTable(false,
                      SystemKeyspace.COMPACTION_HISTORY,
                      SystemKeyspace.COMPACTION_HISTORY,
@@ -179,7 +202,7 @@ public class SystemKeyspaceMigrator41
                                    "keyspace_name",
                                    "rows_merged",
                                    "compaction_properties" },
-                     row -> Collections.singletonList(new Object[]{ row.getTimeUUID("id") ,
+                     row -> Collections.singletonList(new Object[]{ row.getTimeUUID("id"),
                                                                     row.has("bytes_in") ? row.getLong("bytes_in") : null,
                                                                     row.has("bytes_out") ? row.getLong("bytes_out") : null,
                                                                     row.has("columnfamily_name") ? row.getString("columnfamily_name") : null,


### PR DESCRIPTION
### What is the issue
in SCM HCD_1, system.compaction_history uses the legacy schema without compaction_properties, but migrateCompactionHistory() always tries to insert that column during startup migration. 

### What does this PR fix and why was it fixed
use the legacy column list when storage compatibility mode is before 5.0.  
