### PR TITLE
CNDB-14041: Revert enable Adaptive Compression by default for new tables

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -753,7 +753,7 @@ public enum CassandraRelevantProperties
      * Which compression algorithm to use for SSTable compression when not specified explicitly in the sstable options.
      * Can be "fast", which selects {@link LZ4Compressor}, or "adaptive" which selects {@link AdaptiveCompressor}.
      */
-    DEFAULT_SSTABLE_COMPRESSION("cassandra.default_sstable_compression", "adaptive"),
+    DEFAULT_SSTABLE_COMPRESSION("cassandra.default_sstable_compression", "fast"),
 
     /**
      * Do not try to calculate optimal streaming candidates. This can take a lot of time in some configs specially

--- a/test/unit/org/apache/cassandra/cql3/CQLTester.java
+++ b/test/unit/org/apache/cassandra/cql3/CQLTester.java
@@ -65,6 +65,9 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+
+import org.apache.cassandra.io.compress.AdaptiveCompressor;
+import org.apache.cassandra.io.compress.LZ4Compressor;
 import org.apache.cassandra.service.ClientWarn;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -3068,5 +3071,12 @@ public abstract class CQLTester
             Assert.assertEquals(1, warnings.size());
             Assert.assertEquals(expectedWarning, warnings.get(0));
         }
+    }
+
+    public static String defaultCompressor()
+    {
+        return DatabaseDescriptor.shouldUseAdaptiveCompressionByDefault()
+               ? AdaptiveCompressor.class.getName()
+               : LZ4Compressor.class.getName();
     }
 }

--- a/test/unit/org/apache/cassandra/cql3/statements/DescribeStatementTest.java
+++ b/test/unit/org/apache/cassandra/cql3/statements/DescribeStatementTest.java
@@ -1021,7 +1021,7 @@ public class DescribeStatementTest extends CQLTester
                "    AND cdc = false\n" +
                "    AND comment = ''\n" +
                "    AND compaction = " + cqlQuoted(CompactionParams.DEFAULT.asMap()) + "\n" +
-               "    AND compression = {'chunk_length_in_kb': '16', 'class': 'org.apache.cassandra.io.compress.AdaptiveCompressor'}\n" +
+               "    AND compression = {'chunk_length_in_kb': '16', 'class': '" + defaultCompressor() + "'}\n" +
                "    AND memtable = {}\n" +
                "    AND crc_check_chance = 1.0\n" +
                "    AND default_time_to_live = 0\n" +
@@ -1047,7 +1047,7 @@ public class DescribeStatementTest extends CQLTester
                "    AND cdc = false\n" +
                "    AND comment = ''\n" +
                "    AND compaction = " + cqlQuoted(CompactionParams.DEFAULT.asMap()) + "\n" +
-               "    AND compression = {'chunk_length_in_kb': '16', 'class': 'org.apache.cassandra.io.compress.AdaptiveCompressor'}\n" +
+               "    AND compression = {'chunk_length_in_kb': '16', 'class': '" + defaultCompressor() + "'}\n" +
                "    AND memtable = {}\n" +
                "    AND crc_check_chance = 1.0\n" +
                "    AND extensions = {}\n" +

--- a/test/unit/org/apache/cassandra/cql3/validation/operations/AlterTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/operations/AlterTest.java
@@ -598,7 +598,7 @@ public class AlterTest extends CQLTester
                                   SchemaKeyspaceTables.TABLES),
                            KEYSPACE,
                            currentTable()),
-                   row(map("chunk_length_in_kb", "16", "class", "org.apache.cassandra.io.compress.AdaptiveCompressor")));
+                   row(map("chunk_length_in_kb", "16", "class", defaultCompressor())));
 
         alterTable("ALTER TABLE %s WITH compression = { 'class' : 'SnappyCompressor', 'chunk_length_in_kb' : 32 };");
 

--- a/test/unit/org/apache/cassandra/cql3/validation/operations/CreateTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/operations/CreateTest.java
@@ -806,7 +806,7 @@ public class CreateTest extends CQLTester
                                   SchemaKeyspaceTables.TABLES),
                            KEYSPACE,
                            currentTable()),
-                   row(map("chunk_length_in_kb", "16", "class", "org.apache.cassandra.io.compress.AdaptiveCompressor")));
+                   row(map("chunk_length_in_kb", "16", "class", defaultCompressor())));
 
         createTable("CREATE TABLE %s (a text, b int, c int, primary key (a, b))"
                 + " WITH compression = { 'class' : 'SnappyCompressor', 'chunk_length_in_kb' : 32 };");


### PR DESCRIPTION
### What is the issue

https://github.com/datastax/cassandra/pull/2415 enabled adaptive compression by default. We've decided to revert it in July release, as we do not want this change to happen on all tenants at the same time. 

Slack thread to discuss how to safely enable it in the next/August release: https://datastax.slack.com/archives/C05LHP4HX5J/p1781100106874619

### What does this PR fix and why was it fixed

Disable adaptive compression by default, while keeping the fixes and improvements in [the patch](https://github.com/datastax/cassandra/pull/2415/changes) that enabled it.