### PR TITLE
CNDB-17871: Tie FusedPQ feature to FA index version, deprecate cassandra.sai.vector.enable_fused

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -451,8 +451,12 @@ public enum CassandraRelevantProperties
     SAI_VECTOR_FLUSH_THRESHOLD_MAX_ROWS("cassandra.sai.vector_flush_threshold_max_rows", "-1"),
     // Use non-positive value to disable it. Period in millis to trigger a flush for SAI vector memtable index.
     SAI_VECTOR_FLUSH_PERIOD_IN_MILLIS("cassandra.sai.vector_flush_period_in_millis", "-1"),
-    // Whether compaction should build vector indexes using a fused graph, aka a graph where the quantized vectors
-    // are stored inline with a graph node. Feature is still experimental, so defaults to false.
+    /**
+     * @deprecated This property is deprecated and no longer has any effect. FusedPQ is now automatically enabled
+     * for all indexes using version FA or later (jvector file format version 6+). The property cannot be used to
+     * disable FusedPQ for FA+ versions.
+     */
+    @Deprecated
     SAI_VECTOR_ENABLE_FUSED("cassandra.sai.vector.enable_fused", "false"),
     // Use nvq when building graphs in compaction. Disabled by default for now. Enabling will reduce recall slightly
     // while also reducing the storage footprint.

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/JVectorVersionUtil.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/JVectorVersionUtil.java
@@ -22,11 +22,9 @@ import org.apache.cassandra.index.sai.disk.format.Version;
 public class JVectorVersionUtil
 {
     /**
-     * Whether to fuse quantized vectors into the graph when writing indexes, assuming all other conditions are met.
-     * Variables are volatile to allow for changing in unit tests. They are only accessed on flush, so their access
-     * is infrequent.
+     * Variables are volatile to allow for changing in unit tests. They are only accessed on flush and compaction,
+     * so their access is infrequent.
      */
-    public static volatile boolean ENABLE_FUSED = CassandraRelevantProperties.SAI_VECTOR_ENABLE_FUSED.getBoolean();
     public static volatile boolean ENABLE_NVQ = CassandraRelevantProperties.SAI_VECTOR_ENABLE_NVQ.getBoolean();
     public static final int NUM_SUB_VECTORS = CassandraRelevantProperties.SAI_VECTOR_NVQ_NUM_SUB_VECTORS.getInt();
 
@@ -52,12 +50,17 @@ public class JVectorVersionUtil
      * Decide whether to attempt to write the quantized vectors as fused parts of the graph. Note that this method
      * does not take into account whether the graph has enough information to build a quantization, as that depends on
      * external factors.
+     * <p>
+     * FusedPQ is automatically enabled for all indexes using version FA or later (jvector file format version 6+).
+     * The deprecated ENABLE_FUSED property is ignored for these versions.
+     *
      * @param version the SAI on disk format to use when writing to disk
      * @return true if conditions are met, false otherwise
      */
     public static boolean shouldWriteFused(Version version)
     {
-        return ENABLE_FUSED && versionSupportsFused(version);
+        // For FA version and later, FusedPQ is always enabled (tied to the version)
+        return versionSupportsFused(version);
     }
 
     public static boolean versionSupportsFused(Version version)

--- a/test/unit/org/apache/cassandra/index/sai/SAIUtil.java
+++ b/test/unit/org/apache/cassandra/index/sai/SAIUtil.java
@@ -118,24 +118,6 @@ public class SAIUtil
         }
     }
 
-    public static void setEnableFused(boolean enableFused)
-    {
-        try
-        {
-            CassandraRelevantProperties.SAI_VECTOR_ENABLE_FUSED.setBoolean(enableFused);
-            Field field = JVectorVersionUtil.class.getDeclaredField("ENABLE_FUSED");
-            field.setAccessible(true);
-            Field modifiersField = ReflectionUtils.getField(Field.class, "modifiers");
-            modifiersField.setAccessible(true);
-            modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
-            field.set(null, enableFused);
-        }
-        catch (Exception e)
-        {
-            throw new RuntimeException(e);
-        }
-    }
-
     public static class CustomVersionSelector implements Version.Selector
     {
         private final Version defaultVersion;

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorCompactionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorCompactionTest.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.stream.Collectors;
 
@@ -53,9 +52,7 @@ import org.apache.cassandra.index.sai.disk.vector.JVectorVersionUtil;
 import org.apache.cassandra.io.sstable.format.SSTableReadsListener;
 
 import static org.apache.cassandra.index.sai.disk.vector.CassandraOnHeapGraph.MIN_PQ_ROWS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 @Ignore
 @RunWith(Parameterized.class)
@@ -66,7 +63,7 @@ abstract public class VectorCompactionTest extends VectorTester
     // Subclasses must implement this to cover different dimensions
     abstract public int dimension();
 
-    @Parameterized.Parameter(0)
+    @Parameterized.Parameter()
     public Version version;
 
     @Parameterized.Parameter(1)
@@ -95,7 +92,7 @@ abstract public class VectorCompactionTest extends VectorTester
     }
 
     @Before
-    public void setEnableNVQ() throws Throwable
+    public void setEnableNVQ()
     {
         SAIUtil.setEnableNVQ(enableNVQ);
     }
@@ -408,10 +405,13 @@ abstract public class VectorCompactionTest extends VectorTester
                                 // reasonable for now.
                                 assertEquals(1.0f, quantizedSim, 0.01f);
                             }
-                            else
+                            else if (numRows >= MIN_PQ_ROWS)
                             {
-                                // We should only hit this case when we don't have enough rows to build a PQ.
-                                assertTrue("Found " + numRows + " but no PQ", MIN_PQ_ROWS > numRows);
+                                // With FA + fused PQ, PQ metadata is present and used by the graph, but there is no
+                                // standalone CompressedVectors instance to validate against.
+                                // TODO: further investigate what other checks are needed here
+                                assertEquals("Expected fused PQ path only for FA+", Version.FA, version);
+                                assertNotNull("Expected PQ metadata for FA fused PQ", searcher.getPQ());
                             }
                         }
                     }

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorMetricsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorMetricsTest.java
@@ -20,7 +20,6 @@ package org.apache.cassandra.index.sai.cql;
 
 import java.util.Collection;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -32,6 +31,7 @@ import org.apache.cassandra.index.sai.SAIUtil;
 import org.apache.cassandra.index.sai.StorageAttachedIndex;
 import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.index.sai.disk.vector.CassandraOnHeapGraph;
+import org.apache.cassandra.index.sai.disk.vector.JVectorVersionUtil;
 import org.apache.cassandra.index.sai.metrics.ColumnQueryMetrics;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -44,10 +44,14 @@ public class VectorMetricsTest extends VectorTester
     @Parameterized.Parameter
     public Version version;
 
-    @Parameterized.Parameters(name = "{0}")
+    @Parameterized.Parameters(name = "version={0}")
     public static Collection<Object[]> data()
     {
-        return Stream.of(Version.CA, Version.DC).map(v -> new Object[]{ v}).collect(Collectors.toList());
+        // Test all versions that support vector indexes
+        return Version.ALL.stream()
+                          .filter(v -> v.onOrAfter(Version.JVECTOR_EARLIEST))
+                          .map(v -> new Object[]{ v })
+                          .collect(Collectors.toList());
     }
 
     @BeforeClass
@@ -92,22 +96,50 @@ public class VectorMetricsTest extends VectorTester
         assertEquals(0, vectorMetrics.onDiskGraphVectorsCount.sum());
         assertEquals(0, vectorMetrics.annGraphSearchLatency.getCount());
 
-        // Insert 10 rows to simplify some of the assertions
         for (int i = 0; i < CassandraOnHeapGraph.MIN_PQ_ROWS; i++)
             execute("INSERT INTO %s (pk, val) VALUES (?, ?)", i, vector(1 + i, 2 + i, 3 + i));
         flush();
 
-        assertTrue(vectorMetrics.quantizationMemoryBytes.sum() > 0);
-        assertEquals(0, vectorMetrics.ordinalsMapMemoryBytes.sum()); // unique vectors means no cache required
-        assertEquals(1, vectorMetrics.onDiskGraphsCount.sum());
-        assertEquals( CassandraOnHeapGraph.MIN_PQ_ROWS, vectorMetrics.onDiskGraphVectorsCount.sum());
+        // FusedPQ is tied to version: enabled for FA+, disabled for pre-FA
+        boolean fusedPQ = JVectorVersionUtil.versionSupportsFused(version);
+        long pqMemoryAfterFlush = vectorMetrics.quantizationMemoryBytes.sum();
 
-        // Compaction should not impact metrics
-        compact();
-        assertTrue(vectorMetrics.quantizationMemoryBytes.sum() > 0);
+        if (fusedPQ)
+        {
+            // With FusedPQ, quantized vectors are stored inline with graph nodes, so no separate PQ memory
+            assertEquals("Version " + version + " should have no separate PQ memory with FusedPQ",
+                        0L, pqMemoryAfterFlush);
+        }
+        else
+        {
+            // Without FusedPQ, PQ vectors are stored separately, so we expect some memory usage
+            assertTrue("Version " + version + " should have PQ memory without FusedPQ",
+                      pqMemoryAfterFlush > 0);
+        }
+        
         assertEquals(0, vectorMetrics.ordinalsMapMemoryBytes.sum()); // unique vectors means no cache required
         assertEquals(1, vectorMetrics.onDiskGraphsCount.sum());
-        assertEquals( CassandraOnHeapGraph.MIN_PQ_ROWS, vectorMetrics.onDiskGraphVectorsCount.sum());
+        assertEquals(CassandraOnHeapGraph.MIN_PQ_ROWS, vectorMetrics.onDiskGraphVectorsCount.sum());
+
+        compact();
+        long pqMemoryAfterCompaction = vectorMetrics.quantizationMemoryBytes.sum();
+
+        if (fusedPQ)
+        {
+            // With FusedPQ, quantized vectors are stored inline with graph nodes, so no separate PQ memory
+            assertEquals("Version " + version + " should have no separate PQ memory with FusedPQ after compaction",
+                        0L, pqMemoryAfterCompaction);
+        }
+        else
+        {
+            // Without FusedPQ, PQ vectors are stored separately, so we expect some memory usage
+            assertTrue("Version " + version + " should have PQ memory without FusedPQ after compaction",
+                      pqMemoryAfterCompaction > 0);
+        }
+        
+        assertEquals(0, vectorMetrics.ordinalsMapMemoryBytes.sum()); // unique vectors means no cache required
+        assertEquals(1, vectorMetrics.onDiskGraphsCount.sum());
+        assertEquals(CassandraOnHeapGraph.MIN_PQ_ROWS, vectorMetrics.onDiskGraphVectorsCount.sum());
 
         // Now run a pure ann query and verify we hit the ann graph
         var result = execute("SELECT pk FROM %s ORDER BY val ANN OF [2.5, 3.5, 4.5] LIMIT 2");

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorTester.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorTester.java
@@ -191,10 +191,7 @@ public class VectorTester extends SAITester
         @Parameterized.Parameter(1)
         public boolean ENABLE_NVQ;
 
-        @Parameterized.Parameter(2)
-        public boolean ENABLE_FUSED;
-
-        @Parameterized.Parameters(name = "version={0} enableNVQ={1} enableFused={2}")
+        @Parameterized.Parameters(name = "{0} {1}")
         public static Collection<Object[]> data()
         {
             // See Version file for explanation of changes associated with each version
@@ -204,12 +201,7 @@ public class VectorTester extends SAITester
                                   var enableNVQ = JVectorVersionUtil.versionSupportsNVQ(v)
                                                   ? new Boolean[]{ true, false }
                                                   : new Boolean[]{ false };
-                                  var enableFused = JVectorVersionUtil.versionSupportsFused(v)
-                                                    ? new Boolean[]{ true, false }
-                                                    : new Boolean[]{ false };
-                                  return Arrays.stream(enableNVQ).flatMap(nvq ->
-                                      Arrays.stream(enableFused).map(fused -> new Object[]{ v, nvq, fused })
-                                  );
+                                  return Arrays.stream(enableNVQ).map(nvq -> new Object[]{ v, nvq });
                               }).collect(Collectors.toList());
         }
 
@@ -223,12 +215,6 @@ public class VectorTester extends SAITester
         public void setEnableNVQ()
         {
             SAIUtil.setEnableNVQ(ENABLE_NVQ);
-        }
-
-        @Before
-        public void setEnableFused()
-        {
-            SAIUtil.setEnableFused(ENABLE_FUSED);
         }
     }
 

--- a/test/unit/org/apache/cassandra/index/sai/disk/vector/JVectorVersionUtilTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/vector/JVectorVersionUtilTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.disk.vector;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.apache.cassandra.index.sai.SAITester;
+import org.apache.cassandra.index.sai.disk.format.Version;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link JVectorVersionUtil} to verify feature support (FusedPQ, NVQ)
+ * is correctly determined based on jvector format version across all SAI versions.
+ */
+@RunWith(Parameterized.class)
+public class JVectorVersionUtilTest extends SAITester
+{
+    private static final int JVECTOR_FORMAT_FUSED_PQ = 6;  // Format version that introduced FusedPQ
+    private static final int JVECTOR_FORMAT_NVQ = 4;       // Format version that introduced NVQ
+
+    @Parameterized.Parameter()
+    public Version version;
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection<Object[]> data()
+    {
+        // Test all versions that support vector indexes
+        return Version.ALL.stream()
+                          .filter(v -> v.onOrAfter(Version.JVECTOR_EARLIEST))
+                          .map(v -> new Object[]{ v })
+                          .collect(Collectors.toList());
+    }
+
+    @Test
+    public void testFusedPQSupport()
+    {
+        // FusedPQ requires jvector format 6 or later (FA+)
+        int jvectorFormat = version.onDiskFormat().jvectorFileFormatVersion();
+        boolean expectedSupport = jvectorFormat >= JVECTOR_FORMAT_FUSED_PQ;
+        
+        assertEquals(String.format("Version %s (jvector format %d) FusedPQ support mismatch", version, jvectorFormat),
+                     expectedSupport,
+                     JVectorVersionUtil.versionSupportsFused(version));
+        
+        // For FA+, FusedPQ is always enabled (tied to version)
+        assertEquals(String.format("Version %s (jvector format %d) shouldWriteFused mismatch", version, jvectorFormat),
+                     expectedSupport,
+                     JVectorVersionUtil.shouldWriteFused(version));
+    }
+
+    @Test
+    public void testNVQSupport()
+    {
+        // NVQ requires jvector format 4 or later
+        int jvectorFormat = version.onDiskFormat().jvectorFileFormatVersion();
+        boolean expectedSupport = jvectorFormat >= JVECTOR_FORMAT_NVQ;
+        
+        assertEquals(String.format("Version %s (jvector format %d) NVQ support mismatch", version, jvectorFormat),
+                     expectedSupport,
+                     JVectorVersionUtil.versionSupportsNVQ(version));
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/disk/vector/JVectorVersionUtilTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/vector/JVectorVersionUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright DataStax, Inc.
+ * Copyright IBM Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This is a new PR - https://github.com/datastax/cassandra/pull/2440 is already approved but Sonar doesn't get triggered, trying a new PR if it will unblock us quickly. 

### What is the issue
...
Vector features should be tied to index version if we want them enabled always by default when we enable FA version.

### What does this PR fix and why was it fixed
...
Tie FusedPQ feature to FA index version, deprecate cassandra.sai.vector.enable_fused

This patch was already committed to the cndb-main-release-202604 branch.