### PR TITLE
CNDB-14041: Enable Adaptive Compression by default for new tables

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -749,7 +749,7 @@ public enum CassandraRelevantProperties
      * Which compression algorithm to use for SSTable compression when not specified explicitly in the sstable options.
      * Can be "fast", which selects {@link LZ4Compressor}, or "adaptive" which selects {@link AdaptiveCompressor}.
      */
-    DEFAULT_SSTABLE_COMPRESSION("cassandra.default_sstable_compression", "fast"),
+    DEFAULT_SSTABLE_COMPRESSION("cassandra.default_sstable_compression", "adaptive"),
 
     /**
      * Do not try to calculate optimal streaming candidates. This can take a lot of time in some configs specially

--- a/src/java/org/apache/cassandra/io/compress/AdaptiveCompressor.java
+++ b/src/java/org/apache/cassandra/io/compress/AdaptiveCompressor.java
@@ -460,11 +460,12 @@ public class AdaptiveCompressor implements ICompressor
         // 0.0 if actualRate >= rateLimit
         // 1.0 if actualRate <= 0.8 * rateLimit;
         double rateLimitFactor = Math.min(1.0, Math.max(0.0, (rateLimit - actualRate) / (0.2 * rateLimit)));
+        assert rateLimitFactor >= 0.0 : "rateLimitFactor (" + rateLimitFactor + " out of valid range [0.0, 1.0]";
 
         long pendingCompactions = compactionManager.getPendingTasks();
-        long activeCompactions = compactionManager.getActiveCompactions();
-        long queuedCompactions = pendingCompactions - activeCompactions;
-        double compactionQueuePressure = Math.min(1.0, (double) queuedCompactions / (maxCompactionQueueLength * DatabaseDescriptor.getConcurrentCompactors()));
+        double compactionQueuePressure = Math.min(1.0, (double) pendingCompactions / (maxCompactionQueueLength * DatabaseDescriptor.getConcurrentCompactors()));
+        assert compactionQueuePressure >= 0.0 && compactionQueuePressure <= 1.0
+            : "compactionQueuePressure (" + compactionQueuePressure + ") out of valid range [0.0, 1.0]";
         return compactionQueuePressure * rateLimitFactor;
     }
 

--- a/src/java/org/apache/cassandra/metrics/CompactionMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/CompactionMetrics.java
@@ -35,6 +35,7 @@ import org.apache.cassandra.db.compaction.CompactionAggregateStatistics;
 import org.apache.cassandra.db.compaction.CompactionManager;
 import org.apache.cassandra.db.compaction.CompactionStrategyStatistics;
 import org.apache.cassandra.db.compaction.TableOperation;
+import org.apache.cassandra.exceptions.UnknownKeyspaceException;
 import org.apache.cassandra.schema.Schema;
 import org.apache.cassandra.schema.TableMetadata;
 
@@ -112,7 +113,7 @@ public class CompactionMetrics
             // add estimate number of compactions need to be done
             for (String keyspaceName : Schema.instance.getKeyspaces())
             {
-                for (ColumnFamilyStore cfs : Keyspace.open(keyspaceName).getColumnFamilyStores())
+                for (ColumnFamilyStore cfs : getColumnFamilyStores(keyspaceName))
                     n += cfs.getCompactionStrategy().getEstimatedRemainingTasks();
             }
             // add number of currently running compactions
@@ -124,7 +125,7 @@ public class CompactionMetrics
             // estimation of compactions need to be done
             for (String keyspaceName : Schema.instance.getKeyspaces())
             {
-                for (ColumnFamilyStore cfs : Keyspace.open(keyspaceName).getColumnFamilyStores())
+                for (ColumnFamilyStore cfs : getColumnFamilyStores(keyspaceName))
                 {
                     int taskNumber = cfs.getCompactionStrategy().getEstimatedRemainingTasks();
                     if (taskNumber > 0)
@@ -174,7 +175,7 @@ public class CompactionMetrics
             {
                 Map<String, Double> ksMap = new HashMap<>();
                 resultMap.put(keyspaceName, ksMap);
-                for (ColumnFamilyStore cfs : Keyspace.open(keyspaceName).getColumnFamilyStores())
+                for (ColumnFamilyStore cfs : getColumnFamilyStores(keyspaceName))
                     ksMap.put(cfs.getTableName(), cfs.getWA());
             }
 
@@ -216,7 +217,7 @@ public class CompactionMetrics
                                                         for (String keyspaceName : Schema.instance.getKeyspaces())
                                                         {
                                                             // Scan all the compactions strategies of all tables and find those that have compactions in progress.
-                                                            for (ColumnFamilyStore cfs : Keyspace.open(keyspaceName).getColumnFamilyStores())
+                                                            for (ColumnFamilyStore cfs : getColumnFamilyStores(keyspaceName))
                                                                 // For those return the statistics.
                                                                 ret.addAll(cfs.getCompactionStrategy().getStatistics());
                                                         }
@@ -235,7 +236,7 @@ public class CompactionMetrics
                                             {
                                                 Map<String, Map<String, String>> ksMap = new HashMap<>();
                                                 ret.put(keyspaceName, ksMap);
-                                                for (ColumnFamilyStore cfs : Keyspace.open(keyspaceName).getColumnFamilyStores())
+                                                for (ColumnFamilyStore cfs : getColumnFamilyStores(keyspaceName))
                                                 {
                                                     Map<String, String> overlaps = cfs.getCompactionStrategy().getMaxOverlapsMap();
                                                     ksMap.put(cfs.getTableName(), overlaps);
@@ -306,6 +307,23 @@ public class CompactionMetrics
                        .sum();
             }
         });
+    }
+
+    /**
+     * Returns a list of all ColumnFamilyStores in a keyspace if it exists.
+     * If the keyspace does not exist, returns an empty list.
+     * This is useful to avoid throwing when a keyspace gets dropped while we are iterating all keyspaces.
+     */
+    private static Collection<ColumnFamilyStore> getColumnFamilyStores(String keyspaceName)
+    {
+        try
+        {
+            return Keyspace.open(keyspaceName).getColumnFamilyStores();
+        }
+        catch (UnknownKeyspaceException e)
+        {
+            return Collections.emptyList();
+        }
     }
 
     /**

--- a/test/distributed/org/apache/cassandra/distributed/test/SSTableEncryptionTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/SSTableEncryptionTest.java
@@ -136,7 +136,8 @@ public class SSTableEncryptionTest extends TestBaseImpl
         {
             // given tables with and without encryption
             String keyspace = createKeyspace(cluster);
-            TestTable nonEncryptedTable = createTableWithSampleData(cluster, keyspace, "");
+            // force no compression because some compression algorithms likely won't preserve the sensitive key
+            TestTable nonEncryptedTable = createTableWithSampleData(cluster, keyspace, " WITH compression = {'class': 'NoopCompressor'}");
             Path secretKey = createLocalSecretKey(cluster);
             TestTable encryptedTable = createTableWithSampleData(cluster, keyspace, localSystemKeyEncryptionCompressionSuffix("Encryptor", secretKey.toAbsolutePath().toString()));
 

--- a/test/unit/org/apache/cassandra/cql3/statements/DescribeStatementTest.java
+++ b/test/unit/org/apache/cassandra/cql3/statements/DescribeStatementTest.java
@@ -1021,7 +1021,7 @@ public class DescribeStatementTest extends CQLTester
                "    AND cdc = false\n" +
                "    AND comment = ''\n" +
                "    AND compaction = " + cqlQuoted(CompactionParams.DEFAULT.asMap()) + "\n" +
-               "    AND compression = {'chunk_length_in_kb': '16', 'class': 'org.apache.cassandra.io.compress.LZ4Compressor'}\n" +
+               "    AND compression = {'chunk_length_in_kb': '16', 'class': 'org.apache.cassandra.io.compress.AdaptiveCompressor'}\n" +
                "    AND memtable = {}\n" +
                "    AND crc_check_chance = 1.0\n" +
                "    AND default_time_to_live = 0\n" +
@@ -1047,7 +1047,7 @@ public class DescribeStatementTest extends CQLTester
                "    AND cdc = false\n" +
                "    AND comment = ''\n" +
                "    AND compaction = " + cqlQuoted(CompactionParams.DEFAULT.asMap()) + "\n" +
-               "    AND compression = {'chunk_length_in_kb': '16', 'class': 'org.apache.cassandra.io.compress.LZ4Compressor'}\n" +
+               "    AND compression = {'chunk_length_in_kb': '16', 'class': 'org.apache.cassandra.io.compress.AdaptiveCompressor'}\n" +
                "    AND memtable = {}\n" +
                "    AND crc_check_chance = 1.0\n" +
                "    AND extensions = {}\n" +

--- a/test/unit/org/apache/cassandra/cql3/validation/operations/AlterTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/operations/AlterTest.java
@@ -598,7 +598,7 @@ public class AlterTest extends CQLTester
                                   SchemaKeyspaceTables.TABLES),
                            KEYSPACE,
                            currentTable()),
-                   row(map("chunk_length_in_kb", "16", "class", "org.apache.cassandra.io.compress.LZ4Compressor")));
+                   row(map("chunk_length_in_kb", "16", "class", "org.apache.cassandra.io.compress.AdaptiveCompressor")));
 
         alterTable("ALTER TABLE %s WITH compression = { 'class' : 'SnappyCompressor', 'chunk_length_in_kb' : 32 };");
 
@@ -609,41 +609,41 @@ public class AlterTest extends CQLTester
                            currentTable()),
                    row(map("chunk_length_in_kb", "32", "class", "org.apache.cassandra.io.compress.SnappyCompressor")));
 
-        alterTable("ALTER TABLE %s WITH compression = { 'class' : 'LZ4Compressor', 'chunk_length_in_kb' : 64 };");
+        alterTable("ALTER TABLE %s WITH compression = { 'class' : 'AdaptiveCompressor', 'chunk_length_in_kb' : 64 };");
 
         assertRows(execute(format("SELECT compression FROM %s.%s WHERE keyspace_name = ? and table_name = ?;",
                                   SchemaConstants.SCHEMA_KEYSPACE_NAME,
                                   SchemaKeyspaceTables.TABLES),
                            KEYSPACE,
                            currentTable()),
-                   row(map("chunk_length_in_kb", "64", "class", "org.apache.cassandra.io.compress.LZ4Compressor")));
+                   row(map("chunk_length_in_kb", "64", "class", "org.apache.cassandra.io.compress.AdaptiveCompressor")));
 
-        alterTable("ALTER TABLE %s WITH compression = { 'class' : 'LZ4Compressor', 'min_compress_ratio' : 2 };");
-
-        assertRows(execute(format("SELECT compression FROM %s.%s WHERE keyspace_name = ? and table_name = ?;",
-                                  SchemaConstants.SCHEMA_KEYSPACE_NAME,
-                                  SchemaKeyspaceTables.TABLES),
-                           KEYSPACE,
-                           currentTable()),
-                   row(map("chunk_length_in_kb", "16", "class", "org.apache.cassandra.io.compress.LZ4Compressor", "min_compress_ratio", "2.0")));
-
-        alterTable("ALTER TABLE %s WITH compression = { 'class' : 'LZ4Compressor', 'min_compress_ratio' : 1 };");
+        alterTable("ALTER TABLE %s WITH compression = { 'class' : 'AdaptiveCompressor', 'min_compress_ratio' : 2 };");
 
         assertRows(execute(format("SELECT compression FROM %s.%s WHERE keyspace_name = ? and table_name = ?;",
                                   SchemaConstants.SCHEMA_KEYSPACE_NAME,
                                   SchemaKeyspaceTables.TABLES),
                            KEYSPACE,
                            currentTable()),
-                   row(map("chunk_length_in_kb", "16", "class", "org.apache.cassandra.io.compress.LZ4Compressor", "min_compress_ratio", "1.0")));
+                   row(map("chunk_length_in_kb", "16", "class", "org.apache.cassandra.io.compress.AdaptiveCompressor", "min_compress_ratio", "2.0")));
 
-        alterTable("ALTER TABLE %s WITH compression = { 'class' : 'LZ4Compressor', 'min_compress_ratio' : 0 };");
+        alterTable("ALTER TABLE %s WITH compression = { 'class' : 'AdaptiveCompressor', 'min_compress_ratio' : 1 };");
 
         assertRows(execute(format("SELECT compression FROM %s.%s WHERE keyspace_name = ? and table_name = ?;",
                                   SchemaConstants.SCHEMA_KEYSPACE_NAME,
                                   SchemaKeyspaceTables.TABLES),
                            KEYSPACE,
                            currentTable()),
-                   row(map("chunk_length_in_kb", "16", "class", "org.apache.cassandra.io.compress.LZ4Compressor")));
+                   row(map("chunk_length_in_kb", "16", "class", "org.apache.cassandra.io.compress.AdaptiveCompressor", "min_compress_ratio", "1.0")));
+
+        alterTable("ALTER TABLE %s WITH compression = { 'class' : 'AdaptiveCompressor', 'min_compress_ratio' : 0 };");
+
+        assertRows(execute(format("SELECT compression FROM %s.%s WHERE keyspace_name = ? and table_name = ?;",
+                                  SchemaConstants.SCHEMA_KEYSPACE_NAME,
+                                  SchemaKeyspaceTables.TABLES),
+                           KEYSPACE,
+                           currentTable()),
+                   row(map("chunk_length_in_kb", "16", "class", "org.apache.cassandra.io.compress.AdaptiveCompressor")));
 
         alterTable("ALTER TABLE %s WITH compression = { 'class' : 'SnappyCompressor', 'chunk_length_in_kb' : 32 };");
         alterTable("ALTER TABLE %s WITH compression = { 'enabled' : 'false'};");

--- a/test/unit/org/apache/cassandra/cql3/validation/operations/CreateTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/operations/CreateTest.java
@@ -806,7 +806,7 @@ public class CreateTest extends CQLTester
                                   SchemaKeyspaceTables.TABLES),
                            KEYSPACE,
                            currentTable()),
-                   row(map("chunk_length_in_kb", "16", "class", "org.apache.cassandra.io.compress.LZ4Compressor")));
+                   row(map("chunk_length_in_kb", "16", "class", "org.apache.cassandra.io.compress.AdaptiveCompressor")));
 
         createTable("CREATE TABLE %s (a text, b int, c int, primary key (a, b))"
                 + " WITH compression = { 'class' : 'SnappyCompressor', 'chunk_length_in_kb' : 32 };");

--- a/test/unit/org/apache/cassandra/db/compaction/writers/CompactionAwareWriterTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/writers/CompactionAwareWriterTest.java
@@ -52,7 +52,8 @@ public class CompactionAwareWriterTest extends CQLTester
     {
         // Disabling durable write since we don't care
         schemaChange("CREATE KEYSPACE IF NOT EXISTS " + KEYSPACE + " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'} AND durable_writes=false");
-        schemaChange(String.format("CREATE TABLE %s.%s (k int, t int, v blob, PRIMARY KEY (k, t))", KEYSPACE, TABLE));
+        // Force LZ4Compressor, because it guarantees creating sstables of the same size after compaction as after flush
+        schemaChange(String.format("CREATE TABLE %s.%s (k int, t int, v blob, PRIMARY KEY (k, t)) WITH compression = { 'class': 'LZ4Compressor' }", KEYSPACE, TABLE));
     }
 
     @AfterClass

--- a/test/unit/org/apache/cassandra/index/sai/functional/CompactionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/functional/CompactionTest.java
@@ -410,7 +410,8 @@ public class CompactionTest extends AbstractMetricsTest
         createIndex(String.format(CREATE_INDEX_TEMPLATE, "v2"));
         disableCompaction(keyspace(), currentTable());
 
-        int rowsPerSSTable = 2000;
+        // Might need to increase this if stronger sstable compression is used, so large enough sstables are produced
+        int rowsPerSSTable = 4000;
         int numSSTables = 4;
         int key = 0;
         for (int s = 0; s < numSSTables; s++)

--- a/test/unit/org/apache/cassandra/io/compress/CQLCompressionTest.java
+++ b/test/unit/org/apache/cassandra/io/compress/CQLCompressionTest.java
@@ -24,6 +24,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.config.Config;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.CQLTester;
@@ -130,6 +131,8 @@ public class CQLCompressionTest extends CQLTester
     @Test
     public void lz4hcFlushTest() throws Throwable
     {
+        DatabaseDescriptor.setFlushCompression(Config.FlushCompression.fast);
+
         createTable("CREATE TABLE %s (k text PRIMARY KEY, v text) WITH compression = " +
                     "{'sstable_compression': 'LZ4Compressor', 'lz4_compressor_type': 'high'};");
         ColumnFamilyStore store = flushTwice();
@@ -158,10 +161,11 @@ public class CQLCompressionTest extends CQLTester
         createTable("CREATE TABLE %s (k text PRIMARY KEY, v text) WITH compression = {'sstable_compression': 'ZstdCompressor'};");
         ColumnFamilyStore store = flushTwice();
 
-        // Should flush as LZ4
+        // Should flush as LZ4 or Adaptive
         Set<SSTableReader> sstables = store.getLiveSSTables();
         sstables.forEach(sstable -> {
-            assertTrue(sstable.getCompressionMetadata().parameters.getSstableCompressor() instanceof LZ4Compressor);
+            var compressor = sstable.getCompressionMetadata().parameters.getSstableCompressor();
+            assertTrue(compressor instanceof LZ4Compressor || compressor instanceof AdaptiveCompressor);
         });
 
         // Should compact to Zstd
@@ -213,10 +217,11 @@ public class CQLCompressionTest extends CQLTester
         createTable("CREATE TABLE %s (k text PRIMARY KEY, v text) WITH compression = {'sstable_compression': 'DeflateCompressor'};");
         ColumnFamilyStore store = flushTwice();
 
-        // Should flush as LZ4
+        // Should flush as LZ4 or Adaptive
         Set<SSTableReader> sstables = store.getLiveSSTables();
         sstables.forEach(sstable -> {
-            assertTrue(sstable.getCompressionMetadata().parameters.getSstableCompressor() instanceof LZ4Compressor);
+            var compressor = sstable.getCompressionMetadata().parameters.getSstableCompressor();
+            assertTrue(compressor instanceof LZ4Compressor || compressor instanceof AdaptiveCompressor);
         });
 
         // Should compact to Deflate
@@ -273,10 +278,11 @@ public class CQLCompressionTest extends CQLTester
         createTable("CREATE TABLE %s (k text PRIMARY KEY, v text) WITH compression = {'sstable_compression': 'ZstdCompressor'};");
         ColumnFamilyStore store = flushTwice();
 
-        // Should flush as LZ4
+        // Should flush as LZ4 or Adaptive
         Set<SSTableReader> sstables = store.getLiveSSTables();
         sstables.forEach(sstable -> {
-            assertTrue(sstable.getCompressionMetadata().parameters.getSstableCompressor() instanceof LZ4Compressor);
+            var compressor = sstable.getCompressionMetadata().parameters.getSstableCompressor();
+            assertTrue(compressor instanceof LZ4Compressor || compressor instanceof AdaptiveCompressor);
         });
 
         // Should compact to Zstd


### PR DESCRIPTION
This is now possible because AC has been supported in CNDB prod since
March 2025 release, and we can easily switch back to LZ4 if
AC causes any performance issues.
