### PR TITLE
CNDB-14041: Enable Adaptive Compression by default for new tables

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -749,7 +749,7 @@ public enum CassandraRelevantProperties
      * Which compression algorithm to use for SSTable compression when not specified explicitly in the sstable options.
      * Can be "fast", which selects {@link LZ4Compressor}, or "adaptive" which selects {@link AdaptiveCompressor}.
      */
-    DEFAULT_SSTABLE_COMPRESSION("cassandra.default_sstable_compression", "fast"),
+    DEFAULT_SSTABLE_COMPRESSION("cassandra.default_sstable_compression", "adaptive"),
 
     /**
      * Do not try to calculate optimal streaming candidates. This can take a lot of time in some configs specially


### PR DESCRIPTION
This is now possible because AC has been supported in CNDB prod since
March 2025 release, and we can easily switch back to LZ4 if
AC causes any performance issues.
