### PR TITLE
CNDB-17832: HCD-355: Upgrade Netty to 4.1.133.Final

### DIFF
--- a/.build/parent-pom-template.xml
+++ b/.build/parent-pom-template.xml
@@ -755,7 +755,7 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-all</artifactId>
-        <version>4.1.132.Final</version>
+        <version>4.1.133.Final</version>
         <exclusions>
           <exclusion>
             <groupId>io.netty</groupId>


### PR DESCRIPTION
### What is the issue
[CNDB-17832: HCD-355: Upgrade Netty to 4.1.133.Final](https://github.com/riptano/cndb/issues/17832)

### What does this PR fix and why was it fixed
Upgrade Netty to 4.1.133.Final to address recent CVEs


