### PR TITLE
Expose UnifiedCompactionStrategy.Level stats

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.java
+++ b/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.java
@@ -1512,6 +1512,34 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
             return index;
         }
 
+        // The stats below are set up by getLevels and useful for diagnostics.
+        public int getFanout()
+        {
+            return fanout;
+        }
+
+        public int getThreshold()
+        {
+            return threshold;
+        }
+
+        public double getMinDensity()
+        {
+            return min;
+        }
+
+        public double getMaxDensity()
+        {
+            return max;
+        }
+
+        public double getAverageSSTableSize()
+        {
+            return avg;
+        }
+
+        // We don't expose max overlap as it's not valid until getCompactionAggregates gets called.
+
         void add(CompactionSSTable sstable)
         {
             this.sstables.add(sstable);
@@ -1528,8 +1556,8 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
         }
 
         private List<CompactionAggregate.UnifiedAggregate> getOversizeShardsAggregates(Arena arena,
-                                                                               Controller controller,
-                                                                               ShardManager shardManager)
+                                                                                       Controller controller,
+                                                                                       ShardManager shardManager)
         {
             List<CompactionAggregate.UnifiedAggregate> aggregates = new ArrayList<>();
             double shardThreshold = fanout * controller.getMaxSstablesPerShardFactor();

--- a/test/unit/org/apache/cassandra/db/compaction/BaseCompactionStrategyTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/BaseCompactionStrategyTest.java
@@ -237,6 +237,7 @@ public class BaseCompactionStrategyTest
         when(ret.isSuitableForCompaction()).thenReturn(true);
         when(ret.getSSTableLevel()).thenReturn(level);
         when(ret.onDiskLength()).thenReturn(bytesOnDisk);
+        when(ret.onDiskComponentsSize()).thenReturn(bytesOnDisk);
         when(ret.uncompressedLength()).thenReturn(bytesOnDisk); // let's assume no compression
         when(ret.hotness()).thenReturn(hotness);
         when(ret.getMaxTimestamp()).thenReturn(timestamp);

--- a/test/unit/org/apache/cassandra/db/compaction/UnifiedCompactionStrategyTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/UnifiedCompactionStrategyTest.java
@@ -375,11 +375,24 @@ public class UnifiedCompactionStrategyTest extends BaseCompactionStrategyTest
         {
             List<UnifiedCompactionStrategy.Level> levels = entry.getValue();
             assertEquals(expectedLevels, levels.size());
+            double expectedMin = 0.0;
 
             for (int i = 0; i < expectedLevels; i++)
             {
                 UnifiedCompactionStrategy.Level level = levels.get(i);
                 assertEquals(i, level.getIndex());
+                assertEquals(expectedMin, level.getMinDensity(), 1.0);
+                expectedMin = level.getMaxDensity();
+                assertEquals(level.scalingParameter >= 0 ? level.scalingParameter + 2 : 2, level.getThreshold());
+                assertEquals(2 + Math.abs(level.scalingParameter), level.getFanout());
+                if (level.getSSTables().size() > 0)
+                    assertEquals(level.getSSTables()
+                                      .stream()
+                                      .mapToLong(CompactionSSTable::onDiskLength)
+                                      .summaryStatistics()
+                                      .getAverage(),
+                                 level.getAverageSSTableSize(),
+                                 1.0);
 
                 Collection<CompactionAggregate.UnifiedAggregate> compactionAggregates =
                     level.getCompactionAggregates(entry.getKey(), controller, shardManager, dataSetSizeBytes);


### PR DESCRIPTION
### What is the issue
CNDB-17538 Add more meaningful compaction metrics


### What does this PR fix and why was it fixed
Exposes a few statistics collected by `UnifiedCompactionStrategy.Level` to be used by CNDB's per-level compaction metrics.
