### PR TITLE
HCD-25: Add Netty native epoll libs for ARM

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -663,6 +663,7 @@
           <dependency groupId="io.netty" artifactId="netty-all" version="${netty.version}" />
           <dependency groupId="io.netty" artifactId="netty-transport-native-epoll" version="${netty.version}"/>
           <dependency groupId="io.netty" artifactId="netty-transport-native-epoll" version="${netty.version}" classifier="linux-x86_64"/>
+          <dependency groupId="io.netty" artifactId="netty-transport-native-epoll" version="${netty.version}" classifier="linux-aarch_64"/>
           <dependency groupId="io.netty" artifactId="netty-tcnative-boringssl-static" version="2.0.74.Final"/>
           <dependency groupId="net.openhft" artifactId="chronicle-queue" version="${chronicle-queue.version}">
             <exclusion groupId="com.sun" artifactId="tools" />
@@ -899,6 +900,7 @@
         <dependency groupId="io.netty" artifactId="netty-all"/>
         <dependency groupId="io.netty" artifactId="netty-transport-native-epoll"/>
         <dependency groupId="io.netty" artifactId="netty-transport-native-epoll" classifier="linux-x86_64"/>
+        <dependency groupId="io.netty" artifactId="netty-transport-native-epoll" classifier="linux-aarch_64"/>
         <dependency groupId="net.openhft" artifactId="chronicle-queue"/>
         <dependency groupId="net.openhft" artifactId="chronicle-core"/>
         <dependency groupId="net.openhft" artifactId="chronicle-bytes"/>


### PR DESCRIPTION
This patch adds the linux-aarch_64 native epoll libs so that epoll can be used on Linux ARM machines

### What is the issue
Native Netty Epoll libraries for Linux ARM64/aarch_64 are missing from the build

### What does this PR fix and why was it fixed
Adds the Linux ARM64 native Netty Epoll libraries to the dependency list
