### PR TITLE
CNDB-17944: Fix threshold zero bug: Use enable flags instead of threshold=0 in profiles

### DIFF
--- a/src/java/org/apache/cassandra/config/GuardrailsOptions.java
+++ b/src/java/org/apache/cassandra/config/GuardrailsOptions.java
@@ -88,10 +88,10 @@ public class GuardrailsOptions implements GuardrailsConfig
         validateMaxIntThreshold(config.keyspaces_warn_threshold, config.keyspaces_fail_threshold, "keyspaces");
         validateMaxIntThreshold(config.tables_warn_threshold, config.tables_fail_threshold, "tables");
         validateMaxIntThreshold(config.columns_per_table_warn_threshold, config.columns_per_table_fail_threshold, "columns_per_table");
-        validateMaxIntThreshold(config.secondary_indexes_per_table_warn_threshold, config.secondary_indexes_per_table_fail_threshold, "secondary_indexes_per_table", true);
+        validateMaxIntThreshold(config.secondary_indexes_per_table_warn_threshold, config.secondary_indexes_per_table_fail_threshold, "secondary_indexes_per_table");
         validateMaxIntThreshold(config.sai_indexes_per_table_warn_threshold, config.sai_indexes_per_table_fail_threshold, "sai_indexes_per_table");
         validateMaxIntThreshold(config.sai_indexes_total_warn_threshold, config.sai_indexes_total_fail_threshold, "sai_indexes_total");
-        validateMaxIntThreshold(config.sasi_indexes_per_table_warn_threshold, config.sasi_indexes_per_table_fail_threshold, "sasi_indexes_per_table", true);
+        validateMaxIntThreshold(config.sasi_indexes_per_table_warn_threshold, config.sasi_indexes_per_table_fail_threshold, "sasi_indexes_per_table");
         validateMaxIntThreshold(config.materialized_views_per_table_warn_threshold, config.materialized_views_per_table_fail_threshold, "materialized_views_per_table");
         config.table_properties_warned = validateTableProperties(config.table_properties_warned, "table_properties_warned");
         config.table_properties_ignored = validateTableProperties(config.table_properties_ignored, "table_properties_ignored");
@@ -372,7 +372,7 @@ public class GuardrailsOptions implements GuardrailsConfig
 
     public void setSecondaryIndexesPerTableThreshold(int warn, int fail)
     {
-        validateMaxIntThreshold(warn, fail, "secondary_indexes_per_table", true);
+        validateMaxIntThreshold(warn, fail, "secondary_indexes_per_table");
         updatePropertyWithLogging("secondary_indexes_per_table_warn_threshold",
                                   warn,
                                   () -> config.secondary_indexes_per_table_warn_threshold,
@@ -397,7 +397,7 @@ public class GuardrailsOptions implements GuardrailsConfig
 
     public void setSasiIndexesPerTableThreshold(int warn, int fail)
     {
-        validateMaxIntThreshold(warn, fail, "sasi_indexes_per_table", true);
+        validateMaxIntThreshold(warn, fail, "sasi_indexes_per_table");
         updatePropertyWithLogging("sasi_indexes_per_table_warn_threshold",
                                   warn,
                                   () -> config.sasi_indexes_per_table_warn_threshold,

--- a/src/java/org/apache/cassandra/config/GuardrailsOptions.java
+++ b/src/java/org/apache/cassandra/config/GuardrailsOptions.java
@@ -92,7 +92,7 @@ public class GuardrailsOptions implements GuardrailsConfig
         validateMaxIntThreshold(config.sai_indexes_per_table_warn_threshold, config.sai_indexes_per_table_fail_threshold, "sai_indexes_per_table");
         validateMaxIntThreshold(config.sai_indexes_total_warn_threshold, config.sai_indexes_total_fail_threshold, "sai_indexes_total");
         validateMaxIntThreshold(config.sasi_indexes_per_table_warn_threshold, config.sasi_indexes_per_table_fail_threshold, "sasi_indexes_per_table", true);
-        validateMaxIntThreshold(config.materialized_views_per_table_warn_threshold, config.materialized_views_per_table_fail_threshold, "materialized_views_per_table", true);
+        validateMaxIntThreshold(config.materialized_views_per_table_warn_threshold, config.materialized_views_per_table_fail_threshold, "materialized_views_per_table");
         config.table_properties_warned = validateTableProperties(config.table_properties_warned, "table_properties_warned");
         config.table_properties_ignored = validateTableProperties(config.table_properties_ignored, "table_properties_ignored");
         config.table_properties_disallowed = validateTableProperties(config.table_properties_disallowed, "table_properties_disallowed");

--- a/src/java/org/apache/cassandra/config/GuardrailsOptions.java
+++ b/src/java/org/apache/cassandra/config/GuardrailsOptions.java
@@ -182,9 +182,18 @@ public class GuardrailsOptions implements GuardrailsConfig
         enforceDefault("vector_dimensions_fail_threshold", v -> config.vector_dimensions_fail_threshold = v, 8192, 8192, 8192);
 
         enforceDefault("columns_per_table_fail_threshold", v -> config.columns_per_table_fail_threshold = v, -1, 50, 200);
-        enforceDefault("secondary_indexes_per_table_fail_threshold", v -> config.secondary_indexes_per_table_fail_threshold = v, NO_LIMIT, 1, 0);
-        enforceDefault("sasi_indexes_per_table_fail_threshold", v -> config.sasi_indexes_per_table_fail_threshold = v, NO_LIMIT, 0, 0);
-        enforceDefault("materialized_views_per_table_fail_threshold", v -> config.materialized_views_per_table_fail_threshold = v, NO_LIMIT, 2, 0);
+
+        // For secondary indexes: use node-level flag to control feature blocking
+        enforceDefault("secondary_indexes_enabled", v -> config.secondary_indexes_enabled = v, true, true, false);
+        enforceDefault("secondary_indexes_per_table_fail_threshold", v -> config.secondary_indexes_per_table_fail_threshold = v, NO_LIMIT, 1, NO_LIMIT);
+
+        // For SASI indexes: use node-level flag (deprecated in CC5, will throw startup exception if enabled)
+        enforceDefault("sasi_indexes_enabled", v -> config.sasi_indexes_enabled = v, false, false, false);
+        enforceDefault("sasi_indexes_per_table_fail_threshold", v -> config.sasi_indexes_per_table_fail_threshold = v, NO_LIMIT, NO_LIMIT, NO_LIMIT);
+
+        // For materialized views: use node-level flag to control feature blocking
+        enforceDefault("materialized_views_enabled", v -> config.materialized_views_enabled = v, false, false, false);
+        enforceDefault("materialized_views_per_table_fail_threshold", v -> config.materialized_views_per_table_fail_threshold = v, NO_LIMIT, 2, NO_LIMIT);
         enforceDefault("tables_warn_threshold", v -> config.tables_warn_threshold = v, -1, 100, 100);
         enforceDefault("tables_fail_threshold", v -> config.tables_fail_threshold = v, -1, 200, 200);
 
@@ -384,6 +393,21 @@ public class GuardrailsOptions implements GuardrailsConfig
     }
 
     @Override
+    public boolean getSecondaryIndexesEnabled()
+    {
+        return config.secondary_indexes_enabled;
+    }
+
+    @Override
+    public void setSecondaryIndexesEnabled(boolean enabled)
+    {
+        updatePropertyWithLogging("secondary_indexes_enabled",
+                                  enabled,
+                                  () -> config.secondary_indexes_enabled,
+                                  x -> config.secondary_indexes_enabled = x);
+    }
+
+    @Override
     public int getSasiIndexesPerTableWarnThreshold()
     {
         return config.sasi_indexes_per_table_warn_threshold;
@@ -402,7 +426,7 @@ public class GuardrailsOptions implements GuardrailsConfig
                                   warn,
                                   () -> config.sasi_indexes_per_table_warn_threshold,
                                   x -> config.sasi_indexes_per_table_warn_threshold = x);
-        updatePropertyWithLogging("sai_indexes_per_table_fail_threshold",
+        updatePropertyWithLogging("sasi_indexes_per_table_fail_threshold",
                                   fail,
                                   () -> config.sasi_indexes_per_table_fail_threshold,
                                   x -> config.sasi_indexes_per_table_fail_threshold = x);
@@ -670,20 +694,6 @@ public class GuardrailsOptions implements GuardrailsConfig
                                   enabled,
                                   () -> config.drop_keyspace_enabled,
                                   x -> config.drop_keyspace_enabled = x);
-    }
-
-    @Override
-    public boolean getSecondaryIndexesEnabled()
-    {
-        return config.secondary_indexes_enabled;
-    }
-
-    public void setSecondaryIndexesEnabled(boolean enabled)
-    {
-        updatePropertyWithLogging("secondary_indexes_enabled",
-                                  enabled,
-                                  () -> config.secondary_indexes_enabled,
-                                  x -> config.secondary_indexes_enabled = x);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/guardrails/GuardrailsConfig.java
+++ b/src/java/org/apache/cassandra/db/guardrails/GuardrailsConfig.java
@@ -92,6 +92,8 @@ public interface GuardrailsConfig
      */
     boolean getSecondaryIndexesEnabled();
 
+    void setSecondaryIndexesEnabled(boolean enabled);
+
     /**
      * @return The threshold to warn when creating more SASI indexes per table than threshold.
      */

--- a/test/unit/org/apache/cassandra/db/guardrails/GuardrailSecondaryIndexesPerTableTest.java
+++ b/test/unit/org/apache/cassandra/db/guardrails/GuardrailSecondaryIndexesPerTableTest.java
@@ -22,7 +22,6 @@ import com.google.common.base.Strings;
 import org.junit.Test;
 
 import static java.lang.String.format;
-import static org.junit.Assert.assertNotNull;
 
 /**
  * Tests the guardrail for the number of secondary indexes in a table, {@link Guardrails#secondaryIndexesPerTable}.
@@ -46,13 +45,6 @@ public class GuardrailSecondaryIndexesPerTableTest extends ThresholdTester
     protected long currentValue()
     {
         return getCurrentColumnFamilyStore().indexManager.listIndexes().size();
-    }
-
-    @Test
-    public void testConfigValidation()
-    {
-        assertNotNull(guardrail);
-        testValidationOfThresholdProperties(guardrail.name + "_warn_threshold", guardrail.name + "_fail_threshold", true);
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/db/guardrails/GuardrailsConfigDefaultsTest.java
+++ b/test/unit/org/apache/cassandra/db/guardrails/GuardrailsConfigDefaultsTest.java
@@ -223,7 +223,7 @@ public class GuardrailsConfigDefaultsTest
         assertEquals("vector_dimensions_fail_threshold", 8192, guardrails.getVectorDimensionsFailThreshold());
         assertEquals("columns_per_table_fail_threshold", 50, guardrails.getColumnsPerTableFailThreshold());
         assertEquals("secondary_indexes_per_table_fail_threshold", 1, guardrails.getSecondaryIndexesPerTableFailThreshold());
-        assertEquals("sasi_indexes_per_table_fail_threshold", 0, guardrails.getSasiIndexesPerTableFailThreshold());
+        assertEquals("sasi_indexes_per_table_fail_threshold", GuardrailsOptions.NO_LIMIT, guardrails.getSasiIndexesPerTableFailThreshold());
         assertEquals("materialized_views_per_table_fail_threshold", 2, guardrails.getMaterializedViewsPerTableFailThreshold());
         assertEquals("tables_warn_threshold", 100, guardrails.getTablesWarnThreshold());
         assertEquals("tables_fail_threshold", 200, guardrails.getTablesFailThreshold());
@@ -283,9 +283,9 @@ public class GuardrailsConfigDefaultsTest
         assertEquals("vector_dimensions_warn_threshold", GuardrailsOptions.NO_LIMIT, guardrails.getVectorDimensionsWarnThreshold());
         assertEquals("vector_dimensions_fail_threshold", 8192, guardrails.getVectorDimensionsFailThreshold());
         assertEquals("columns_per_table_fail_threshold", 200, guardrails.getColumnsPerTableFailThreshold());
-        assertEquals("secondary_indexes_per_table_fail_threshold", 0, guardrails.getSecondaryIndexesPerTableFailThreshold());
-        assertEquals("sasi_indexes_per_table_fail_threshold", 0, guardrails.getSasiIndexesPerTableFailThreshold());
-        assertEquals("materialized_views_per_table_fail_threshold", 0, guardrails.getMaterializedViewsPerTableFailThreshold());
+        assertEquals("secondary_indexes_per_table_fail_threshold", GuardrailsOptions.NO_LIMIT, guardrails.getSecondaryIndexesPerTableFailThreshold());
+        assertEquals("sasi_indexes_per_table_fail_threshold", GuardrailsOptions.NO_LIMIT, guardrails.getSasiIndexesPerTableFailThreshold());
+        assertEquals("materialized_views_per_table_fail_threshold", GuardrailsOptions.NO_LIMIT, guardrails.getMaterializedViewsPerTableFailThreshold());
         assertEquals("tables_warn_threshold", 100, guardrails.getTablesWarnThreshold());
         assertEquals("tables_fail_threshold", 200, guardrails.getTablesFailThreshold());
 


### PR DESCRIPTION
### What is the issue
Fixes #17944

### What does this PR fix and why was it fixed
DBaaS/HCD profiles incorrectly used threshold=0 to block features, but threshold=0 is treated as disabled/unlimited at runtime in 5.0. Remove allowZero=true validation and update profiles to use existing node-level flags (secondary_indexes_enabled, sasi_indexes_enabled, materialized_views_enabled) with thresholds set to -1.

