### PR TITLE
HCD-200 followup: Reject cancelled tasks with an exception

### DIFF
--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -37,7 +37,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.Callable;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -2805,8 +2804,8 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
                 ActiveRepairService.instance.abort((prs) -> prs.getTableIds().contains(metadata.id),
                                                    "Stopping parent sessions {} due to truncation of tableId="+metadata.id);
                 data.notifyTruncated(replayAfter, truncatedAt);
-                
-                if (!noSnapshot && DatabaseDescriptor.isAutoSnapshot()) 
+
+                if (!noSnapshot && DatabaseDescriptor.isAutoSnapshot())
                     snapshot(Keyspace.getTimestampedSnapshotNameWithPrefix(name, SNAPSHOT_TRUNCATE_PREFIX));
 
                 discardSSTables(truncatedAt);
@@ -2896,7 +2895,7 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
             {
                 // Cancel scheduled compactions matching predicate. This must be done first because tasks progress from
                 // scheduled to active.
-                CompactionManager.instance.active.cancelScheduledTasksAffecting(toInterruptFor, sstablesPredicate);
+                CompactionManager.instance.active.cancelScheduledTasksAffecting(toInterruptFor, sstablesPredicate, trigger);
                 // interrupt in-progress compactions
                 CompactionManager.instance.interruptCompactionForCFs(toInterruptFor, sstablesPredicate, interruptValidation, trigger);
 

--- a/src/java/org/apache/cassandra/db/compaction/AbstractCompactionTask.java
+++ b/src/java/org/apache/cassandra/db/compaction/AbstractCompactionTask.java
@@ -232,7 +232,7 @@ public abstract class AbstractCompactionTask extends WrappedRunnable
     /**
      * Reject/cancel the task if it affects any sstable that satisfies the given predicate.
      */
-    public boolean cancelIfAffects(CompactionRealm realm, Predicate<SSTableReader> sstablePredicate)
+    public boolean cancelIfAffects(CompactionRealm realm, Predicate<SSTableReader> sstablePredicate, TableOperation.StopTrigger trigger)
     {
         if (realm != this.realm)
             return false;
@@ -241,7 +241,10 @@ public abstract class AbstractCompactionTask extends WrappedRunnable
         {
             if (sstablePredicate.test(r))
             {
-                Throwables.maybeFail(rejected(null));
+                // Reject with an exception to notify observers task wasn't successful.
+                Throwable err = rejected(new CompactionInterruptedException(null, trigger));
+                if (err != null && !(err instanceof CompactionInterruptedException))
+                    logger.warn("Failed to reject task with id={}", getTransaction().opId(), err);
                 return true;
             }
         }

--- a/src/java/org/apache/cassandra/db/compaction/ActiveOperations.java
+++ b/src/java/org/apache/cassandra/db/compaction/ActiveOperations.java
@@ -176,7 +176,7 @@ public class ActiveOperations implements TableOperationObserver
         scheduledTasks.remove(task);
     }
 
-    public void cancelScheduledTasksAffecting(Iterable<ColumnFamilyStore> cfss, Predicate<SSTableReader> predicate)
+    public void cancelScheduledTasksAffecting(Iterable<ColumnFamilyStore> cfss, Predicate<SSTableReader> predicate, TableOperation.StopTrigger trigger)
     {
         Iterable<AbstractCompactionTask> tasksCopy;
         synchronized (scheduledTasks)
@@ -186,7 +186,7 @@ public class ActiveOperations implements TableOperationObserver
 
         for (AbstractCompactionTask task : tasksCopy)
             for (ColumnFamilyStore cfs : cfss)
-                task.cancelIfAffects(cfs, predicate);
+                task.cancelIfAffects(cfs, predicate, trigger);
     }
 
     @VisibleForTesting

--- a/src/java/org/apache/cassandra/db/compaction/CompositeCompactionTask.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompositeCompactionTask.java
@@ -79,7 +79,7 @@ public class CompositeCompactionTask extends AbstractCompactionTask
     }
 
     @Override
-    public boolean cancelIfAffects(CompactionRealm realm, Predicate<SSTableReader> sstablePredicate)
+    public boolean cancelIfAffects(CompactionRealm realm, Predicate<SSTableReader> sstablePredicate, TableOperation.StopTrigger trigger)
     {
         // Leave cancellation to the individual tasks.
         return false;

--- a/test/unit/org/apache/cassandra/db/compaction/CancelCompactionsTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CancelCompactionsTest.java
@@ -585,7 +585,7 @@ public class CancelCompactionsTest extends CQLTester
         Thread t = new Thread(() -> {
             Uninterruptibles.awaitUninterruptibly(waitForBeginCompaction);
             getCurrentColumnFamilyStore().getCompactionStrategyContainer().pause();
-            CompactionManager.instance.active.cancelScheduledTasksAffecting(cfss, Predicates.alwaysTrue());
+            CompactionManager.instance.active.cancelScheduledTasksAffecting(cfss, Predicates.alwaysTrue(), UNIT_TESTS);
             CompactionManager.instance.interruptCompactionFor(Iterables.transform(cfss, ColumnFamilyStore::metadata),
                                                               Predicates.alwaysTrue(), false, UNIT_TESTS);
             waitForStart.countDown();

--- a/test/unit/org/apache/cassandra/db/compaction/CompactionTaskTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CompactionTaskTest.java
@@ -125,7 +125,7 @@ public class CompactionTaskTest
             }
         };
         Assert.assertNotNull(task);
-        task.cancelIfAffects(cfs, Predicates.alwaysTrue());
+        task.cancelIfAffects(cfs, Predicates.alwaysTrue(), TableOperation.StopTrigger.UNIT_TESTS);
         try
         {
             task.execute(CompactionManager.instance.active);

--- a/test/unit/org/apache/cassandra/db/compaction/RandomizedCancelCompactionsTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/RandomizedCancelCompactionsTest.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;


### PR DESCRIPTION
to notify observers task wasn't successful

### What is the issue
The committed patch for HCD-200, 9ee2af55bc7e86f4a30a312f25457f35be85acbd, contained a potential problem where observers will get a null error value when a scheduled task is cancelled and treat it as successfully completed.

### What does this PR fix and why was it fixed
Passes a `CompactionInterruptedException` as the argument to `AbstractCompactionTask.rejected`.
