### PR TITLE
CNDB-17829: Add a property to configure the Digest file checksum type (main-5.0)

### DIFF
--- a/.build/cassandra-build-deps-template.xml
+++ b/.build/cassandra-build-deps-template.xml
@@ -155,5 +155,9 @@
       <groupId>com.bpodgursky</groupId>
       <artifactId>jbool_expressions</artifactId>
     </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk.crt</groupId>
+      <artifactId>aws-crt</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/.build/cassandra-deps-template.xml
+++ b/.build/cassandra-deps-template.xml
@@ -412,5 +412,9 @@
       <groupId>de.huxhorn.sulky</groupId>
       <artifactId>de.huxhorn.sulky.ulid</artifactId>
     </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk.crt</groupId>
+      <artifactId>aws-crt</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/.build/cassandra-deps-template.xml
+++ b/.build/cassandra-deps-template.xml
@@ -408,5 +408,9 @@
       <groupId>de.huxhorn.sulky</groupId>
       <artifactId>de.huxhorn.sulky.ulid</artifactId>
     </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk.crt</groupId>
+      <artifactId>aws-crt</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/.build/cassandra-deps-template.xml
+++ b/.build/cassandra-deps-template.xml
@@ -412,9 +412,5 @@
       <groupId>de.huxhorn.sulky</groupId>
       <artifactId>de.huxhorn.sulky.ulid</artifactId>
     </dependency>
-    <dependency>
-      <groupId>software.amazon.awssdk.crt</groupId>
-      <artifactId>aws-crt</artifactId>
-    </dependency>
   </dependencies>
 </project>

--- a/.build/parent-pom-template.xml
+++ b/.build/parent-pom-template.xml
@@ -1304,6 +1304,11 @@
         <artifactId>de.huxhorn.sulky.ulid</artifactId>
         <version>8.2.0</version>
       </dependency>
+      <dependency>
+        <groupId>software.amazon.awssdk.crt</groupId>
+        <artifactId>aws-crt</artifactId>
+        <version>0.45.4</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 </project>

--- a/.build/parent-pom-template.xml
+++ b/.build/parent-pom-template.xml
@@ -1299,6 +1299,11 @@
         <artifactId>de.huxhorn.sulky.ulid</artifactId>
         <version>8.2.0</version>
       </dependency>
+      <dependency>
+        <groupId>software.amazon.awssdk.crt</groupId>
+        <artifactId>aws-crt</artifactId>
+        <version>0.45.4</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 </project>

--- a/src/java/org/apache/cassandra/cache/AutoSavingCache.java
+++ b/src/java/org/apache/cassandra/cache/AutoSavingCache.java
@@ -121,7 +121,7 @@ public class AutoSavingCache<K extends CacheKey, V> extends InstrumentingCache<K
 
         public DataOutputStreamPlus getOutputStream(File dataPath, File crcPath)
         {
-            return new ChecksummedSequentialWriter(dataPath, crcPath, null, writerOption);
+            return new ChecksummedSequentialWriter(dataPath, crcPath, writerOption);
         }
     };
 

--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -948,6 +948,7 @@ public enum CassandraRelevantProperties
     SNAPSHOT_MIN_ALLOWED_TTL_SECONDS("cassandra.snapshot.min_allowed_ttl_seconds", "60"),
     SSL_ENABLE("ssl.enable"),
     SSL_STORAGE_PORT("cassandra.ssl_storage_port"),
+    SSTABLE_CHECKSUM_TYPE("cassandra.sstable.checksum_type", "CRC32"),
     SSTABLE_FORMAT_DEFAULT("cassandra.sstable.format.default"),
 
     // in OSS, when UUID based SSTable generation identifiers are enabled, they use TimeUUID

--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -997,7 +997,10 @@ public enum CassandraRelevantProperties
     SNAPSHOT_MIN_ALLOWED_TTL_SECONDS("cassandra.snapshot.min_allowed_ttl_seconds", "60"),
     SSL_ENABLE("ssl.enable"),
     SSL_STORAGE_PORT("cassandra.ssl_storage_port"),
+    SSTABLE_CHECKSUM_AWS_CRT_DETECTION_ENABLED("cassandra.sstable.checksums.aws_crt_detection_enabled", "true"),
+    SSTABLE_CHECKSUM_TYPE("cassandra.sstable.checksums.type", "CRC32"),
     SSTABLE_FORMAT_DEFAULT("cassandra.sstable.format.default"),
+    SSTABLE_FORMAT_STREAM_NEW_CHECKSUMS("cassandra.sstable.format.stream_new_checksums", "false"),
 
     // in OSS, when UUID based SSTable generation identifiers are enabled, they use TimeUUID
     // though, for CNDB we want to use ULID - this property allows for that

--- a/src/java/org/apache/cassandra/io/compress/CompressedSequentialWriter.java
+++ b/src/java/org/apache/cassandra/io/compress/CompressedSequentialWriter.java
@@ -28,6 +28,7 @@ import java.util.Optional;
 import java.util.zip.CRC32;
 import java.util.zip.CheckedInputStream;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,6 +45,7 @@ import org.apache.cassandra.io.util.SequentialWriter;
 import org.apache.cassandra.io.util.SequentialWriterOption;
 import org.apache.cassandra.schema.CompressionParams;
 import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.ChecksumType;
 
 import static org.apache.cassandra.utils.Throwables.merge;
 
@@ -93,6 +95,7 @@ public class CompressedSequentialWriter extends SequentialWriter
     public CompressedSequentialWriter(File file,
                                       File offsetsFile,
                                       File digestFile,
+                                      ChecksumType checksumType,
                                       SequentialWriterOption option,
                                       CompressionParams parameters,
                                       MetadataCollector sstableMetadataCollector)
@@ -116,7 +119,18 @@ public class CompressedSequentialWriter extends SequentialWriter
         metadataWriter = CompressionMetadata.Writer.open(parameters, offsetsFile);
 
         this.sstableMetadataCollector = sstableMetadataCollector;
-        crcMetadata = new ChecksumWriter(new DataOutputStream(Channels.newOutputStream(channel)));
+        crcMetadata = new ChecksumWriter(new DataOutputStream(Channels.newOutputStream(channel)), checksumType);
+    }
+
+    @VisibleForTesting
+    public CompressedSequentialWriter(File file,
+                                      File offsetsPath,
+                                      File digestFile,
+                                      SequentialWriterOption option,
+                                      CompressionParams parameters,
+                                      MetadataCollector sstableMetadataCollector)
+    {
+        this(file, offsetsPath, digestFile, ChecksumType.CRC32, option, parameters, sstableMetadataCollector);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/io/compress/CompressedSequentialWriter.java
+++ b/src/java/org/apache/cassandra/io/compress/CompressedSequentialWriter.java
@@ -27,8 +27,8 @@ import java.nio.channels.FileChannel;
 import java.util.Optional;
 import java.util.zip.CRC32;
 import java.util.zip.CheckedInputStream;
+import java.util.zip.Checksum;
 
-import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -73,6 +73,7 @@ public class CompressedSequentialWriter extends SequentialWriter
 
     private final ByteBuffer crcCheckBuffer = ByteBuffer.allocate(4);
     private final Optional<File> digestFile;
+    private final ChecksumType checksumType;
 
     private final int maxCompressedLength;
 
@@ -109,6 +110,7 @@ public class CompressedSequentialWriter extends SequentialWriter
                                           .build());
         this.compressor = parameters.getSstableCompressor();
         this.digestFile = Optional.ofNullable(digestFile);
+        this.checksumType = checksumType;
 
         // buffer for compression should be the same size as buffer itself
         compressed = compressor.preferredBufferType().allocate(compressor.initialCompressedBufferLength(buffer.capacity()));
@@ -120,17 +122,6 @@ public class CompressedSequentialWriter extends SequentialWriter
 
         this.sstableMetadataCollector = sstableMetadataCollector;
         crcMetadata = new ChecksumWriter(new DataOutputStream(Channels.newOutputStream(channel)), checksumType);
-    }
-
-    @VisibleForTesting
-    public CompressedSequentialWriter(File file,
-                                      File offsetsPath,
-                                      File digestFile,
-                                      SequentialWriterOption option,
-                                      CompressionParams parameters,
-                                      MetadataCollector sstableMetadataCollector)
-    {
-        this(file, offsetsPath, digestFile, ChecksumType.CRC32, option, parameters, sstableMetadataCollector);
     }
 
     @Override
@@ -478,7 +469,7 @@ public class CompressedSequentialWriter extends SequentialWriter
             try (FileChannel fileChannel = StorageProvider.instance.writeTimeReadFileChannelFor(file);
                  InputStream stream = Channels.newInputStream(fileChannel))
             {
-                CRC32 checksum = new CRC32();
+                Checksum checksum = checksumType.newInstance();
                 try (CheckedInputStream checkedInputStream = new CheckedInputStream(stream, checksum))
                 {
                     byte[] chunk = new byte[64 * 1024];

--- a/src/java/org/apache/cassandra/io/compress/EncryptedSequentialWriter.java
+++ b/src/java/org/apache/cassandra/io/compress/EncryptedSequentialWriter.java
@@ -36,6 +36,7 @@ import org.apache.cassandra.io.util.SequentialWriter;
 import org.apache.cassandra.io.util.SequentialWriterOption;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.io.util.PageAware;
+import org.apache.cassandra.utils.ChecksumType;
 
 /**
  * Encryption-only writer. This is not a normal file writer in the sense that it is not meant to just accept a sequence
@@ -104,7 +105,7 @@ public class EncryptedSequentialWriter extends SequentialWriter
         this.encrypted = BufferType.preferredForCompression().allocate(CHUNK_SIZE);
 
         maxBytesInChunk = buffer.capacity();
-        crcMetadata = new ChecksumWriter(new DataOutputStream(Channels.newOutputStream(channel)));
+        crcMetadata = new ChecksumWriter(new DataOutputStream(Channels.newOutputStream(channel)), ChecksumType.CRC32);
     }
 
     public static int maxBytesInPage(ICompressor encryptor)

--- a/src/java/org/apache/cassandra/io/sstable/SSTableZeroCopyWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableZeroCopyWriter.java
@@ -23,8 +23,6 @@ import java.nio.channels.ClosedChannelException;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableList;
 import org.slf4j.Logger;
@@ -46,7 +44,6 @@ import org.apache.cassandra.net.AsyncStreamingInputPlus;
 import org.apache.cassandra.schema.TableId;
 import org.apache.cassandra.utils.ByteBufferUtil;
 
-import static java.lang.String.format;
 import static org.apache.cassandra.utils.FBUtilities.prettyPrintMemory;
 
 public class SSTableZeroCopyWriter extends SSTable implements SSTableMultiWriter
@@ -54,7 +51,7 @@ public class SSTableZeroCopyWriter extends SSTable implements SSTableMultiWriter
     private static final Logger logger = LoggerFactory.getLogger(SSTableZeroCopyWriter.class);
 
     private volatile SSTableReader finalReader;
-    private final Map<String, ZeroCopySequentialWriter> componentWriters; // indexed by component name
+    private final Map<Component, ZeroCopySequentialWriter> componentWriters;
     private final LifecycleNewTracker lifecycleNewTracker;
 
     public SSTableZeroCopyWriter(Builder<?, ?> builder,
@@ -68,7 +65,7 @@ public class SSTableZeroCopyWriter extends SSTable implements SSTableMultiWriter
         this.componentWriters = new HashMap<>();
 
         for (Component c : components())
-            componentWriters.put(c.name, makeWriter(descriptor, c));
+            componentWriters.put(c, makeWriter(descriptor, c));
     }
 
     @Override
@@ -207,7 +204,7 @@ public class SSTableZeroCopyWriter extends SSTable implements SSTableMultiWriter
 
     public void writeComponent(Component component, DataInputPlus in, long size) throws ClosedChannelException
     {
-        ZeroCopySequentialWriter writer = componentWriters.get(component.name);
+        ZeroCopySequentialWriter writer = componentWriters.get(component);
         logger.info("Writing component {} to {} length {}", component, writer.getFile(), prettyPrintMemory(size));
 
         if (in instanceof AsyncStreamingInputPlus)

--- a/src/java/org/apache/cassandra/io/sstable/SSTableZeroCopyWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableZeroCopyWriter.java
@@ -67,12 +67,6 @@ public class SSTableZeroCopyWriter extends SSTable implements SSTableMultiWriter
         lifecycleNewTracker.trackNew(this);
         this.componentWriters = new HashMap<>();
 
-        Set<Component> unsupported = components().stream()
-                                               .filter(c -> !c.type.streamable)
-                                               .collect(Collectors.toSet());
-        if (!unsupported.isEmpty())
-            throw new AssertionError(format("Unsupported streaming components detected: %s", unsupported));
-
         for (Component c : components())
             componentWriters.put(c.name, makeWriter(descriptor, c));
     }

--- a/src/java/org/apache/cassandra/io/sstable/format/DataComponent.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/DataComponent.java
@@ -20,12 +20,14 @@ package org.apache.cassandra.io.sstable.format;
 
 import java.util.Optional;
 
+import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.config.Config.FlushCompression;
 import org.apache.cassandra.db.compaction.OperationType;
 import org.apache.cassandra.io.compress.CompressedSequentialWriter;
 import org.apache.cassandra.io.compress.EncryptedSequentialWriter;
 import org.apache.cassandra.io.compress.Encryptor;
 import org.apache.cassandra.io.compress.ICompressor;
+import org.apache.cassandra.io.sstable.Component;
 import org.apache.cassandra.io.sstable.Descriptor;
 import org.apache.cassandra.io.sstable.format.SSTableFormat.Components;
 import org.apache.cassandra.io.sstable.metadata.MetadataCollector;
@@ -34,9 +36,28 @@ import org.apache.cassandra.io.util.SequentialWriter;
 import org.apache.cassandra.io.util.SequentialWriterOption;
 import org.apache.cassandra.schema.CompressionParams;
 import org.apache.cassandra.schema.TableMetadata;
+import org.apache.cassandra.utils.ChecksumType;
 
 public class DataComponent
 {
+    private static final ChecksumType checksumType = CassandraRelevantProperties.SSTABLE_CHECKSUM_TYPE.getEnum(ChecksumType.CRC32);
+    private static final Component digestComponent = getDigestComponent();
+
+    private static Component getDigestComponent()
+    {
+        switch (checksumType)
+        {
+            case CRC32:
+                return Components.DIGEST;
+            case CRC32C:
+                return Components.DIGEST_CRC32C;
+            case CRC64NVME:
+                return Components.DIGEST_CRC64NVME;
+            default:
+                throw new IllegalStateException("Unexpected checksumType for digest file: " + checksumType);
+        }
+    }
+
     public static SequentialWriter buildWriter(Descriptor descriptor,
                                                TableMetadata metadata,
                                                SequentialWriterOption options,
@@ -60,7 +81,8 @@ public class DataComponent
             {
                 return new CompressedSequentialWriter(descriptor.fileFor(Components.DATA),
                                                       descriptor.fileFor(Components.COMPRESSION_INFO),
-                                                      descriptor.fileFor(Components.DIGEST),
+                                                      descriptor.fileFor(digestComponent),
+                                                      checksumType,
                                                       options,
                                                       compressionParams,
                                                       metadataCollector);
@@ -70,7 +92,8 @@ public class DataComponent
         {
             return new ChecksummedSequentialWriter(descriptor.fileFor(Components.DATA),
                                                    descriptor.fileFor(Components.CRC),
-                                                   descriptor.fileFor(Components.DIGEST),
+                                                   descriptor.fileFor(digestComponent),
+                                                   checksumType,
                                                    options);
         }
     }

--- a/src/java/org/apache/cassandra/io/sstable/format/DataComponent.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/DataComponent.java
@@ -41,7 +41,7 @@ import org.apache.cassandra.utils.ChecksumType;
 public class DataComponent
 {
     private static final ChecksumType checksumType = CassandraRelevantProperties.SSTABLE_CHECKSUM_TYPE.getEnum(ChecksumType.CRC32);
-    private static final Component digestComponent = getDigestComponent();
+    static final Component digestComponent = getDigestComponent();
 
     private static Component getDigestComponent()
     {

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableFormat.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableFormat.java
@@ -166,6 +166,10 @@ public interface SSTableFormat<R extends SSTableReader, W extends SSTableWriter>
             public static final Component.Type FILTER = Component.Type.createSingleton("FILTER", "Filter.db", true, null);
             // holds CRC32 checksum of the data file
             public static final Component.Type DIGEST = Component.Type.createSingleton("DIGEST", "Digest.crc32", true, null);
+            // holds CRC32 checksum of the data file
+            public static final Component.Type DIGEST_CRC32C = Component.Type.createSingleton("DIGEST_CRC32C", "Digest.crc32c", true, null);
+            // holds CRC32 checksum of the data file
+            public static final Component.Type DIGEST_CRC64NVME = Component.Type.createSingleton("DIGEST_CRC64NVME", "Digest.crc64nvme", true, null);
             // holds the CRC32 for chunks in an uncompressed file.
             public static final Component.Type CRC = Component.Type.createSingleton("CRC", "CRC.db", true, null);
             // table of contents, stores the list of all components for the sstable
@@ -182,6 +186,8 @@ public interface SSTableFormat<R extends SSTableReader, W extends SSTableWriter>
         public final static Component STATS = Types.STATS.getSingleton();
         public final static Component FILTER = Types.FILTER.getSingleton();
         public final static Component DIGEST = Types.DIGEST.getSingleton();
+        public final static Component DIGEST_CRC32C = Types.DIGEST_CRC32C.getSingleton();
+        public final static Component DIGEST_CRC64NVME = Types.DIGEST_CRC64NVME.getSingleton();
         public final static Component CRC = Types.CRC.getSingleton();
         public final static Component TOC = Types.TOC.getSingleton();
     }

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableFormat.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableFormat.java
@@ -39,6 +39,8 @@ import org.apache.cassandra.schema.TableMetadataRef;
 import org.apache.cassandra.utils.OutputHandler;
 import org.apache.cassandra.utils.Pair;
 
+import static org.apache.cassandra.config.CassandraRelevantProperties.SSTABLE_FORMAT_STREAM_NEW_CHECKSUMS;
+
 /**
  * Provides the accessors to data on disk.
  */
@@ -166,6 +168,10 @@ public interface SSTableFormat<R extends SSTableReader, W extends SSTableWriter>
             public static final Component.Type FILTER = Component.Type.createSingleton("FILTER", "Filter.db", true, null);
             // holds CRC32 checksum of the data file
             public static final Component.Type DIGEST = Component.Type.createSingleton("DIGEST", "Digest.crc32", true, null);
+            // holds CRC32 checksum of the data file
+            public static final Component.Type DIGEST_CRC32C = Component.Type.createSingleton("DIGEST_CRC32C", "Digest.crc32c", SSTABLE_FORMAT_STREAM_NEW_CHECKSUMS.getBoolean(), null);
+            // holds CRC32 checksum of the data file
+            public static final Component.Type DIGEST_CRC64NVME = Component.Type.createSingleton("DIGEST_CRC64NVME", "Digest.crc64nvme", SSTABLE_FORMAT_STREAM_NEW_CHECKSUMS.getBoolean(), null);
             // holds the CRC32 for chunks in an uncompressed file.
             public static final Component.Type CRC = Component.Type.createSingleton("CRC", "CRC.db", true, null);
             // table of contents, stores the list of all components for the sstable
@@ -182,6 +188,8 @@ public interface SSTableFormat<R extends SSTableReader, W extends SSTableWriter>
         public final static Component STATS = Types.STATS.getSingleton();
         public final static Component FILTER = Types.FILTER.getSingleton();
         public final static Component DIGEST = Types.DIGEST.getSingleton();
+        public final static Component DIGEST_CRC32C = Types.DIGEST_CRC32C.getSingleton();
+        public final static Component DIGEST_CRC64NVME = Types.DIGEST_CRC64NVME.getSingleton();
         public final static Component CRC = Types.CRC.getSingleton();
         public final static Component TOC = Types.TOC.getSingleton();
     }

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableFormat.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableFormat.java
@@ -168,9 +168,9 @@ public interface SSTableFormat<R extends SSTableReader, W extends SSTableWriter>
             public static final Component.Type FILTER = Component.Type.createSingleton("FILTER", "Filter.db", true, null);
             // holds CRC32 checksum of the data file
             public static final Component.Type DIGEST = Component.Type.createSingleton("DIGEST", "Digest.crc32", true, null);
-            // holds CRC32 checksum of the data file
+            // holds CRC32C checksum of the data file
             public static final Component.Type DIGEST_CRC32C = Component.Type.createSingleton("DIGEST_CRC32C", "Digest.crc32c", SSTABLE_FORMAT_STREAM_NEW_CHECKSUMS.getBoolean(), null);
-            // holds CRC32 checksum of the data file
+            // holds CRC64-NVME checksum of the data file
             public static final Component.Type DIGEST_CRC64NVME = Component.Type.createSingleton("DIGEST_CRC64NVME", "Digest.crc64nvme", SSTABLE_FORMAT_STREAM_NEW_CHECKSUMS.getBoolean(), null);
             // holds the CRC32 for chunks in an uncompressed file.
             public static final Component.Type CRC = Component.Type.createSingleton("CRC", "CRC.db", true, null);

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
@@ -105,6 +105,7 @@ import org.apache.cassandra.schema.SchemaConstants;
 import org.apache.cassandra.schema.TableMetadataRef;
 import org.apache.cassandra.service.ActiveRepairService;
 import org.apache.cassandra.utils.BloomFilter;
+import org.apache.cassandra.utils.ChecksumType;
 import org.apache.cassandra.utils.EstimatedHistogram;
 import org.apache.cassandra.utils.ExecutorUtils;
 import org.apache.cassandra.utils.FBUtilities;
@@ -560,10 +561,14 @@ public abstract class SSTableReader extends SSTable implements UnfilteredSource,
 
     public DataIntegrityMetadata.FileDigestValidator maybeGetDigestValidator() throws IOException
     {
+        File dataFile = descriptor.fileFor(Components.DATA);
         if (descriptor.fileFor(Components.DIGEST).exists())
-            return new DataIntegrityMetadata.FileDigestValidator(descriptor.fileFor(Components.DATA), descriptor.fileFor(Components.DIGEST));
-        else
-            return null;
+            return new DataIntegrityMetadata.FileDigestValidator(dataFile, descriptor.fileFor(Components.DIGEST), ChecksumType.CRC32);
+        if (descriptor.fileFor(Components.DIGEST_CRC32C).exists())
+            return new DataIntegrityMetadata.FileDigestValidator(dataFile, descriptor.fileFor(Components.DIGEST_CRC32C), ChecksumType.CRC32C);
+        if (descriptor.fileFor(Components.DIGEST_CRC64NVME).exists())
+            return new DataIntegrityMetadata.FileDigestValidator(dataFile, descriptor.fileFor(Components.DIGEST_CRC64NVME), ChecksumType.CRC64NVME);
+        return null;
     }
 
     public static long getTotalBytes(Iterable<SSTableReader> sstables)

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableWriter.java
@@ -546,7 +546,7 @@ public abstract class SSTableWriter extends SSTable implements Transactional, SS
         {
             checkNotNull(getTableMetadataRef());
 
-            addComponents(ImmutableSet.of(Components.DATA, Components.STATS, Components.DIGEST, Components.TOC));
+            addComponents(ImmutableSet.of(Components.DATA, Components.STATS, DataComponent.digestComponent, Components.TOC));
 
             if (getTableMetadataRef().getLocal().params.compression.isEnabled())
             {

--- a/src/java/org/apache/cassandra/io/sstable/format/big/BigFormat.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/BigFormat.java
@@ -122,6 +122,8 @@ public class BigFormat extends AbstractSSTableFormat<BigTableReader, BigTableWri
                                                                              FILTER,
                                                                              SUMMARY,
                                                                              DIGEST,
+                                                                             DIGEST_CRC32C,
+                                                                             DIGEST_CRC64NVME,
                                                                              CRC,
                                                                              TOC);
     }

--- a/src/java/org/apache/cassandra/io/sstable/format/bti/BtiFormat.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/bti/BtiFormat.java
@@ -113,6 +113,8 @@ public class BtiFormat extends AbstractSSTableFormat<BtiTableReader, BtiTableWri
                                                                              COMPRESSION_INFO,
                                                                              FILTER,
                                                                              DIGEST,
+                                                                             DIGEST_CRC32C,
+                                                                             DIGEST_CRC64NVME,
                                                                              CRC,
                                                                              TOC);
 

--- a/src/java/org/apache/cassandra/io/util/ChecksumWriter.java
+++ b/src/java/org/apache/cassandra/io/util/ChecksumWriter.java
@@ -23,22 +23,24 @@ import java.io.IOError;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.util.zip.CRC32;
+import java.util.zip.Checksum;
 
 import javax.annotation.Nonnull;
 
 import org.apache.cassandra.io.FSWriteError;
 import org.apache.cassandra.io.compress.CompressedSequentialWriter;
+import org.apache.cassandra.utils.ChecksumType;
 
 public class ChecksumWriter
 {
-    private final CRC32 incrementalChecksum = new CRC32();
+    private final Checksum incrementalChecksum = ChecksumType.CRC32.newInstance();
     private final DataOutput incrementalOut;
-    private final CRC32 fullChecksum = new CRC32();
+    private final Checksum fullChecksum;
 
-    public ChecksumWriter(DataOutput incrementalOut)
+    public ChecksumWriter(DataOutput incrementalOut, ChecksumType fullChecksumType)
     {
         this.incrementalOut = incrementalOut;
+        this.fullChecksum = fullChecksumType.newInstance();
     }
 
     public void writeChunkSize(int length)

--- a/src/java/org/apache/cassandra/io/util/ChecksummedSequentialWriter.java
+++ b/src/java/org/apache/cassandra/io/util/ChecksummedSequentialWriter.java
@@ -20,6 +20,8 @@ package org.apache.cassandra.io.util;
 import java.nio.ByteBuffer;
 import java.util.Optional;
 
+import org.apache.cassandra.utils.ChecksumType;
+
 public class ChecksummedSequentialWriter extends SequentialWriter
 {
     private static final SequentialWriterOption CRC_WRITER_OPTION = SequentialWriterOption.newBuilder()
@@ -30,13 +32,18 @@ public class ChecksummedSequentialWriter extends SequentialWriter
     private final ChecksumWriter crcMetadata;
     private final Optional<File> digestFile;
 
-    public ChecksummedSequentialWriter(File file, File crcPath, File digestFile, SequentialWriterOption option)
+    public ChecksummedSequentialWriter(File file, File crcPath, File digestFile, ChecksumType checksumType, SequentialWriterOption option)
     {
         super(file, option);
         crcWriter = new SequentialWriter(crcPath, CRC_WRITER_OPTION);
-        crcMetadata = new ChecksumWriter(crcWriter);
+        crcMetadata = new ChecksumWriter(crcWriter, checksumType);
         crcMetadata.writeChunkSize(buffer.capacity());
         this.digestFile = Optional.ofNullable(digestFile);
+    }
+
+    public ChecksummedSequentialWriter(File file, File crcPath, SequentialWriterOption option)
+    {
+        this(file, crcPath, null, ChecksumType.CRC32, option);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/io/util/DataIntegrityMetadata.java
+++ b/src/java/org/apache/cassandra/io/util/DataIntegrityMetadata.java
@@ -105,11 +105,11 @@ public class DataIntegrityMetadata
         private final File dataFile;
         private final File digestFile;
 
-        public FileDigestValidator(File dataFile, File digestFile) throws IOException
+        public FileDigestValidator(File dataFile, File digestFile, ChecksumType checksumType) throws IOException
         {
             this.dataFile = dataFile;
             this.digestFile = digestFile;
-            this.checksum = ChecksumType.CRC32.newInstance();
+            this.checksum = checksumType.newInstance();
         }
 
         // Validate the entire file

--- a/src/java/org/apache/cassandra/service/paxos/uncommitted/UncommittedDataFile.java
+++ b/src/java/org/apache/cassandra/service/paxos/uncommitted/UncommittedDataFile.java
@@ -225,7 +225,7 @@ public class UncommittedDataFile
 
             this.file = new File(this.directory, fileName(generation) + TMP_SUFFIX);
             this.crcFile = new File(this.directory, crcName(generation) + TMP_SUFFIX);
-            this.writer = new ChecksummedSequentialWriter(file, crcFile, null, SequentialWriterOption.DEFAULT);
+            this.writer = new ChecksummedSequentialWriter(file, crcFile, SequentialWriterOption.DEFAULT);
             this.writer.writeInt(VERSION);
         }
 

--- a/src/java/org/apache/cassandra/utils/ChecksumType.java
+++ b/src/java/org/apache/cassandra/utils/ChecksumType.java
@@ -18,11 +18,16 @@
 package org.apache.cassandra.utils;
 
 import java.nio.ByteBuffer;
+import java.util.zip.CRC32C;
 import java.util.zip.Checksum;
 import java.util.zip.CRC32;
 import java.util.zip.Adler32;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.netty.util.concurrent.FastThreadLocal;
+import software.amazon.awssdk.crt.checksums.CRC64NVME;
 
 public enum ChecksumType
 {
@@ -57,7 +62,56 @@ public enum ChecksumType
             ((CRC32)checksum).update(buf);
         }
 
+    },
+    CRC32C
+    {
+
+        @Override
+        public Checksum newInstance()
+        {
+            return new CRC32C();
+        }
+
+        @Override
+        public void update(Checksum checksum, ByteBuffer buf)
+        {
+            ((CRC32C)checksum).update(buf);
+        }
+
+    },
+    CRC64NVME
+    {
+
+        @Override
+        public Checksum newInstance()
+        {
+            if (HAS_AWS_CRT_CRC64NVME)
+                return new CRC64NVME();
+            return new PureJavaCRC64NVME();
+        }
+
+        @Override
+        public void update(Checksum checksum, ByteBuffer buf)
+        {
+            ((CRC32C)checksum).update(buf);
+        }
+
     };
+
+    private static final Logger logger = LoggerFactory.getLogger(ChecksumType.class);
+    private static final boolean HAS_AWS_CRT_CRC64NVME;
+
+    static {
+        boolean available = false;
+        try {
+            Class.forName("software.amazon.awssdk.crt.checksums.CRC64NVME");
+            available = true;
+        } catch (ClassNotFoundException e) {
+            logger.debug("software.amazon.awssdk.crt.checksums.CRC64NVME not found, " +
+                         "falling back to PureJavaCRC64NVME for CRC64NVME checksum");
+        }
+        HAS_AWS_CRT_CRC64NVME = available;
+    }
 
     public abstract Checksum newInstance();
     public abstract void update(Checksum checksum, ByteBuffer buf);

--- a/src/java/org/apache/cassandra/utils/ChecksumType.java
+++ b/src/java/org/apache/cassandra/utils/ChecksumType.java
@@ -18,11 +18,18 @@
 package org.apache.cassandra.utils;
 
 import java.nio.ByteBuffer;
+import java.util.zip.CRC32C;
 import java.util.zip.Checksum;
 import java.util.zip.CRC32;
 import java.util.zip.Adler32;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.netty.util.concurrent.FastThreadLocal;
+import software.amazon.awssdk.crt.checksums.CRC64NVME;
+
+import static org.apache.cassandra.config.CassandraRelevantProperties.SSTABLE_CHECKSUM_AWS_CRT_DETECTION_ENABLED;
 
 public enum ChecksumType
 {
@@ -57,7 +64,62 @@ public enum ChecksumType
             ((CRC32)checksum).update(buf);
         }
 
+    },
+    CRC32C
+    {
+
+        @Override
+        public Checksum newInstance()
+        {
+            return new CRC32C();
+        }
+
+        @Override
+        public void update(Checksum checksum, ByteBuffer buf)
+        {
+            ((CRC32C)checksum).update(buf);
+        }
+
+    },
+    CRC64NVME
+    {
+
+        @Override
+        public Checksum newInstance()
+        {
+            if (HAS_AWS_CRT_CRC64NVME)
+                return new CRC64NVME();
+            return new PureJavaCRC64NVME();
+        }
+
+        @Override
+        public void update(Checksum checksum, ByteBuffer buf)
+        {
+            ((CRC32C)checksum).update(buf);
+        }
+
     };
+
+    private static final Logger logger = LoggerFactory.getLogger(ChecksumType.class);
+    private static final boolean HAS_AWS_CRT_CRC64NVME;
+
+    static {
+        boolean available = false;
+        if (SSTABLE_CHECKSUM_AWS_CRT_DETECTION_ENABLED.getBoolean())
+        {
+            try
+            {
+                Class.forName("software.amazon.awssdk.crt.checksums.CRC64NVME");
+                available = true;
+            }
+            catch (ClassNotFoundException e)
+            {
+                logger.debug("software.amazon.awssdk.crt.checksums.CRC64NVME not found, " +
+                             "falling back to PureJavaCRC64NVME for CRC64NVME checksum");
+            }
+        }
+        HAS_AWS_CRT_CRC64NVME = available;
+    }
 
     public abstract Checksum newInstance();
     public abstract void update(Checksum checksum, ByteBuffer buf);

--- a/src/java/org/apache/cassandra/utils/ChecksumType.java
+++ b/src/java/org/apache/cassandra/utils/ChecksumType.java
@@ -95,7 +95,7 @@ public enum ChecksumType
         @Override
         public void update(Checksum checksum, ByteBuffer buf)
         {
-            ((CRC32C)checksum).update(buf);
+            ((CRC64NVME)checksum).update(buf);
         }
 
     };

--- a/src/java/org/apache/cassandra/utils/ChecksumType.java
+++ b/src/java/org/apache/cassandra/utils/ChecksumType.java
@@ -17,6 +17,7 @@
  */
 package org.apache.cassandra.utils;
 
+import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
 import java.util.zip.CRC32C;
 import java.util.zip.Checksum;
@@ -27,7 +28,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.netty.util.concurrent.FastThreadLocal;
-import software.amazon.awssdk.crt.checksums.CRC64NVME;
 
 import static org.apache.cassandra.config.CassandraRelevantProperties.SSTABLE_CHECKSUM_AWS_CRT_DETECTION_ENABLED;
 
@@ -87,30 +87,39 @@ public enum ChecksumType
         @Override
         public Checksum newInstance()
         {
-            if (HAS_AWS_CRT_CRC64NVME)
-                return new CRC64NVME();
+            if (AWS_CRT_CRC64NVME_CLASS != null)
+            {
+                try
+                {
+                    return (Checksum) AWS_CRT_CRC64NVME_CLASS.getDeclaredConstructor().newInstance();
+                }
+                catch (ReflectiveOperationException e)
+                {
+                    throw new RuntimeException(e);
+                }
+            }
             return new PureJavaCRC64NVME();
         }
 
         @Override
         public void update(Checksum checksum, ByteBuffer buf)
         {
-            ((CRC64NVME)checksum).update(buf);
+            checksum.update(buf);
         }
-
     };
 
     private static final Logger logger = LoggerFactory.getLogger(ChecksumType.class);
-    private static final boolean HAS_AWS_CRT_CRC64NVME;
+    private static final Class<?> AWS_CRT_CRC64NVME_CLASS;
 
     static {
-        boolean available = false;
+        Class<?> cls = null;
         if (SSTABLE_CHECKSUM_AWS_CRT_DETECTION_ENABLED.getBoolean())
         {
             try
             {
-                Class.forName("software.amazon.awssdk.crt.checksums.CRC64NVME");
-                available = true;
+                cls = Class.forName("software.amazon.awssdk.crt.checksums.CRC64NVME");
+                logger.debug("software.amazon.awssdk.crt.checksums.CRC64NVME found, " +
+                             "using it for CRC64NVME checksum");
             }
             catch (ClassNotFoundException e)
             {
@@ -118,7 +127,7 @@ public enum ChecksumType
                              "falling back to PureJavaCRC64NVME for CRC64NVME checksum");
             }
         }
-        HAS_AWS_CRT_CRC64NVME = available;
+        AWS_CRT_CRC64NVME_CLASS = cls;
     }
 
     public abstract Checksum newInstance();

--- a/src/java/org/apache/cassandra/utils/ChecksumType.java
+++ b/src/java/org/apache/cassandra/utils/ChecksumType.java
@@ -17,7 +17,7 @@
  */
 package org.apache.cassandra.utils;
 
-import java.lang.reflect.Method;
+import java.lang.reflect.Constructor;
 import java.nio.ByteBuffer;
 import java.util.zip.CRC32C;
 import java.util.zip.Checksum;
@@ -87,11 +87,11 @@ public enum ChecksumType
         @Override
         public Checksum newInstance()
         {
-            if (AWS_CRT_CRC64NVME_CLASS != null)
+            if (AWS_CRT_CRC64NVME_CONSTRUCTOR != null)
             {
                 try
                 {
-                    return (Checksum) AWS_CRT_CRC64NVME_CLASS.getDeclaredConstructor().newInstance();
+                    return (Checksum) AWS_CRT_CRC64NVME_CONSTRUCTOR.newInstance();
                 }
                 catch (ReflectiveOperationException e)
                 {
@@ -109,25 +109,26 @@ public enum ChecksumType
     };
 
     private static final Logger logger = LoggerFactory.getLogger(ChecksumType.class);
-    private static final Class<?> AWS_CRT_CRC64NVME_CLASS;
+    private static final Constructor<?> AWS_CRT_CRC64NVME_CONSTRUCTOR;
 
     static {
-        Class<?> cls = null;
+        Constructor<?> constructor = null;
         if (SSTABLE_CHECKSUM_AWS_CRT_DETECTION_ENABLED.getBoolean())
         {
             try
             {
-                cls = Class.forName("software.amazon.awssdk.crt.checksums.CRC64NVME");
+                Class<?> cls = Class.forName("software.amazon.awssdk.crt.checksums.CRC64NVME");
+                constructor = cls.getDeclaredConstructor();
                 logger.debug("software.amazon.awssdk.crt.checksums.CRC64NVME found, " +
                              "using it for CRC64NVME checksum");
             }
-            catch (ClassNotFoundException e)
+            catch (ClassNotFoundException | NoSuchMethodException e)
             {
                 logger.debug("software.amazon.awssdk.crt.checksums.CRC64NVME not found, " +
                              "falling back to PureJavaCRC64NVME for CRC64NVME checksum");
             }
         }
-        AWS_CRT_CRC64NVME_CLASS = cls;
+        AWS_CRT_CRC64NVME_CONSTRUCTOR = constructor;
     }
 
     public abstract Checksum newInstance();

--- a/src/java/org/apache/cassandra/utils/PureJavaCRC64NVME.java
+++ b/src/java/org/apache/cassandra/utils/PureJavaCRC64NVME.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.utils;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.nio.ByteOrder;
+import java.util.zip.Checksum;
+
+public final class PureJavaCRC64NVME implements Checksum
+{
+    private static final long POLY = 0x9A6C9329AC4BC9B5L;
+
+    private static final long[][] TABLE = new long[8][256];
+
+    private static final VarHandle LONG_LE = MethodHandles.byteArrayViewVarHandle(long[].class, ByteOrder.LITTLE_ENDIAN);
+
+    static
+    {
+        for (int i = 0; i < 256; i++)
+        {
+            long crc = i;
+
+            for (int j = 0; j < 8; j++)
+            {
+                crc = ((crc & 1) != 0)
+                      ? (crc >>> 1) ^ POLY
+                      : (crc >>> 1);
+            }
+
+            TABLE[0][i] = crc;
+        }
+
+        for (int t = 1; t < 8; t++)
+        {
+            for (int i = 0; i < 256; i++)
+            {
+                long crc = TABLE[t - 1][i];
+                TABLE[t][i] = TABLE[0][(int) (crc & 0xFF)] ^ (crc >>> 8);
+            }
+        }
+    }
+
+    private long crc;
+
+    @Override
+    public void update(int b)
+    {
+        long c = crc ^ ~0L;
+        c = (c >>> 8) ^ TABLE[0][(int) ((c ^ b) & 0xFF)];
+        crc = c ^ ~0L;
+    }
+
+    @Override
+    public void update(byte[] b, int off, int len)
+    {
+        long c = crc ^ ~0L;
+
+        int end = off + len;
+
+        while (off + 8 <= end)
+        {
+            long x = (long) LONG_LE.get(b, off) ^ c;
+
+            c = TABLE[7][(int) (x & 0xFF)] ^
+                TABLE[6][(int) ((x >>> 8) & 0xFF)] ^
+                TABLE[5][(int) ((x >>> 16) & 0xFF)] ^
+                TABLE[4][(int) ((x >>> 24) & 0xFF)] ^
+                TABLE[3][(int) ((x >>> 32) & 0xFF)] ^
+                TABLE[2][(int) ((x >>> 40) & 0xFF)] ^
+                TABLE[1][(int) ((x >>> 48) & 0xFF)] ^
+                TABLE[0][(int) ((x >>> 56) & 0xFF)];
+
+            off += 8;
+        }
+
+        while (off < end)
+        {
+            c = (c >>> 8) ^ TABLE[0][(int) ((c ^ b[off++]) & 0xFF)];
+        }
+
+        crc = c ^ ~0L;
+    }
+
+    @Override
+    public long getValue()
+    {
+        return crc;
+    }
+
+    @Override
+    public void reset()
+    {
+        crc = 0;
+    }
+}

--- a/test/distributed/org/apache/cassandra/distributed/test/SSTableDigestTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/SSTableDigestTest.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+
+import org.junit.Test;
+
+import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.distributed.Cluster;
+import org.apache.cassandra.distributed.shared.WithProperties;
+import org.apache.cassandra.io.sstable.Component;
+import org.apache.cassandra.io.sstable.format.SSTableFormat.Components;
+import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.utils.ChecksumType;
+
+import static java.lang.String.format;
+import static org.apache.cassandra.config.CassandraRelevantProperties.SSTABLE_CHECKSUM_TYPE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SSTableDigestTest extends TestBaseImpl
+{
+    public void testDigestFile(ChecksumType checksumType, Component digestComponent) throws IOException
+    {
+        try (WithProperties properties = new WithProperties())
+        {
+            if (checksumType != null)
+                properties.set(SSTABLE_CHECKSUM_TYPE, checksumType.toString());
+
+            try (Cluster cluster = init(Cluster.build(1)
+                                               .withDataDirCount(1)
+                                               .start()))
+            {
+                cluster.disableAutoCompaction(KEYSPACE);
+                cluster.schemaChange(createTableStmt(KEYSPACE));
+                cluster.get(1).executeInternal(format("INSERT INTO %s.%s (pk, ck, v) VALUES (?, ?, ?)", KEYSPACE, "tbl"), 1, 1, 1);
+                cluster.get(1).flush(KEYSPACE);
+
+                String digestFileName = digestComponent.type.repr;
+
+                cluster.get(1).runOnInstance(() -> {
+                    try
+                    {
+                        SSTableReader ssTable = new ArrayList<>(Keyspace.open(KEYSPACE).getColumnFamilyStore("tbl").getLiveSSTables()).get(0);
+
+                        Path digestPath = ssTable.descriptor.pathFor(Component.parse(digestFileName, null));
+
+                        assertThat(digestPath).exists();
+
+                        long digest = Long.parseLong(Files.readString(digestPath));
+
+                        Path data = ssTable.descriptor.pathFor(Components.DATA);
+                        byte[] bytes = Files.readAllBytes(data);
+
+                        ChecksumType effectiveChecksumType = checksumType == null ? ChecksumType.CRC32 : checksumType;
+                        long checksum = effectiveChecksumType.of(bytes, 0, bytes.length);
+
+                        assertThat(checksum).isEqualTo(digest);
+                    }
+                    catch (IOException e)
+                    {
+                        throw new RuntimeException(e);
+                    }
+                });
+            }
+        }
+    }
+
+    @Test
+    public void testDigestFileDefault() throws IOException
+    {
+        testDigestFile(null, Components.DIGEST);
+    }
+
+    @Test
+    public void testDigestFileCRC32() throws IOException
+    {
+        testDigestFile(ChecksumType.CRC32, Components.DIGEST);
+    }
+
+    @Test
+    public void testDigestFileCRC32C() throws IOException
+    {
+        testDigestFile(ChecksumType.CRC32C, Components.DIGEST_CRC32C);
+    }
+
+    @Test
+    public void testDigestFileCRC64NVME() throws IOException
+    {
+        testDigestFile(ChecksumType.CRC64NVME, Components.DIGEST_CRC64NVME);
+    }
+
+    private static String createTableStmt(String ks)
+    {
+        return format("CREATE TABLE %s.%s (pk int, ck int, v int, PRIMARY KEY (pk, ck)) " +
+                      "WITH compaction = {'class':'SizeTieredCompactionStrategy', 'enabled':'false'}",
+                      ks, "tbl");
+    }
+}

--- a/test/distributed/org/apache/cassandra/distributed/test/streaming/ChecksumStreamingTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/streaming/ChecksumStreamingTest.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.distributed.test.streaming;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+
+import org.junit.Test;
+
+import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.distributed.Cluster;
+import static org.apache.cassandra.distributed.api.Feature.GOSSIP;
+import static org.apache.cassandra.distributed.api.Feature.NETWORK;
+import org.apache.cassandra.distributed.api.IInvokableInstance;
+import org.apache.cassandra.distributed.shared.WithProperties;
+import org.apache.cassandra.distributed.test.TestBaseImpl;
+import org.apache.cassandra.io.sstable.format.SSTableFormat.Components;
+import org.apache.cassandra.io.sstable.format.SSTableReader;
+
+import static org.apache.cassandra.config.CassandraRelevantProperties.SSTABLE_CHECKSUM_TYPE;
+import static org.apache.cassandra.config.CassandraRelevantProperties.SSTABLE_FORMAT_STREAM_NEW_CHECKSUMS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Distributed tests verifying which digest components are streamed between cluster nodes
+ * depending on the checksum type and the {@code cassandra.sstable.format.stream_new_checksums} flag.
+ * <p>
+ * The {@code cassandra.sstable.format.stream_new_checksums} flag shall be enabled only when the target cluster
+ * is running a version of Cassandra that supports the new digest components.
+ *
+ * <p>The streamability of each digest component type is fixed at class-load time:
+ * <ul>
+ *   <li>{@code Digest.crc32}    — {@code streamable=true} always</li>
+ *   <li>{@code Digest.crc32c}   — {@code streamable=SSTABLE_FORMAT_STREAM_NEW_CHECKSUMS}</li>
+ *   <li>{@code Digest.crc64nvme}— {@code streamable=SSTABLE_FORMAT_STREAM_NEW_CHECKSUMS}</li>
+ * </ul>
+ *
+ * <p>Both properties must be set <em>before</em> the cluster starts because the in-process instance
+ * classloader reads {@code SSTABLE_FORMAT_STREAM_NEW_CHECKSUMS} once when it first initialises
+ * {@code SSTableFormat.Components.Types}.
+ */
+public class ChecksumStreamingTest extends TestBaseImpl
+{
+    // -------------------------------------------------------------------------
+    // CRC32 — always streamed regardless of stream_new_checksums
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testCRC32DigestIsStreamedWhenStreamNewChecksumsDisabled() throws IOException
+    {
+        testDigestStreaming("CRC32", false, true);
+    }
+
+    @Test
+    public void testCRC32DigestIsStreamedWhenStreamNewChecksumsEnabled() throws IOException
+    {
+        testDigestStreaming("CRC32", true, true);
+    }
+
+    // -------------------------------------------------------------------------
+    // CRC32C — only streamed when stream_new_checksums=true
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testCRC32CDigestIsNotStreamedByDefault() throws IOException
+    {
+        testDigestStreaming("CRC32C", false, false);
+    }
+
+    @Test
+    public void testCRC32CDigestIsStreamedWhenEnabled() throws IOException
+    {
+        testDigestStreaming("CRC32C", true, true);
+    }
+
+    // -------------------------------------------------------------------------
+    // CRC64NVME — only streamed when stream_new_checksums=true
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testCRC64NVMEDigestIsNotStreamedByDefault() throws IOException
+    {
+        testDigestStreaming("CRC64NVME", false, false);
+    }
+
+    @Test
+    public void testCRC64NVMEDigestIsStreamedWhenEnabled() throws IOException
+    {
+        testDigestStreaming("CRC64NVME", true, true);
+    }
+
+    // -------------------------------------------------------------------------
+    // Shared helper
+    // -------------------------------------------------------------------------
+
+    /**
+     * Populates an SSTable on node 1 with the given checksum type, streams it to node 2 via
+     * {@code nodetool rebuild}, and asserts whether the digest file is present on node 2.
+     *
+     * @param checksumType       value for {@code cassandra.sstable.checksums.type}
+     * @param streamNewChecksums value for {@code cassandra.sstable.format.stream_new_checksums}
+     * @param expectStreamed     whether the digest file should be present on the receiving node
+     */
+    private void testDigestStreaming(String checksumType, boolean streamNewChecksums, boolean expectStreamed)
+    throws IOException
+    {
+        try (WithProperties properties = new WithProperties())
+        {
+            // Both properties must be set before the cluster starts so that the isolated
+            // instance classloader picks them up when it first loads SSTableFormat.Components.Types.
+            properties.set(SSTABLE_CHECKSUM_TYPE, checksumType);
+            properties.set(SSTABLE_FORMAT_STREAM_NEW_CHECKSUMS, streamNewChecksums);
+
+            try (Cluster cluster = init(Cluster.build(2)
+                                               .withConfig(c -> c.with(NETWORK, GOSSIP)
+                                                                 .set("stream_entire_sstables", true))
+                                               .start()))
+            {
+                cluster.stream().forEach(i -> i.nodetoolResult("disableautocompaction", KEYSPACE).asserts().success());
+                cluster.schemaChange(withKeyspace("CREATE TABLE %s.tbl (pk int PRIMARY KEY) " +
+                                                  "WITH compression = { 'enabled': false }"));
+
+                IInvokableInstance node1 = cluster.get(1);
+                IInvokableInstance node2 = cluster.get(2);
+
+                // Write and flush data only on node 1 so that a rebuild of node 2 triggers streaming.
+                for (int i = 0; i < 10; i++)
+                    node1.executeInternal(withKeyspace("INSERT INTO %s.tbl (pk) VALUES (?)"), i);
+                node1.flush(KEYSPACE);
+
+                // Verify that node 1 has written the expected digest file before streaming.
+                node1.runOnInstance(() -> {
+                    SSTableReader sstable = new ArrayList<>(Keyspace.open(KEYSPACE)
+                                                                    .getColumnFamilyStore("tbl")
+                                                                    .getLiveSSTables()).get(0);
+                    Path digestPath = digestPath(sstable, checksumType);
+                    assertThat(digestPath)
+                        .as("Digest file for %s should exist on node1 before streaming", checksumType)
+                        .exists();
+                });
+
+                // Trigger entire-SSTable streaming from node 1 → node 2.
+                node2.nodetoolResult("rebuild", "--keyspace", KEYSPACE).asserts().success();
+
+                // Verify whether the digest file was (or was not) received by node 2.
+                node2.runOnInstance(() -> {
+                    SSTableReader sstable = new ArrayList<>(Keyspace.open(KEYSPACE)
+                                                                    .getColumnFamilyStore("tbl")
+                                                                    .getLiveSSTables()).get(0);
+                    Path digestPath = digestPath(sstable, checksumType);
+                    if (expectStreamed)
+                        assertThat(digestPath)
+                            .as("Digest file for %s should have been streamed to node2 " +
+                                "(stream_new_checksums=%s)", checksumType, streamNewChecksums)
+                            .exists();
+                    else
+                        assertThat(digestPath)
+                            .as("Digest file for %s should NOT have been streamed to node2 " +
+                                "(stream_new_checksums=%s)", checksumType, streamNewChecksums)
+                            .doesNotExist();
+                });
+            }
+        }
+    }
+
+    /** Returns the path of the digest file on disk for the given checksum type. */
+    private static Path digestPath(SSTableReader sstable, String checksumType)
+    {
+        switch (checksumType)
+        {
+            case "CRC32":    return sstable.descriptor.pathFor(Components.DIGEST);
+            case "CRC32C":   return sstable.descriptor.pathFor(Components.DIGEST_CRC32C);
+            case "CRC64NVME": return sstable.descriptor.pathFor(Components.DIGEST_CRC64NVME);
+            default: throw new IllegalArgumentException("Unknown checksum type: " + checksumType);
+        }
+    }
+}

--- a/test/microbench/org/apache/cassandra/test/microbench/ChecksumBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/ChecksumBench.java
@@ -22,6 +22,8 @@ import com.google.common.hash.Hasher;
 import com.google.common.hash.Hashing;
 import com.google.common.primitives.Longs;
 import org.apache.cassandra.utils.ChecksumType;
+import org.apache.cassandra.utils.FBUtilities;
+import org.apache.cassandra.utils.PureJavaCRC64NVME;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -35,10 +37,13 @@ import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
 import org.xerial.snappy.PureJavaCrc32C;
+import software.amazon.awssdk.crt.checksums.CRC64NVME;
 
+import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
+import java.util.zip.CRC32C;
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
@@ -104,27 +109,59 @@ public class ChecksumBench
         return Longs.toByteArray(pureJavaCrc32C.getValue());
     }
 
-    // Below benchmarks are commented because CRC32C is unavailable in Java 8.
-//    @Benchmark
-//    @Fork(value = 1, jvmArgsAppend = { "-Xmx512M", "-Djmh.executor=CUSTOM",
-//            "-Djmh.executor.class=org.apache.cassandra.test.microbench.FastThreadExecutor",
-//    })
-//    public byte[] benchCrc32c()
-//    {
-//        CRC32C crc32C = new CRC32C();
-//        crc32C.update(array);
-//        return Longs.toByteArray(crc32C.getValue());
-//    }
-//
-//    @Benchmark
-//    @Fork(value = 1, jvmArgsAppend = { "-Xmx512M", "-Djmh.executor=CUSTOM",
-//            "-Djmh.executor.class=org.apache.cassandra.test.microbench.FastThreadExecutor",
-//            "-XX:+UnlockDiagnosticVMOptions", "-XX:-UseCRC32CIntrinsics",
-//    })
-//    public byte[] benchCrc32cNoIntrinsic()
-//    {
-//        CRC32C crc32C = new CRC32C();
-//        crc32C.update(array);
-//        return Longs.toByteArray(crc32C.getValue());
-//    }
+    @Benchmark
+    @Fork(value = 1, jvmArgsAppend = { "-Xmx512M", "-Djmh.executor=CUSTOM",
+            "-Djmh.executor.class=org.apache.cassandra.test.microbench.FastThreadExecutor",
+    })
+    public byte[] benchCrc32c()
+    {
+        CRC32C crc32C = new CRC32C();
+        crc32C.update(array);
+        return Longs.toByteArray(crc32C.getValue());
+    }
+
+    @Benchmark
+    @Fork(value = 1, jvmArgsAppend = { "-Xmx512M", "-Djmh.executor=CUSTOM",
+            "-Djmh.executor.class=org.apache.cassandra.test.microbench.FastThreadExecutor",
+            "-XX:+UnlockDiagnosticVMOptions", "-XX:-UseCRC32CIntrinsics",
+    })
+    public byte[] benchCrc32cNoIntrinsic()
+    {
+        CRC32C crc32C = new CRC32C();
+        crc32C.update(array);
+        return Longs.toByteArray(crc32C.getValue());
+    }
+
+    @Benchmark
+    @Fork(value = 1, jvmArgsAppend = { "-Xmx512M", "-Djmh.executor=CUSTOM",
+                                       "-Djmh.executor.class=org.apache.cassandra.test.microbench.FastThreadExecutor",
+    })
+    public byte[] benchAwsCrtCrc64nvme()
+    {
+        CRC64NVME crc64nvme = new CRC64NVME();
+        crc64nvme.update(array, 0, array.length);
+        return Longs.toByteArray(crc64nvme.getValue());
+    }
+
+    @Benchmark
+    @Fork(value = 1, jvmArgsAppend = { "-Xmx512M", "-Djmh.executor=CUSTOM",
+                                       "-Djmh.executor.class=org.apache.cassandra.test.microbench.FastThreadExecutor",
+    })
+    public byte[] benchPureJavaCrc64nvme()
+    {
+        PureJavaCRC64NVME pureJavaCrc64nvme = new PureJavaCRC64NVME();
+        pureJavaCrc64nvme.update(array, 0, array.length);
+        return Longs.toByteArray(pureJavaCrc64nvme.getValue());
+    }
+
+    @Benchmark
+    @Fork(value = 1, jvmArgsAppend = { "-Xmx512M", "-Djmh.executor=CUSTOM",
+                                       "-Djmh.executor.class=org.apache.cassandra.test.microbench.FastThreadExecutor",
+    })
+    public byte[] benchMd5()
+    {
+        MessageDigest md5 = FBUtilities.newMessageDigest("MD5");
+        md5.update(array, 0, array.length);
+        return md5.digest();
+    }
 }

--- a/test/unit/org/apache/cassandra/io/compress/CompressedRandomAccessReaderTest.java
+++ b/test/unit/org/apache/cassandra/io/compress/CompressedRandomAccessReaderTest.java
@@ -41,6 +41,7 @@ import org.apache.cassandra.io.util.RandomAccessReader;
 import org.apache.cassandra.io.util.SequentialWriter;
 import org.apache.cassandra.io.util.SequentialWriterOption;
 import org.apache.cassandra.schema.CompressionParams;
+import org.apache.cassandra.utils.ChecksumType;
 import org.apache.cassandra.utils.SyncUtil;
 import org.assertj.core.api.Assertions;
 
@@ -105,7 +106,7 @@ public class CompressedRandomAccessReaderTest
         String filename = f.absolutePath();
         MetadataCollector sstableMetadataCollector = new MetadataCollector(new ClusteringComparator(BytesType.instance));
         try(CompressedSequentialWriter writer = new CompressedSequentialWriter(f, new File(filename + ".metadata"),
-                                                                               null, SequentialWriterOption.DEFAULT,
+                                                                               null, ChecksumType.CRC32, SequentialWriterOption.DEFAULT,
                                                                                CompressionParams.snappy(32),
                                                                                sstableMetadataCollector))
         {
@@ -208,7 +209,7 @@ public class CompressedRandomAccessReaderTest
         MetadataCollector sstableMetadataCollector = new MetadataCollector(new ClusteringComparator(BytesType.instance));
         try(SequentialWriter writer = params != null
                 ? new CompressedSequentialWriter(f, new File(filename + ".metadata"),
-                                                 null, SequentialWriterOption.DEFAULT,
+                                                 null, ChecksumType.CRC32, SequentialWriterOption.DEFAULT,
                                                  params, sstableMetadataCollector)
                 : new SequentialWriter(f))
         {
@@ -248,7 +249,7 @@ public class CompressedRandomAccessReaderTest
 
         MetadataCollector sstableMetadataCollector = new MetadataCollector(new ClusteringComparator(BytesType.instance));
         try (SequentialWriter writer = new CompressedSequentialWriter(file, metadata,
-                                                                      null, SequentialWriterOption.DEFAULT,
+                                                                      null, ChecksumType.CRC32, SequentialWriterOption.DEFAULT,
                                                                       CompressionParams.snappy(), sstableMetadataCollector))
         {
             writer.write(CONTENT.getBytes());

--- a/test/unit/org/apache/cassandra/io/compress/CompressedSequentialWriterTest.java
+++ b/test/unit/org/apache/cassandra/io/compress/CompressedSequentialWriterTest.java
@@ -48,6 +48,7 @@ import org.apache.cassandra.io.util.SequentialWriterOption;
 import org.apache.cassandra.io.util.SequentialWriterTest;
 import org.apache.cassandra.schema.CompressionParams;
 import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.ChecksumType;
 
 import static org.apache.cassandra.schema.CompressionParams.DEFAULT_CHUNK_LENGTH;
 import static org.apache.commons.io.FileUtils.readFileToByteArray;
@@ -129,9 +130,9 @@ public class CompressedSequentialWriterTest extends SequentialWriterTest
         byte[] dataPre = new byte[bytesToTest];
         byte[] rawPost = new byte[bytesToTest];
         try (CompressedSequentialWriter writer = new CompressedSequentialWriter(f, new File(filename + ".metadata"),
-                null, SequentialWriterOption.DEFAULT,
-                compressionParameters,
-                sstableMetadataCollector))
+                                                                                null, ChecksumType.CRC32, SequentialWriterOption.DEFAULT,
+                                                                                compressionParameters,
+                                                                                sstableMetadataCollector))
         {
             Random r = new Random(42);
 
@@ -229,7 +230,7 @@ public class CompressedSequentialWriterTest extends SequentialWriterTest
                                                       MockCompressor.paramsFor(ratio, extra),
                                                       DEFAULT_CHUNK_LENGTH, ratio);
         try (CompressedSequentialWriter writer = new CompressedSequentialWriter(f, new File(f.path() + ".metadata"),
-                                                                                null, SequentialWriterOption.DEFAULT,
+                                                                                null, ChecksumType.CRC32, SequentialWriterOption.DEFAULT,
                                                                                 compressionParameters,
                                                                                 sstableMetadataCollector))
         {
@@ -289,7 +290,7 @@ public class CompressedSequentialWriterTest extends SequentialWriterTest
         final int writeSize = 64;
         byte[] toWrite = new byte[writeSize];
         try (SequentialWriter writer = new CompressedSequentialWriter(tempFile, offsetsFile,
-                                                                      digestFile, SequentialWriterOption.DEFAULT,
+                                                                      digestFile, ChecksumType.CRC32, SequentialWriterOption.DEFAULT,
                                                                       CompressionParams.lz4(bufferSize),
                                                                       new MetadataCollector(new ClusteringComparator(UTF8Type.instance))))
         {
@@ -349,7 +350,7 @@ public class CompressedSequentialWriterTest extends SequentialWriterTest
         private TestableCSW(File file, File offsetsFile) throws IOException
         {
             this(file, offsetsFile, new CompressedSequentialWriter(file, offsetsFile,
-                                                                   null, SequentialWriterOption.DEFAULT,
+                                                                   null, ChecksumType.CRC32, SequentialWriterOption.DEFAULT,
                                                                    CompressionParams.lz4(BUFFER_SIZE, MAX_COMPRESSED),
                                                                    new MetadataCollector(new ClusteringComparator(UTF8Type.instance))));
 

--- a/test/unit/org/apache/cassandra/io/sstable/VerifyTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/VerifyTest.java
@@ -79,6 +79,7 @@ import org.apache.cassandra.schema.CompressionParams;
 import org.apache.cassandra.schema.KeyspaceParams;
 import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.ChecksumType;
 import org.apache.cassandra.utils.OutputHandler;
 
 import static org.apache.cassandra.SchemaLoader.counterCFMD;
@@ -361,6 +362,57 @@ public class VerifyTest
         }
     }
 
+    private void testVerifyDigest(ChecksumType checksumType, Component digestComponent) throws Exception
+    {
+        CompactionManager.instance.disableAutoCompaction();
+        Keyspace keyspace = Keyspace.open(KEYSPACE);
+        ColumnFamilyStore cfs = keyspace.getColumnFamilyStore(CF);
+
+        fillCF(cfs, 2);
+
+        SSTableReader sstable = cfs.getLiveSSTables().iterator().next();
+
+        // Delete default digest file
+        sstable.descriptor.fileFor(Components.DIGEST).delete();
+
+        File digestFile = sstable.descriptor.fileFor(digestComponent);
+        File dataFile = sstable.descriptor.fileFor(Components.DATA);
+
+        byte[] bytes = Files.readAllBytes(dataFile.toPath());
+        long correctChecksum = checksumType.of(bytes, 0, bytes.length);
+        writeChecksum(correctChecksum, digestFile);
+
+        try (IVerifier verifier = sstable.getVerifier(cfs, new OutputHandler.LogOutput(), false, IVerifier.options().invokeDiskFailurePolicy(true).build()))
+        {
+            verifier.verify();
+        }
+        catch (CorruptSSTableException err)
+        {
+            fail("Unexpected CorruptSSTableException");
+        }
+
+        writeChecksum(++correctChecksum, digestFile);
+
+        try (IVerifier verifier = sstable.getVerifier(cfs, new OutputHandler.LogOutput(), false, IVerifier.options().invokeDiskFailurePolicy(true).build()))
+        {
+            verifier.verify();
+            fail("Expected a CorruptSSTableException to be thrown");
+        }
+        catch (CorruptSSTableException err) {}
+
+    }
+
+    @Test
+    public void testVerifyDigestCRC32C() throws Exception
+    {
+        testVerifyDigest(ChecksumType.CRC32C, Components.DIGEST_CRC32C);
+    }
+
+    @Test
+    public void testVerifyDigestCRC64NVME() throws Exception
+    {
+        testVerifyDigest(ChecksumType.CRC64NVME, Components.DIGEST_CRC64NVME);
+    }
 
     @Test
     public void testVerifyCorruptRowCorrectDigest() throws IOException, WriteTimeoutException

--- a/test/unit/org/apache/cassandra/io/sstable/VerifyTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/VerifyTest.java
@@ -367,6 +367,7 @@ public class VerifyTest
         CompactionManager.instance.disableAutoCompaction();
         Keyspace keyspace = Keyspace.open(KEYSPACE);
         ColumnFamilyStore cfs = keyspace.getColumnFamilyStore(CF);
+        cfs.truncateBlocking();
 
         fillCF(cfs, 2);
 

--- a/test/unit/org/apache/cassandra/io/sstable/VerifyTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/VerifyTest.java
@@ -399,7 +399,9 @@ public class VerifyTest
             verifier.verify();
             fail("Expected a CorruptSSTableException to be thrown");
         }
-        catch (CorruptSSTableException err) {}
+        catch (CorruptSSTableException expected)
+        {
+        }
 
     }
 

--- a/test/unit/org/apache/cassandra/io/sstable/format/bti/RowIndexCompressedTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/format/bti/RowIndexCompressedTest.java
@@ -32,6 +32,7 @@ import org.apache.cassandra.io.util.RandomAccessReader;
 import org.apache.cassandra.io.util.SequentialWriterOption;
 import org.apache.cassandra.schema.CompressionParams;
 import org.apache.cassandra.schema.TableMetadata;
+import org.apache.cassandra.utils.ChecksumType;
 
 import static org.junit.Assert.assertEquals;
 
@@ -56,6 +57,7 @@ public class RowIndexCompressedTest extends RowIndexTest
               new CompressedSequentialWriter(file,
                       offsetsFile,
                       null,
+                      ChecksumType.CRC32,
                       SequentialWriterOption.newBuilder().finishOnClose(true).build(),
                       CompressionParams.lz4(4096, 4096), new MetadataCollector(
                               TableMetadata.builder("k", "t")

--- a/test/unit/org/apache/cassandra/io/util/ChecksummedRandomAccessReaderTest.java
+++ b/test/unit/org/apache/cassandra/io/util/ChecksummedRandomAccessReaderTest.java
@@ -49,7 +49,7 @@ public class ChecksummedRandomAccessReaderTest
         final byte[] expected = new byte[70 * 1024];   // bit more than crc chunk size, so we can test rebuffering.
         ThreadLocalRandom.current().nextBytes(expected);
 
-        try (SequentialWriter writer = new ChecksummedSequentialWriter(data, crc, null, SequentialWriterOption.DEFAULT))
+        try (SequentialWriter writer = new ChecksummedSequentialWriter(data, crc, SequentialWriterOption.DEFAULT))
         {
             writer.write(expected);
             writer.finish();
@@ -77,7 +77,7 @@ public class ChecksummedRandomAccessReaderTest
         final byte[] dataBytes = new byte[70 * 1024];   // bit more than crc chunk size
         ThreadLocalRandom.current().nextBytes(dataBytes);
 
-        try (SequentialWriter writer = new ChecksummedSequentialWriter(data, crc, null, SequentialWriterOption.DEFAULT))
+        try (SequentialWriter writer = new ChecksummedSequentialWriter(data, crc, SequentialWriterOption.DEFAULT))
         {
             writer.write(dataBytes);
             writer.finish();
@@ -111,7 +111,7 @@ public class ChecksummedRandomAccessReaderTest
         final byte[] expected = new byte[5 * 1024];
         Arrays.fill(expected, (byte) 0);
 
-        try (SequentialWriter writer = new ChecksummedSequentialWriter(data, crc, null, SequentialWriterOption.DEFAULT))
+        try (SequentialWriter writer = new ChecksummedSequentialWriter(data, crc, SequentialWriterOption.DEFAULT))
         {
             writer.write(expected);
             writer.finish();

--- a/test/unit/org/apache/cassandra/io/util/ChecksummedSequentialWriterTest.java
+++ b/test/unit/org/apache/cassandra/io/util/ChecksummedSequentialWriterTest.java
@@ -66,7 +66,7 @@ public class ChecksummedSequentialWriterTest extends SequentialWriterTest
 
         private TestableCSW(File file, File crcFile) throws IOException
         {
-            this(file, crcFile, new ChecksummedSequentialWriter(file, crcFile, null, SequentialWriterOption.newBuilder()
+            this(file, crcFile, new ChecksummedSequentialWriter(file, crcFile, SequentialWriterOption.newBuilder()
                                                                                                            .bufferSize(BUFFER_SIZE)
                                                                                                            .build()));
         }

--- a/test/unit/org/apache/cassandra/io/util/CompressedChunkReaderTest.java
+++ b/test/unit/org/apache/cassandra/io/util/CompressedChunkReaderTest.java
@@ -27,6 +27,7 @@ import org.apache.cassandra.io.compress.CompressionMetadata;
 import org.apache.cassandra.io.filesystem.ListenableFileSystem;
 import org.apache.cassandra.io.sstable.metadata.MetadataCollector;
 import org.apache.cassandra.schema.CompressionParams;
+import org.apache.cassandra.utils.ChecksumType;
 import org.assertj.core.api.Assertions;
 
 import org.junit.Assert;
@@ -61,7 +62,7 @@ public class CompressedChunkReaderTest
             });
             long length = lengthGen.nextLong(rs);
             CompressionMetadata metadata1, metadata2;
-            try (CompressedSequentialWriter writer = new CompressedSequentialWriter(f, new File("/file.offset"), new File("/file.digest"), option, params, new MetadataCollector(new ClusteringComparator())))
+            try (CompressedSequentialWriter writer = new CompressedSequentialWriter(f, new File("/file.offset"), new File("/file.digest"), ChecksumType.CRC32, option, params, new MetadataCollector(new ClusteringComparator())))
             {
                 for (long i = 0; i < length; i++)
                     writer.writeLong(i);

--- a/test/unit/org/apache/cassandra/io/util/MmappedRegionsTest.java
+++ b/test/unit/org/apache/cassandra/io/util/MmappedRegionsTest.java
@@ -39,6 +39,7 @@ import org.apache.cassandra.io.compress.CompressionMetadata.Chunk;
 import org.apache.cassandra.io.sstable.metadata.MetadataCollector;
 import org.apache.cassandra.schema.CompressionParams;
 import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.ChecksumType;
 
 import static org.apache.cassandra.utils.Clock.Global.nanoTime;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -345,7 +346,7 @@ public class MmappedRegionsTest
 
         MetadataCollector sstableMetadataCollector = new MetadataCollector(new ClusteringComparator(BytesType.instance));
         try (SequentialWriter writer = new CompressedSequentialWriter(f, cf,
-                                                                      null, SequentialWriterOption.DEFAULT,
+                                                                      null, ChecksumType.CRC32, SequentialWriterOption.DEFAULT,
                                                                       CompressionParams.snappy(), sstableMetadataCollector))
         {
             writer.write(buffer);
@@ -428,7 +429,7 @@ public class MmappedRegionsTest
         cf.deleteOnExit();
 
         MetadataCollector sstableMetadataCollector = new MetadataCollector(new ClusteringComparator(BytesType.instance));
-        try (CompressedSequentialWriter writer = new CompressedSequentialWriter(f, cf, null,
+        try (CompressedSequentialWriter writer = new CompressedSequentialWriter(f, cf, null, ChecksumType.CRC32,
                                                                                 SequentialWriterOption.DEFAULT,
                                                                                 CompressionParams.deflate(chunkSize << 10),
                                                                                 sstableMetadataCollector))

--- a/test/unit/org/apache/cassandra/streaming/compression/CompressedInputStreamTest.java
+++ b/test/unit/org/apache/cassandra/streaming/compression/CompressedInputStreamTest.java
@@ -131,6 +131,7 @@ public class CompressedInputStreamTest
         try (CompressedSequentialWriter writer = new CompressedSequentialWriter(tmp,
                                                                                 desc.fileFor(Components.COMPRESSION_INFO),
                                                                                 null,
+                                                                                ChecksumType.CRC32,
                                                                                 SequentialWriterOption.DEFAULT,
                                                                                 param, collector))
         {

--- a/test/unit/org/apache/cassandra/utils/PureJavaCRC64NVMETest.java
+++ b/test/unit/org/apache/cassandra/utils/PureJavaCRC64NVMETest.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.utils;
+
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+// We use the same values to test as in AWS S3 SDK tests.
+// See https://github.com/aws/aws-sdk-java-v2/blob/0c5e331bd2544e7d43fabd3db046a95b94d0a2dd/core/checksums/src/test/java/software/amazon/awssdk/checksums/internal/Crc64NvmeChecksumTest.java
+public class PureJavaCRC64NVMETest
+{
+
+    private PureJavaCRC64NVME crc64NVME;
+    private static final String TEST_STRING = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+
+    @Before
+    public void setUp()
+    {
+        crc64NVME = new PureJavaCRC64NVME();
+    }
+
+    @Test
+    public void validateCrcChecksumValues()
+    {
+        byte[] bytes = TEST_STRING.getBytes(StandardCharsets.UTF_8);
+        crc64NVME.update(bytes, 0, bytes.length);
+        assertThat(getAsString(getAsBytes(crc64NVME.getValue()))).isEqualTo("0000000000000000000000008b8f30cfc6f16409");
+    }
+
+    @Test
+    public void validateEncodedBase64ForCrc()
+    {
+        crc64NVME.update("abc".getBytes(StandardCharsets.UTF_8));
+        String toBase64 = toBase64(crc64NVME.getValue());
+        assertThat(toBase64).isEqualTo("BeXKuz/B+us=");
+    }
+
+    @Test
+    public void validateEncodedBase64ForCrcSingleByte()
+    {
+        for (byte value : "abc".getBytes(StandardCharsets.UTF_8))
+        {
+            crc64NVME.update(value);
+        }
+        String toBase64 = toBase64(crc64NVME.getValue());
+        assertThat(toBase64).isEqualTo("BeXKuz/B+us=");
+    }
+
+    @Test
+    public void validateResetForCrc() {
+        crc64NVME.update("beta".getBytes(StandardCharsets.UTF_8));
+        crc64NVME.reset();
+        crc64NVME.update("alpha".getBytes(StandardCharsets.UTF_8));
+        String toBase64 = toBase64(crc64NVME.getValue());
+        // Checksum of "alpha"
+        assertThat(toBase64).isEqualTo("Ehnh98TMQlQ=");
+    }
+
+    private String toBase64(long value)
+    {
+        byte[] bytes = getAsBytes(value);
+        return Base64.getEncoder().encodeToString(bytes);
+    }
+
+    private byte[] getAsBytes(long value)
+    {
+        ByteBuffer buffer = ByteBuffer.allocate(Long.BYTES);
+        buffer.putLong(value);
+        return buffer.array();
+    }
+
+    private String getAsString(byte[] checksumBytes) {
+        return String.format("%040x", new BigInteger(1, checksumBytes));
+    }
+}

--- a/test/unit/org/apache/cassandra/utils/PureJavaCRC64NVMETest.java
+++ b/test/unit/org/apache/cassandra/utils/PureJavaCRC64NVMETest.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.utils;
+
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import software.amazon.awssdk.crt.checksums.CRC64NVME;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+// We use the same values to test as in AWS S3 SDK tests.
+// See https://github.com/aws/aws-sdk-java-v2/blob/0c5e331bd2544e7d43fabd3db046a95b94d0a2dd/core/checksums/src/test/java/software/amazon/awssdk/checksums/internal/Crc64NvmeChecksumTest.java
+public class PureJavaCRC64NVMETest
+{
+
+    private PureJavaCRC64NVME crc64NVME;
+    private static final String TEST_STRING = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+
+    @Before
+    public void setUp()
+    {
+        crc64NVME = new PureJavaCRC64NVME();
+    }
+
+    @Test
+    public void validateCrcChecksumValues()
+    {
+        byte[] bytes = TEST_STRING.getBytes(StandardCharsets.UTF_8);
+        crc64NVME.update(bytes, 0, bytes.length);
+        assertThat(getAsString(getAsBytes(crc64NVME.getValue()))).isEqualTo("0000000000000000000000008b8f30cfc6f16409");
+        CRC64NVME awsCrc64 = new CRC64NVME();
+        awsCrc64.update(bytes, 0, bytes.length);
+        assertThat(awsCrc64.getValue()).isEqualTo(crc64NVME.getValue());
+    }
+
+    @Test
+    public void validateEncodedBase64ForCrc()
+    {
+        crc64NVME.update("abc".getBytes(StandardCharsets.UTF_8));
+        String toBase64 = toBase64(crc64NVME.getValue());
+        assertThat(toBase64).isEqualTo("BeXKuz/B+us=");
+    }
+
+    @Test
+    public void validateEncodedBase64ForCrcSingleByte()
+    {
+        for (byte value : "abc".getBytes(StandardCharsets.UTF_8))
+        {
+            crc64NVME.update(value);
+        }
+        String toBase64 = toBase64(crc64NVME.getValue());
+        assertThat(toBase64).isEqualTo("BeXKuz/B+us=");
+    }
+
+    @Test
+    public void validateResetForCrc() {
+        crc64NVME.update("beta".getBytes(StandardCharsets.UTF_8));
+        crc64NVME.reset();
+        crc64NVME.update("alpha".getBytes(StandardCharsets.UTF_8));
+        String toBase64 = toBase64(crc64NVME.getValue());
+        // Checksum of "alpha"
+        assertThat(toBase64).isEqualTo("Ehnh98TMQlQ=");
+    }
+
+    private String toBase64(long value)
+    {
+        byte[] bytes = getAsBytes(value);
+        return Base64.getEncoder().encodeToString(bytes);
+    }
+
+    private byte[] getAsBytes(long value)
+    {
+        ByteBuffer buffer = ByteBuffer.allocate(Long.BYTES);
+        buffer.putLong(value);
+        return buffer.array();
+    }
+
+    private String getAsString(byte[] checksumBytes) {
+        return String.format("%040x", new BigInteger(1, checksumBytes));
+    }
+}


### PR DESCRIPTION
### What is the issue

https://github.com/riptano/cndb/issues/17829

### What does this PR fix and why was it fixed

This PR adds the possibility to configure the type of checksum written together with SSTables.
The config property `cassandra.sstable.checksums.type` can be set to `CRC32`, `CRC32C` and `CRC64NVME` (default `CRC32`). Respectively, a `Digest.crc`, `Digest.crc32c` or `Digest.crc64nvme` file will be written when an SSTable is committed to disk.

PR in CNDB: https://github.com/riptano/cndb/pull/19217
Port of https://github.com/datastax/cassandra/pull/2434 on `main-5.0` branch
