### PR TITLE
CNDB-17983: Redact expressions and orderers in SAI query plan

### DIFF
--- a/src/java/org/apache/cassandra/cql3/CqlBuilder.java
+++ b/src/java/org/apache/cassandra/cql3/CqlBuilder.java
@@ -29,6 +29,7 @@ import com.google.common.annotations.VisibleForTesting;
 import org.apache.cassandra.cql3.functions.FunctionName;
 import org.apache.cassandra.db.filter.RowFilter;
 import org.apache.cassandra.db.marshal.AbstractType;
+import org.apache.cassandra.db.marshal.Redaction;
 
 /**
  * Utility class to facilitate the creation of the CQL representation of {@code SchemaElements}.
@@ -285,12 +286,12 @@ public final class CqlBuilder
      *
      * @param filter the row filter to append
      * @param hasKeyRestrictions whether the query has key restrictions that have already been appended
-     * @param redact whether to redact the column values in the row filter
+     * @param redaction whether to redact the column values in the row filter
      * @return this CQL builder after appending the row filter
      */
-    public CqlBuilder append(RowFilter filter, boolean hasKeyRestrictions, boolean redact)
+    public CqlBuilder append(RowFilter filter, boolean hasKeyRestrictions, Redaction redaction)
     {
-        return filter.isEmpty() ? this : appendRestrictions(filter.toCQLString(redact), hasKeyRestrictions);
+        return filter.isEmpty() ? this : appendRestrictions(filter.toCQLString(redaction), hasKeyRestrictions);
     }
 
     /**

--- a/src/java/org/apache/cassandra/db/AbstractReadQuery.java
+++ b/src/java/org/apache/cassandra/db/AbstractReadQuery.java
@@ -19,8 +19,6 @@ package org.apache.cassandra.db;
 
 import java.util.Set;
 
-import com.google.common.annotations.VisibleForTesting;
-
 import org.apache.cassandra.cql3.ColumnIdentifier;
 import org.apache.cassandra.cql3.CqlBuilder;
 import org.apache.cassandra.cql3.statements.SelectOptions;
@@ -28,6 +26,7 @@ import org.apache.cassandra.db.filter.ColumnFilter;
 import org.apache.cassandra.db.filter.DataLimits;
 import org.apache.cassandra.db.filter.IndexHints;
 import org.apache.cassandra.db.filter.RowFilter;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.db.monitoring.MonitorableImpl;
 import org.apache.cassandra.db.partitions.PartitionIterator;
 import org.apache.cassandra.db.partitions.UnfilteredPartitionIterators;
@@ -64,7 +63,7 @@ abstract class AbstractReadQuery extends MonitorableImpl implements ReadQuery
     // Monitorable interface
     public String name()
     {
-        return toRedactedCQLString();
+        return toCQLString(Redaction.REDACT);
     }
 
     @Override
@@ -98,27 +97,6 @@ abstract class AbstractReadQuery extends MonitorableImpl implements ReadQuery
     }
 
     /**
-     * Recreates the CQL string corresponding to this query, representing any specific values with '?',
-     * to prevent leaking sensitive data.
-     * @see #toCQLString(boolean)
-     */
-    public String toRedactedCQLString()
-    {
-        return toCQLString(true);
-    }
-
-    /**
-     * Recreates the CQL string corresponding to this query, printing specific values without any redaction.
-     * This might leak sensitive data if the query string ends up in logs or any other unprotected place, so this only
-     * should be used for debugging purposes or to present the query string to the same end user that created the query.
-     * @see #toCQLString(boolean)
-     */
-    public String toUnredactedCQLString()
-    {
-        return toCQLString(false);
-    }
-
-    /**
      * Recreates the CQL string corresponding to this query.
      * </p>
      * If the {@code redact} parameter is set to {@code true}, the query string will be redacted, replacing any specific
@@ -133,18 +111,17 @@ abstract class AbstractReadQuery extends MonitorableImpl implements ReadQuery
      * we query them all). So this shouldn't be relied upon too strongly, but this should be good enough for
      * debugging purposes which is what this is for.
      *
-     * @param redact whether to redact the queried column values.
+     * @param redaction whether to redact the queried column values.
      */
-    @VisibleForTesting
-    protected String toCQLString(boolean redact)
+    public String toCQLString(Redaction redaction)
     {
         CqlBuilder builder = new CqlBuilder();
-        builder.append("SELECT ").append(columnFilter().toCQLString(redact));
+        builder.append("SELECT ").append(columnFilter().toCQLString(redaction));
         builder.append(" FROM ").append(ColumnIdentifier.maybeQuote(metadata().keyspace))
                .append('.')
                .append(ColumnIdentifier.maybeQuote(metadata().name));
 
-        appendCQLWhereClause(builder, redact);
+        appendCQLWhereClause(builder, redaction);
 
         if (limits() != DataLimits.NONE)
             builder.append(' ').append(limits());
@@ -164,5 +141,5 @@ abstract class AbstractReadQuery extends MonitorableImpl implements ReadQuery
         return builder.toString();
     }
 
-    protected abstract void appendCQLWhereClause(CqlBuilder builder, boolean redact);
+    protected abstract void appendCQLWhereClause(CqlBuilder builder, Redaction redaction);
 }

--- a/src/java/org/apache/cassandra/db/Clustering.java
+++ b/src/java/org/apache/cassandra/db/Clustering.java
@@ -23,6 +23,7 @@ import java.nio.ByteBuffer;
 import java.util.List;
 
 import org.apache.cassandra.db.marshal.ByteArrayAccessor;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.db.marshal.AbstractType;
@@ -78,14 +79,14 @@ public interface Clustering<V> extends ClusteringPrefix<V>
         return sb.toString();
     }
 
-    default String toCQLString(TableMetadata metadata, boolean redact)
+    default String toCQLString(TableMetadata metadata, Redaction redaction)
     {
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < size(); i++)
         {
             ColumnMetadata c = metadata.clusteringColumns().get(i);
             ByteBuffer value = bufferAt(i);
-            sb.append(i == 0 ? "" : ", ").append(c.type.toCQLString(value, redact));
+            sb.append(i == 0 ? "" : ", ").append(c.type.toCQLString(value, redaction));
         }
         return sb.toString();
     }

--- a/src/java/org/apache/cassandra/db/DataRange.java
+++ b/src/java/org/apache/cassandra/db/DataRange.java
@@ -19,6 +19,7 @@ package org.apache.cassandra.db;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.db.filter.*;
@@ -271,7 +272,7 @@ public class DataRange
         return String.format("range=%s pfilter=%s", keyRange.getString(metadata.partitionKeyType), clusteringIndexFilter.toString(metadata));
     }
 
-    public String toCQLString(TableMetadata metadata, boolean redact)
+    public String toCQLString(TableMetadata metadata, Redaction redaction)
     {
         if (isUnrestricted())
             return "";
@@ -283,20 +284,20 @@ public class DataRange
              * key are the same. If that is the case, we want to print the query as an equality on the partition key
              * rather than a token range, as if it was a partition query, for better readability.
              */
-            return ((DecoratedKey) startKey()).toCQLString(metadata, redact);
+            return ((DecoratedKey) startKey()).toCQLString(metadata, redaction);
         }
         else
         {
             StringBuilder builder = new StringBuilder();
             if (!startKey().isMinimum())
             {
-                appendCQLClause(startKey(), builder, metadata, true, keyRange.isStartInclusive(), redact);
+                appendCQLClause(startKey(), builder, metadata, true, keyRange.isStartInclusive(), redaction);
             }
             if (!stopKey().isMinimum())
             {
                 if (builder.length() > 0)
                     builder.append(" AND ");
-                appendCQLClause(stopKey(), builder, metadata, false, keyRange.isEndInclusive(), redact);
+                appendCQLClause(stopKey(), builder, metadata, false, keyRange.isEndInclusive(), redaction);
             }
             return builder.toString();
         }
@@ -307,7 +308,7 @@ public class DataRange
                                  TableMetadata metadata,
                                  boolean isStart,
                                  boolean isInclusive,
-                                 boolean redact)
+                                 Redaction redaction)
     {
         builder.append("token(");
         builder.append(ColumnMetadata.toCQLString(metadata.partitionKeyColumns()));
@@ -316,14 +317,14 @@ public class DataRange
         {
             builder.append(getOperator(isStart, isInclusive)).append(' ');
             builder.append("token(");
-            appendKeyString(builder, metadata.partitionKeyType, ((DecoratedKey)pos).getKey(), redact);
+            appendKeyString(builder, metadata.partitionKeyType, ((DecoratedKey)pos).getKey(), redaction);
             builder.append(')');
         }
         else
         {
             Token.KeyBound keyBound = (Token.KeyBound) pos;
             builder.append(getOperator(isStart, isStart == keyBound.isMinimumBound)).append(' ');
-            builder.append(redact ? "?" : keyBound.getToken());
+            builder.append(redaction == Redaction.REDACT ? "?" : keyBound.getToken());
         }
     }
 
@@ -336,18 +337,18 @@ public class DataRange
 
     // TODO: this is reused in SinglePartitionReadCommand but this should not really be here. Ideally
     // we need a more "native" handling of composite partition keys.
-    public static void appendKeyString(StringBuilder builder, AbstractType<?> type, ByteBuffer key, boolean redact)
+    public static void appendKeyString(StringBuilder builder, AbstractType<?> type, ByteBuffer key, Redaction redaction)
     {
         if (type instanceof CompositeType)
         {
             CompositeType ct = (CompositeType)type;
             ByteBuffer[] values = ct.split(key);
             for (int i = 0; i < ct.subTypes().size(); i++)
-                builder.append(i == 0 ? "" : ", ").append(ct.subTypes().get(i).toCQLString(values[i], redact));
+                builder.append(i == 0 ? "" : ", ").append(ct.subTypes().get(i).toCQLString(values[i], redaction));
         }
         else
         {
-            builder.append(type.toCQLString(key, redact));
+            builder.append(type.toCQLString(key, redaction));
         }
     }
 

--- a/src/java/org/apache/cassandra/db/DecoratedKey.java
+++ b/src/java/org/apache/cassandra/db/DecoratedKey.java
@@ -24,6 +24,7 @@ import java.util.StringJoiner;
 import java.util.function.BiFunction;
 
 import org.apache.cassandra.db.marshal.CompositeType;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.dht.IPartitioner;
 import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.dht.Token.KeyBound;
@@ -172,27 +173,27 @@ public abstract class DecoratedKey implements PartitionPosition, FilterKey
      * For multi-column keys: "k1 = 1 AND k2 = 2"
      *
      * @param metadata the table metadata
-     * @param redact whether to redact the key value, as in "k1 = ? AND k2 = ?".
+     * @param redaction whether to redact the key value, as in "k1 = ? AND k2 = ?".
      */
-    public String toCQLString(TableMetadata metadata, boolean redact)
+    public String toCQLString(TableMetadata metadata, Redaction redaction)
     {
         List<ColumnMetadata> columns = metadata.partitionKeyColumns();
 
         if (columns.size() == 1)
-            return toCQLString(columns.get(0), getKey(), redact);
+            return toCQLString(columns.get(0), getKey(), redaction);
 
         ByteBuffer[] values = ((CompositeType) metadata.partitionKeyType).split(getKey());
         StringJoiner joiner = new StringJoiner(" AND ");
 
         for (int i = 0; i < columns.size(); i++)
-            joiner.add(toCQLString(columns.get(i), values[i], redact));
+            joiner.add(toCQLString(columns.get(i), values[i], redaction));
 
         return joiner.toString();
     }
 
-    private static String toCQLString(ColumnMetadata metadata, ByteBuffer key, boolean redact)
+    private static String toCQLString(ColumnMetadata metadata, ByteBuffer key, Redaction redaction)
     {
-        return String.format("%s = %s", metadata.name.toCQLString(), metadata.type.toCQLString(key, redact));
+        return String.format("%s = %s", metadata.name.toCQLString(), metadata.type.toCQLString(key, redaction));
     }
 
     public Token getToken()

--- a/src/java/org/apache/cassandra/db/MultiPartitionReadQuery.java
+++ b/src/java/org/apache/cassandra/db/MultiPartitionReadQuery.java
@@ -19,6 +19,7 @@ package org.apache.cassandra.db;
 import java.util.List;
 
 import org.apache.cassandra.cql3.CqlBuilder;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.schema.TableMetadata;
 
 /**
@@ -28,18 +29,18 @@ public interface MultiPartitionReadQuery extends ReadQuery
 {
     List<DataRange> ranges();
 
-    default void appendCQLWhereClause(CqlBuilder builder, boolean redact)
+    default void appendCQLWhereClause(CqlBuilder builder, Redaction redaction)
     {
         // Append the data ranges.
         TableMetadata metadata = metadata();
-        boolean hasRanges = appendRanges(builder, redact);
+        boolean hasRanges = appendRanges(builder, redaction);
 
         // Append the clustering index filter and the row filter.
-        String filter = ranges().get(0).clusteringIndexFilter.toCQLString(metadata, rowFilter(), redact);
+        String filter = ranges().get(0).clusteringIndexFilter.toCQLString(metadata, rowFilter(), redaction);
         builder.appendRestrictions(filter, hasRanges);
     }
 
-    private boolean appendRanges(CqlBuilder builder, boolean redact)
+    private boolean appendRanges(CqlBuilder builder, Redaction redaction)
     {
         List<DataRange> ranges = ranges();
         if (ranges.size() == 1)
@@ -48,7 +49,7 @@ public interface MultiPartitionReadQuery extends ReadQuery
             if (range.isUnrestricted())
                 return false;
 
-            String rangeString = range.toCQLString(metadata(), redact);
+            String rangeString = range.toCQLString(metadata(), redaction);
             if (!rangeString.isEmpty())
             {
                 builder.append(" WHERE ").append(rangeString);
@@ -62,7 +63,7 @@ public interface MultiPartitionReadQuery extends ReadQuery
             {
                 if (i > 0)
                     builder.append(" OR ");
-                builder.append(ranges.get(i).toCQLString(metadata(), redact));
+                builder.append(ranges.get(i).toCQLString(metadata(), redaction));
             }
             builder.append(')');
             return true;

--- a/src/java/org/apache/cassandra/db/MultiRangeReadCommand.java
+++ b/src/java/org/apache/cassandra/db/MultiRangeReadCommand.java
@@ -32,6 +32,7 @@ import org.apache.cassandra.db.filter.ClusteringIndexFilter;
 import org.apache.cassandra.db.filter.ColumnFilter;
 import org.apache.cassandra.db.filter.DataLimits;
 import org.apache.cassandra.db.filter.RowFilter;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.db.partitions.PartitionIterator;
 import org.apache.cassandra.db.partitions.UnfilteredPartitionIterator;
 import org.apache.cassandra.db.partitions.UnfilteredPartitionIterators;
@@ -321,9 +322,9 @@ public class MultiRangeReadCommand extends ReadCommand implements MultiPartition
     }
 
     @Override
-    public void appendCQLWhereClause(CqlBuilder builder, boolean redact)
+    public void appendCQLWhereClause(CqlBuilder builder, Redaction redaction)
     {
-        MultiPartitionReadQuery.super.appendCQLWhereClause(builder, redact);
+        MultiPartitionReadQuery.super.appendCQLWhereClause(builder, redaction);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/PartitionRangeReadCommand.java
+++ b/src/java/org/apache/cassandra/db/PartitionRangeReadCommand.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.cassandra.cql3.CqlBuilder;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.db.memtable.Memtable;
 import org.apache.cassandra.net.Verb;
 import org.apache.cassandra.schema.TableMetadata;
@@ -391,9 +392,9 @@ public class PartitionRangeReadCommand extends ReadCommand implements PartitionR
     }
 
     @Override
-    public void appendCQLWhereClause(CqlBuilder builder, boolean redact)
+    public void appendCQLWhereClause(CqlBuilder builder, Redaction redaction)
     {
-        PartitionRangeReadQuery.super.appendCQLWhereClause(builder, redact);
+        PartitionRangeReadQuery.super.appendCQLWhereClause(builder, redaction);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/ReadCommand.java
+++ b/src/java/org/apache/cassandra/db/ReadCommand.java
@@ -45,6 +45,7 @@ import org.apache.cassandra.db.filter.ColumnFilter;
 import org.apache.cassandra.db.filter.DataLimits;
 import org.apache.cassandra.db.filter.RowFilter;
 import org.apache.cassandra.db.filter.TombstoneOverwhelmingException;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.db.monitoring.Monitorable;
 import org.apache.cassandra.db.partitions.PartitionIterator;
 import org.apache.cassandra.db.partitions.PurgeFunction;
@@ -635,7 +636,7 @@ public abstract class ReadCommand extends AbstractReadQuery
                 Threshold guardrail = shouldRespectTombstoneThresholds()
                                                 ? Guardrails.scannedTombstones
                                                 : DefaultGuardrail.DefaultThreshold.NEVER_TRIGGERED;
-                return guardrail.newCounter(ReadCommand.this::toRedactedCQLString, false, null);
+                return guardrail.newCounter(() -> ReadCommand.this.toCQLString(Redaction.REDACT), false, null);
             }
 
             private MetricRecording()
@@ -699,7 +700,7 @@ public abstract class ReadCommand extends AbstractReadQuery
                 {
                     metric.tombstoneFailures.inc();
                     throw new TombstoneOverwhelmingException(tombstones.get(),
-                                                             ReadCommand.this.toRedactedCQLString(),
+                                                             ReadCommand.this.toCQLString(Redaction.REDACT),
                                                              ReadCommand.this.metadata(),
                                                              currentKey,
                                                              clustering);

--- a/src/java/org/apache/cassandra/db/ReadExecutionController.java
+++ b/src/java/org/apache/cassandra/db/ReadExecutionController.java
@@ -24,6 +24,7 @@ import com.google.common.annotations.VisibleForTesting;
 
 import com.codahale.metrics.Histogram;
 import org.apache.cassandra.db.filter.DataLimits;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.index.Index;
 import org.apache.cassandra.metrics.DecayingEstimatedHistogramReservoir;
 import org.apache.cassandra.schema.TableMetadata;
@@ -265,7 +266,7 @@ public class ReadExecutionController implements AutoCloseable
 
     private void addSample()
     {
-        String cql = command.toRedactedCQLString();
+        String cql = command.toCQLString(Redaction.REDACT);
         int timeMicros = (int) Math.min(TimeUnit.NANOSECONDS.toMicros(clock.now() - createdAtNanos), Integer.MAX_VALUE);
         ColumnFamilyStore cfs = ColumnFamilyStore.getIfExists(baseMetadata.id);
         if (cfs != null)

--- a/src/java/org/apache/cassandra/db/SinglePartitionReadCommand.java
+++ b/src/java/org/apache/cassandra/db/SinglePartitionReadCommand.java
@@ -34,6 +34,7 @@ import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.CqlBuilder;
 import org.apache.cassandra.db.filter.*;
 import org.apache.cassandra.db.lifecycle.*;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.db.memtable.Memtable;
 import org.apache.cassandra.db.partitions.*;
 import org.apache.cassandra.db.rows.*;
@@ -1152,9 +1153,9 @@ public class SinglePartitionReadCommand extends ReadCommand implements SinglePar
     }
 
     @Override
-    public void appendCQLWhereClause(CqlBuilder builder, boolean redact)
+    public void appendCQLWhereClause(CqlBuilder builder, Redaction redaction)
     {
-        SinglePartitionReadQuery.super.appendCQLWhereClause(builder, redact);
+        SinglePartitionReadQuery.super.appendCQLWhereClause(builder, redaction);
     }
 
     protected void serializeSelection(DataOutputPlus out, int version) throws IOException

--- a/src/java/org/apache/cassandra/db/SinglePartitionReadQuery.java
+++ b/src/java/org/apache/cassandra/db/SinglePartitionReadQuery.java
@@ -32,6 +32,7 @@ import org.apache.cassandra.db.filter.ClusteringIndexFilter;
 import org.apache.cassandra.db.filter.ColumnFilter;
 import org.apache.cassandra.db.filter.DataLimits;
 import org.apache.cassandra.db.filter.RowFilter;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.db.partitions.PartitionIterator;
 import org.apache.cassandra.db.partitions.UnfilteredPartitionIterator;
 import org.apache.cassandra.db.partitions.UnfilteredPartitionIterators;
@@ -161,16 +162,16 @@ public interface SinglePartitionReadQuery extends ReadQuery
         return rowFilter().clusteringKeyRestrictionsAreSatisfiedBy(clustering);
     }
 
-    default void appendCQLWhereClause(CqlBuilder builder, boolean redact)
+    default void appendCQLWhereClause(CqlBuilder builder, Redaction redaction)
     {
         builder.append(" WHERE ");
 
         // Append the partition key restrictions.
         TableMetadata metadata = metadata();
-        builder.append(partitionKey().toCQLString(metadata, redact));
+        builder.append(partitionKey().toCQLString(metadata, redaction));
 
         // Append the clustering index filter and the row filter.
-        String filter = clusteringIndexFilter().toCQLString(metadata(), rowFilter(), redact);
+        String filter = clusteringIndexFilter().toCQLString(metadata(), rowFilter(), redaction);
         builder.appendRestrictions(filter, true);
     }
 

--- a/src/java/org/apache/cassandra/db/Slices.java
+++ b/src/java/org/apache/cassandra/db/Slices.java
@@ -27,6 +27,7 @@ import com.google.common.collect.Iterators;
 import org.apache.cassandra.cql3.CqlBuilder;
 import org.apache.cassandra.cql3.Operator;
 import org.apache.cassandra.db.filter.RowFilter;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.db.marshal.AbstractType;
@@ -154,10 +155,10 @@ public abstract class Slices implements Iterable<Slice>
      *
      * @param metadata the table metadata
      * @param rowFilter a row filter
-     * @param redact whether to redact the slice column values
+     * @param redaction whether to redact the slice column values
      * @return a CQL string representing this slice and the specified {@link RowFilter}
      */
-    public abstract String toCQLString(TableMetadata metadata, RowFilter rowFilter, boolean redact);
+    public abstract String toCQLString(TableMetadata metadata, RowFilter rowFilter, Redaction redaction);
 
     /**
      * Checks if this <code>Slices</code> is empty.
@@ -567,7 +568,7 @@ public abstract class Slices implements Iterable<Slice>
         }
 
         @Override
-        public String toCQLString(TableMetadata metadata, RowFilter rowFilter, boolean redact)
+        public String toCQLString(TableMetadata metadata, RowFilter rowFilter, Redaction redaction)
         {
             CqlBuilder builder = new CqlBuilder();
 
@@ -619,7 +620,7 @@ public abstract class Slices implements Iterable<Slice>
 
                     if (values.size() == 1)
                     {
-                        builder.append(" = ").append(column.type.toCQLString(first.startValue, redact));
+                        builder.append(" = ").append(column.type.toCQLString(first.startValue, redaction));
                     }
                     else
                     {
@@ -627,7 +628,7 @@ public abstract class Slices implements Iterable<Slice>
                         int j = 0;
                         for (ByteBuffer value : values)
                         {
-                            builder.append(j++ == 0 ? "" : ", ").append(column.type.toCQLString(value, redact));
+                            builder.append(j++ == 0 ? "" : ", ").append(column.type.toCQLString(value, redaction));
                         }
                         builder.append(')');
                     }
@@ -651,7 +652,7 @@ public abstract class Slices implements Iterable<Slice>
                             operator = first.startInclusive ? Operator.GTE : Operator.GT;
 
                         builder.append(' ').append(operator).append(' ')
-                          .append(column.type.toCQLString(first.startValue, redact));
+                          .append(column.type.toCQLString(first.startValue, redaction));
                     }
                     if (first.endValue != null)
                     {
@@ -665,7 +666,7 @@ public abstract class Slices implements Iterable<Slice>
                             operator = first.endInclusive ? Operator.LTE : Operator.LT;
 
                         builder.append(' ').append(operator).append(' ')
-                          .append(column.type.toCQLString(first.endValue, redact));
+                          .append(column.type.toCQLString(first.endValue, redaction));
                     }
                 }
 
@@ -678,7 +679,7 @@ public abstract class Slices implements Iterable<Slice>
             }
 
             // Append the row filter.
-            builder.append(rowFilter, true, redact);
+            builder.append(rowFilter, true, redaction);
 
             return builder.toString();
         }
@@ -802,9 +803,9 @@ public abstract class Slices implements Iterable<Slice>
         }
 
         @Override
-        public String toCQLString(TableMetadata metadata, RowFilter rowFilter, boolean redact)
+        public String toCQLString(TableMetadata metadata, RowFilter rowFilter, Redaction redaction)
         {
-            return rowFilter.toCQLString(redact);
+            return rowFilter.toCQLString(redaction);
         }
     }
 
@@ -884,7 +885,7 @@ public abstract class Slices implements Iterable<Slice>
         }
 
         @Override
-        public String toCQLString(TableMetadata metadata, RowFilter rowFilter, boolean redact)
+        public String toCQLString(TableMetadata metadata, RowFilter rowFilter, Redaction redaction)
         {
             return "";
         }

--- a/src/java/org/apache/cassandra/db/VirtualTablePartitionRangeReadQuery.java
+++ b/src/java/org/apache/cassandra/db/VirtualTablePartitionRangeReadQuery.java
@@ -21,6 +21,7 @@ import org.apache.cassandra.cql3.CqlBuilder;
 import org.apache.cassandra.db.filter.ColumnFilter;
 import org.apache.cassandra.db.filter.DataLimits;
 import org.apache.cassandra.db.filter.RowFilter;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.db.partitions.UnfilteredPartitionIterator;
 import org.apache.cassandra.db.virtual.VirtualKeyspaceRegistry;
 import org.apache.cassandra.db.virtual.VirtualTable;
@@ -95,8 +96,8 @@ public class VirtualTablePartitionRangeReadQuery extends VirtualTableReadQuery i
     }
 
     @Override
-    public void appendCQLWhereClause(CqlBuilder builder, boolean redact)
+    public void appendCQLWhereClause(CqlBuilder builder, Redaction redaction)
     {
-        PartitionRangeReadQuery.super.appendCQLWhereClause(builder, redact);
+        PartitionRangeReadQuery.super.appendCQLWhereClause(builder, redaction);
     }
 }

--- a/src/java/org/apache/cassandra/db/VirtualTableSinglePartitionReadQuery.java
+++ b/src/java/org/apache/cassandra/db/VirtualTableSinglePartitionReadQuery.java
@@ -27,6 +27,7 @@ import org.apache.cassandra.db.filter.ClusteringIndexFilter;
 import org.apache.cassandra.db.filter.ColumnFilter;
 import org.apache.cassandra.db.filter.DataLimits;
 import org.apache.cassandra.db.filter.RowFilter;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.db.partitions.PartitionIterator;
 import org.apache.cassandra.db.partitions.PartitionIterators;
 import org.apache.cassandra.db.partitions.UnfilteredPartitionIterator;
@@ -75,9 +76,9 @@ public class VirtualTableSinglePartitionReadQuery extends VirtualTableReadQuery 
     }
 
     @Override
-    public void appendCQLWhereClause(CqlBuilder builder, boolean redact)
+    public void appendCQLWhereClause(CqlBuilder builder, Redaction redaction)
     {
-        SinglePartitionReadQuery.super.appendCQLWhereClause(builder, redact);
+        SinglePartitionReadQuery.super.appendCQLWhereClause(builder, redaction);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/filter/ClusteringIndexFilter.java
+++ b/src/java/org/apache/cassandra/db/filter/ClusteringIndexFilter.java
@@ -20,6 +20,7 @@ package org.apache.cassandra.db.filter;
 import java.io.IOException;
 
 import org.apache.cassandra.db.*;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.db.partitions.CachedPartition;
 import org.apache.cassandra.db.partitions.Partition;
 import org.apache.cassandra.db.rows.*;
@@ -159,10 +160,10 @@ public interface ClusteringIndexFilter
      *
      * @param metadata the table metadata
      * @param rowFilter a row filter
-     * @param redact whether to redact the clustering column value
+     * @param redaction whether to redact the clustering column value
      * @return a CQL string representing this clustering index filter and the specified {@link RowFilter}
      */
-    String toCQLString(TableMetadata metadata, RowFilter rowFilter, boolean redact);
+    String toCQLString(TableMetadata metadata, RowFilter rowFilter, Redaction redaction);
 
     public interface Serializer
     {

--- a/src/java/org/apache/cassandra/db/filter/ClusteringIndexNamesFilter.java
+++ b/src/java/org/apache/cassandra/db/filter/ClusteringIndexNamesFilter.java
@@ -22,6 +22,7 @@ import java.util.*;
 
 import org.apache.cassandra.cql3.CqlBuilder;
 import org.apache.cassandra.db.*;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.db.partitions.*;
 import org.apache.cassandra.db.rows.*;
 import org.apache.cassandra.db.transform.Transformation;
@@ -163,10 +164,10 @@ public class ClusteringIndexNamesFilter extends AbstractClusteringIndexFilter
     }
 
     @Override
-    public String toCQLString(TableMetadata metadata, RowFilter rowFilter, boolean redact)
+    public String toCQLString(TableMetadata metadata, RowFilter rowFilter, Redaction redaction)
     {
         if (metadata.clusteringColumns().isEmpty() || clusterings.isEmpty())
-            return rowFilter.toCQLString(redact);
+            return rowFilter.toCQLString(redaction);
 
         boolean isSingleColumn = metadata.clusteringColumns().size() == 1;
         boolean isSingleClustering = clusterings.size() == 1;
@@ -183,7 +184,7 @@ public class ClusteringIndexNamesFilter extends AbstractClusteringIndexFilter
         {
             builder.append(i++ == 0 ? "" : ", ")
               .append(isSingleColumn ? "" : '(')
-              .append(clustering.toCQLString(metadata, redact))
+              .append(clustering.toCQLString(metadata, redaction))
               .append(isSingleColumn ? "" : ')');
 
             maxClusteringSize = Math.max(maxClusteringSize, clustering.size());
@@ -198,7 +199,7 @@ public class ClusteringIndexNamesFilter extends AbstractClusteringIndexFilter
         for (i = 0; i < clusterings.first().size(); i++)
             rowFilter = rowFilter.withoutFirstLevelExpression(metadata.clusteringColumns().get(i));
 
-        builder.append(rowFilter, true, redact);
+        builder.append(rowFilter, true, redaction);
         appendOrderByToCQLString(metadata, builder);
         return builder.toString();
     }

--- a/src/java/org/apache/cassandra/db/filter/ClusteringIndexSliceFilter.java
+++ b/src/java/org/apache/cassandra/db/filter/ClusteringIndexSliceFilter.java
@@ -20,6 +20,7 @@ package org.apache.cassandra.db.filter;
 import java.io.IOException;
 
 import org.apache.cassandra.cql3.CqlBuilder;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.db.*;
 import org.apache.cassandra.db.rows.*;
@@ -135,10 +136,10 @@ public class ClusteringIndexSliceFilter extends AbstractClusteringIndexFilter
     }
 
     @Override
-    public String toCQLString(TableMetadata metadata, RowFilter rowFilter, boolean redact)
+    public String toCQLString(TableMetadata metadata, RowFilter rowFilter, Redaction redaction)
     {
         CqlBuilder builder = new CqlBuilder();
-        builder.append(slices.toCQLString(metadata, rowFilter, redact));
+        builder.append(slices.toCQLString(metadata, rowFilter, redaction));
         appendOrderByToCQLString(metadata, builder);
         return builder.toString();
     }

--- a/src/java/org/apache/cassandra/db/filter/ColumnFilter.java
+++ b/src/java/org/apache/cassandra/db/filter/ColumnFilter.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.cql3.ColumnIdentifier;
 import org.apache.cassandra.db.*;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.db.rows.CellPath;
 import org.apache.cassandra.gms.Gossiper;
 import org.apache.cassandra.io.util.DataInputPlus;
@@ -385,10 +386,10 @@ public abstract class ColumnFilter
     /**
      * Returns the CQL string corresponding to this {@code ColumnFilter}.
      *
-     * @param redact whether to redact the queried column names, in case they contain sensitive data.
+     * @param redaction whether to redact the queried column names, in case they contain sensitive data.
      * @return the CQL string corresponding to this {@code ColumnFilter}.
      */
-    public abstract String toCQLString(boolean redact);
+    public abstract String toCQLString(Redaction redaction);
 
     /**
      * Returns the sub-selections or {@code null} if there are none.
@@ -724,7 +725,7 @@ public abstract class ColumnFilter
         }
 
         @Override
-        public String toCQLString(boolean redact)
+        public String toCQLString(Redaction redaction)
         {
             return "*";
         }
@@ -926,21 +927,21 @@ public abstract class ColumnFilter
             {
                 prefix = queried.statics.isEmpty()
                        ? "<all regulars>/"
-                       : String.format("<all regulars>+%s/", toString(queried.statics.selectOrderIterator(), false, false));
+                       : String.format("<all regulars>+%s/", toString(queried.statics.selectOrderIterator(), false, Redaction.NONE));
             }
 
-            return prefix + toString(queried.selectOrderIterator(), false, false);
+            return prefix + toString(queried.selectOrderIterator(), false, Redaction.NONE);
         }
 
         @Override
-        public String toCQLString(boolean redact)
+        public String toCQLString(Redaction redaction)
         {
-            return queried.isEmpty() ? "*" : toString(queried.selectOrderIterator(), true, redact);
+            return queried.isEmpty() ? "*" : toString(queried.selectOrderIterator(), true, redaction);
         }
 
-        private String toString(Iterator<ColumnMetadata> columns, boolean cql, boolean redact)
+        private String toString(Iterator<ColumnMetadata> columns, boolean cql, Redaction redaction)
         {
-            assert cql || !redact : "Cannot redact non-CQL representation";
+            assert cql || redaction == Redaction.NONE : "Cannot redact non-CQL representation";
 
             StringJoiner joiner = cql ? new StringJoiner(", ") : new StringJoiner(", ", "[", "]");
 
@@ -956,7 +957,7 @@ public abstract class ColumnFilter
                 if (s.isEmpty())
                     joiner.add(columnName);
                 else
-                    s.forEach(subSel -> joiner.add(String.format("%s%s", columnName, subSel.toString(cql, redact))));
+                    s.forEach(subSel -> joiner.add(String.format("%s%s", columnName, subSel.toString(cql, redaction))));
             }
             return joiner.toString();
         }

--- a/src/java/org/apache/cassandra/db/filter/ColumnSubselection.java
+++ b/src/java/org/apache/cassandra/db/filter/ColumnSubselection.java
@@ -24,6 +24,7 @@ import java.util.Comparator;
 import org.apache.cassandra.db.TypeSizes;
 import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.db.marshal.CollectionType;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.db.marshal.UTF8Type;
 import org.apache.cassandra.db.rows.CellPath;
 import org.apache.cassandra.exceptions.UnknownColumnException;
@@ -91,17 +92,17 @@ public abstract class ColumnSubselection implements Comparable<ColumnSubselectio
     @Override
     public String toString()
     {
-        return toString(false, false);
+        return toString(false, Redaction.NONE);
     }
 
     /**
      * Returns a string representation of this subselection.
      *
      * @param cql if true, the string representation will be in CQL format
-     * @param redact if true, the string representation will redact sensitive data
+     * @param redaction if true, the string representation will redact sensitive data
      * @return a string representation of this subselection
      */
-    protected abstract String toString(boolean cql, boolean redact);
+    protected abstract String toString(boolean cql, Redaction redaction);
 
     private static class Slice extends ColumnSubselection
     {
@@ -137,13 +138,13 @@ public abstract class ColumnSubselection implements Comparable<ColumnSubselectio
         }
 
         @Override
-        protected String toString(boolean cql, boolean redact)
+        protected String toString(boolean cql, Redaction redaction)
         {
             // This asserts we're dealing with a collection since that's the only thing it's used for so far.
             AbstractType<?> type = ((CollectionType<?>)column().type).nameComparator();
             return String.format("[%s:%s]",
-                                 from == CellPath.BOTTOM ? "" : (cql ? type.toCQLString(from.get(0), redact) : type.getString(from.get(0))),
-                                 to == CellPath.TOP ? "" : (cql ? type.toCQLString(to.get(0), redact) : type.getString(to.get(0))));
+                                 from == CellPath.BOTTOM ? "" : (cql ? type.toCQLString(from.get(0), redaction) : type.getString(from.get(0))),
+                                 to == CellPath.TOP ? "" : (cql ? type.toCQLString(to.get(0), redaction) : type.getString(to.get(0))));
         }
     }
 
@@ -173,11 +174,11 @@ public abstract class ColumnSubselection implements Comparable<ColumnSubselectio
         }
 
         @Override
-        protected String toString(boolean cql, boolean redact)
+        protected String toString(boolean cql, Redaction redaction)
         {
             // This asserts we're dealing with a collection since that's the only thing it's used for so far.
             AbstractType<?> type = ((CollectionType<?>)column().type).nameComparator();
-            return String.format("[%s]", cql ? type.toCQLString(element.get(0), redact) : type.getString(element.get(0)));
+            return String.format("[%s]", cql ? type.toCQLString(element.get(0), redaction) : type.getString(element.get(0)));
         }
     }
 

--- a/src/java/org/apache/cassandra/db/filter/RowFilter.java
+++ b/src/java/org/apache/cassandra/db/filter/RowFilter.java
@@ -343,9 +343,9 @@ public class RowFilter
         return root.toString();
     }
 
-    public String toCQLString(boolean redact)
+    public String toCQLString(Redaction redaction)
     {
-        return root.toCQLString(redact);
+        return root.toCQLString(redaction);
     }
 
     public static Builder builder()
@@ -747,10 +747,10 @@ public class RowFilter
         @Override
         public String toString()
         {
-            return toCQLString(false);
+            return toCQLString(Redaction.NONE);
         }
 
-        public String toCQLString(boolean redact)
+        public String toCQLString(Redaction redaction)
         {
             StringBuilder sb = new StringBuilder();
             for (Expression expression : expressions)
@@ -759,14 +759,14 @@ public class RowFilter
                     continue;
                 if (sb.length() > 0)
                     sb.append(isDisjunction ? " OR " : " AND ");
-                sb.append(expression.toCQLString(redact));
+                sb.append(expression.toCQLString(redaction));
             }
             for (FilterElement child : children)
             {
                 if (sb.length() > 0)
                     sb.append(isDisjunction ? " OR " : " AND ");
                 sb.append('(');
-                sb.append(child.toCQLString(redact));
+                sb.append(child.toCQLString(redaction));
                 sb.append(')');
             }
             for (Expression expression : expressions)
@@ -775,7 +775,7 @@ public class RowFilter
                     continue;
                 if (sb.length() > 0)
                     sb.append(' ');
-                sb.append(expression.toCQLString(redact));
+                sb.append(expression.toCQLString(redaction));
             }
             return sb.toString();
         }
@@ -1061,10 +1061,10 @@ public class RowFilter
         @Override
         public String toString()
         {
-            return toCQLString(false);
+            return toCQLString(Redaction.NONE);
         }
 
-        public String toCQLString(boolean redact)
+        public String toCQLString(Redaction redaction)
         {
             return "";
         }
@@ -1374,7 +1374,7 @@ public class RowFilter
         }
 
         @Override
-        public String toCQLString(boolean redact)
+        public String toCQLString(Redaction redaction)
         {
             AbstractType<?> type = column.type;
             switch (operator)
@@ -1399,24 +1399,24 @@ public class RowFilter
                     // These don't have a value, so we return here to prevent an error calling type.getString(value)
                     return String.format("ORDER BY %s %s", column.name.toCQLString(), operator);
                 case ANN:
-                    return String.format("ORDER BY %s ANN OF %s", column.name.toCQLString(), truncateValue(type.toCQLString(value, redact)));
+                    return String.format("ORDER BY %s ANN OF %s", column.name.toCQLString(), truncateValue(type.toCQLString(value, redaction)));
                 case LIKE_PREFIX:
-                    return likeToCQLString("'%s%%'", type, redact);
+                    return likeToCQLString("'%s%%'", type, redaction);
                 case LIKE_SUFFIX:
-                    return likeToCQLString("'%%%s'", type, redact);
+                    return likeToCQLString("'%%%s'", type, redaction);
                 case LIKE_CONTAINS:
-                    return likeToCQLString("'%%%s%%'", type, redact);
+                    return likeToCQLString("'%%%s%%'", type, redaction);
                 case LIKE_MATCHES:
-                    return likeToCQLString("'%s'", type, redact);
+                    return likeToCQLString("'%s'", type, redaction);
                 default:
                     break;
             }
-            return String.format("%s %s %s", column.name.toCQLString(), operator, truncateValue(type.toCQLString(value, redact)));
+            return String.format("%s %s %s", column.name.toCQLString(), operator, truncateValue(type.toCQLString(value, redaction)));
         }
 
-        private String likeToCQLString(String pattern, AbstractType<?> type, boolean redact)
+        private String likeToCQLString(String pattern, AbstractType<?> type, Redaction redaction)
         {
-            if (redact)
+            if (redaction == Redaction.REDACT)
                 return String.format("%s LIKE ?", column.name.toCQLString());
 
             String stringValue = String.format(pattern, type.getString(value));
@@ -1537,14 +1537,14 @@ public class RowFilter
         }
 
         @Override
-        public String toCQLString(boolean redact)
+        public String toCQLString(Redaction redaction)
         {
             MapType<?, ?> mt = (MapType<?, ?>) column.type;
             return String.format("%s[%s] %s %s",
                                  column.name.toCQLString(),
-                                 mt.nameComparator().toCQLString(key, redact),
+                                 mt.nameComparator().toCQLString(key, redaction),
                                  operator,
-                                 mt.valueComparator().toCQLString(value, redact));
+                                 mt.valueComparator().toCQLString(value, redaction));
         }
 
         @Override
@@ -1711,13 +1711,13 @@ public class RowFilter
         }
 
         @Override
-        public String toCQLString(boolean redact)
+        public String toCQLString(Redaction redaction)
         {
             return String.format("GEO_DISTANCE(%s, %s) %s %s",
                                  column.name.toCQLString(),
-                                 column.type.toCQLString(value, redact),
+                                 column.type.toCQLString(value, redaction),
                                  distanceOperator,
-                                 FloatType.instance.toCQLString(distance, redact));
+                                 FloatType.instance.toCQLString(distance, redaction));
         }
 
         @Override
@@ -1791,7 +1791,7 @@ public class RowFilter
         }
 
         @Override
-        public String toCQLString(boolean redact)
+        public String toCQLString(Redaction redaction)
         {
             return String.format("expr(%s, %s)",
                                  targetIndex.name,

--- a/src/java/org/apache/cassandra/db/marshal/AbstractType.java
+++ b/src/java/org/apache/cassandra/db/marshal/AbstractType.java
@@ -222,6 +222,14 @@ public abstract class AbstractType<T> implements Comparator<ByteBuffer>, Assignm
 
     public final String getString(ByteBuffer bytes)
     {
+        return getString(bytes, false);
+    }
+
+    public final String getString(ByteBuffer bytes, boolean redact)
+    {
+        if (redact)
+            return RedactionUtil.redact(bytes, isValueLengthFixed());
+
         return getString(bytes, ByteBufferAccessor.instance);
     }
 

--- a/src/java/org/apache/cassandra/db/marshal/AbstractType.java
+++ b/src/java/org/apache/cassandra/db/marshal/AbstractType.java
@@ -195,11 +195,11 @@ public abstract class AbstractType<T> implements Comparator<ByteBuffer>, Assignm
      * Returns a CQL literal representing the specified binary value, or "?" if redaction is requested.
      *
      * @param bytes the value to convert to a CQL literal
-     * @param redact whether to mask the value with '?' (for redaction purposes)
+     * @param redaction whether to mask the value with '?' (for redaction purposes)
      */
-    public String toCQLString(ByteBuffer bytes, boolean redact)
+    public String toCQLString(ByteBuffer bytes, Redaction redaction)
     {
-        if (redact)
+        if (redaction == Redaction.REDACT)
             return RedactionUtil.redact(bytes, isValueLengthFixed());
 
         if (bytes == null)

--- a/src/java/org/apache/cassandra/db/marshal/Privacy.java
+++ b/src/java/org/apache/cassandra/db/marshal/Privacy.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.marshal;
+
+/**
+ * Named boolan to express whether some sensistive data should be presented in clear or redacted.
+ * This is generally applied to column values, or things containing column values.
+ * Column values should be redacted when printed in logs.
+ * They shouldn't be redacted when used in user-facing error messages or query tracing.
+ */
+public enum Privacy
+{
+    NONE, REDACT
+}

--- a/src/java/org/apache/cassandra/db/marshal/Redaction.java
+++ b/src/java/org/apache/cassandra/db/marshal/Redaction.java
@@ -17,12 +17,13 @@
 package org.apache.cassandra.db.marshal;
 
 /**
- * Named boolan to express whether some sensistive data should be presented in clear or redacted.
+ * Named boolan to express whether sensitive data should be presented in clear or redacted.
  * This is generally applied to column values, or things containing column values.
+ * </p>
  * Column values should be redacted when printed in logs.
  * They shouldn't be redacted when used in user-facing error messages or query tracing.
  */
-public enum Privacy
+public enum Redaction
 {
     NONE, REDACT
 }

--- a/src/java/org/apache/cassandra/db/rows/AbstractRow.java
+++ b/src/java/org/apache/cassandra/db/rows/AbstractRow.java
@@ -23,6 +23,7 @@ import java.util.stream.StreamSupport;
 
 import com.google.common.collect.Iterables;
 
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.db.marshal.ValueAccessor;
 import org.apache.cassandra.db.Clustering;
 import org.apache.cassandra.db.Digest;
@@ -143,7 +144,7 @@ public abstract class AbstractRow implements Row
         if (includeClusterKeys)
             sb.append(clustering().toString(metadata));
         else
-            sb.append(clustering().toCQLString(metadata, false));
+            sb.append(clustering().toCQLString(metadata, Redaction.NONE));
         sb.append(" | ");
         boolean isFirst = true;
         for (ColumnData cd : this)

--- a/src/java/org/apache/cassandra/index/sai/plan/Expression.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Expression.java
@@ -532,16 +532,22 @@ public class Expression
         return boundedAnnEuclideanDistanceThreshold;
     }
 
+    @Override
     public String toString()
+    {
+        return toString(false);
+    }
+
+    public String toString(boolean redact)
     {
         return String.format("Expression{name: %s, op: %s, lower: (%s, %s), upper: (%s, %s), exclusions: %s}",
                              context.getColumnName(),
                              operation,
-                             lower == null ? "null" : validator.getString(lower.value.raw),
+                             lower == null ? "null" : validator.getString(lower.value.raw, redact),
                              lower != null && lower.inclusive,
-                             upper == null ? "null" : validator.getString(upper.value.raw),
+                             upper == null ? "null" : validator.getString(upper.value.raw, redact),
                              upper != null && upper.inclusive,
-                             Iterators.toString(Iterators.transform(exclusions.iterator(), validator::getString)));
+                             Iterators.toString(Iterators.transform(exclusions.iterator(), x -> validator.getString(x, redact))));
     }
 
     public String getIndexName()

--- a/src/java/org/apache/cassandra/index/sai/plan/Orderer.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Orderer.java
@@ -35,7 +35,7 @@ import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
 import org.apache.cassandra.cql3.Operator;
 import org.apache.cassandra.db.filter.ANNOptions;
 import org.apache.cassandra.db.filter.RowFilter;
-import org.apache.cassandra.db.marshal.Privacy;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.db.marshal.RedactionUtil;
 import org.apache.cassandra.index.SecondaryIndexManager;
 import org.apache.cassandra.index.sai.IndexContext;
@@ -173,23 +173,23 @@ public class Orderer
     @Override
     public String toString()
     {
-        return toString(Privacy.NONE);
+        return toString(Redaction.NONE);
     }
 
-    public String toString(Privacy privacy)
+    public String toString(Redaction redaction)
     {
         String direction = isAscending() ? "ASC" : "DESC";
         String annOptionsString = annOptions != null ? annOptions.toCQLString() : "";
         if (isANN())
-            return context.getColumnName() + " ANN OF " + getVectorTermAsString(privacy) + ' ' + direction + annOptionsString;
+            return context.getColumnName() + " ANN OF " + getVectorTermAsString(redaction) + ' ' + direction + annOptionsString;
         if (isBM25())
-            return context.getColumnName() + " BM25 OF " + context.getValidator().toCQLString(term, privacy == Privacy.REDACT) + ' ' + direction;
+            return context.getColumnName() + " BM25 OF " + context.getValidator().toCQLString(term, redaction) + ' ' + direction;
         return context.getColumnName() + ' ' + direction;
     }
 
-    public String getVectorTermAsString(Privacy privacy)
+    public String getVectorTermAsString(Redaction redaction)
     {
-        return privacy == Privacy.REDACT
+        return redaction == Redaction.REDACT
                ? RedactionUtil.redact(0)
                : Arrays.toString(getRawVectorTerm());
     }

--- a/src/java/org/apache/cassandra/index/sai/plan/Orderer.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Orderer.java
@@ -35,6 +35,8 @@ import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
 import org.apache.cassandra.cql3.Operator;
 import org.apache.cassandra.db.filter.ANNOptions;
 import org.apache.cassandra.db.filter.RowFilter;
+import org.apache.cassandra.db.marshal.Privacy;
+import org.apache.cassandra.db.marshal.RedactionUtil;
 import org.apache.cassandra.index.SecondaryIndexManager;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.StorageAttachedIndex;
@@ -171,13 +173,25 @@ public class Orderer
     @Override
     public String toString()
     {
+        return toString(Privacy.NONE);
+    }
+
+    public String toString(Privacy privacy)
+    {
         String direction = isAscending() ? "ASC" : "DESC";
         String annOptionsString = annOptions != null ? annOptions.toCQLString() : "";
         if (isANN())
-            return context.getColumnName() + " ANN OF " + Arrays.toString(getRawVectorTerm()) + ' ' + direction + annOptionsString;
+            return context.getColumnName() + " ANN OF " + getVectorTermAsString(privacy) + ' ' + direction + annOptionsString;
         if (isBM25())
-            return context.getColumnName() + " BM25 OF " + TypeUtil.getString(term, context.getValidator()) + ' ' + direction;
+            return context.getColumnName() + " BM25 OF " + context.getValidator().toCQLString(term, privacy == Privacy.REDACT) + ' ' + direction;
         return context.getColumnName() + ' ' + direction;
+    }
+
+    public String getVectorTermAsString(Privacy privacy)
+    {
+        return privacy == Privacy.REDACT
+               ? RedactionUtil.redact(0)
+               : Arrays.toString(getRawVectorTerm());
     }
 
     public VectorFloat<?> getVectorTerm()

--- a/src/java/org/apache/cassandra/index/sai/plan/Plan.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Plan.java
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
 import org.apache.cassandra.cache.ChunkCache;
 import org.apache.cassandra.db.filter.IndexHints;
 import org.apache.cassandra.db.filter.RowFilter;
-import org.apache.cassandra.db.marshal.Privacy;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.index.sai.iterators.KeyRangeIntersectionIterator;
@@ -290,44 +290,44 @@ abstract public class Plan
     /**
      * Formats the whole plan as a pretty tree
      *
-     * @param privacy whether to redact the queried column values.
+     * @param redaction whether to redact the queried column values.
      */
-    public String toStringRecursive(Privacy privacy)
+    public String toStringRecursive(Redaction redaction)
     {
-        return toStringRecursive(privacy, null);
+        return toStringRecursive(redaction, null);
     }
 
     /**
      * Formats the whole plan as a pretty tree, with indentation
      *
-     * @param privacy whether to redact the queried column values.
+     * @param redaction whether to redact the queried column values.
      * @param indent a string used for indentation
      */
-    public String toStringRecursive(Privacy privacy, String indent)
+    public String toStringRecursive(Redaction redaction, String indent)
     {
-        TreeFormatter<Plan> formatter = new TreeFormatter<>(plan -> plan.toString(privacy), Plan::subplans, indent);
+        TreeFormatter<Plan> formatter = new TreeFormatter<>(plan -> plan.toString(redaction), Plan::subplans, indent);
         return formatter.format(this);
     }
 
     /**
      * Returns the string representation of this node only, without redacting the queried column values.
-     * @see #toString(Privacy)
+     * @see #toString(Redaction)
      */
     @Override
     public final String toString()
     {
-        return toString(Privacy.NONE);
+        return toString(Redaction.NONE);
     }
 
     /**
      * Returns the string representation of this node only
      *
-     * @param privacy whether to redact the queried column values.
+     * @param redaction whether to redact the queried column values.
      */
-    public final String toString(Privacy privacy)
+    public final String toString(Redaction redaction)
     {
-        String title = title(privacy);
-        String description = description(privacy);
+        String title = title(redaction);
+        String description = description(redaction);
         return (title.isEmpty())
                ? String.format("%s (%s)\n%s", getClass().getSimpleName(), cost(), description).stripTrailing()
                : String.format("%s %s (%s)\n%s", getClass().getSimpleName(), title, cost(), description).stripTrailing();
@@ -338,7 +338,7 @@ abstract public class Plan
      * The information is included in the output of {@link #toString()} and {@link #toRedactedStringRecursive()}.
      * It is up to subclasses to implement it.
      */
-    protected String title(Privacy privacy)
+    protected String title(Redaction redaction)
     {
         return "";
     }
@@ -348,7 +348,7 @@ abstract public class Plan
      * The information is included in the output of {@link #toString()} and {@link #toRedactedStringRecursive()}.
      * It is up to subclasses to implement it.
      */
-    protected String description(Privacy privacy)
+    protected String description(Redaction redaction)
     {
         return "";
     }
@@ -383,7 +383,7 @@ abstract public class Plan
     protected Plan optimize()
     {
         if (logger.isTraceEnabled())
-            logger.trace("Optimizing plan:\n{}", toStringRecursive(Privacy.REDACT));
+            logger.trace("Optimizing plan:\n{}", toStringRecursive(Redaction.REDACT));
 
         Plan bestPlanSoFar = this;
         List<Leaf> leaves = nodesOfType(Leaf.class);
@@ -398,14 +398,14 @@ abstract public class Plan
 
             Plan candidate = bestPlanSoFar.removeRestriction(leaf.id);
             if (logger.isTraceEnabled())
-                logger.trace("Candidate query plan:\n{}", candidate.toStringRecursive(Privacy.REDACT));
+                logger.trace("Candidate query plan:\n{}", candidate.toStringRecursive(Redaction.REDACT));
 
             if (candidate.fullCost() <= bestPlanSoFar.fullCost())
                 bestPlanSoFar = candidate;
         }
 
         if (logger.isTraceEnabled())
-            logger.trace("Optimized plan:\n{}", bestPlanSoFar.toStringRecursive(Privacy.REDACT));
+            logger.trace("Optimized plan:\n{}", bestPlanSoFar.toStringRecursive(Redaction.REDACT));
         return bestPlanSoFar;
     }
 
@@ -908,26 +908,26 @@ abstract public class Plan
         }
 
         @Override
-        protected final String title(Privacy privacy)
+        protected final String title(Redaction redaction)
         {
             return String.format("of %s (sel: %.9f, step: %.1f)",
                                  getIndexName(), selectivity(), access.meanDistance());
         }
 
         @Override
-        protected String description(Privacy privacy)
+        protected String description(Redaction redaction)
         {
             StringBuilder sb = new StringBuilder();
             if (predicate != null)
             {
                 sb.append("predicate: ");
-                sb.append(predicate.toString(privacy == Privacy.REDACT));
+                sb.append(predicate.toString(redaction == Redaction.REDACT));
                 sb.append('\n');
             }
             if (ordering != null)
             {
                 sb.append("ordering: ");
-                sb.append(ordering.toString(privacy));
+                sb.append(ordering.toString(redaction));
                 sb.append('\n');
             }
             return sb.toString();
@@ -1517,9 +1517,9 @@ abstract public class Plan
         }
 
         @Override
-        protected String description(Privacy privacy)
+        protected String description(Redaction redaction)
         {
-            return ordering.toString(privacy);
+            return ordering.toString(redaction);
         }
     }
 
@@ -1607,9 +1607,9 @@ abstract public class Plan
         }
 
         @Override
-        protected String description(Privacy privacy)
+        protected String description(Redaction redaction)
         {
-            return ordering.toString(privacy);
+            return ordering.toString(redaction);
         }
     }
 
@@ -1653,9 +1653,9 @@ abstract public class Plan
         }
 
         @Override
-        protected String description(Privacy privacy)
+        protected String description(Redaction redaction)
         {
-            return ordering.toString(privacy);
+            return ordering.toString(redaction);
         }
     }
 
@@ -1845,9 +1845,9 @@ abstract public class Plan
         }
 
         @Override
-        protected String title(Privacy privacy)
+        protected String title(Redaction redaction)
         {
-            return String.format("%s (sel: %.9f)", filter.toCQLString(privacy == Privacy.REDACT), selectivity() / source.get().selectivity());
+            return String.format("%s (sel: %.9f)", filter.toCQLString(redaction), selectivity() / source.get().selectivity());
         }
     }
 
@@ -1913,7 +1913,7 @@ abstract public class Plan
         }
 
         @Override
-        protected String title(Privacy privacy)
+        protected String title(Redaction redaction)
         {
             return "" + limit;
         }

--- a/src/java/org/apache/cassandra/index/sai/plan/Plan.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Plan.java
@@ -36,6 +36,7 @@ import org.slf4j.LoggerFactory;
 import org.apache.cassandra.cache.ChunkCache;
 import org.apache.cassandra.db.filter.IndexHints;
 import org.apache.cassandra.db.filter.RowFilter;
+import org.apache.cassandra.db.marshal.Privacy;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.index.sai.iterators.KeyRangeIntersectionIterator;
@@ -287,62 +288,46 @@ abstract public class Plan
     protected abstract double estimateSelectivity();
 
     /**
-     * Formats the whole plan as a pretty tree, not redacting the queried column values.
-     */
-    public final String toUnredactedStringRecursive()
-    {
-        return toStringRecursive(false, null);
-    }
-
-    /**
-     * Formats the whole plan as a pretty tree, redacting the queried column values.
-     */
-    public final String toRedactedStringRecursive()
-    {
-        return toRedactedStringRecursive(null);
-    }
-
-    /**
-     * Formats the whole plan as a pretty tree, redacting the queried column values, with indentation.
+     * Formats the whole plan as a pretty tree
      *
-     * @param indent a string used for indentation
+     * @param privacy whether to redact the queried column values.
      */
-    public final String toRedactedStringRecursive(String indent)
+    public String toStringRecursive(Privacy privacy)
     {
-        return toStringRecursive(true, indent);
+        return toStringRecursive(privacy, null);
     }
 
     /**
      * Formats the whole plan as a pretty tree, with indentation
      *
-     * @param redact whether to redact the queried column values.
+     * @param privacy whether to redact the queried column values.
      * @param indent a string used for indentation
      */
-    private String toStringRecursive(boolean redact, String indent)
+    public String toStringRecursive(Privacy privacy, String indent)
     {
-        TreeFormatter<Plan> formatter = new TreeFormatter<>(plan -> plan.toString(redact), Plan::subplans, indent);
+        TreeFormatter<Plan> formatter = new TreeFormatter<>(plan -> plan.toString(privacy), Plan::subplans, indent);
         return formatter.format(this);
     }
 
     /**
      * Returns the string representation of this node only, without redacting the queried column values.
-     * @see #toString(boolean)
+     * @see #toString(Privacy)
      */
     @Override
     public final String toString()
     {
-        return toString(false);
+        return toString(Privacy.NONE);
     }
 
     /**
      * Returns the string representation of this node only
      *
-     * @param redact whether to redact the queried column values.
+     * @param privacy whether to redact the queried column values.
      */
-    public final String toString(boolean redact)
+    public final String toString(Privacy privacy)
     {
-        String title = title(redact);
-        String description = description();
+        String title = title(privacy);
+        String description = description(privacy);
         return (title.isEmpty())
                ? String.format("%s (%s)\n%s", getClass().getSimpleName(), cost(), description).stripTrailing()
                : String.format("%s %s (%s)\n%s", getClass().getSimpleName(), title, cost(), description).stripTrailing();
@@ -353,7 +338,7 @@ abstract public class Plan
      * The information is included in the output of {@link #toString()} and {@link #toRedactedStringRecursive()}.
      * It is up to subclasses to implement it.
      */
-    protected String title(boolean redact)
+    protected String title(Privacy privacy)
     {
         return "";
     }
@@ -363,7 +348,7 @@ abstract public class Plan
      * The information is included in the output of {@link #toString()} and {@link #toRedactedStringRecursive()}.
      * It is up to subclasses to implement it.
      */
-    protected String description()
+    protected String description(Privacy privacy)
     {
         return "";
     }
@@ -398,7 +383,7 @@ abstract public class Plan
     protected Plan optimize()
     {
         if (logger.isTraceEnabled())
-            logger.trace("Optimizing plan:\n{}", toRedactedStringRecursive());
+            logger.trace("Optimizing plan:\n{}", toStringRecursive(Privacy.REDACT));
 
         Plan bestPlanSoFar = this;
         List<Leaf> leaves = nodesOfType(Leaf.class);
@@ -413,14 +398,14 @@ abstract public class Plan
 
             Plan candidate = bestPlanSoFar.removeRestriction(leaf.id);
             if (logger.isTraceEnabled())
-                logger.trace("Candidate query plan:\n{}", candidate.toRedactedStringRecursive());
+                logger.trace("Candidate query plan:\n{}", candidate.toStringRecursive(Privacy.REDACT));
 
             if (candidate.fullCost() <= bestPlanSoFar.fullCost())
                 bestPlanSoFar = candidate;
         }
 
         if (logger.isTraceEnabled())
-            logger.trace("Optimized plan:\n{}", bestPlanSoFar.toRedactedStringRecursive());
+            logger.trace("Optimized plan:\n{}", bestPlanSoFar.toStringRecursive(Privacy.REDACT));
         return bestPlanSoFar;
     }
 
@@ -923,26 +908,26 @@ abstract public class Plan
         }
 
         @Override
-        protected final String title(boolean redact)
+        protected final String title(Privacy privacy)
         {
             return String.format("of %s (sel: %.9f, step: %.1f)",
                                  getIndexName(), selectivity(), access.meanDistance());
         }
 
         @Override
-        protected String description()
+        protected String description(Privacy privacy)
         {
             StringBuilder sb = new StringBuilder();
             if (predicate != null)
             {
                 sb.append("predicate: ");
-                sb.append(predicate);
+                sb.append(predicate.toString(privacy == Privacy.REDACT));
                 sb.append('\n');
             }
             if (ordering != null)
             {
                 sb.append("ordering: ");
-                sb.append(ordering);
+                sb.append(ordering.toString(privacy));
                 sb.append('\n');
             }
             return sb.toString();
@@ -1532,9 +1517,9 @@ abstract public class Plan
         }
 
         @Override
-        protected String description()
+        protected String description(Privacy privacy)
         {
-            return ordering.toString();
+            return ordering.toString(privacy);
         }
     }
 
@@ -1622,9 +1607,9 @@ abstract public class Plan
         }
 
         @Override
-        protected String description()
+        protected String description(Privacy privacy)
         {
-            return ordering.toString();
+            return ordering.toString(privacy);
         }
     }
 
@@ -1665,6 +1650,12 @@ abstract public class Plan
         protected void visitIndexes(Consumer<IndexContext> consumer)
         {
             consumer.accept(ordering.context);
+        }
+
+        @Override
+        protected String description(Privacy privacy)
+        {
+            return ordering.toString(privacy);
         }
     }
 
@@ -1854,9 +1845,9 @@ abstract public class Plan
         }
 
         @Override
-        protected String title(boolean redact)
+        protected String title(Privacy privacy)
         {
-            return String.format("%s (sel: %.9f)", filter.toCQLString(redact), selectivity() / source.get().selectivity());
+            return String.format("%s (sel: %.9f)", filter.toCQLString(privacy == Privacy.REDACT), selectivity() / source.get().selectivity());
         }
     }
 
@@ -1922,7 +1913,7 @@ abstract public class Plan
         }
 
         @Override
-        protected String title(boolean redact)
+        protected String title(Privacy privacy)
         {
             return "" + limit;
         }

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -32,6 +32,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.db.Clustering;
+import org.apache.cassandra.db.marshal.Privacy;
 import org.apache.cassandra.index.FeatureNeedsIndexRebuildException;
 import org.apache.cassandra.index.sai.disk.format.Version;
 import org.slf4j.Logger;
@@ -407,11 +408,11 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
         updateIndexMetricsQueriesCount(plan);
 
         if (logger.isTraceEnabled())
-            logger.trace("Query execution plan:\n" + plan.toRedactedStringRecursive());
+            logger.trace("Query execution plan:\n" + plan.toStringRecursive(Privacy.REDACT));
 
         if (Tracing.isTracing())
         {
-            Tracing.trace("Query execution plan:\n" + plan.toUnredactedStringRecursive());
+            Tracing.trace("Query execution plan:\n" + plan.toStringRecursive(Privacy.NONE));
             List<Plan.IndexScan> origIndexScans = keysIterationPlan.nodesOfType(Plan.IndexScan.class);
             List<Plan.IndexScan> selectedIndexScans = plan.nodesOfType(Plan.IndexScan.class);
             Tracing.trace("Selecting {} {} of {} out of {} indexes",

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -32,7 +32,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.db.Clustering;
-import org.apache.cassandra.db.marshal.Privacy;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.index.FeatureNeedsIndexRebuildException;
 import org.apache.cassandra.index.sai.disk.format.Version;
 import org.slf4j.Logger;
@@ -408,11 +408,11 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
         updateIndexMetricsQueriesCount(plan);
 
         if (logger.isTraceEnabled())
-            logger.trace("Query execution plan:\n" + plan.toStringRecursive(Privacy.REDACT));
+            logger.trace("Query execution plan:\n" + plan.toStringRecursive(Redaction.REDACT));
 
         if (Tracing.isTracing())
         {
-            Tracing.trace("Query execution plan:\n" + plan.toStringRecursive(Privacy.NONE));
+            Tracing.trace("Query execution plan:\n" + plan.toStringRecursive(Redaction.NONE));
             List<Plan.IndexScan> origIndexScans = keysIterationPlan.nodesOfType(Plan.IndexScan.class);
             List<Plan.IndexScan> selectedIndexScans = plan.nodesOfType(Plan.IndexScan.class);
             Tracing.trace("Selecting {} {} of {} out of {} indexes",

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryMonitorableExecutionInfo.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryMonitorableExecutionInfo.java
@@ -19,7 +19,7 @@ package org.apache.cassandra.index.sai.plan;
 import java.util.function.Supplier;
 
 import org.apache.cassandra.config.CassandraRelevantProperties;
-import org.apache.cassandra.db.marshal.Privacy;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.db.monitoring.Monitorable;
 import org.apache.cassandra.index.sai.QueryContext;
 
@@ -94,7 +94,7 @@ public class QueryMonitorableExecutionInfo implements Monitorable.ExecutionInfo
 
     private static String toLogString(Plan plan)
     {
-        String s = plan.toStringRecursive(Privacy.REDACT, DOUBLE_INDENT);
+        String s = plan.toStringRecursive(Redaction.REDACT, DOUBLE_INDENT);
         return s.endsWith("\n") ? s.substring(0, s.length() - 1) : s;
     }
 

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryMonitorableExecutionInfo.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryMonitorableExecutionInfo.java
@@ -19,6 +19,7 @@ package org.apache.cassandra.index.sai.plan;
 import java.util.function.Supplier;
 
 import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.db.marshal.Privacy;
 import org.apache.cassandra.db.monitoring.Monitorable;
 import org.apache.cassandra.index.sai.QueryContext;
 
@@ -93,7 +94,7 @@ public class QueryMonitorableExecutionInfo implements Monitorable.ExecutionInfo
 
     private static String toLogString(Plan plan)
     {
-        String s = plan.toRedactedStringRecursive(DOUBLE_INDENT);
+        String s = plan.toStringRecursive(Privacy.REDACT, DOUBLE_INDENT);
         return s.endsWith("\n") ? s.substring(0, s.length() - 1) : s;
     }
 

--- a/src/java/org/apache/cassandra/service/context/DefaultOperationContext.java
+++ b/src/java/org/apache/cassandra/service/context/DefaultOperationContext.java
@@ -21,6 +21,7 @@ package org.apache.cassandra.service.context;
 import java.util.function.Supplier;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.ReadCommand;
+import org.apache.cassandra.db.marshal.Redaction;
 
 /**
  * Default implementation of {@link OperationContext}.
@@ -58,7 +59,7 @@ public class DefaultOperationContext implements OperationContext
         @Override
         public OperationContext forRead(ReadCommand command, ColumnFamilyStore cfs)
         {
-            return new DefaultOperationContext(command::toUnredactedCQLString);
+            return new DefaultOperationContext(() -> command.toCQLString(Redaction.NONE));
         }
     }
 }

--- a/src/java/org/apache/cassandra/service/reads/ReplicaFilteringProtection.java
+++ b/src/java/org/apache/cassandra/service/reads/ReplicaFilteringProtection.java
@@ -45,6 +45,7 @@ import org.apache.cassandra.db.filter.ClusteringIndexFilter;
 import org.apache.cassandra.db.filter.ClusteringIndexNamesFilter;
 import org.apache.cassandra.db.filter.DataLimits;
 import org.apache.cassandra.db.filter.RowFilter;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.db.partitions.PartitionIterator;
 import org.apache.cassandra.db.partitions.PartitionIterators;
 import org.apache.cassandra.db.partitions.UnfilteredPartitionIterator;
@@ -203,8 +204,8 @@ public class ReplicaFilteringProtection<E extends Endpoints<E>>
                 // of cached rows we have had during the query.
                 if (!hitFailureThreshold && maxRowsCached > cachedRowsWarnThreshold)
                 {
-                    String unredactedMessage = cachedRowsWarnMessage(false);
-                    String redactedMessage = cachedRowsWarnMessage(true);
+                    String unredactedMessage = cachedRowsWarnMessage(Redaction.NONE);
+                    String redactedMessage = cachedRowsWarnMessage(Redaction.REDACT);
 
                     ClientWarn.instance.warn(unredactedMessage);
                     oneMinuteLogger.warn(redactedMessage);
@@ -212,11 +213,11 @@ public class ReplicaFilteringProtection<E extends Endpoints<E>>
                 }
             }
 
-            private String cachedRowsWarnMessage(boolean redact)
+            private String cachedRowsWarnMessage(Redaction redaction)
             {
                 return String.format(CACHED_ROWS_WARN_MESSAGE,
                                      maxRowsCached,
-                                     redact ? command.toRedactedCQLString() : command.toUnredactedCQLString(),
+                                     command.toCQLString(redaction),
                                      cachedRowsWarnThreshold);
             }
 
@@ -299,8 +300,8 @@ public class ReplicaFilteringProtection<E extends Endpoints<E>>
         if (currentRowsCached == cachedRowsFailThreshold + 1)
         {
             hitFailureThreshold = true;
-            String unredactedMessage = cachedRowsFailMessage(false);
-            String redactedMessage = cachedRowsFailMessage(true);
+            String unredactedMessage = cachedRowsFailMessage(Redaction.NONE);
+            String redactedMessage = cachedRowsFailMessage(Redaction.REDACT);
 
             logger.error(redactedMessage);
             Tracing.trace(unredactedMessage);
@@ -308,11 +309,11 @@ public class ReplicaFilteringProtection<E extends Endpoints<E>>
         }
     }
 
-    private String cachedRowsFailMessage(boolean redact)
+    private String cachedRowsFailMessage(Redaction redaction)
     {
         return String.format(CACHED_ROWS_FAIL_MESSAGE,
                              currentRowsCached,
-                             redact ? command.toRedactedCQLString() : command.toUnredactedCQLString(),
+                             command.toCQLString(redaction),
                              cachedRowsFailThreshold);
     }
 

--- a/src/java/org/apache/cassandra/service/reads/repair/ReadRepairEvent.java
+++ b/src/java/org/apache/cassandra/service/reads/repair/ReadRepairEvent.java
@@ -32,6 +32,7 @@ import com.google.common.annotations.VisibleForTesting;
 
 import org.apache.cassandra.db.ConsistencyLevel;
 import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.diag.DiagnosticEvent;
 import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.service.reads.DigestResolver;
@@ -65,7 +66,7 @@ final class ReadRepairEvent extends DiagnosticEvent
     {
         this.keyspace = readRepair.cfs.keyspace;
         this.tableName = readRepair.cfs.getTableName();
-        this.cqlCommand = readRepair.command.toRedactedCQLString();
+        this.cqlCommand = readRepair.command.toCQLString(Redaction.REDACT);
         this.consistency = readRepair.replicaPlan().consistencyLevel();
         this.speculativeRetry = readRepair.cfs.metadata().params.speculativeRetry.kind();
         this.destinations = destinations;

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/SlowSAIQueryLoggerTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/SlowSAIQueryLoggerTest.java
@@ -18,6 +18,7 @@ package org.apache.cassandra.distributed.test.sai;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Pattern;
 
 import com.google.common.util.concurrent.Uninterruptibles;
 import org.junit.Test;
@@ -108,7 +109,8 @@ public class SlowSAIQueryLoggerTest extends TestBaseImpl
                               "bkdPostingsDecodes: 4",
                               "annGraphSearchLatencyNanos: 0",
                               "SAI slow query plan:",
-                              "NumericIndexScan");
+                              "NumericIndexScan",
+                              Pattern.quote("predicate: Expression{name: n, op: RANGE, lower: (?, false), upper: (null, false), exclusions: []}"));
 
             // test aggregated numeric query
             mark = node.logs().mark();
@@ -134,7 +136,8 @@ public class SlowSAIQueryLoggerTest extends TestBaseImpl
                               "bkdPostingsDecodes: 4",
                               "annGraphSearchLatencyNanos: 0",
                               "SAI slowest query plan:",
-                              "NumericIndexScan");
+                              "NumericIndexScan",
+                              Pattern.quote("predicate: Expression{name: n, op: RANGE, lower: (?, false), upper: (null, false), exclusions: []}"));
 
             // test single text query
             mark = node.logs().mark();
@@ -160,7 +163,8 @@ public class SlowSAIQueryLoggerTest extends TestBaseImpl
                               "bkdPostingsDecodes: 0",
                               "annGraphSearchLatencyNanos: 0",
                               "SAI slow query plan:",
-                              "LiteralIndexScan");
+                              "LiteralIndexScan",
+                              Pattern.quote("predicate: Expression{name: s, op: EQ, lower: (?, true), upper: (?, true), exclusions: []}"));
 
             // test aggregated text query
             mark = node.logs().mark();
@@ -186,7 +190,8 @@ public class SlowSAIQueryLoggerTest extends TestBaseImpl
                               "bkdPostingsDecodes: 0",
                               "annGraphSearchLatencyNanos: 0",
                               "SAI slowest query plan:",
-                              "LiteralIndexScan");
+                              "LiteralIndexScan",
+                              Pattern.quote("predicate: Expression{name: s, op: EQ, lower: (?, true), upper: (?, true), exclusions: []}"));
 
             // test single ANN query
             mark = node.logs().mark();
@@ -212,7 +217,8 @@ public class SlowSAIQueryLoggerTest extends TestBaseImpl
                               "bkdPostingsDecodes: 0",
                               "annGraphSearchLatencyNanos: [1-9][0-9]*", // unknown, but greater than zero
                               "SAI slow query plan:",
-                              "AnnIndexScan");
+                              "AnnIndexScan",
+                              Pattern.quote("v ANN OF ? DESC"));
 
             // test aggregated ANN query
             mark = node.logs().mark();
@@ -238,7 +244,8 @@ public class SlowSAIQueryLoggerTest extends TestBaseImpl
                               "bkdPostingsDecodes: 0",
                               "annGraphSearchLatencyNanos: [1-9][0-9]*", // unknown, but greater than zero
                               "SAI slowest query plan:",
-                              "AnnIndexScan");
+                              "AnnIndexScan",
+                              Pattern.quote("v ANN OF ? DESC"));
 
             // test single hybrid query
             mark = node.logs().mark();
@@ -264,7 +271,8 @@ public class SlowSAIQueryLoggerTest extends TestBaseImpl
                               "bkdPostingsDecodes: 0",
                               "annGraphSearchLatencyNanos: 0",
                               "SAI slow query plan:",
-                              "LiteralIndexScan");
+                              "LiteralIndexScan",
+                              Pattern.quote("ordering: s ASC"));
 
             // test aggregated hybrid query
             mark = node.logs().mark();
@@ -290,7 +298,8 @@ public class SlowSAIQueryLoggerTest extends TestBaseImpl
                               "bkdPostingsDecodes: 0",
                               "annGraphSearchLatencyNanos: 0",
                               "SAI slowest query plan:",
-                              "LiteralIndexScan");
+                              "LiteralIndexScan",
+                              Pattern.quote("ordering: s ASC"));
 
             // Disable query optimizer to prevent skipping hybrid query logic and hit orderByResults to verify metrics update
             node.runOnInstance(() -> QueryController.QUERY_OPT_LEVEL = 0);
@@ -317,7 +326,8 @@ public class SlowSAIQueryLoggerTest extends TestBaseImpl
                               "annGraphSearchLatencyNanos: 0",
                               "SAI slow query plan:",
                               "KeysSort",
-                              "NumericIndexScan");
+                              "NumericIndexScan",
+                              Pattern.quote("predicate: Expression{name: n, op: RANGE, lower: (?, false), upper: (null, false), exclusions: []}"));
 
             node.runOnInstance(() -> QueryController.QUERY_OPT_LEVEL = CassandraRelevantProperties.SAI_QUERY_OPTIMIZATION_LEVEL.getInt());
 

--- a/test/unit/org/apache/cassandra/Util.java
+++ b/test/unit/org/apache/cassandra/Util.java
@@ -90,6 +90,7 @@ import org.apache.cassandra.db.lifecycle.LifecycleTransaction;
 import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.db.marshal.AsciiType;
 import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.db.marshal.UTF8Type;
 import org.apache.cassandra.db.marshal.UserType;
 import org.apache.cassandra.db.partitions.FilteredPartition;
@@ -421,7 +422,7 @@ public class Util
             {
                 try (UnfilteredRowIterator partition = iterator.next())
                 {
-                    throw new AssertionError("Expected no results for query " + command.toUnredactedCQLString() + " but got key " + command.metadata().partitionKeyType.getString(partition.partitionKey().getKey()));
+                    throw new AssertionError("Expected no results for query " + command.toCQLString(Redaction.NONE) + " but got key " + command.metadata().partitionKeyType.getString(partition.partitionKey().getKey()));
                 }
             }
         }
@@ -436,7 +437,7 @@ public class Util
             {
                 try (RowIterator partition = iterator.next())
                 {
-                    throw new AssertionError("Expected no results for query " + command.toUnredactedCQLString() + " but got key " + command.metadata().partitionKeyType.getString(partition.partitionKey().getKey()));
+                    throw new AssertionError("Expected no results for query " + command.toCQLString(Redaction.NONE) + " but got key " + command.metadata().partitionKeyType.getString(partition.partitionKey().getKey()));
                 }
             }
         }

--- a/test/unit/org/apache/cassandra/db/ReadCommandCQLTester.java
+++ b/test/unit/org/apache/cassandra/db/ReadCommandCQLTester.java
@@ -21,6 +21,7 @@ import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 
 import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.assertj.core.api.Assertions;
 
 public abstract class ReadCommandCQLTester<T extends ReadCommand> extends CQLTester
@@ -66,11 +67,11 @@ public abstract class ReadCommandCQLTester<T extends ReadCommand> extends CQLTes
         {
             T command = commands.get(i);
 
-            String actualUnredactedCQL = command.toUnredactedCQLString();
+            String actualUnredactedCQL = command.toCQLString(Redaction.NONE);
             Assertions.assertThat(actualUnredactedCQL)
                       .isEqualTo(formatQuery(expectedUnredactedCQL.get(i)));
 
-            String actualRedactedCQL = command.toRedactedCQLString();
+            String actualRedactedCQL = command.toCQLString(Redaction.REDACT);
             Assertions.assertThat(actualRedactedCQL)
                       .isEqualTo(formatQuery(expectedRedactedCQL.get(i)));
 

--- a/test/unit/org/apache/cassandra/db/SinglePartitionSliceCommandTest.java
+++ b/test/unit/org/apache/cassandra/db/SinglePartitionSliceCommandTest.java
@@ -41,6 +41,7 @@ import org.junit.Test;
 import org.apache.cassandra.SchemaLoader;
 import org.apache.cassandra.db.lifecycle.SSTableSet;
 import org.apache.cassandra.db.lifecycle.View;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.db.rows.*;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.sstable.format.SSTableReadsListener;
@@ -484,7 +485,7 @@ public class SinglePartitionSliceCommandTest
                                                             DataLimits.NONE,
                                                             key,
                                                             sliceFilter);
-        String ret = cmd.toRedactedCQLString();
+        String ret = cmd.toCQLString(Redaction.REDACT);
         Assert.assertNotNull(ret);
         assertFalse(ret.isEmpty());
     }

--- a/test/unit/org/apache/cassandra/db/filter/ANNOptionsTest.java
+++ b/test/unit/org/apache/cassandra/db/filter/ANNOptionsTest.java
@@ -35,6 +35,7 @@ import org.apache.cassandra.cql3.statements.schema.IndexTarget;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.ReadCommand;
 import org.apache.cassandra.db.TypeSizes;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.exceptions.SyntaxException;
 import org.apache.cassandra.index.Index;
@@ -190,22 +191,22 @@ public class ANNOptionsTest extends CQLTester
         // without ANN options
         String formattedQuery = formatQuery("SELECT * FROM %%s ORDER BY v ANN OF [1, 1]");
         ReadCommand command = parseReadCommand(formattedQuery);
-        Assertions.assertThat(command.toRedactedCQLString()).doesNotContain("WITH ann_options");
+        Assertions.assertThat(command.toCQLString(Redaction.NONE)).doesNotContain("WITH ann_options");
 
         // with rerank_k option
         formattedQuery = formatQuery("SELECT * FROM %%s ORDER BY v ANN OF [1, 1] LIMIT 1 WITH ann_options = {'rerank_k': 2}");
         command = parseReadCommand(formattedQuery);
-        Assertions.assertThat(command.toRedactedCQLString()).contains("WITH ann_options = {'rerank_k': 2}");
+        Assertions.assertThat(command.toCQLString(Redaction.NONE)).contains("WITH ann_options = {'rerank_k': 2}");
 
         // with use_pruning option
         formattedQuery = formatQuery("SELECT * FROM %%s ORDER BY v ANN OF [1, 1] WITH ann_options = {'use_pruning': true}");
         command = parseReadCommand(formattedQuery);
-        Assertions.assertThat(command.toRedactedCQLString()).contains("WITH ann_options = {'use_pruning': true}");
+        Assertions.assertThat(command.toCQLString(Redaction.NONE)).contains("WITH ann_options = {'use_pruning': true}");
 
         // with both options
         formattedQuery = formatQuery("SELECT * FROM %%s ORDER BY v ANN OF [1, 1] LIMIT 1 WITH ann_options = {'rerank_k': 2, 'use_pruning': false}");
         command = parseReadCommand(formattedQuery);
-        Assertions.assertThat(command.toRedactedCQLString()).contains("WITH ann_options = {'rerank_k': 2, 'use_pruning': false}");
+        Assertions.assertThat(command.toCQLString(Redaction.NONE)).contains("WITH ann_options = {'rerank_k': 2, 'use_pruning': false}");
     }
 
     /**

--- a/test/unit/org/apache/cassandra/db/filter/ColumnFilterTest.java
+++ b/test/unit/org/apache/cassandra/db/filter/ColumnFilterTest.java
@@ -36,6 +36,7 @@ import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.ColumnIdentifier;
 import org.apache.cassandra.db.RegularAndStaticColumns;
 import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.db.marshal.SetType;
 import org.apache.cassandra.db.rows.CellPath;
 import org.apache.cassandra.dht.Murmur3Partitioner;
@@ -115,8 +116,8 @@ public class ColumnFilterTest
         Consumer<ColumnFilter> check = filter -> {
             testRoundTrips(filter);
             assertEquals("*/*", filter.toString());
-            assertEquals("*", filter.toCQLString(false));
-            assertEquals("*", filter.toCQLString(true));
+            assertEquals("*", filter.toCQLString(Redaction.NONE));
+            assertEquals("*", filter.toCQLString(Redaction.REDACT));
             assertFetchedQueried(true, true, filter, v1, v2, s1, s2);
             assertCellFetchedQueried(true, true, filter, v2, path0, path1, path2, path3, path4);
             assertCellFetchedQueried(true, true, filter, s2, path0, path1, path2, path3, path4);
@@ -135,8 +136,8 @@ public class ColumnFilterTest
         Consumer<ColumnFilter> check = filter -> {
             testRoundTrips(filter);
             assertEquals("[]", filter.toString());
-            assertEquals("*", filter.toCQLString(true));
-            assertEquals("*", filter.toCQLString(false));
+            assertEquals("*", filter.toCQLString(Redaction.REDACT));
+            assertEquals("*", filter.toCQLString(Redaction.NONE));
             assertFetchedQueried(false, false, filter, v1, v2, s1, s2);
             assertCellFetchedQueried(false, false, filter, v2, path0, path1, path2, path3, path4);
             assertCellFetchedQueried(false, false, filter, s2, path0, path1, path2, path3, path4);
@@ -152,8 +153,8 @@ public class ColumnFilterTest
         Consumer<ColumnFilter> check = filter -> {
             testRoundTrips(filter);
             assertEquals("[v1]", filter.toString());
-            assertEquals("v1", filter.toCQLString(true));
-            assertEquals("v1", filter.toCQLString(false));
+            assertEquals("v1", filter.toCQLString(Redaction.REDACT));
+            assertEquals("v1", filter.toCQLString(Redaction.NONE));
             assertFetchedQueried(true, true, filter, v1);
             assertFetchedQueried(false, false, filter, v2, s1, s2);
             assertCellFetchedQueried(false, false, filter, v2, path0, path1, path2, path3, path4);
@@ -170,8 +171,8 @@ public class ColumnFilterTest
         Consumer<ColumnFilter> check = filter -> {
             testRoundTrips(filter);
             assertEquals("[Escaped Name]", filter.toString());
-            assertEquals("\"Escaped Name\"", filter.toCQLString(false));
-            assertEquals("\"Escaped Name\"", filter.toCQLString(true));
+            assertEquals("\"Escaped Name\"", filter.toCQLString(Redaction.NONE));
+            assertEquals("\"Escaped Name\"", filter.toCQLString(Redaction.REDACT));
             assertFetchedQueried(true, true, filter, escaped);
             assertFetchedQueried(false, false, filter, v2, s1, s2);
             assertCellFetchedQueried(false, false, filter, v2, path0, path1, path2, path3, path4);
@@ -188,8 +189,8 @@ public class ColumnFilterTest
         Consumer<ColumnFilter> check = filter -> {
             testRoundTrips(filter);
             assertEquals("[v2]", filter.toString());
-            assertEquals("v2", filter.toCQLString(false));
-            assertEquals("v2", filter.toCQLString(true));
+            assertEquals("v2", filter.toCQLString(Redaction.NONE));
+            assertEquals("v2", filter.toCQLString(Redaction.REDACT));
             assertFetchedQueried(true, true, filter, v2);
             assertFetchedQueried(false, false, filter, v1, s1, s2);
             assertCellFetchedQueried(true, true, filter, v2, path0, path1, path2, path3, path4);
@@ -206,8 +207,8 @@ public class ColumnFilterTest
         Consumer<ColumnFilter> check = filter -> {
             testRoundTrips(filter);
             assertEquals("[s1]", filter.toString());
-            assertEquals("s1", filter.toCQLString(false));
-            assertEquals("s1", filter.toCQLString(true));
+            assertEquals("s1", filter.toCQLString(Redaction.NONE));
+            assertEquals("s1", filter.toCQLString(Redaction.REDACT));
             assertFetchedQueried(true, true, filter, s1);
             assertFetchedQueried(false, false, filter, v1, v2, s2);
             assertCellFetchedQueried(false, false, filter, v2, path0, path1, path2, path3, path4);
@@ -224,8 +225,8 @@ public class ColumnFilterTest
         Consumer<ColumnFilter> check = filter -> {
             testRoundTrips(filter);
             assertEquals("[s2]", filter.toString());
-            assertEquals("s2", filter.toCQLString(false));
-            assertEquals("s2", filter.toCQLString(true));
+            assertEquals("s2", filter.toCQLString(Redaction.NONE));
+            assertEquals("s2", filter.toCQLString(Redaction.REDACT));
             assertFetchedQueried(true, true, filter, s2);
             assertFetchedQueried(false, false, filter, v1, v2, s1);
             assertCellFetchedQueried(false, false, filter, v2, path0, path1, path2, path3, path4);
@@ -242,8 +243,8 @@ public class ColumnFilterTest
         Consumer<ColumnFilter> check = filter -> {
             testRoundTrips(filter);
             assertEquals("[s1, s2, v1, v2]", filter.toString());
-            assertEquals("s1, s2, v1, v2", filter.toCQLString(false));
-            assertEquals("s1, s2, v1, v2", filter.toCQLString(true));
+            assertEquals("s1, s2, v1, v2", filter.toCQLString(Redaction.NONE));
+            assertEquals("s1, s2, v1, v2", filter.toCQLString(Redaction.REDACT));
             assertFetchedQueried(true, true, filter, v1, v2, s1, s2);
             assertCellFetchedQueried(true, true, filter, v2, path0, path1, path2, path3, path4);
             assertCellFetchedQueried(true, true, filter, s2, path0, path1, path2, path3, path4);
@@ -259,8 +260,8 @@ public class ColumnFilterTest
         ColumnFilter filter = ColumnFilter.selectionBuilder().select(v2, path1).select(v2, path3).build();
         testRoundTrips(filter);
         assertEquals("[v2[1], v2[3]]", filter.toString());
-        assertEquals("v2[1], v2[3]", filter.toCQLString(false));
-        assertEquals("v2[?], v2[?]", filter.toCQLString(true));
+        assertEquals("v2[1], v2[3]", filter.toCQLString(Redaction.NONE));
+        assertEquals("v2[?], v2[?]", filter.toCQLString(Redaction.REDACT));
         assertFetchedQueried(true, true, filter, v2);
         assertFetchedQueried(false, false, filter, v1, s1, s2);
         assertCellFetchedQueried(true, true, filter, v2, path1, path3);
@@ -274,8 +275,8 @@ public class ColumnFilterTest
         ColumnFilter filter = ColumnFilter.selectionBuilder().select(s2, path1).select(s2, path3).build();
         testRoundTrips(filter);
         assertEquals("[s2[1], s2[3]]", filter.toString());
-        assertEquals("s2[1], s2[3]", filter.toCQLString(false));
-        assertEquals("s2[?], s2[?]", filter.toCQLString(true));
+        assertEquals("s2[1], s2[3]", filter.toCQLString(Redaction.NONE));
+        assertEquals("s2[?], s2[?]", filter.toCQLString(Redaction.REDACT));
         assertFetchedQueried(true, true, filter, s2);
         assertFetchedQueried(false, false, filter, v1, v2, s1);
         assertCellFetchedQueried(false, false, filter, v2, path0, path1, path2, path3, path4);
@@ -289,8 +290,8 @@ public class ColumnFilterTest
         ColumnFilter filter = ColumnFilter.selectionBuilder().slice(v2, path1, path3).build();
         testRoundTrips(filter);
         assertEquals("[v2[1:3]]", filter.toString());
-        assertEquals("v2[1:3]", filter.toCQLString(false));
-        assertEquals("v2[?:?]", filter.toCQLString(true));
+        assertEquals("v2[1:3]", filter.toCQLString(Redaction.NONE));
+        assertEquals("v2[?:?]", filter.toCQLString(Redaction.REDACT));
         assertFetchedQueried(true, true, filter, v2);
         assertFetchedQueried(false, false, filter, v1, s1, s2);
         assertCellFetchedQueried(true, true, filter, v2, path1, path2, path3);
@@ -304,8 +305,8 @@ public class ColumnFilterTest
         ColumnFilter filter = ColumnFilter.selectionBuilder().slice(s2, path1, path3).build();
         testRoundTrips(filter);
         assertEquals("[s2[1:3]]", filter.toString());
-        assertEquals("s2[1:3]", filter.toCQLString(false));
-        assertEquals("s2[?:?]", filter.toCQLString(true));
+        assertEquals("s2[1:3]", filter.toCQLString(Redaction.NONE));
+        assertEquals("s2[?:?]", filter.toCQLString(Redaction.REDACT));
         assertFetchedQueried(true, true, filter, s2);
         assertFetchedQueried(false, false, filter, v1, v2, s1);
         assertCellFetchedQueried(false, false, filter, v2, path0, path1, path2, path3, path4);
@@ -326,8 +327,8 @@ public class ColumnFilterTest
                                           .build();
         testRoundTrips(filter);
         assertEquals("[s1, s2[0], s2[2:4], v1, v2[0:2], v2[4]]", filter.toString());
-        assertEquals("s1, s2[0], s2[2:4], v1, v2[0:2], v2[4]", filter.toCQLString(false));
-        assertEquals("s1, s2[?], s2[?:?], v1, v2[?:?], v2[?]", filter.toCQLString(true));
+        assertEquals("s1, s2[0], s2[2:4], v1, v2[0:2], v2[4]", filter.toCQLString(Redaction.NONE));
+        assertEquals("s1, s2[?], s2[?:?], v1, v2[?:?], v2[?]", filter.toCQLString(Redaction.REDACT));
         assertFetchedQueried(true, true, filter, v1, v2, s1, s2);
         assertCellFetchedQueried(true, true, filter, v2, path0, path1, path2, path4);
         assertCellFetchedQueried(false, false, filter, v2, path3);
@@ -357,8 +358,8 @@ public class ColumnFilterTest
             if ("3.0".equals(clusterMinVersion))
             {
                 assertEquals("*/*", filter.toString());
-                assertEquals("*", filter.toCQLString(false));
-                assertEquals("*", filter.toCQLString(true));
+                assertEquals("*", filter.toCQLString(Redaction.NONE));
+                assertEquals("*", filter.toCQLString(Redaction.REDACT));
                 assertFetchedQueried(true, true, filter, s1, s2, v2);
                 assertCellFetchedQueried(true, true, filter, v2, path0, path1, path2, path3, path4);
                 assertCellFetchedQueried(true, true, filter, s2, path0, path1, path2, path3, path4);
@@ -366,8 +367,8 @@ public class ColumnFilterTest
             else if ("3.11".equals(clusterMinVersion) || (returnStaticContentOnPartitionWithNoRows && "4.0".equals(clusterMinVersion)))
             {
                 assertEquals("*/[v1]", filter.toString());
-                assertEquals("v1", filter.toCQLString(false));
-                assertEquals("v1", filter.toCQLString(true));
+                assertEquals("v1", filter.toCQLString(Redaction.NONE));
+                assertEquals("v1", filter.toCQLString(Redaction.REDACT));
                 assertFetchedQueried(true, false, filter, s1, s2, v2);
                 assertCellFetchedQueried(true, false, filter, v2, path0, path1, path2, path3, path4);
                 assertCellFetchedQueried(true, false, filter, s2, path0, path1, path2, path3, path4);
@@ -375,8 +376,8 @@ public class ColumnFilterTest
             else
             {
                 assertEquals("<all regulars>/[v1]", filter.toString());
-                assertEquals("v1", filter.toCQLString(false));
-                assertEquals("v1", filter.toCQLString(true));
+                assertEquals("v1", filter.toCQLString(Redaction.NONE));
+                assertEquals("v1", filter.toCQLString(Redaction.REDACT));
                 assertFetchedQueried(true, false, filter, v2);
                 assertFetchedQueried(false, false, filter, s1, s2);
                 assertCellFetchedQueried(true, false, filter, v2, path0, path1, path2, path3, path4);
@@ -408,8 +409,8 @@ public class ColumnFilterTest
             if ("3.0".equals(clusterMinVersion))
             {
                 assertEquals("*/*", filter.toString());
-                assertEquals("*", filter.toCQLString(false));
-                assertEquals("*", filter.toCQLString(true));
+                assertEquals("*", filter.toCQLString(Redaction.NONE));
+                assertEquals("*", filter.toCQLString(Redaction.REDACT));
                 assertFetchedQueried(true, true, filter, v1, v2, s2);
                 assertCellFetchedQueried(true, true, filter, v2, path0, path1, path2, path3, path4);
                 assertCellFetchedQueried(true, true, filter, s2, path0, path1, path2, path3, path4);
@@ -417,8 +418,8 @@ public class ColumnFilterTest
             else if ("3.11".equals(clusterMinVersion) || (returnStaticContentOnPartitionWithNoRows && "4.0".equals(clusterMinVersion)))
             {
                 assertEquals("*/[s1]", filter.toString());
-                assertEquals("s1", filter.toCQLString(false));
-                assertEquals("s1", filter.toCQLString(true));
+                assertEquals("s1", filter.toCQLString(Redaction.NONE));
+                assertEquals("s1", filter.toCQLString(Redaction.REDACT));
                 assertFetchedQueried(true, false, filter, v1, v2, s2);
                 assertCellFetchedQueried(true, false, filter, v2, path0, path1, path2, path3, path4);
                 assertCellFetchedQueried(false, false, filter, s2, path0, path1, path2, path3, path4);
@@ -426,8 +427,8 @@ public class ColumnFilterTest
             else
             {
                 assertEquals("<all regulars>+[s1]/[s1]", filter.toString());
-                assertEquals("s1", filter.toCQLString(false));
-                assertEquals("s1", filter.toCQLString(true));
+                assertEquals("s1", filter.toCQLString(Redaction.NONE));
+                assertEquals("s1", filter.toCQLString(Redaction.REDACT));
                 assertFetchedQueried(true, false, filter, v1, v2);
                 assertFetchedQueried(false, false, filter, s2);
                 assertCellFetchedQueried(true, false, filter, v2, path0, path1, path2, path3, path4);
@@ -461,8 +462,8 @@ public class ColumnFilterTest
         if ("3.0".equals(clusterMinVersion))
         {
             assertEquals("*/*", filter.toString());
-            assertEquals("*", filter.toCQLString(false));
-            assertEquals("*", filter.toCQLString(true));
+            assertEquals("*", filter.toCQLString(Redaction.NONE));
+            assertEquals("*", filter.toCQLString(Redaction.REDACT));
             assertFetchedQueried(true, true, filter, s1, s2, v1);
             assertCellFetchedQueried(true, true, filter, v2, path0, path1, path2, path3, path4);
             assertCellFetchedQueried(true, true, filter, s2, path0, path1, path2, path3, path4);
@@ -470,8 +471,8 @@ public class ColumnFilterTest
         else if ("3.11".equals(clusterMinVersion) || (returnStaticContentOnPartitionWithNoRows && "4.0".equals(clusterMinVersion)))
         {
             assertEquals("*/[v2[1]]", filter.toString());
-            assertEquals("v2[1]", filter.toCQLString(false));
-            assertEquals("v2[?]", filter.toCQLString(true));
+            assertEquals("v2[1]", filter.toCQLString(Redaction.NONE));
+            assertEquals("v2[?]", filter.toCQLString(Redaction.REDACT));
             assertFetchedQueried(true, false, filter, s1, s2, v1);
             assertCellFetchedQueried(true, true, filter, v2, path1);
             assertCellFetchedQueried(true, false, filter, v2, path0, path2, path3, path4);
@@ -480,8 +481,8 @@ public class ColumnFilterTest
         else
         {
             assertEquals("<all regulars>/[v2[1]]", filter.toString());
-            assertEquals("v2[1]", filter.toCQLString(false));
-            assertEquals("v2[?]", filter.toCQLString(true));
+            assertEquals("v2[1]", filter.toCQLString(Redaction.NONE));
+            assertEquals("v2[?]", filter.toCQLString(Redaction.REDACT));
             assertFetchedQueried(true, false, filter, v1);
             assertFetchedQueried(false, false, filter, s1, s2);
             assertCellFetchedQueried(true, true, filter, v2, path1);
@@ -512,8 +513,8 @@ public class ColumnFilterTest
         if ("3.0".equals(clusterMinVersion))
         {
             assertEquals("*/*", filter.toString());
-            assertEquals("*", filter.toCQLString(false));
-            assertEquals("*", filter.toCQLString(true));
+            assertEquals("*", filter.toCQLString(Redaction.NONE));
+            assertEquals("*", filter.toCQLString(Redaction.REDACT));
             assertFetchedQueried(true, true, filter, v1, v2, s1);
             assertCellFetchedQueried(true, true, filter, v2, path0, path1, path2, path3, path4);
             assertCellFetchedQueried(true, true, filter, s2, path1, path0, path2, path3, path4);
@@ -521,8 +522,8 @@ public class ColumnFilterTest
         else if ("3.11".equals(clusterMinVersion) || (returnStaticContentOnPartitionWithNoRows && "4.0".equals(clusterMinVersion)))
         {
             assertEquals("*/[s2[1]]", filter.toString());
-            assertEquals("s2[1]", filter.toCQLString(false));
-            assertEquals("s2[?]", filter.toCQLString(true));
+            assertEquals("s2[1]", filter.toCQLString(Redaction.NONE));
+            assertEquals("s2[?]", filter.toCQLString(Redaction.REDACT));
             assertFetchedQueried(true, false, filter, v1, v2, s1);
             assertCellFetchedQueried(true, false, filter, v2, path0, path1, path2, path3, path4);
             assertCellFetchedQueried(true, true, filter, s2, path1);
@@ -531,8 +532,8 @@ public class ColumnFilterTest
         else
         {
             assertEquals("<all regulars>+[s2[1]]/[s2[1]]", filter.toString());
-            assertEquals("s2[1]", filter.toCQLString(false));
-            assertEquals("s2[?]", filter.toCQLString(true));
+            assertEquals("s2[1]", filter.toCQLString(Redaction.NONE));
+            assertEquals("s2[?]", filter.toCQLString(Redaction.REDACT));
             assertFetchedQueried(true, false, filter, v1, v2);
             assertFetchedQueried(false, false, filter, s1);
             assertCellFetchedQueried(false, false, filter, v2, path0, path1, path2, path3, path4);

--- a/test/unit/org/apache/cassandra/db/filter/IndexHintsTest.java
+++ b/test/unit/org/apache/cassandra/db/filter/IndexHintsTest.java
@@ -27,6 +27,7 @@ import org.apache.cassandra.cql3.QualifiedName;
 import org.apache.cassandra.cql3.restrictions.SingleColumnRestriction;
 import org.apache.cassandra.cql3.statements.PropertyDefinitions;
 import org.apache.cassandra.cql3.statements.SelectOptions;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.index.sai.analyzer.AnalyzerEqOperatorSupport;
 
 import org.junit.BeforeClass;
@@ -357,7 +358,7 @@ public class IndexHintsTest extends CQLTester
         // without index hints
         String formattedQuery = formatQuery("SELECT * FROM %%s WHERE a = 0");
         ReadCommand command = parseReadCommand(formattedQuery);
-        Assertions.assertThat(command.toRedactedCQLString())
+        Assertions.assertThat(command.toCQLString(Redaction.REDACT))
                   .doesNotContain("included_indexes")
                   .doesNotContain("excluded_indexes");
 
@@ -365,7 +366,7 @@ public class IndexHintsTest extends CQLTester
         formattedQuery = formatQuery("SELECT * FROM %%s WHERE a = 0 AND b = 0 " +
                                      "WITH included_indexes={} AND excluded_indexes={}");
         command = parseReadCommand(formattedQuery);
-        Assertions.assertThat(command.toRedactedCQLString())
+        Assertions.assertThat(command.toCQLString(Redaction.REDACT))
                   .doesNotContain("included_indexes")
                   .doesNotContain("excluded_indexes");
 
@@ -373,7 +374,7 @@ public class IndexHintsTest extends CQLTester
         formattedQuery = formatQuery("SELECT * FROM %%s WHERE a = 0 AND b = 0 " +
                                      "WITH included_indexes={idx1,idx2}");
         command = parseReadCommand(formattedQuery);
-        Assertions.assertThat(command.toRedactedCQLString())
+        Assertions.assertThat(command.toCQLString(Redaction.REDACT))
                   .contains(" WITH included_indexes = {idx1, idx2}")
                   .doesNotContain("excluded_indexes");
 
@@ -381,7 +382,7 @@ public class IndexHintsTest extends CQLTester
         formattedQuery = formatQuery("SELECT * FROM %%s WHERE a = 0 AND b = 0 ALLOW FILTERING " +
                                      "WITH excluded_indexes={idx1,idx2}");
         command = parseReadCommand(formattedQuery);
-        Assertions.assertThat(command.toRedactedCQLString())
+        Assertions.assertThat(command.toCQLString(Redaction.REDACT))
                   .contains(" WITH excluded_indexes = {idx1, idx2}")
                   .doesNotContain("included_indexes");
 
@@ -389,14 +390,14 @@ public class IndexHintsTest extends CQLTester
         formattedQuery = formatQuery("SELECT * FROM %%s WHERE a = 0 AND b = 0 ALLOW FILTERING " +
                                      "WITH included_indexes={idx1} AND excluded_indexes={idx2}");
         command = parseReadCommand(formattedQuery);
-        Assertions.assertThat(command.toRedactedCQLString())
+        Assertions.assertThat(command.toCQLString(Redaction.REDACT))
                   .contains(" WITH included_indexes = {idx1} AND excluded_indexes = {idx2}");
 
         // with a single-partition read command
         formattedQuery = formatQuery("SELECT * FROM %%s WHERE k=1 AND a = 0 AND b = 0 ALLOW FILTERING " +
                                      "WITH included_indexes={idx1} AND excluded_indexes={idx2}");
         command = parseReadCommand(formattedQuery);
-        Assertions.assertThat(command.toRedactedCQLString())
+        Assertions.assertThat(command.toCQLString(Redaction.REDACT))
                   .contains(" WITH included_indexes = {idx1} AND excluded_indexes = {idx2}");
     }
 

--- a/test/unit/org/apache/cassandra/index/sai/cql/QueryTracingTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/QueryTracingTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.cql;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.index.sai.SAITester;
+import org.apache.cassandra.service.ClientState;
+import org.apache.cassandra.tracing.Tracing;
+import org.apache.cassandra.tracing.TracingTestImpl;
+import org.assertj.core.api.Assertions;
+
+public class QueryTracingTest extends SAITester
+{
+    private static TracingTestImpl tracing;
+
+    @BeforeClass
+    public static void setUpClass()
+    {
+        System.setProperty("cassandra.custom_tracing_class", "org.apache.cassandra.tracing.TracingTestImpl");
+        SAITester.setUpClass();
+        Tracing.instance.newSession(ClientState.forInternalCalls(), Tracing.TraceType.QUERY);
+        tracing = (TracingTestImpl) Tracing.instance;
+    }
+
+    @AfterClass
+    public static void tearDownClass()
+    {
+        tracing.stopSession();
+        SAITester.tearDownClass();
+    }
+
+    @Test
+    public void testTracing()
+    {
+        createTable("CREATE TABLE %s(k int PRIMARY KEY, n int, t text, at text, v vector<float,2>)");
+        execute("INSERT INTO %s(k, n, t, at, v) VALUES (0, 0, 'hello', 'good bye', [1, 2])");
+        createIndex("CREATE CUSTOM INDEX ON %s(n) USING 'org.apache.cassandra.index.sai.StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX ON %s(t) USING 'org.apache.cassandra.index.sai.StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX ON %s(at) USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' WITH OPTIONS = { 'index_analyzer': 'standard' }");
+        createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'org.apache.cassandra.index.sai.StorageAttachedIndex'");
+
+        // queries on numeric index
+        assertTraceHasPlan("SELECT * FROM %s WHERE n = 0",
+                           "Filter n = 0",
+                           "NumericIndexScan",
+                           "predicate: Expression{name: n, op: EQ, lower: (0, true), upper: (0, true), exclusions: []}");
+        assertTraceHasPlan("SELECT * FROM %s WHERE n > 0",
+                           "Filter n > 0",
+                           "NumericIndexScan",
+                           "predicate: Expression{name: n, op: RANGE, lower: (0, false), upper: (null, false), exclusions: []}");
+        assertTraceHasPlan("SELECT * FROM %s WHERE n < 0",
+                           "Filter n < 0",
+                           "NumericIndexScan",
+                           "predicate: Expression{name: n, op: RANGE, lower: (null, false), upper: (0, false), exclusions: []}");
+        assertTraceHasPlan("SELECT * FROM %s WHERE n >= 0",
+                           "Filter n >= 0",
+                           "NumericIndexScan",
+                           "predicate: Expression{name: n, op: RANGE, lower: (0, true), upper: (null, false), exclusions: []}");
+        assertTraceHasPlan("SELECT * FROM %s WHERE n <= 0",
+                           "Filter n <= 0",
+                           "NumericIndexScan",
+                           "predicate: Expression{name: n, op: RANGE, lower: (null, false), upper: (0, true), exclusions: []}");
+        assertTraceHasPlan("SELECT * FROM %s ORDER BY n LIMIT 10",
+                           "NumericIndexScan",
+                           "ordering: n ASC");
+
+        // queries on literal index
+        assertTraceHasPlan("SELECT * FROM %s WHERE t = 'hello'",
+                           "Filter t = 'hello'",
+                           "LiteralIndexScan",
+                           "predicate: Expression{name: t, op: EQ, lower: (hello, true), upper: (hello, true), exclusions: []}");
+        assertTraceHasPlan("SELECT * FROM %s ORDER BY t LIMIT 10",
+                           "LiteralIndexScan",
+                           "ordering: t ASC");
+
+        // queries on analyzed index
+        assertTraceHasPlan("SELECT * FROM %s WHERE at : 'good'",
+                           "Filter at : 'good'",
+                           "LiteralIndexScan",
+                           "predicate: Expression{name: at, op: MATCH, lower: (good, true), upper: (good, true), exclusions: []}");
+        assertTraceHasPlan("SELECT * FROM %s ORDER BY at BM25 OF 'good' LIMIT 10",
+                           "Bm25IndexScan",
+                           "at BM25 OF 'good' DESC");
+
+        // queries on vector index
+        assertTraceHasPlan("SELECT * FROM %s ORDER BY v ANN OF [1.2, 3.4] LIMIT 10",
+                           "AnnIndexScan",
+                           "v ANN OF [1.2, 3.4] DESC");
+    }
+
+    private void assertTraceHasPlan(String query, String... expected)
+    {
+        TracingTestImpl tracing = (TracingTestImpl) Tracing.instance;
+        tracing.getTraces().clear();
+
+        execute(query);
+
+        for (String trace : tracing.getTraces())
+        {
+            if (!trace.startsWith("Query execution plan"))
+                continue;
+
+            for (String s : expected)
+            {
+                Assertions.assertThat(trace).as("Trace should contain {} but found: {}", expected, trace).contains(s);
+            }
+            return;
+        }
+        Assert.fail("Query plan not found in traces");
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/plan/ExpressionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/plan/ExpressionTest.java
@@ -22,10 +22,13 @@ import java.nio.ByteBuffer;
 
 import org.junit.Test;
 
+import org.apache.cassandra.cql3.Operator;
 import org.apache.cassandra.db.marshal.UTF8Type;
+import org.apache.cassandra.index.sai.SAITester;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ExpressionTest
 {
@@ -50,5 +53,56 @@ public class ExpressionTest
         Expression.Bound b2 = new Expression.Bound(buf2, UTF8Type.instance, true);
         assertNotEquals(b1, b2);
         assertNotEquals(b1.hashCode(), b2.hashCode());
+    }
+
+    @Test
+    public void toStringRedactionTest()
+    {
+        // test a few operators, just enough to see different variants to the string representations
+        Expression expression = makeExpression(Operator.EQ);
+        assertThat(expression.toString(true))
+                .isEqualTo("Expression{name: col, op: EQ, lower: (?, true), upper: (?, true), exclusions: []}");
+        assertThat(expression.toString(false))
+                .isEqualTo("Expression{name: col, op: EQ, lower: (sensitive, true), upper: (sensitive, true), exclusions: []}");
+
+        expression = makeExpression(Operator.GT);
+        assertThat(expression.toString(true))
+                .isEqualTo("Expression{name: col, op: RANGE, lower: (?, false), upper: (null, false), exclusions: []}");
+        assertThat(expression.toString(false))
+                .isEqualTo("Expression{name: col, op: RANGE, lower: (sensitive, false), upper: (null, false), exclusions: []}");
+
+        expression = makeExpression(Operator.GTE);
+        assertThat(expression.toString(true))
+                .isEqualTo("Expression{name: col, op: RANGE, lower: (?, true), upper: (null, false), exclusions: []}");
+        assertThat(expression.toString(false))
+                .isEqualTo("Expression{name: col, op: RANGE, lower: (sensitive, true), upper: (null, false), exclusions: []}");
+
+        expression = makeExpression(Operator.LT);
+        assertThat(expression.toString(true))
+                .isEqualTo("Expression{name: col, op: RANGE, lower: (null, false), upper: (?, false), exclusions: []}");
+        assertThat(expression.toString(false))
+                .isEqualTo("Expression{name: col, op: RANGE, lower: (null, false), upper: (sensitive, false), exclusions: []}");
+
+        expression = makeExpression(Operator.LTE);
+        assertThat(expression.toString(true))
+                .isEqualTo("Expression{name: col, op: RANGE, lower: (null, false), upper: (?, true), exclusions: []}");
+        assertThat(expression.toString(false))
+                .isEqualTo("Expression{name: col, op: RANGE, lower: (null, false), upper: (sensitive, true), exclusions: []}");
+
+        // test exclusions, which also need redaction
+        expression = new Expression(SAITester.createIndexContext("col", UTF8Type.instance));
+        expression.add(Operator.GT, UTF8Type.instance.decompose("sensitive_1"));
+        expression.add(Operator.NEQ, UTF8Type.instance.decompose("sensitive_2"));
+        assertThat(expression.toString(true))
+                .isEqualTo("Expression{name: col, op: RANGE, lower: (?, false), upper: (null, false), exclusions: [?]}");
+        assertThat(expression.toString(false))
+                .isEqualTo("Expression{name: col, op: RANGE, lower: (sensitive_1, false), upper: (null, false), exclusions: [sensitive_2]}");
+    }
+
+    private static Expression makeExpression(Operator op)
+    {
+        Expression expression = new Expression(SAITester.createIndexContext("col", UTF8Type.instance));
+        expression.add(op, UTF8Type.instance.decompose("sensitive"));
+        return expression;
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/plan/OrdererTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/plan/OrdererTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.plan;
+
+import org.junit.Test;
+
+import org.apache.cassandra.cql3.Operator;
+import org.apache.cassandra.db.filter.ANNOptions;
+import org.apache.cassandra.db.marshal.FloatType;
+import org.apache.cassandra.db.marshal.Privacy;
+import org.apache.cassandra.db.marshal.UTF8Type;
+import org.apache.cassandra.db.marshal.VectorType;
+import org.apache.cassandra.index.sai.IndexContext;
+import org.apache.cassandra.index.sai.SAITester;
+import org.apache.cassandra.index.sai.cql.VectorTester;
+import org.assertj.core.api.Assertions;
+
+public class OrdererTest extends VectorTester
+{
+    @Test
+    public void toStringRedactionTest()
+    {
+        // ANN
+        VectorType<Float> vectorType = VectorType.getInstance(FloatType.instance, 2);
+        IndexContext context = SAITester.createIndexContext("col", vectorType);
+        Orderer orderer = new Orderer(context, Operator.ANN, vectorType.decompose(vector(1, 2)), ANNOptions.NONE);
+        assertToString(orderer, "col ANN OF ? DESC", "col ANN OF [1.0, 2.0] DESC");
+
+        // BM25
+        IndexContext textContext = SAITester.createIndexContext("col", UTF8Type.instance);
+        orderer = new Orderer(textContext, Operator.BM25, UTF8Type.instance.decompose("sensitive"), ANNOptions.NONE);
+        assertToString(orderer, "col BM25 OF ? DESC", "col BM25 OF 'sensitive' DESC");
+
+        // Generic ORDER BY
+        orderer = new Orderer(textContext, Operator.ORDER_BY_ASC, null, ANNOptions.NONE);
+        assertToString(orderer, "col ASC", "col ASC");
+        orderer = new Orderer(textContext, Operator.ORDER_BY_DESC, null, ANNOptions.NONE);
+        assertToString(orderer, "col DESC", "col DESC");
+    }
+
+    private static void assertToString(Orderer orderer, String expectedRedacted, String expectedUnredacted)
+    {
+        Assertions.assertThat(orderer.toString(Privacy.REDACT))
+                  .isEqualTo(expectedRedacted);
+        Assertions.assertThat(orderer.toString(Privacy.NONE))
+                  .isEqualTo(expectedUnredacted);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/plan/OrdererTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/plan/OrdererTest.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 import org.apache.cassandra.cql3.Operator;
 import org.apache.cassandra.db.filter.ANNOptions;
 import org.apache.cassandra.db.marshal.FloatType;
-import org.apache.cassandra.db.marshal.Privacy;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.db.marshal.UTF8Type;
 import org.apache.cassandra.db.marshal.VectorType;
 import org.apache.cassandra.index.sai.IndexContext;
@@ -54,9 +54,9 @@ public class OrdererTest extends VectorTester
 
     private static void assertToString(Orderer orderer, String expectedRedacted, String expectedUnredacted)
     {
-        Assertions.assertThat(orderer.toString(Privacy.REDACT))
+        Assertions.assertThat(orderer.toString(Redaction.REDACT))
                   .isEqualTo(expectedRedacted);
-        Assertions.assertThat(orderer.toString(Privacy.NONE))
+        Assertions.assertThat(orderer.toString(Redaction.NONE))
                   .isEqualTo(expectedUnredacted);
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/plan/PlanTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/plan/PlanTest.java
@@ -36,7 +36,7 @@ import org.junit.Test;
 import org.apache.cassandra.cql3.Operator;
 import org.apache.cassandra.db.filter.IndexHints;
 import org.apache.cassandra.db.filter.RowFilter;
-import org.apache.cassandra.index.SecondaryIndexManager;
+import org.apache.cassandra.db.marshal.Privacy;
 import org.apache.cassandra.index.sai.disk.vector.VectorMemtableIndex;
 import org.apache.cassandra.index.sai.iterators.KeyRangeIterator;
 import org.apache.cassandra.index.sai.iterators.LongIterator;
@@ -68,14 +68,15 @@ public class PlanTest
     {
         Orderer orderer = Mockito.mock(Orderer.class);
         Mockito.when(orderer.isANN()).thenReturn(true);
-        Mockito.when(orderer.toString()).thenReturn("ORDER BY v ANN OF [...]");
+        Mockito.when(orderer.toString(Privacy.REDACT)).thenReturn("ORDER BY v ANN OF ?");
+        Mockito.when(orderer.toString(Privacy.NONE)).thenReturn("ORDER BY v ANN OF X");
         return orderer;
     }
 
-    private static final RowFilter.Expression pred1 = filerPred("pred1", Operator.LT);
-    private static final RowFilter.Expression pred2 = filerPred("pred2", Operator.LT);
-    private static final RowFilter.Expression pred3 = filerPred("pred3", Operator.LT);
-    private static final RowFilter.Expression pred4 = filerPred("pred4", Operator.LT);
+    private static final RowFilter.Expression pred1 = filterPred("pred1", Operator.LT);
+    private static final RowFilter.Expression pred2 = filterPred("pred2", Operator.LT);
+    private static final RowFilter.Expression pred3 = filterPred("pred3", Operator.LT);
+    private static final RowFilter.Expression pred4 = filterPred("pred4", Operator.LT);
 
     private static final Expression saiPred1 = saiPred("pred1", Expression.Op.RANGE, false);
     private static final  Expression saiPred2 = saiPred("pred2", Expression.Op.RANGE, false);
@@ -100,14 +101,15 @@ public class PlanTest
     private static Expression saiPred(String column, Expression.Op operation, boolean isLiteral)
     {
         Expression pred = Mockito.mock(Expression.class);
-        Mockito.when(pred.toString()).thenReturn(operation.toString() + '(' + column + ')');
+        Mockito.when(pred.toString(false)).thenReturn(operation.toString() + '(' + column + ", X)");
+        Mockito.when(pred.toString(true)).thenReturn(operation.toString() + '(' + column + ", ?)");
         Mockito.when(pred.getIndexName()).thenReturn(column + "_idx");
         Mockito.when(pred.getOp()).thenReturn(operation);
         Mockito.when(pred.isLiteral()).thenReturn(isLiteral);
         return pred;
     }
 
-    private static RowFilter.Expression filerPred(String column, Operator operation)
+    private static RowFilter.Expression filterPred(String column, Operator operation)
     {
         RowFilter.Expression pred = Mockito.mock(RowFilter.Expression.class);
         Mockito.when(pred.toCQLString(false)).thenReturn(column + ' ' + operation + " X");
@@ -573,18 +575,18 @@ public class PlanTest
                               " └─ Filter pred1 < %s AND pred2 < %<s AND pred4 < %<s (sel: 1.000000000) (rows: 3.0, cost/row: 3895.8, cost: 44171.3..55858.7)\n" +
                               "     └─ Fetch (rows: 3.0, cost/row: 3895.8, cost: 44171.3..55858.7)\n" +
                               "         └─ KeysSort (keys: 3.0, cost/key: 3792.4, cost: 44171.3..55548.4)\n" +
-                              "            ORDER BY v ANN OF [...]\n" +
+                              "            ORDER BY v ANN OF %<s\n" +
                               "             └─ Union (keys: 1999.0, cost/key: 14.8, cost: 13500.0..43001.3)\n" +
                               "                 ├─ Intersection (keys: 1000.0, cost/key: 29.4, cost: 9000.0..38401.3)\n" +
                               "                 │   ├─ NumericIndexScan of pred2_idx (sel: 0.002000000, step: 1.0) (keys: 2000.0, cost/key: 0.1, cost: 4500.0..4700.0)\n" +
-                              "                 │   │  predicate: RANGE(pred2)\n" +
+                              "                 │   │  predicate: RANGE(pred2, %<s)\n" +
                               "                 │   └─ NumericIndexScan of pred1_idx (sel: 0.500000000, step: 250.0) (keys: 2000.0, cost/key: 14.6, cost: 4500.0..33701.3)\n" +
-                              "                 │      predicate: RANGE(pred1)\n" +
+                              "                 │      predicate: RANGE(pred1, %<s)\n" +
                               "                 └─ LiteralIndexScan of pred4_idx (sel: 0.001000000, step: 1.0) (keys: 1000.0, cost/key: 0.1, cost: 4500.0..4600.0)\n" +
-                              "                    predicate: RANGE(pred4)\n";
+                              "                    predicate: RANGE(pred4, %<s)\n";
 
-        assertEquals(String.format(expectedPlan, 'X'), limit.toUnredactedStringRecursive());
-        assertEquals(String.format(expectedPlan, '?'), limit.toRedactedStringRecursive());
+        assertEquals(String.format(expectedPlan, 'X'), limit.toStringRecursive(Privacy.NONE));
+        assertEquals(String.format(expectedPlan, '?'), limit.toStringRecursive(Privacy.REDACT));
     }
 
     @Test
@@ -876,7 +878,7 @@ public class PlanTest
 
         Plan optimizedPlan = origPlan.optimize();
         List<Plan.IndexScan> resultIndexScans = optimizedPlan.nodesOfType(Plan.IndexScan.class);
-        assertTrue("original:\n" + origPlan.toRedactedStringRecursive() + "optimized:\n" + optimizedPlan.toRedactedStringRecursive(),
+        assertTrue("original:\n" + origPlan.toStringRecursive(Privacy.REDACT) + "optimized:\n" + optimizedPlan.toStringRecursive(Privacy.REDACT),
                      expectedIndexScanCount.contains(resultIndexScans.size()));
     }
 
@@ -994,7 +996,7 @@ public class PlanTest
             Plan.KeysIteration indexScan = factory.indexScan(saiPred(column, operation, operation == Expression.Op.EQ),
                                                                     (long) (selectivities.get(i) * metrics.rows));
             indexScans.add(indexScan);
-            rowFilterBuilder.add(filerPred(column, operation == Expression.Op.RANGE ? Operator.LT : Operator.EQ));
+            rowFilterBuilder.add(filterPred(column, operation == Expression.Op.RANGE ? Operator.LT : Operator.EQ));
         }
 
         Plan.KeysIteration intersection = factory.intersection(indexScans);
@@ -1005,7 +1007,7 @@ public class PlanTest
 
         Plan optimizedPlan = origPlan.optimize();
         List<Plan.IndexScan> resultIndexScans = optimizedPlan.nodesOfType(Plan.IndexScan.class);
-        assertTrue("original:\n" + origPlan.toRedactedStringRecursive() + "optimized:\n" + optimizedPlan.toRedactedStringRecursive(),
+        assertTrue("original:\n" + origPlan.toStringRecursive(Privacy.REDACT) + "optimized:\n" + optimizedPlan.toStringRecursive(Privacy.REDACT),
                      expectedIndexScanCount.contains(resultIndexScans.size()));
     }
 

--- a/test/unit/org/apache/cassandra/index/sai/plan/PlanTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/plan/PlanTest.java
@@ -36,7 +36,7 @@ import org.junit.Test;
 import org.apache.cassandra.cql3.Operator;
 import org.apache.cassandra.db.filter.IndexHints;
 import org.apache.cassandra.db.filter.RowFilter;
-import org.apache.cassandra.db.marshal.Privacy;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.index.sai.disk.vector.VectorMemtableIndex;
 import org.apache.cassandra.index.sai.iterators.KeyRangeIterator;
 import org.apache.cassandra.index.sai.iterators.LongIterator;
@@ -68,8 +68,8 @@ public class PlanTest
     {
         Orderer orderer = Mockito.mock(Orderer.class);
         Mockito.when(orderer.isANN()).thenReturn(true);
-        Mockito.when(orderer.toString(Privacy.REDACT)).thenReturn("ORDER BY v ANN OF ?");
-        Mockito.when(orderer.toString(Privacy.NONE)).thenReturn("ORDER BY v ANN OF X");
+        Mockito.when(orderer.toString(Redaction.REDACT)).thenReturn("ORDER BY v ANN OF ?");
+        Mockito.when(orderer.toString(Redaction.NONE)).thenReturn("ORDER BY v ANN OF X");
         return orderer;
     }
 
@@ -112,8 +112,8 @@ public class PlanTest
     private static RowFilter.Expression filterPred(String column, Operator operation)
     {
         RowFilter.Expression pred = Mockito.mock(RowFilter.Expression.class);
-        Mockito.when(pred.toCQLString(false)).thenReturn(column + ' ' + operation + " X");
-        Mockito.when(pred.toCQLString(true)).thenReturn(column + ' ' + operation + " ?");
+        Mockito.when(pred.toCQLString(Redaction.NONE)).thenReturn(column + ' ' + operation + " X");
+        Mockito.when(pred.toCQLString(Redaction.REDACT)).thenReturn(column + ' ' + operation + " ?");
         Mockito.when(pred.operator()).thenReturn(operation);
         return pred;
     }
@@ -585,8 +585,8 @@ public class PlanTest
                               "                 └─ LiteralIndexScan of pred4_idx (sel: 0.001000000, step: 1.0) (keys: 1000.0, cost/key: 0.1, cost: 4500.0..4600.0)\n" +
                               "                    predicate: RANGE(pred4, %<s)\n";
 
-        assertEquals(String.format(expectedPlan, 'X'), limit.toStringRecursive(Privacy.NONE));
-        assertEquals(String.format(expectedPlan, '?'), limit.toStringRecursive(Privacy.REDACT));
+        assertEquals(String.format(expectedPlan, 'X'), limit.toStringRecursive(Redaction.NONE));
+        assertEquals(String.format(expectedPlan, '?'), limit.toStringRecursive(Redaction.REDACT));
     }
 
     @Test
@@ -878,7 +878,7 @@ public class PlanTest
 
         Plan optimizedPlan = origPlan.optimize();
         List<Plan.IndexScan> resultIndexScans = optimizedPlan.nodesOfType(Plan.IndexScan.class);
-        assertTrue("original:\n" + origPlan.toStringRecursive(Privacy.REDACT) + "optimized:\n" + optimizedPlan.toStringRecursive(Privacy.REDACT),
+        assertTrue("original:\n" + origPlan.toStringRecursive(Redaction.REDACT) + "optimized:\n" + optimizedPlan.toStringRecursive(Redaction.REDACT),
                      expectedIndexScanCount.contains(resultIndexScans.size()));
     }
 
@@ -1007,7 +1007,7 @@ public class PlanTest
 
         Plan optimizedPlan = origPlan.optimize();
         List<Plan.IndexScan> resultIndexScans = optimizedPlan.nodesOfType(Plan.IndexScan.class);
-        assertTrue("original:\n" + origPlan.toStringRecursive(Privacy.REDACT) + "optimized:\n" + optimizedPlan.toStringRecursive(Privacy.REDACT),
+        assertTrue("original:\n" + origPlan.toStringRecursive(Redaction.REDACT) + "optimized:\n" + optimizedPlan.toStringRecursive(Redaction.REDACT),
                      expectedIndexScanCount.contains(resultIndexScans.size()));
     }
 


### PR DESCRIPTION
### What is the issue

[CNDB-15280](https://github.com/riptano/cndb/issues/15280) added redaction of user data to queries printed in logs and other observability systems. This includes the SAI query plan printed by, at least, the slow query logger. However, it seems the SAI expressions are printed without redaction:
```
SAI slowest query plan:
  Limit 5000 (rows: 15.0, cost/row: 131.3, cost: 9097.1..11067.0)
   └─ Filter column : ? (sel: 1.000000000) (rows: 15.0, cost/row: 131.3, cost: 9097.1..11067.0)
       └─ Fetch (rows: 15.0, cost/row: 131.3, cost: 9097.1..11067.0)
           └─ LiteralIndexScan of column_index (sel: 0.000226398, step: 1.0) (keys: 15.0, cost/key: 0.1, cost: 9097.1..9098.6)
              predicate: Expression{name: column, op: MATCH, lower: (USER_VALUE, true), upper: (USER_VALUE, true), exclusions: []}
```
We should redact those values too. 

### What does this PR fix and why was it fixed

Adds the missing redaction of plan expressions and orderers, so the above example is:
```
SAI slowest query plan:
  Limit 5000 (rows: 15.0, cost/row: 131.3, cost: 9097.1..11067.0)
   └─ Filter column : ? (sel: 1.000000000) (rows: 15.0, cost/row: 131.3, cost: 9097.1..11067.0)
       └─ Fetch (rows: 15.0, cost/row: 131.3, cost: 9097.1..11067.0)
           └─ LiteralIndexScan of column_index (sel: 0.000226398, step: 1.0) (keys: 15.0, cost/key: 0.1, cost: 9097.1..9098.6)
              predicate: Expression{name: column, op: MATCH, lower: (?, true), upper: (?, true), exclusions: []}
```
