### PR TITLE
CNDB-18001: BM25 counter metrics for completed and timedout BM25 queries

### DIFF
--- a/src/java/org/apache/cassandra/db/ReadCommand.java
+++ b/src/java/org/apache/cassandra/db/ReadCommand.java
@@ -257,18 +257,18 @@ public abstract class ReadCommand extends AbstractReadQuery
         return indexQueryPlan != null && indexQueryPlan.usesIndexFiltering();
     }
 
+    @Override
+    public boolean isTopK()
+    {
+        return indexQueryPlan != null && indexQueryPlan.isTopK();
+    }
+
     /**
      * @return {@code true} if this command is a BM25 request, {@code false} otherwise
      */
     public boolean isBM25()
     {
         return indexQueryPlan != null && indexQueryPlan.isBM25();
-    }
-
-    @Override
-    public boolean isTopK()
-    {
-        return indexQueryPlan != null && indexQueryPlan.isTopK();
     }
 
     /**

--- a/src/java/org/apache/cassandra/db/ReadCommand.java
+++ b/src/java/org/apache/cassandra/db/ReadCommand.java
@@ -257,6 +257,14 @@ public abstract class ReadCommand extends AbstractReadQuery
         return indexQueryPlan != null && indexQueryPlan.usesIndexFiltering();
     }
 
+    /**
+     * @return {@code true} if this command is a BM25 request, {@code false} otherwise
+     */
+    public boolean isBM25()
+    {
+        return indexQueryPlan != null && indexQueryPlan.isBM25();
+    }
+
     @Override
     public boolean isTopK()
     {

--- a/src/java/org/apache/cassandra/index/Index.java
+++ b/src/java/org/apache/cassandra/index/Index.java
@@ -1106,6 +1106,14 @@ public interface Index
         }
 
         /**
+         * @return {@code true} if this plan is a BM25 request, {@code false} otherwise
+         */
+        default boolean isBM25()
+        {
+            return false;
+        }
+
+        /**
          * @return {@code true} if this plan uses index-based filtering, {@code false} otherwise
          */
         default boolean usesIndexFiltering()

--- a/src/java/org/apache/cassandra/index/sai/metrics/TableQueryMetrics.java
+++ b/src/java/org/apache/cassandra/index/sai/metrics/TableQueryMetrics.java
@@ -64,8 +64,12 @@ public class TableQueryMetrics
     /** Per query metrics for all kinds of queries (timers and histograms). */
     public final EnumMap<QueryKind, PerQuery> perQueryMetrics = new EnumMap<>(QueryKind.class);
 
+    /** Table-level BM25 counters that are not multiplexed by query kind. */
+    public final BM25PerTable bm25PerTable;
+
     public TableQueryMetrics(TableMetadata table)
     {
+        bm25PerTable = new BM25PerTable(table);
         addMetrics(table, QueryKind.ALL, cmd -> true);
         addMetrics(table, QueryKind.SP_FILTER_ONLY, cmd -> !cmd.isTopK() && cmd.usesIndexFiltering() && cmd.isSinglePartition()); // single-partition-queries that are filtering only
         addMetrics(table, QueryKind.MP_FILTER_ONLY, cmd -> !cmd.isTopK() && cmd.usesIndexFiltering() && !cmd.isSinglePartition()); // multi-partition queries that are filtering only
@@ -111,6 +115,7 @@ public class TableQueryMetrics
     public void record(QueryContext context, ReadCommand command)
     {
         QueryContext.Snapshot snapshot = context.snapshot();
+        bm25PerTable.record(snapshot, command);
         perTableMetrics.values().forEach(m -> m.record(snapshot, command));
         perQueryMetrics.values().forEach(m -> m.record(snapshot, command));
 
@@ -147,6 +152,7 @@ public class TableQueryMetrics
      */
     public void release()
     {
+        bm25PerTable.release();
         perTableMetrics.values().forEach(PerTable::release);
         perQueryMetrics.values().forEach(PerQuery::release);
     }
@@ -229,7 +235,7 @@ public class TableQueryMetrics
         }
 
         @Override
-        public void record(QueryContext.Snapshot snapshot)
+        protected void record(QueryContext.Snapshot snapshot)
         {
             if (snapshot.queryTimeouts > 0)
             {
@@ -281,6 +287,37 @@ public class TableQueryMetrics
 
                 sortThenFilterQueriesCompleted = Metrics.counter(createMetricName("SortThenFilterQueriesCompleted"));
                 filterThenSortQueriesCompleted = Metrics.counter(createMetricName("FilterThenSortQueriesCompleted"));
+            }
+        }
+    }
+
+    /**
+     * Table-level BM25 counters that are not multiplexed by query kind.
+     */
+    public static class BM25PerTable extends AbstractMetrics
+    {
+        public static final String METRIC_TYPE = PerTable.METRIC_TYPE;
+
+        public final Counter totalBM25QueriesCompleted;
+        public final Counter totalBM25QueryTimeouts;
+
+        public BM25PerTable(TableMetadata table)
+        {
+            super(table.keyspace, table.name, METRIC_TYPE);
+            totalBM25QueriesCompleted = Metrics.counter(createMetricName("TotalBM25QueriesCompleted"));
+            totalBM25QueryTimeouts = Metrics.counter(createMetricName("TotalBM25QueryTimeouts"));
+        }
+
+        public void record(QueryContext.Snapshot snapshot, ReadCommand command)
+        {
+            if (!command.isBM25())
+                return;
+
+            totalBM25QueriesCompleted.inc();
+            if (snapshot.queryTimeouts > 0)
+            {
+                assert snapshot.queryTimeouts == 1;
+                totalBM25QueryTimeouts.inc();
             }
         }
     }

--- a/src/java/org/apache/cassandra/index/sai/metrics/TableQueryMetrics.java
+++ b/src/java/org/apache/cassandra/index/sai/metrics/TableQueryMetrics.java
@@ -237,7 +237,7 @@ public class TableQueryMetrics
         }
 
         @Override
-        protected void record(QueryContext.Snapshot snapshot)
+        public void record(QueryContext.Snapshot snapshot)
         {
             if (snapshot.queryTimeouts > 0)
             {

--- a/src/java/org/apache/cassandra/index/sai/metrics/TableQueryMetrics.java
+++ b/src/java/org/apache/cassandra/index/sai/metrics/TableQueryMetrics.java
@@ -64,13 +64,9 @@ public class TableQueryMetrics
     /** Per query metrics for all kinds of queries (timers and histograms). */
     public final EnumMap<QueryKind, PerQuery> perQueryMetrics = new EnumMap<>(QueryKind.class);
 
-    /** Table-level BM25 counters that are not multiplexed by query kind. */
-    public final BM25PerTable bm25PerTable;
-
     public TableQueryMetrics(TableMetadata table)
     {
-        bm25PerTable = new BM25PerTable(table);
-        addMetrics(table, QueryKind.ALL, cmd -> true);
+        addMetrics(table, QueryKind.ALL, _ -> true);
         addMetrics(table, QueryKind.SP_FILTER_ONLY, cmd -> !cmd.isTopK() && cmd.usesIndexFiltering() && cmd.isSinglePartition()); // single-partition-queries that are filtering only
         addMetrics(table, QueryKind.MP_FILTER_ONLY, cmd -> !cmd.isTopK() && cmd.usesIndexFiltering() && !cmd.isSinglePartition()); // multi-partition queries that are filtering only
         addMetrics(table, QueryKind.SP_TOPK_ONLY, cmd -> cmd.isTopK() && !cmd.usesIndexFiltering() && cmd.isSinglePartition()); // single-partition queries that are top-k only
@@ -99,11 +95,19 @@ public class TableQueryMetrics
 
     private void addMetrics(TableMetadata table, QueryKind queryKind, Predicate<ReadCommand> filter)
     {
-        if (queryKind == QueryKind.ALL || CassandraRelevantProperties.SAI_QUERY_KIND_PER_TABLE_METRICS_ENABLED.getBoolean())
-            perTableMetrics.put(queryKind, new PerTable(table, queryKind, filter));
-
-        if (queryKind == QueryKind.ALL || CassandraRelevantProperties.SAI_QUERY_KIND_PER_QUERY_METRICS_ENABLED.getBoolean())
+        if (queryKind == QueryKind.ALL)
+        {
+            perTableMetrics.put(queryKind, new PerTableAll(table, queryKind, filter));
             perQueryMetrics.put(queryKind, new PerQuery(table, queryKind, filter));
+        }
+        else
+        {
+            if (CassandraRelevantProperties.SAI_QUERY_KIND_PER_TABLE_METRICS_ENABLED.getBoolean())
+                perTableMetrics.put(queryKind, new PerTable(table, queryKind, filter));
+
+            if (CassandraRelevantProperties.SAI_QUERY_KIND_PER_QUERY_METRICS_ENABLED.getBoolean())
+                perQueryMetrics.put(queryKind, new PerQuery(table, queryKind, filter));
+        }
     }
 
     /**
@@ -115,7 +119,6 @@ public class TableQueryMetrics
     public void record(QueryContext context, ReadCommand command)
     {
         QueryContext.Snapshot snapshot = context.snapshot();
-        bm25PerTable.record(snapshot, command);
         perTableMetrics.values().forEach(m -> m.record(snapshot, command));
         perQueryMetrics.values().forEach(m -> m.record(snapshot, command));
 
@@ -152,7 +155,6 @@ public class TableQueryMetrics
      */
     public void release()
     {
-        bm25PerTable.release();
         perTableMetrics.values().forEach(PerTable::release);
         perQueryMetrics.values().forEach(PerQuery::release);
     }
@@ -177,7 +179,7 @@ public class TableQueryMetrics
             this.filter = filter;
         }
 
-        public final void record(QueryContext.Snapshot snapshot, ReadCommand command)
+        public void record(QueryContext.Snapshot snapshot, ReadCommand command)
         {
             if (filter.test(command))
                 record(snapshot);
@@ -291,34 +293,29 @@ public class TableQueryMetrics
         }
     }
 
-    /**
-     * Table-level BM25 counters that are not multiplexed by query kind.
-     */
-    public static class BM25PerTable extends AbstractMetrics
+    public static class PerTableAll extends PerTable
     {
-        public static final String METRIC_TYPE = PerTable.METRIC_TYPE;
-
         public final Counter totalBM25QueriesCompleted;
-        public final Counter totalBM25QueryTimeouts;
 
-        public BM25PerTable(TableMetadata table)
+        public PerTableAll(TableMetadata table, QueryKind queryKind, Predicate<ReadCommand> filter)
         {
-            super(table.keyspace, table.name, METRIC_TYPE);
+            super(table, queryKind, filter);
             totalBM25QueriesCompleted = Metrics.counter(createMetricName("TotalBM25QueriesCompleted"));
-            totalBM25QueryTimeouts = Metrics.counter(createMetricName("TotalBM25QueryTimeouts"));
         }
 
-        public void record(QueryContext.Snapshot snapshot, ReadCommand command)
+        @Override
+        protected void record(QueryContext.Snapshot snapshot)
         {
-            if (!command.isBM25())
-                return;
+            super.record(snapshot);
+        }
 
-            totalBM25QueriesCompleted.inc();
-            if (snapshot.queryTimeouts > 0)
-            {
-                assert snapshot.queryTimeouts == 1;
-                totalBM25QueryTimeouts.inc();
-            }
+        @Override
+        public final void record(QueryContext.Snapshot snapshot, ReadCommand command)
+        {
+            super.record(snapshot, command);
+
+            if (command.isBM25())
+                totalBM25QueriesCompleted.inc();
         }
     }
 
@@ -408,7 +405,7 @@ public class TableQueryMetrics
         }
 
         @Override
-        public void record(QueryContext.Snapshot snapshot)
+        protected void record(QueryContext.Snapshot snapshot)
         {
             queryLatency.ifPresent(timer -> timer.update(snapshot.totalQueryTimeNs, TimeUnit.NANOSECONDS));
             sstablesHit.update(snapshot.sstablesHit);

--- a/src/java/org/apache/cassandra/index/sai/metrics/TableQueryMetrics.java
+++ b/src/java/org/apache/cassandra/index/sai/metrics/TableQueryMetrics.java
@@ -304,7 +304,7 @@ public class TableQueryMetrics
         }
 
         @Override
-        protected void record(QueryContext.Snapshot snapshot)
+        public void record(QueryContext.Snapshot snapshot)
         {
             super.record(snapshot);
         }
@@ -405,7 +405,7 @@ public class TableQueryMetrics
         }
 
         @Override
-        protected void record(QueryContext.Snapshot snapshot)
+        public void record(QueryContext.Snapshot snapshot)
         {
             queryLatency.ifPresent(timer -> timer.update(snapshot.totalQueryTimeNs, TimeUnit.NANOSECONDS));
             sstablesHit.update(snapshot.sstablesHit);

--- a/src/java/org/apache/cassandra/index/sai/metrics/TableQueryMetrics.java
+++ b/src/java/org/apache/cassandra/index/sai/metrics/TableQueryMetrics.java
@@ -66,7 +66,7 @@ public class TableQueryMetrics
 
     public TableQueryMetrics(TableMetadata table)
     {
-        addMetrics(table, QueryKind.ALL, _ -> true);
+        addMetrics(table, QueryKind.ALL, cmd -> true);
         addMetrics(table, QueryKind.SP_FILTER_ONLY, cmd -> !cmd.isTopK() && cmd.usesIndexFiltering() && cmd.isSinglePartition()); // single-partition-queries that are filtering only
         addMetrics(table, QueryKind.MP_FILTER_ONLY, cmd -> !cmd.isTopK() && cmd.usesIndexFiltering() && !cmd.isSinglePartition()); // multi-partition queries that are filtering only
         addMetrics(table, QueryKind.SP_TOPK_ONLY, cmd -> cmd.isTopK() && !cmd.usesIndexFiltering() && cmd.isSinglePartition()); // single-partition queries that are top-k only

--- a/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexQueryPlan.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexQueryPlan.java
@@ -257,6 +257,12 @@ public class StorageAttachedIndexQueryPlan implements Index.QueryPlan
     }
 
     @Override
+    public boolean isBM25()
+    {
+        return orderer != null && orderer.isBM25();
+    }
+
+    @Override
     public boolean usesIndexFiltering()
     {
         return usesIndexFiltering;

--- a/test/unit/org/apache/cassandra/index/sai/metrics/QueryMetricsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/metrics/QueryMetricsTest.java
@@ -433,36 +433,40 @@ public class QueryMetricsTest extends AbstractMetricsTest
     @Test
     public void testQueryKindFlags()
     {
-        createTable("CREATE TABLE %s (k int, c int, n int, s text, v vector<float, 2>, PRIMARY KEY(k, c))");
+        createTable("CREATE TABLE %s (k int, c int, n int, s text, t text, v vector<float, 2>, PRIMARY KEY(k, c))");
 
         // test without indexes
-        assertQueryTypeFlags("SELECT * FROM %s", false, false);
-        assertQueryTypeFlags("SELECT * FROM %s WHERE n = 1 ALLOW FILTERING", false, false);
+        assertQueryTypeFlags("SELECT * FROM %s", false, false, false);
+        assertQueryTypeFlags("SELECT * FROM %s WHERE n = 1 ALLOW FILTERING", false, false, false);
 
         // test with legacy indexes
         String idx = createIndex("CREATE INDEX ON %s(n)");
-        assertQueryTypeFlags("SELECT * FROM %s", false, false);
-        assertQueryTypeFlags("SELECT * FROM %s WHERE n = 1", false, true);
-        assertQueryTypeFlags("SELECT * FROM %s WHERE n = 1 AND s = 'a' ALLOW FILTERING", false, true);
-        assertQueryTypeFlags("SELECT * FROM %s WHERE n = 1 OR s = 'a' ALLOW FILTERING", false, false);
+        assertQueryTypeFlags("SELECT * FROM %s", false, false, false);
+        assertQueryTypeFlags("SELECT * FROM %s WHERE n = 1", false, true, false);
+        assertQueryTypeFlags("SELECT * FROM %s WHERE n = 1 AND s = 'a' ALLOW FILTERING", false, true, false);
+        assertQueryTypeFlags("SELECT * FROM %s WHERE n = 1 OR s = 'a' ALLOW FILTERING", false, false, false);
 
         // test with SAI indexes
         dropIndex("DROP INDEX %s." + idx);
         createIndex("CREATE CUSTOM INDEX ON %s(n) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
-        assertQueryTypeFlags("SELECT * FROM %s", false, false);
-        assertQueryTypeFlags("SELECT * FROM %s WHERE n = 1", false, true);
-        assertQueryTypeFlags("SELECT * FROM %s WHERE n = 1 AND s = 'a' ALLOW FILTERING", false, true);
-        assertQueryTypeFlags("SELECT * FROM %s WHERE n = 1 OR s = 'a' ALLOW FILTERING", false, false);
-        assertQueryTypeFlags("SELECT * FROM %s ORDER BY v ANN OF [1, 1] LIMIT 10", true, false);
-        assertQueryTypeFlags("SELECT * FROM %s WHERE n=1 ORDER BY v ANN OF [1, 1] LIMIT 10", true, true);
+        createIndex("CREATE CUSTOM INDEX ON %s(t) USING 'StorageAttachedIndex' WITH OPTIONS = {'index_analyzer': 'standard', 'query_analyzer': 'standard'}");
+        assertQueryTypeFlags("SELECT * FROM %s", false, false, false);
+        assertQueryTypeFlags("SELECT * FROM %s WHERE n = 1", false, true, false);
+        assertQueryTypeFlags("SELECT * FROM %s WHERE n = 1 AND s = 'a' ALLOW FILTERING", false, true, false);
+        assertQueryTypeFlags("SELECT * FROM %s WHERE n = 1 OR s = 'a' ALLOW FILTERING", false, false, false);
+        assertQueryTypeFlags("SELECT * FROM %s ORDER BY v ANN OF [1, 1] LIMIT 10", true, false, false);
+        assertQueryTypeFlags("SELECT * FROM %s WHERE n=1 ORDER BY v ANN OF [1, 1] LIMIT 10", true, true, false);
+        assertQueryTypeFlags("SELECT * FROM %s ORDER BY t BM25 OF 'foo' LIMIT 10", true, false, true);
+        assertQueryTypeFlags("SELECT * FROM %s WHERE n = 1 ORDER BY t BM25 OF 'foo' LIMIT 10", true, true, true);
     }
 
-    private void assertQueryTypeFlags(String query, boolean expectedIsTopK, boolean expectedUsesIndexFiltering)
+    private void assertQueryTypeFlags(String query, boolean expectedIsTopK, boolean expectedUsesIndexFiltering, boolean expectedIsBM25)
     {
         ReadCommand command = parseReadCommand(query);
         Assert.assertEquals(expectedIsTopK, command.isTopK());
         Assert.assertEquals(expectedUsesIndexFiltering, command.usesIndexFiltering());
+        Assert.assertEquals(expectedIsBM25, command.isBM25());
     }
 
     /**
@@ -659,6 +663,39 @@ public class QueryMetricsTest extends AbstractMetricsTest
         waitForHistogramCountEqualsIfExists(hasPerQueryKindMetrics, objectName(name, PER_MP_TOPK_QUERY_METRIC_TYPE), 1);
         waitForHistogramCountEqualsIfExists(hasPerQueryKindMetrics, objectName(name, PER_SP_HYBRID_QUERY_METRIC_TYPE), 2);
         waitForHistogramCountEqualsIfExists(hasPerQueryKindMetrics, objectName(name, PER_MP_HYBRID_QUERY_METRIC_TYPE), 2);
+    }
+
+    @Test
+    public void testBM25Metrics()
+    {
+        createTable("CREATE TABLE %s (k int, c int, n int, s text, v vector<float, 2>, PRIMARY KEY(k, c))");
+        createIndex("CREATE CUSTOM INDEX ON %s(n) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX ON %s(s) USING 'StorageAttachedIndex' WITH OPTIONS = {'index_analyzer': 'standard', 'query_analyzer': 'standard'}");
+
+        for (int k = 0; k < 3; k++)
+            for (int c = 0; c < 4; c++)
+                execute("INSERT INTO %s (k, c, n, s, v) VALUES (?, ?, ?, ?, [1, 1])", k, c, 1, "foo bar baz");
+
+        UntypedResultSet rows = execute("SELECT k, c FROM %s ORDER BY s BM25 OF 'foo' LIMIT 100");
+        assertEquals(12, rows.size());
+
+        rows = execute("SELECT k, c FROM %s WHERE k = 0 ORDER BY s BM25 OF 'foo' LIMIT 100");
+        assertEquals(4, rows.size());
+
+        rows = execute("SELECT k, c FROM %s WHERE n = 1 ORDER BY s BM25 OF 'foo' LIMIT 100");
+        assertEquals(12, rows.size());
+
+        rows = execute("SELECT k, c FROM %s WHERE k = 0 AND n = 1 ORDER BY s BM25 OF 'foo' LIMIT 100");
+        assertEquals(4, rows.size());
+
+        rows = execute("SELECT k, c FROM %s ORDER BY v ANN OF [1, 1] LIMIT 100");
+        assertEquals(12, rows.size());
+
+        waitForEquals(objectName("TotalBM25QueriesCompleted", TABLE_QUERY_METRIC_TYPE), 4);
+        waitForEquals(objectName("TotalBM25QueryTimeouts", TABLE_QUERY_METRIC_TYPE), 0);
+        waitForEquals(objectName("TotalQueriesCompleted", TABLE_QUERY_METRIC_TYPE), 5);
+        waitForEquals(objectName("TotalQueryTimeouts", TABLE_QUERY_METRIC_TYPE), 0);
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/index/sai/metrics/QueryMetricsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/metrics/QueryMetricsTest.java
@@ -693,7 +693,6 @@ public class QueryMetricsTest extends AbstractMetricsTest
         assertEquals(12, rows.size());
 
         waitForEquals(objectName("TotalBM25QueriesCompleted", TABLE_QUERY_METRIC_TYPE), 4);
-        waitForEquals(objectName("TotalBM25QueryTimeouts", TABLE_QUERY_METRIC_TYPE), 0);
         waitForEquals(objectName("TotalQueriesCompleted", TABLE_QUERY_METRIC_TYPE), 5);
         waitForEquals(objectName("TotalQueryTimeouts", TABLE_QUERY_METRIC_TYPE), 0);
     }


### PR DESCRIPTION
### What is the issue
...
#18001
### What does this PR fix and why was it fixed
...
We want to have counters of how many BM25 queries are executed. We introduce with this PR two counters - one for number of BM25 queries completed, and one for number of BM25 queries which timed out. 