### PR TITLE
CNDB-17792: Fix LongVectorTest coordinator warning state handling

### DIFF
--- a/test/burn/org/apache/cassandra/index/sai/LongVectorTest.java
+++ b/test/burn/org/apache/cassandra/index/sai/LongVectorTest.java
@@ -32,8 +32,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.slf4j.Logger;
 
-import org.apache.cassandra.service.reads.thresholds.CoordinatorWarnings;
-
 import static org.apache.cassandra.config.CassandraRelevantProperties.MEMTABLE_SHARD_COUNT;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -86,7 +84,6 @@ public class LongVectorTest extends SAITester
 
     private static void wrappedOp(Op op, Integer i)
     {
-        CoordinatorWarnings.init();  // Initialize for this thread
         try
         {
             op.run(i);
@@ -94,10 +91,6 @@ public class LongVectorTest extends SAITester
         catch (Throwable e)
         {
             throw new RuntimeException(e);
-        }
-        finally
-        {
-            CoordinatorWarnings.reset();  // Clean up thread-local state
         }
     }
 


### PR DESCRIPTION
### What is the issue
After https://github.com/riptano/cndb/issues/17728, LongVectorTest no longer needs to init CoordinatorWarnings

### What does this PR fix and why was it fixed
Remove manual CoordinatorWarnings init/reset from LongVectorTest
