### PR TITLE
CNDB-17832: HCD-355: Upgrade Netty to 4.1.133.Final

### DIFF
--- a/.build/parent-pom-template.xml
+++ b/.build/parent-pom-template.xml
@@ -845,18 +845,18 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-epoll</artifactId>
-        <version>4.1.130.Final</version>
+        <version>4.1.133.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-epoll</artifactId>
-        <version>4.1.130.Final</version>
+        <version>4.1.133.Final</version>
         <classifier>linux-x86_64</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-epoll</artifactId>
-        <version>4.1.130.Final</version>
+        <version>4.1.133.Final</version>
         <classifier>linux-aarch_64</classifier>
       </dependency>
 


### PR DESCRIPTION
This patch updates the Netty version in a few other places that were missed with commit b12bbcf7154e9ea43f91789a06ada9a03116f2ba

### What is the issue
...

### What does this PR fix and why was it fixed
...
