### PR TITLE
CNDB-17291: Fix SlowSAIQueryLoggerTest

### DIFF
--- a/test/distributed/org/apache/cassandra/distributed/test/sai/SlowSAIQueryLoggerTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/SlowSAIQueryLoggerTest.java
@@ -61,6 +61,9 @@ public class SlowSAIQueryLoggerTest extends TestBaseImpl
         // effectively disable the scheduled monitoring task so we control it manually for better test stability
         CassandraRelevantProperties.MONITORING_REPORT_INTERVAL_MS.setInt((int) TimeUnit.HOURS.toMillis(1));
 
+        // enable term statistics, same as in SAITester
+        CassandraRelevantProperties.SAI_QUERY_OPTIMIZATION_USE_TERM_STATISTICS.setBoolean(true);
+
         try (Cluster cluster = init(Cluster.build(1)
                                            .withConfig(c -> c.set("slow_query_log_timeout_in_ms", SLOW_QUERY_LOG_TIMEOUT_IN_MS))
                                            .withInstanceInitializer(BB::install)


### PR DESCRIPTION
### What is the issue

[CNDB-17275](https://github.com/riptano/cndb/issues/17275) broke `SlowSAIQueryLoggerTest` by disabling the use of term stats by the query optimizer by default. While disabled in production, the usage of term stats is enabled by default for utests extending `SAITester`. However, the `SlowSAIQueryLoggerTest` dtest doesn't extend `SAITester`, so it broke after that change. That first failure can be seen in the CI results for [CNDB-17275](https://github.com/riptano/cndb/issues/17275): https://github.com/datastax/cassandra/pull/2290#issuecomment-4177694547

### What does this PR fix and why was it fixed

Enable `SAI_QUERY_OPTIMIZATION_USE_TERM_STATISTICS` in `SlowSAIQueryLoggerTest` to preserve the original behaviour.
