### PR TITLE
CNDB-17881 use Clustering<?> in PrimaryKey

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,9 @@ nbactions.xml
 out/
 target/
 
+# AI agents
+.ai/
+
 # General
 **/__pycache__
 *.pyc

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/PartitionAwarePrimaryKeyFactory.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/PartitionAwarePrimaryKeyFactory.java
@@ -45,7 +45,7 @@ public class PartitionAwarePrimaryKeyFactory implements PrimaryKey.Factory
     }
 
     @Override
-    public PrimaryKey create(DecoratedKey partitionKey, Clustering clustering)
+    public PrimaryKey create(DecoratedKey partitionKey, Clustering<?> clustering)
     {
         assert partitionKey != null;
         return new PartitionAwarePrimaryKey(partitionKey.getToken(), partitionKey, null);
@@ -98,7 +98,7 @@ public class PartitionAwarePrimaryKeyFactory implements PrimaryKey.Factory
         }
 
         @Override
-        public Clustering clustering()
+        public Clustering<?> clustering()
         {
             return Clustering.EMPTY;
         }

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/PrimaryKeyWithSource.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/PrimaryKeyWithSource.java
@@ -87,7 +87,7 @@ class PrimaryKeyWithSource implements PrimaryKey
     }
 
     @Override
-    public Clustering clustering()
+    public Clustering<?> clustering()
     {
         return primaryKey().clustering();
     }

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/RowAwarePrimaryKeyFactory.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/RowAwarePrimaryKeyFactory.java
@@ -57,7 +57,7 @@ public class RowAwarePrimaryKeyFactory implements PrimaryKey.Factory
     }
 
     @Override
-    public PrimaryKey create(DecoratedKey partitionKey, Clustering clustering)
+    public PrimaryKey create(DecoratedKey partitionKey, Clustering<?> clustering)
     {
         return new RowAwarePrimaryKey(partitionKey.getToken(), partitionKey, clustering, null);
     }
@@ -71,10 +71,10 @@ public class RowAwarePrimaryKeyFactory implements PrimaryKey.Factory
     {
         private final Token token;
         private DecoratedKey partitionKey;
-        private Clustering clustering;
+        private Clustering<?> clustering;
         private Supplier<PrimaryKey> primaryKeySupplier;
 
-        private RowAwarePrimaryKey(Token token, DecoratedKey partitionKey, Clustering clustering, Supplier<PrimaryKey> primaryKeySupplier)
+        private RowAwarePrimaryKey(Token token, DecoratedKey partitionKey, Clustering<?> clustering, Supplier<PrimaryKey> primaryKeySupplier)
         {
             this.token = token;
             this.partitionKey = partitionKey;
@@ -102,7 +102,7 @@ public class RowAwarePrimaryKeyFactory implements PrimaryKey.Factory
         }
 
         @Override
-        public Clustering clustering()
+        public Clustering<?> clustering()
         {
             loadDeferred();
             return clustering;

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/RowAwarePrimaryKeyMap.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/RowAwarePrimaryKeyMap.java
@@ -293,7 +293,7 @@ public class RowAwarePrimaryKeyMap implements PrimaryKeyMap
 
             DecoratedKey partitionKey = new BufferDecoratedKey(token, ByteBuffer.wrap(keyBytes));
 
-            Clustering clustering = clusteringComparator.size() == 0
+            Clustering<?> clustering = clusteringComparator.size() == 0
                                     ? Clustering.EMPTY
                                     : clusteringComparator.clusteringFromByteComparable(ByteBufferAccessor.instance,
                                                                                         v -> ByteSourceInverse.nextComponentSource(peekable),

--- a/src/java/org/apache/cassandra/index/sai/utils/PrimaryKey.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/PrimaryKey.java
@@ -97,7 +97,7 @@ public interface PrimaryKey extends Comparable<PrimaryKey>, Accountable
          * @param clustering the {@link Clustering}
          * @return a {@link PrimaryKey} contain the partition key and clustering
          */
-        PrimaryKey create(DecoratedKey partitionKey, Clustering clustering);
+        PrimaryKey create(DecoratedKey partitionKey, Clustering<?> clustering);
     }
 
     /**
@@ -147,7 +147,7 @@ public interface PrimaryKey extends Comparable<PrimaryKey>, Accountable
      *
      * @return the {@link Clustering}
      */
-    Clustering clustering();
+    Clustering<?> clustering();
 
     /**
      * Return whether the primary key has a clustering, i.e., has non-static clustering column(s).


### PR DESCRIPTION
CNDB needs also be approved: https://github.com/riptano/cndb/pull/17904

### What is the issue

`Clustering` is a generics class, thus linter complains when it is used without generics. Such cases are in `PrimaryKey` and `PrimaryKey.Map` interfaces and their implementations.

### What does this PR fix and why was it fixed

Fixes https://github.com/riptano/cndb/issues/17881

Replaces non-generics `Clustering` with `Clustering<?>` in `PrimaryKey` and `PrimaryKey.Map` interfaces and their implementations.

Also adds `.ai` to `.gitignore` as BobIDE annoyingly creates it.