### PR TITLE
CNDB-17831: Use 2038 max deletion time in HCD_1

### DIFF
--- a/src/java/org/apache/cassandra/db/rows/Cell.java
+++ b/src/java/org/apache/cassandra/db/rows/Cell.java
@@ -90,6 +90,9 @@ public abstract class Cell<V> extends ColumnData
 
     public static long getVersionedMaxDeletiontionTime()
     {
+        if (DatabaseDescriptor.getStorageCompatibilityMode().isBefore(5))
+            return Cell.MAX_DELETION_TIME_2038_LEGACY_CAP;
+
         if (DatabaseDescriptor.getStorageCompatibilityMode().disabled())
             // The whole cluster is 2016, we're out of the 2038/2106 mixed cluster scenario. Shortcut to avoid the 'minClusterVersion' volatile read
             return Cell.MAX_DELETION_TIME;

--- a/test/unit/org/apache/cassandra/cql3/validation/operations/TTLTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/operations/TTLTest.java
@@ -48,7 +48,6 @@ import org.apache.cassandra.tools.StandaloneScrubber;
 import org.apache.cassandra.tools.ToolRunner;
 import org.apache.cassandra.tools.ToolRunner.ToolResult;
 import org.apache.cassandra.utils.Clock;
-import org.apache.cassandra.utils.StorageCompatibilityMode;
 import org.assertj.core.data.Offset;
 
 import static org.apache.cassandra.config.CassandraRelevantProperties.TEST_UTIL_ALLOW_TOOL_REINIT_FOR_TEST;
@@ -230,7 +229,7 @@ public class TTLTest extends CQLTester
     @Test
     public void testImprovedMaxTTL()
     {
-        Assume.assumeTrue(DatabaseDescriptor.getStorageCompatibilityMode() != StorageCompatibilityMode.CASSANDRA_4);
+        Assume.assumeFalse(DatabaseDescriptor.getStorageCompatibilityMode().isBefore(5));
         createTable("CREATE TABLE %s (k int PRIMARY KEY, i int)");
         disableCompaction();
         long t0 = Clock.Global.currentTimeMillis();


### PR DESCRIPTION
### What is the issue
Max deletion time is 2038 in 4.0 and should be used in HCD_1 mode

### What does this PR fix and why was it fixed
Use 2038 max deletion time in HCD_1
