### PR TITLE
CNDB-15948: Fix handling of partition-aware keys in anti-joins

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/IndexContext.java
+++ b/src/java/org/apache/cassandra/index/sai/IndexContext.java
@@ -477,7 +477,7 @@ public class IndexContext
     private KeyRangeIterator getNonEqIterator(QueryContext context, Collection<MemtableIndex> memtables, Expression expression, AbstractBounds<PartitionPosition> keyRange)
     {
         KeyRangeIterator allKeys = scanMemtable(keyRange, memtables);
-        if (TypeUtil.supportsRounding(expression.validator))
+        if (TypeUtil.supportsRounding(expression.validator) || !version.onDiskFormat().indexFeatureSet().isRowAware())
         {
             return allKeys;
         }

--- a/src/java/org/apache/cassandra/index/sai/SSTableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/SSTableIndex.java
@@ -253,7 +253,8 @@ public class SSTableIndex
                                               boolean defer) throws IOException
     {
         KeyRangeIterator allKeys = allSSTableKeys(keyRange);
-        if (TypeUtil.supportsRounding(expression.validator))
+        if (TypeUtil.supportsRounding(expression.validator)
+            || !this.getVersion().onDiskFormat().indexFeatureSet().isRowAware())
         {
             return allKeys;
         }

--- a/src/java/org/apache/cassandra/index/sai/iterators/KeyRangeAntiJoinIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/iterators/KeyRangeAntiJoinIterator.java
@@ -26,7 +26,21 @@ import org.apache.cassandra.io.util.FileUtils;
 /**
  * An iterator wrapper that wraps two iterators (left and right) and returns the primary keys from the left iterator
  * that do not match the primary keys from the right iterator. The keys returned by the wrapped iterators must
- * follow token-clustering order.
+ * follow the same order.
+ * <p>
+ * In order to avoid false negatives in the output, this class must not be used with iterators that can
+ * return false positives on the right side, in particular:
+ * <ul>
+ *   <li>returned from different overlapping sstable/memtable indexes, because the indexed terms can be overwritten</li>
+ *   <li>returned from indexes that do not handle overwrites in place and may return stale values</li>
+ *   <li>returned from imprecise indexes that can potentially point to different values than the values actually indexed:
+ *     <ul>
+ *       <li>partition-aware indexes (version AA), because they always match the whole partition even if only one row matches</li>
+ *       <li>indexes over types with rounding, because they truncate the term and might match additional rows with a different value than the one searched for</li>
+ *     </ul>
+ *   </li>
+ * </ul>
+ * The above-mentioned conditions are not checked, and if violated, some results may be missing.
  */
 public class KeyRangeAntiJoinIterator extends KeyRangeIterator
 {

--- a/src/java/org/apache/cassandra/index/sai/utils/PrimaryKeyWithSortKey.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/PrimaryKeyWithSortKey.java
@@ -161,5 +161,4 @@ public abstract class PrimaryKeyWithSortKey implements PrimaryKey
                3L * RamUsageEstimator.NUM_BYTES_OBJECT_REF +
                primaryKey.ramBytesUsed();
     }
-
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/CollectionIndexingTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/CollectionIndexingTest.java
@@ -31,7 +31,7 @@ import static org.junit.Assert.assertEquals;
 // and basic functionality. Comprehensive type testing of collections
 // is in the cql/types/collections package
 //TODO Sort out statement restrictions assertion
-public class CollectionIndexingTest extends SAITester
+public class CollectionIndexingTest extends SAITester.Versioned
 {
     @Before
     public void setup() throws Throwable

--- a/test/unit/org/apache/cassandra/index/sai/iterators/AbstractKeyRangeIteratorTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/iterators/AbstractKeyRangeIteratorTest.java
@@ -30,8 +30,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import javax.annotation.Nullable;
-
+import com.google.common.base.Preconditions;
 import org.junit.Assert;
 
 import org.apache.cassandra.db.Clustering;
@@ -40,6 +39,7 @@ import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.marshal.LongType;
 import org.apache.cassandra.dht.Murmur3Partitioner;
 import org.apache.cassandra.index.sai.SAIUtil;
+import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
 import org.apache.cassandra.index.sai.utils.SaiRandomizedTest;
 import org.apache.cassandra.utils.Pair;
@@ -50,6 +50,9 @@ public class AbstractKeyRangeIteratorTest extends SaiRandomizedTest
 {
     static final PrimaryKey.Factory TEST_PRIMARY_KEY_FACTORY = SAIUtil.currentVersion().onDiskFormat()
                                                                       .newPrimaryKeyFactory(new ClusteringComparator(LongType.instance));
+
+    static final PrimaryKey.Factory TEST_AA_KEY_FACTORY = Version.AA.onDiskFormat()
+                                                                    .newPrimaryKeyFactory(new ClusteringComparator(LongType.instance));
 
     protected long[] arr(long... longArray)
     {
@@ -140,7 +143,7 @@ public class AbstractKeyRangeIteratorTest extends SaiRandomizedTest
 
             // skipping to the same element should also be a no-op
             if (randomBoolean())
-                ri.skipTo(LongIterator.fromToken(totalOrdering[count]));
+                ri.skipTo(LongIterator.makeKey(totalOrdering[count]));
 
             // skip a few elements
             if (nextDouble() < 0.1)
@@ -149,7 +152,7 @@ public class AbstractKeyRangeIteratorTest extends SaiRandomizedTest
                 if (count + n < totalOrdering.length)
                 {
                     count += n;
-                    ri.skipTo(LongIterator.fromToken(totalOrdering[count]));
+                    ri.skipTo(LongIterator.makeKey(totalOrdering[count]));
                 }
             }
             Assert.assertEquals(totalOrdering[count++], ri.next().token().getLongValue());
@@ -183,15 +186,63 @@ public class AbstractKeyRangeIteratorTest extends SaiRandomizedTest
     }
 
     /**
-     * Generates a random list of primary keys with the given average number of partitions and rows per partition.
+     * Generates a list of random primary keys with the given average number of partitions and rows per partition.
+     * Generates keys of various types (mixed) - 25% of keys with static clusterings, 25% of partition-aware keys
+     * and the rest are regular row keys.
+     *
+     * @see this#randomPrimaryKeys(int, int, double, double)
+     */
+    static List<PrimaryKey> randomPrimaryKeysOfMixedTypes(int avgPartitions, int avgRowsPerPartition)
+    {
+        return randomPrimaryKeys(avgPartitions, avgRowsPerPartition, 0.25, 0.25);
+    }
+
+
+    /**
+     * Generates a list of random primary keys with the given average number of partitions and rows per partition.
+     * Generates only keys with regular clusterings (i.e. keys pointing to regular rows, not static rows).
+     *
+     * @see this#randomPrimaryKeys(int, int, double, double)
+     */
+    static List<PrimaryKey> randomPrimaryKeysWithRegularClusterings(int avgPartitions, int avgRowsPerPartition)
+    {
+        return randomPrimaryKeys(avgPartitions, avgRowsPerPartition, 0.0, 0.0);
+    }
+
+    /**
+     * Generates a list of random primary keys with the given average number of partitions and rows per partition.
+     * Generates only keys with static clusterings (i.e. keys pointing to static rows).
+     *
+     * @see this#randomPrimaryKeys(int, int, double, double)
+     */
+    static List<PrimaryKey> randomPrimaryKeysWithStaticClusterings(int avgPartitions, int avgRowsPerPartition)
+    {
+        return randomPrimaryKeys(avgPartitions, avgRowsPerPartition, 1.0, 0.0);
+    }
+
+    /**
+     * Generates a list of random primary keys with the given average number of partitions and rows per partition.
      * Partition keys and clusterings are generated in such a way that when combining two such lists generated with
      * same parameters (but different random), there is a high chance both sets would contain many common keys, as well
      * as each would contain some keys not present in the other set.
      *
+     * @param avgPartitions mean number of partitions to generate
+     * @param avgRowsPerPartition mean number of rows in a partition
+     * @param staticClusteringProbability probability of generating a key for the static row
+     *                                    with respect to the number of partitions
+     * @param partitionAwareKeyProbability probability of generating a key for the whole partition as if coming from
+     *                                     a partition-aware AA index, with respect to the number of partitions
      * @return list of primary keys in (token, clustering) order.
      */
-    static List<PrimaryKey> randomPrimaryKeys(int avgPartitions, int avgRowsPerPartition)
+    private static List<PrimaryKey> randomPrimaryKeys(int avgPartitions,
+                                                      int avgRowsPerPartition,
+                                                      double staticClusteringProbability,
+                                                      double partitionAwareKeyProbability)
     {
+        Preconditions.checkArgument(staticClusteringProbability >= 0.0 && staticClusteringProbability <= 1.0);
+        Preconditions.checkArgument(partitionAwareKeyProbability >= 0.0 && partitionAwareKeyProbability <= 1.0);
+        Preconditions.checkArgument(staticClusteringProbability + partitionAwareKeyProbability <= 1.0);
+
         List<PrimaryKey> keys = new ArrayList<>((int)(avgPartitions * avgRowsPerPartition * 1.5));
 
         for (int p = 0; p < avgPartitions * 2; p++)
@@ -199,16 +250,21 @@ public class AbstractKeyRangeIteratorTest extends SaiRandomizedTest
             if (randomBoolean())   // skip 50% of partitions
                 continue;
 
-            if (randomBoolean())
+            double keyTypeSelector = randomDouble();
+            if (keyTypeSelector < staticClusteringProbability)
             {
-                keys.add(makeKey(p, null)); // add partition key only
+                keys.add(makeKeyForStaticRow(p));
+            }
+            else if (keyTypeSelector < staticClusteringProbability + partitionAwareKeyProbability)
+            {
+                keys.add(makePartitionAwareKey(p));
             }
             else
             {
                 for (int r = 0; r < avgRowsPerPartition * 2; r++)
                 {
                     if (randomBoolean())   // skip 50% of rows
-                        keys.add(makeKey(p, (long) r));
+                        keys.add(makeKeyForRegularRow(p, (long) r));
                 }
             }
         }
@@ -219,16 +275,39 @@ public class AbstractKeyRangeIteratorTest extends SaiRandomizedTest
     }
 
     /**
-      * Helper to create PrimaryKey with/without clustering.
-      * Pass null clustering to create a key with Clustering.EMPTY.
-      */
-    static PrimaryKey makeKey(long partitionKey, @Nullable Long clustering)
+     * Creates a row-aware primary key with non-empty clustering
+     */
+    static PrimaryKey makeKeyForRegularRow(long partitionKey, long clustering)
+    {
+        DecoratedKey decoratedKey = decorate(partitionKey);
+        ByteBuffer clusteringValue = LongType.instance.getSerializer().serialize(clustering);
+        return TEST_PRIMARY_KEY_FACTORY.create(decoratedKey, Clustering.make(clusteringValue));
+    }
+
+    /**
+     * Creates a row-aware primary key with static clustering
+     */
+    static PrimaryKey makeKeyForStaticRow(long partitionKey)
+    {
+        DecoratedKey decoratedKey = decorate(partitionKey);
+        return TEST_PRIMARY_KEY_FACTORY.create(decoratedKey, Clustering.STATIC_CLUSTERING);
+    }
+
+    /**
+     * Creates a partition-aware primary key (keys of this type are used by AA indexes)
+     */
+    static PrimaryKey makePartitionAwareKey(long partitionKey)
+    {
+        DecoratedKey decoratedKey = decorate(partitionKey);
+        return TEST_AA_KEY_FACTORY.createPartitionKeyOnly(decoratedKey);
+    }
+
+
+    private static DecoratedKey decorate(long partitionKey)
     {
         ByteBuffer pkValue = LongType.instance.getSerializer().serialize(partitionKey);
-        ByteBuffer clusteringValue = LongType.instance.getSerializer().serialize(clustering);
         DecoratedKey pk = Murmur3Partitioner.instance.decorateKey(pkValue);
-        Clustering<ByteBuffer> c = clustering == null ? Clustering.EMPTY : Clustering.make(clusteringValue);
-        return TEST_PRIMARY_KEY_FACTORY.create(pk, c);
+        return pk;
     }
 
     /**

--- a/test/unit/org/apache/cassandra/index/sai/iterators/KeyRangeAntiJoinIteratorTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/iterators/KeyRangeAntiJoinIteratorTest.java
@@ -19,13 +19,16 @@
 package org.apache.cassandra.index.sai.iterators;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
+import org.apache.cassandra.index.sai.utils.PrimaryKey;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
-public class KeyRangeAntiJoinIteratorTest
+public class KeyRangeAntiJoinIteratorTest extends AbstractKeyRangeIteratorTest
 {
     public static final long[] EMPTY = { };
 
@@ -81,6 +84,96 @@ public class KeyRangeAntiJoinIteratorTest
         LongIterator right = new LongIterator(new long[] { 2L, 3L, 4L });
         KeyRangeAntiJoinIterator iter = KeyRangeAntiJoinIterator.create(left, right);
         assertEquals(convert(6, 8, 9, 10), convert(iter));
+    }
+
+    @Test
+    public void testRandomRegularRowKeys() throws Throwable
+    {
+        for (int i = 0; i < 200; i++)
+        {
+            var inputs = new ArrayList<List<PrimaryKey>>(2);
+            for (int j = 0; j < 2; j++)
+                inputs.add(randomPrimaryKeysWithRegularClusterings(1 + i / 10, 1 + i / 10));
+
+            testMerge(inputs,
+                      KeyRangeAntiJoinIteratorTest::antiJoin,
+                      KeyRangeAntiJoinIteratorTest::validateAntiJoinResults);
+        }
+    }
+
+    @Test
+    public void testRandomStaticRowKeys() throws Throwable
+    {
+        for (int i = 0; i < 200; i++)
+        {
+            var inputs = new ArrayList<List<PrimaryKey>>(2);
+            for (int j = 0; j < 2; j++)
+                inputs.add(randomPrimaryKeysWithStaticClusterings(1 + i / 10, 1));
+
+            testMerge(inputs,
+                      KeyRangeAntiJoinIteratorTest::antiJoin,
+                      KeyRangeAntiJoinIteratorTest::validateAntiJoinResults);
+        }
+    }
+
+    @Test
+    public void testSkippingWithRandomKeys() throws Throwable
+    {
+        for (int testIteration = 0; testIteration < 200; testIteration++)
+        {
+            int avgPartitions = 1 + testIteration / 10;
+            int avgRowsPerPartition = 1 + testIteration / 10;
+
+            var inputs = new ArrayList<List<PrimaryKey>>(2);
+            for (int j = 0; j < 2; j++)
+                inputs.add(randomPrimaryKeysWithRegularClusterings(avgPartitions, avgRowsPerPartition));
+
+            // Generate random skip positions.
+            // Use a different data set so that some skip positions exist in the merged result and some do not.
+            var skips = randomSkips(randomPrimaryKeysWithRegularClusterings(avgPartitions, avgRowsPerPartition));
+            testSkipping(inputs, skips, KeyRangeAntiJoinIteratorTest::antiJoinIterator);
+        }
+    }
+
+    private static List<PrimaryKey> antiJoin(List<List<PrimaryKey>> inputs)
+    {
+        var iterator = antiJoinIterator(inputs);
+
+        // Limit the size of the result to guarantee the test completes even if the code under test erroneously
+        // generates an iterator that never completes.
+        // We don't need to throw, because excessive results will be checked by validation logic
+        // and that way we get better diagnostics. If we threw an assertion error here, the results wouldn't be printed.
+        int sizeLimit = inputs.get(0).size() + 10;
+        return collectKeys(iterator, sizeLimit);
+    }
+
+    private static @NonNull KeyRangeAntiJoinIterator antiJoinIterator(List<List<PrimaryKey>> inputs)
+    {
+        assert inputs.size() == 2;
+        var left = PrimaryKeyListIterator.create(inputs.get(0));
+        var right = PrimaryKeyListIterator.create(inputs.get(1));
+        return KeyRangeAntiJoinIterator.create(left, right);
+    }
+
+    private static void validateAntiJoinResults(List<List<PrimaryKey>> inputs, List<PrimaryKey> result)
+    {
+        assert inputs.size() == 2;
+        Set<PrimaryKey> left = new HashSet<>(inputs.get(0));
+        Set<PrimaryKey> right = new HashSet<>(inputs.get(1));
+
+        // Check for order and duplicates:
+        assertIncreasing(result);
+
+        var resultSet = new HashSet<>(result);
+
+        // Check that the result contains all the keys on the left except the keys on the right:
+        for (PrimaryKey pk : left)
+            assertTrue("Result should contain key " + pk,
+                       resultSet.contains(pk) || right.contains(pk));
+
+        // Check that the result doesn't contain any of the single-row keys on the right:
+        for (PrimaryKey pk : right)
+            assertFalse("Result should not contain key " + pk, result.contains(pk));
     }
 
     public static List<Long> convert(KeyRangeIterator tokens)

--- a/test/unit/org/apache/cassandra/index/sai/iterators/KeyRangeConcatIteratorTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/iterators/KeyRangeConcatIteratorTest.java
@@ -23,7 +23,6 @@ import java.util.stream.IntStream;
 
 import org.junit.Test;
 
-import org.apache.cassandra.dht.Murmur3Partitioner;
 import org.apache.cassandra.utils.Pair;
 
 import static org.apache.cassandra.index.sai.iterators.LongIterator.convert;
@@ -127,19 +126,19 @@ public class KeyRangeConcatIteratorTest extends AbstractKeyRangeIteratorTest
         KeyRangeIterator tokens;
 
         tokens = init.get();
-        tokens.skipTo(LongIterator.fromToken(5));
+        tokens.skipTo(LongIterator.makeKey(5));
         assertTrue(tokens.hasNext());
         assertEquals(5L, tokens.next().token().getLongValue());
 
         tokens = init.get();
-        tokens.skipTo(LongIterator.fromToken(7L));
+        tokens.skipTo(LongIterator.makeKey(7L));
         assertTrue(tokens.hasNext());
         assertEquals(7L, tokens.next().token().getLongValue());
 
         tokens = init.get();
-        tokens.skipTo(LongIterator.fromToken(2L));
-        tokens.skipTo(LongIterator.fromToken(5L));
-        tokens.skipTo(LongIterator.fromToken(10L));
+        tokens.skipTo(LongIterator.makeKey(2L));
+        tokens.skipTo(LongIterator.makeKey(5L));
+        tokens.skipTo(LongIterator.makeKey(10L));
         assertFalse(tokens.hasNext());
         assertEquals(1L, tokens.getMinimum().token().getLongValue());
         assertEquals(9L, tokens.getMaximum().token().getLongValue());
@@ -154,19 +153,19 @@ public class KeyRangeConcatIteratorTest extends AbstractKeyRangeIteratorTest
         KeyRangeIterator tokens;
 
         tokens = init.get();
-        tokens.skipTo(LongIterator.fromToken(5L));
+        tokens.skipTo(LongIterator.makeKey(5L));
         assertTrue(tokens.hasNext());
         assertEquals(6L, tokens.next().token().getLongValue());
 
         tokens = init.get();
-        tokens.skipTo(LongIterator.fromToken(7L));
+        tokens.skipTo(LongIterator.makeKey(7L));
         assertTrue(tokens.hasNext());
         assertEquals(8L, tokens.next().token().getLongValue());
 
         tokens = init.get();
-        tokens.skipTo(LongIterator.fromToken(2L));
-        tokens.skipTo(LongIterator.fromToken(5L));
-        tokens.skipTo(LongIterator.fromToken(10L));
+        tokens.skipTo(LongIterator.makeKey(2L));
+        tokens.skipTo(LongIterator.makeKey(5L));
+        tokens.skipTo(LongIterator.makeKey(10L));
         assertFalse(tokens.hasNext());
         assertEquals(1L, tokens.getMinimum().token().getLongValue());
         assertEquals(9L, tokens.getMaximum().token().getLongValue());
@@ -424,7 +423,7 @@ public class KeyRangeConcatIteratorTest extends AbstractKeyRangeIteratorTest
     private String createErrorMessage(int max, int min)
     {
         return String.format(KeyRangeConcatIterator.MUST_BE_SORTED_ERROR,
-                             TEST_PRIMARY_KEY_FACTORY.createTokenOnly(new Murmur3Partitioner.LongToken(max)),
-                             TEST_PRIMARY_KEY_FACTORY.createTokenOnly(new Murmur3Partitioner.LongToken(min)));
+                             LongIterator.makeKey(max),
+                             LongIterator.makeKey(min));
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/iterators/KeyRangeIntersectionIteratorTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/iterators/KeyRangeIntersectionIteratorTest.java
@@ -119,15 +119,15 @@ public class KeyRangeIntersectionIteratorTest extends AbstractKeyRangeIteratorTe
         Assert.assertNotNull(range);
 
         // first let's skipTo something before range
-        range.skipTo(LongIterator.fromToken(3L));
+        range.skipTo(LongIterator.makeKey(3L));
         Assert.assertEquals(4L, range.peek().token().getLongValue());
 
         // now let's skip right to the send value
-        range.skipTo(LongIterator.fromToken(5L));
+        range.skipTo(LongIterator.makeKey(5L));
         Assert.assertEquals(6L, range.peek().token().getLongValue());
 
         // now right to the element
-        range.skipTo(LongIterator.fromToken(7L));
+        range.skipTo(LongIterator.makeKey(7L));
         Assert.assertEquals(7L, range.peek().token().getLongValue());
         Assert.assertEquals(7L, range.next().token().getLongValue());
 
@@ -135,7 +135,7 @@ public class KeyRangeIntersectionIteratorTest extends AbstractKeyRangeIteratorTe
         Assert.assertEquals(10L, range.peek().token().getLongValue());
 
         // now right after the last element
-        range.skipTo(LongIterator.fromToken(11L));
+        range.skipTo(LongIterator.makeKey(11L));
         Assert.assertFalse(range.hasNext());
     }
 
@@ -400,7 +400,7 @@ public class KeyRangeIntersectionIteratorTest extends AbstractKeyRangeIteratorTe
     }
 
     @Test
-    public void testRandomized() throws Throwable
+    public void testRandomKeys() throws Throwable
     {
         for (int iteratorCount = 2; iteratorCount <= 5; iteratorCount++)
         {
@@ -408,7 +408,7 @@ public class KeyRangeIntersectionIteratorTest extends AbstractKeyRangeIteratorTe
             {
                 var inputs = new ArrayList<List<PrimaryKey>>(iteratorCount);
                 for (int j = 0; j < iteratorCount; j++)
-                    inputs.add(randomPrimaryKeys(testIteration / 10, testIteration / 10));
+                    inputs.add(randomPrimaryKeysOfMixedTypes(1 + testIteration / 10, 1 + testIteration / 10));
 
                 testMerge(inputs,
                           KeyRangeIntersectionIteratorTest::intersection,
@@ -418,19 +418,22 @@ public class KeyRangeIntersectionIteratorTest extends AbstractKeyRangeIteratorTe
     }
 
     @Test
-    public void testSkippingRandomized() throws Throwable
+    public void testSkippingWithRandomKeys() throws Throwable
     {
         for (int iteratorCount = 2; iteratorCount <= 5; iteratorCount++)
         {
             for (int testIteration = 0; testIteration < 200; testIteration++)
             {
+                int avgPartitions = 1 + testIteration / 10;
+                int avgRowsPerPartition = 1 + testIteration / 10;
+
                 var inputs = new ArrayList<List<PrimaryKey>>(iteratorCount);
                 for (int j = 0; j < iteratorCount; j++)
-                    inputs.add(randomPrimaryKeys(testIteration / 10, testIteration / 10));
+                    inputs.add(randomPrimaryKeysOfMixedTypes(avgPartitions, avgRowsPerPartition));
 
                 // Generate random skip positions.
                 // Use a different data set so that some skip positions exist in the merged result and some do not.
-                var skips = randomSkips(randomPrimaryKeys(testIteration / 10, testIteration / 10));
+                var skips = randomSkips(randomPrimaryKeysOfMixedTypes(avgPartitions, avgRowsPerPartition));
 
                 testSkipping(inputs, skips, KeyRangeIntersectionIteratorTest::intersectionIterator);
             }

--- a/test/unit/org/apache/cassandra/index/sai/iterators/KeyRangeUnionIteratorTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/iterators/KeyRangeUnionIteratorTest.java
@@ -223,15 +223,15 @@ public class KeyRangeUnionIteratorTest extends AbstractKeyRangeIteratorTest
         KeyRangeIterator tokens = builder.build();
         Assert.assertNotNull(tokens);
 
-        tokens.skipTo(LongIterator.fromToken(5L));
+        tokens.skipTo(LongIterator.makeKey(5L));
         Assert.assertTrue(tokens.hasNext());
         Assert.assertEquals(5L, tokens.next().token().getLongValue());
 
-        tokens.skipTo(LongIterator.fromToken(7L));
+        tokens.skipTo(LongIterator.makeKey(7L));
         Assert.assertTrue(tokens.hasNext());
         Assert.assertEquals(7L, tokens.next().token().getLongValue());
 
-        tokens.skipTo(LongIterator.fromToken(10L));
+        tokens.skipTo(LongIterator.makeKey(10L));
         Assert.assertFalse(tokens.hasNext());
         Assert.assertEquals(1L, tokens.getMinimum().token().getLongValue());
         Assert.assertEquals(9L, tokens.getMaximum().token().getLongValue());
@@ -271,19 +271,19 @@ public class KeyRangeUnionIteratorTest extends AbstractKeyRangeIteratorTest
 
         tokens = new LongIterator(new long[] { 0L, 1L, 3L, 5L });
 
-        tokens.skipTo(LongIterator.fromToken(2L));
+        tokens.skipTo(LongIterator.makeKey(2L));
         Assert.assertTrue(tokens.hasNext());
         Assert.assertEquals(3L, tokens.peek().token().getLongValue());
         Assert.assertEquals(3L, tokens.next().token().getLongValue());
 
-        tokens.skipTo(LongIterator.fromToken(5L));
+        tokens.skipTo(LongIterator.makeKey(5L));
         Assert.assertTrue(tokens.hasNext());
         Assert.assertEquals(5L, tokens.peek().token().getLongValue());
         Assert.assertEquals(5L, tokens.next().token().getLongValue());
 
         LongIterator empty = new LongIterator(new long[0]);
 
-        empty.skipTo(LongIterator.fromToken(3L));
+        empty.skipTo(LongIterator.makeKey(3L));
         Assert.assertFalse(empty.hasNext());
     }
 
@@ -406,33 +406,32 @@ public class KeyRangeUnionIteratorTest extends AbstractKeyRangeIteratorTest
     @Test
     public void testEmptyClusteringTwoWayMerge() {
         PrimaryKey[] keysA = {
-        makeKey(1, 1L),
-        makeKey(2, 1L),
-        makeKey(2, 1000L),
-        makeKey(3, null),
-        makeKey(3, 30L),
-        makeKey(3, 31L),
-        makeKey(3, 32L),
-        makeKey(3, 33L),
-        makeKey(4, null)
+        makeKeyForRegularRow(1, 1L),
+        makeKeyForRegularRow(2, 1L),
+        makeKeyForRegularRow(2, 1000L),
+        makePartitionAwareKey(3),
+        makeKeyForRegularRow(3, 30L),
+        makeKeyForRegularRow(3, 31L),
+        makeKeyForRegularRow(3, 32L),
+        makeKeyForRegularRow(3, 33L),
+        makePartitionAwareKey(4)
         };
 
         PrimaryKey[] keysB = {
-        makeKey(0, null),
-        makeKey(1, 2L),
-        makeKey(2, null),
-        makeKey(3, 31L),
-        makeKey(4, null)
+        makePartitionAwareKey(0),
+        makeKeyForRegularRow(1, 2L),
+        makePartitionAwareKey(2),
+        makeKeyForRegularRow(3, 31L),
+        makePartitionAwareKey(4)
         };
 
         List<PrimaryKey> expected = Arrays.asList(
-        makeKey(0, null),
-        makeKey(1, 1L),
-        makeKey(1, 2L),
-        makeKey(2, null),
-        makeKey(3, null),
-        makeKey(4, null)
-        );
+        makePartitionAwareKey(0),
+        makeKeyForRegularRow(1, 1L),
+        makeKeyForRegularRow(1, 2L),
+        makePartitionAwareKey(2),
+        makePartitionAwareKey(3),
+        makeKeyForStaticRow(4));
 
         testUnion(expected, keysA, keysB);
     }
@@ -440,55 +439,55 @@ public class KeyRangeUnionIteratorTest extends AbstractKeyRangeIteratorTest
     @Test
     public void testEmptyClusteringThreeWayMerge() {
         PrimaryKey[] keysA = {
-        makeKey(1, 11L),
-        makeKey(2, 21L),
-        makeKey(2, 1000L),
-        makeKey(3, null),
-        makeKey(3, 0L),
-        makeKey(3, 1L),
-        makeKey(3, 2L),
-        makeKey(4, 41L),
-        makeKey(6, null),
-        makeKey(7, 72L),
-        makeKey(7, 73L)
+        makeKeyForRegularRow(1, 11L),
+        makeKeyForRegularRow(2, 21L),
+        makeKeyForRegularRow(2, 1000L),
+        makePartitionAwareKey(3),
+        makeKeyForRegularRow(3, 0L),
+        makeKeyForRegularRow(3, 1L),
+        makeKeyForRegularRow(3, 2L),
+        makeKeyForRegularRow(4, 41L),
+        makePartitionAwareKey(6),
+        makeKeyForRegularRow(7, 72L),
+        makeKeyForRegularRow(7, 73L)
         };
 
         PrimaryKey[] keysB = {
-        makeKey(0, null),
-        makeKey(1, 13L),
-        makeKey(2, null),
-        makeKey(3, 1L),
-        makeKey(4, 40L),
-        makeKey(4, 42L),
-        makeKey(4, 43L),
-        makeKey(4, 45L),
-        makeKey(5, 50L),
-        makeKey(7, 71L),
-        makeKey(7, 73L),
-        makeKey(7, 74L)
+        makeKeyForStaticRow(0),
+        makeKeyForRegularRow(1, 13L),
+        makePartitionAwareKey(2),
+        makeKeyForRegularRow(3, 1L),
+        makeKeyForRegularRow(4, 40L),
+        makeKeyForRegularRow(4, 42L),
+        makeKeyForRegularRow(4, 43L),
+        makeKeyForRegularRow(4, 45L),
+        makeKeyForRegularRow(5, 50L),
+        makeKeyForRegularRow(7, 71L),
+        makeKeyForRegularRow(7, 73L),
+        makeKeyForRegularRow(7, 74L)
         };
 
         PrimaryKey[] keysC = {
-        makeKey(1, 12L),
-        makeKey(2, 22L),
-        makeKey(2, 5L),
-        makeKey(3, 1L),
-        makeKey(4, null),
-        makeKey(6, 60L),
-        makeKey(7, null)
+        makeKeyForRegularRow(1, 12L),
+        makeKeyForRegularRow(2, 22L),
+        makeKeyForRegularRow(2, 5L),
+        makeKeyForRegularRow(3, 1L),
+        makePartitionAwareKey(4),
+        makeKeyForRegularRow(6, 60L),
+        makePartitionAwareKey(7)
         };
 
         List<PrimaryKey> expected = Arrays.asList(
-        makeKey(0, null),
-        makeKey(1, 11L),
-        makeKey(1, 12L),
-        makeKey(1, 13L),
-        makeKey(2, null),
-        makeKey(3, null),
-        makeKey(4, null),
-        makeKey(5, 50L),
-        makeKey(6, null),
-        makeKey(7, null)
+        makePartitionAwareKey(0),
+        makeKeyForRegularRow(1, 11L),
+        makeKeyForRegularRow(1, 12L),
+        makeKeyForRegularRow(1, 13L),
+        makePartitionAwareKey(2),
+        makePartitionAwareKey(3),
+        makePartitionAwareKey(4),
+        makeKeyForRegularRow(5, 50L),
+        makePartitionAwareKey(6),
+        makePartitionAwareKey(7)
         );
 
         testUnion(expected, keysA, keysB, keysC);
@@ -516,7 +515,7 @@ public class KeyRangeUnionIteratorTest extends AbstractKeyRangeIteratorTest
     }
 
     @Test
-    public void testRandomized() throws Throwable
+    public void testRandomKeys() throws Throwable
     {
         for (int iteratorCount = 2; iteratorCount <= 5; iteratorCount++)
         {
@@ -524,7 +523,7 @@ public class KeyRangeUnionIteratorTest extends AbstractKeyRangeIteratorTest
             {
                 var inputs = new ArrayList<List<PrimaryKey>>(iteratorCount);
                 for (int j = 0; j < iteratorCount; j++)
-                    inputs.add(randomPrimaryKeys(i / 10, i / 10));
+                    inputs.add(randomPrimaryKeysOfMixedTypes(1 + i / 10, 1 + i / 10));
 
                 testMerge(inputs,
                           KeyRangeUnionIteratorTest::union,
@@ -534,19 +533,22 @@ public class KeyRangeUnionIteratorTest extends AbstractKeyRangeIteratorTest
     }
 
     @Test
-    public void testSkippingRandomized() throws Throwable
+    public void testSkippingWithRandomKeys() throws Throwable
     {
         for (int iteratorCount = 2; iteratorCount <= 5; iteratorCount++)
         {
             for (int testIteration = 0; testIteration < 200; testIteration++)
             {
+                int avgPartitions = 1 + testIteration / 10;
+                int avgRowsPerPartition = 1 + testIteration / 10;
+
                 var inputs = new ArrayList<List<PrimaryKey>>(iteratorCount);
                 for (int j = 0; j < iteratorCount; j++)
-                    inputs.add(randomPrimaryKeys(testIteration / 10, testIteration / 10));
+                    inputs.add(randomPrimaryKeysOfMixedTypes(avgPartitions, avgRowsPerPartition));
 
                 // Generate random skip positions.
                 // Use a different data set so that some skip positions exist in the merged result and some do not.
-                var skips = randomSkips(randomPrimaryKeys(testIteration / 10, testIteration / 10));
+                var skips = randomSkips(randomPrimaryKeysOfMixedTypes(avgPartitions, avgRowsPerPartition));
 
                 testSkipping(inputs, skips, KeyRangeUnionIteratorTest::unionIterator);
             }

--- a/test/unit/org/apache/cassandra/index/sai/iterators/LongIterator.java
+++ b/test/unit/org/apache/cassandra/index/sai/iterators/LongIterator.java
@@ -17,10 +17,13 @@
  */
 package org.apache.cassandra.index.sai.iterators;
 
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.LongFunction;
 
+import org.apache.cassandra.db.BufferDecoratedKey;
+import org.apache.cassandra.db.Clustering;
+import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.dht.Murmur3Partitioner;
 import org.apache.cassandra.index.sai.SAITester;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
@@ -32,16 +35,11 @@ public class LongIterator extends KeyRangeIterator
 
     public LongIterator(long[] tokens)
     {
-        this(tokens, t -> t);
-    }
-
-    public LongIterator(long[] tokens, LongFunction<Long> toOffset)
-    {
-        super(tokens.length == 0 ? null : fromToken(tokens[0]), tokens.length == 0 ? null : fromToken(tokens[tokens.length - 1]), tokens.length);
+        super(tokens.length == 0 ? null : makeKey(tokens[0]), tokens.length == 0 ? null : makeKey(tokens[tokens.length - 1]), tokens.length);
 
         this.keys = new ArrayList<>(tokens.length);
         for (long token : tokens)
-            this.keys.add(fromTokenAndRowId(token, toOffset.apply(token)));
+            this.keys.add(makeKey(token));
     }
 
     @Override
@@ -64,11 +62,16 @@ public class LongIterator extends KeyRangeIterator
     public void close()
     {}
 
-    public static PrimaryKey fromToken(long token)
+    /// Generates a row-aware primary key with given token assuming {@link Murmur3Partitioner} is used.
+    /// The partition key is filled with inverse murmur3 hash.
+    /// The clustering of the returned key is empty.
+    public static PrimaryKey makeKey(long token)
     {
-        return SAITester.TEST_FACTORY.createTokenOnly(new Murmur3Partitioner.LongToken(token));
+        Murmur3Partitioner.LongToken longToken =  new Murmur3Partitioner.LongToken(token);
+        ByteBuffer keyBytes = Murmur3Partitioner.LongToken.keyForToken(longToken);
+        DecoratedKey partitionKey = new BufferDecoratedKey(longToken, keyBytes);
+        return SAITester.TEST_FACTORY.create(partitionKey, Clustering.EMPTY);
     }
-
 
     public static List<Long> convert(KeyRangeIterator tokens)
     {
@@ -81,15 +84,10 @@ public class LongIterator extends KeyRangeIterator
 
     public static List<Long> convert(final long... nums)
     {
-        return new ArrayList<Long>(nums.length)
+        return new ArrayList<>(nums.length)
         {{
             for (long n : nums)
                 add(n);
         }};
-    }
-
-    private PrimaryKey fromTokenAndRowId(long token, long rowId)
-    {
-        return SAITester.TEST_FACTORY.createTokenOnly(new Murmur3Partitioner.LongToken(token));
     }
 }


### PR DESCRIPTION
### Why
`KeyRangeAntiJoinIterator` can cause false negatives if partition-aware keys
appear in its input(s). This was caught by 
`CollectionIndexingTest#testUpdateMapToNullValue` reporting missing rows 
after it was run on AA version of indexes.

### Explanation

When a `KeyRangeAntiJoinIterator` got a non-precise, partition-aware
`PrimaryKey`, e.g. a key coming from an AA index or a key
for a static row, it was incorrectly matching it with any other key in 
the same partition. However, for those partition-aware keys, we don't really know
which row exactly was indexed as we're missing the clustering information, 
and we cannot match such keys to each other. 

### What was fixed
The anti-join algorithm is not used on AA indexes.

New randomized tests have been added and `CollectionIndexingTest`
has been extended to run on all index versions.

