### PR TITLE
CNDB-18137 fix linter warnings in files effected by CNDB-15608

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/PrimaryKeyMap.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/PrimaryKeyMap.java
@@ -38,13 +38,12 @@ public interface PrimaryKeyMap extends Closeable
      * A factory for creating {@link PrimaryKeyMap} instances. Implementations of this
      * interface are expected to be threadsafe.
      */
-    public interface Factory extends Closeable
+    interface Factory extends Closeable
     {
         /**
          * Creates a new {@link PrimaryKeyMap} instance
          *
          * @return a {@link PrimaryKeyMap}
-         * @throws IOException
          */
         PrimaryKeyMap newPerSSTablePrimaryKeyMap();
 

--- a/src/java/org/apache/cassandra/index/sai/disk/format/IndexComponents.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/IndexComponents.java
@@ -232,7 +232,7 @@ public interface IndexComponents
          */
         default boolean isValid(boolean validateChecksum)
         {
-            return isValid(validateChecksum, c -> {});
+            return isValid(validateChecksum, _ -> {});
         }
 
         /**
@@ -353,7 +353,6 @@ public interface IndexComponents
          * componentName will produce the same file.
          * @param componentName - unique name within the per index components
          * @return a temprory file for use during index construction
-         * @throws IOException
          */
         File tmpFileFor(String componentName) throws IOException;
     }

--- a/src/java/org/apache/cassandra/index/sai/disk/format/IndexComponents.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/IndexComponents.java
@@ -232,7 +232,7 @@ public interface IndexComponents
          */
         default boolean isValid(boolean validateChecksum)
         {
-            return isValid(validateChecksum, _ -> {});
+            return isValid(validateChecksum, c -> {});
         }
 
         /**

--- a/src/java/org/apache/cassandra/index/sai/disk/format/IndexDescriptor.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/IndexDescriptor.java
@@ -259,7 +259,7 @@ public class IndexDescriptor
         Preconditions.checkArgument(sstable.getDescriptor().equals(this.descriptor));
         SSTableIndexComponentsState discovered = IndexComponentDiscovery.instance().discoverComponents(sstable);
         for (var context : indices)
-            perIndexes.computeIfAbsent(context, k -> initializeGroup(context, discovered.perIndexBuild(context.getIndexName())));
+            perIndexes.computeIfAbsent(context, _ -> initializeGroup(context, discovered.perIndexBuild(context.getIndexName())));
         return this;
     }
 
@@ -540,7 +540,7 @@ public class IndexDescriptor
         }
 
         @Override
-        public File tmpFileFor(String componentName) throws IOException
+        public File tmpFileFor(String componentName)
         {
             String name = context != null ? String.format("%s_%s_%s", buildId, context.getColumnName(), componentName)
                                           :  String.format("%s_%s", buildId, componentName);

--- a/src/java/org/apache/cassandra/index/sai/disk/format/IndexDescriptor.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/IndexDescriptor.java
@@ -259,7 +259,7 @@ public class IndexDescriptor
         Preconditions.checkArgument(sstable.getDescriptor().equals(this.descriptor));
         SSTableIndexComponentsState discovered = IndexComponentDiscovery.instance().discoverComponents(sstable);
         for (var context : indices)
-            perIndexes.computeIfAbsent(context, _ -> initializeGroup(context, discovered.perIndexBuild(context.getIndexName())));
+            perIndexes.computeIfAbsent(context, k -> initializeGroup(context, discovered.perIndexBuild(context.getIndexName())));
         return this;
     }
 

--- a/src/java/org/apache/cassandra/index/sai/disk/format/OnDiskFormat.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/OnDiskFormat.java
@@ -79,7 +79,6 @@ public interface OnDiskFormat
     /**
      * Returns the {@link PrimaryKey.Factory} for the on-disk format
      *
-     * @param comparator
      * @return the primary key factory
      */
     PrimaryKey.Factory newPrimaryKeyFactory(ClusteringComparator comparator);
@@ -91,7 +90,6 @@ public interface OnDiskFormat
      * @param primaryKeyFactory The {@link PrimaryKey.Factory} corresponding to the provided {@code perSSTableComponents}.
      * @param sstable The {@link SSTableReader} associated with the per-sstable components
      * @return a {@link PrimaryKeyMap.Factory} for the SSTable
-     * @throws IOException
      */
     PrimaryKeyMap.Factory newPrimaryKeyMapFactory(IndexComponents.ForRead perSSTableComponents, PrimaryKey.Factory primaryKeyFactory, SSTableReader sstable) throws IOException;
 
@@ -116,7 +114,6 @@ public interface OnDiskFormat
      *
      * @param indexDescriptor The {@link IndexDescriptor} for the SSTable
      * @return The {@link PerSSTableWriter} to write the per-SSTable on-disk components
-     * @throws IOException
      */
     PerSSTableWriter newPerSSTableWriter(IndexDescriptor indexDescriptor) throws IOException;
 

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/bitpack/MonotonicBlockPackedReader.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/bitpack/MonotonicBlockPackedReader.java
@@ -45,7 +45,6 @@ public class MonotonicBlockPackedReader implements LongArray.Factory
     private final PackedLongValues minValues;
     private final float[] averages;
 
-    @SuppressWarnings("resource")
     public MonotonicBlockPackedReader(FileHandle file, NumericValuesMeta meta) throws IOException
     {
         this.valueCount = meta.valueCount;
@@ -83,7 +82,6 @@ public class MonotonicBlockPackedReader implements LongArray.Factory
     }
 
     @Override
-    @SuppressWarnings("resource")
     public LongArray open()
     {
         var indexInput = IndexFileUtils.instance.openInput(file);
@@ -96,7 +94,7 @@ public class MonotonicBlockPackedReader implements LongArray.Factory
             }
 
             @Override
-            public void close() throws IOException
+            public void close()
             {
                 indexInput.close();
             }

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/RowAwarePrimaryKeyFactory.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/RowAwarePrimaryKeyFactory.java
@@ -219,9 +219,9 @@ public class RowAwarePrimaryKeyFactory implements PrimaryKey.Factory
                                  token,
                                  partitionKey,
                                  clustering == null ? null : clustering.kind(),
-                                 clustering == null ? null :String.join(",", Arrays.stream(clustering.getBufferArray())
-                                                                                   .map(ByteBufferUtil::bytesToHex)
-                                                                                   .collect(Collectors.toList())));
+                                 clustering == null ? null : Arrays.stream(clustering.getBufferArray())
+                                                                   .map(ByteBufferUtil::bytesToHex)
+                                                                   .collect(Collectors.joining(",")));
         }
 
         @Override

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/V2OnDiskFormat.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/V2OnDiskFormat.java
@@ -19,13 +19,9 @@
 package org.apache.cassandra.index.sai.disk.v2;
 
 import java.io.IOException;
-import java.lang.invoke.MethodHandles;
 import java.nio.ByteOrder;
 import java.util.EnumSet;
 import java.util.Set;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.db.ClusteringComparator;
 import org.apache.cassandra.db.marshal.AbstractType;
@@ -49,8 +45,6 @@ import org.apache.cassandra.io.sstable.format.SSTableReader;
  */
 public class V2OnDiskFormat extends V1OnDiskFormat
 {
-    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-
     private static final Set<IndexComponentType> PER_SSTABLE_COMPONENTS = EnumSet.of(IndexComponentType.GROUP_COMPLETION_MARKER,
                                                                                      IndexComponentType.GROUP_META,
                                                                                      IndexComponentType.TOKEN_VALUES,

--- a/src/java/org/apache/cassandra/io/sstable/SSTable.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTable.java
@@ -420,7 +420,6 @@ public abstract class SSTable
     /**
      * Appends new component names to the TOC component.
      */
-    @SuppressWarnings("resource")
     protected static void appendTOC(Descriptor descriptor, Collection<Component> components)
     {
         File tocFile = descriptor.fileFor(Component.TOC);

--- a/src/java/org/apache/cassandra/schema/TableMetadata.java
+++ b/src/java/org/apache/cassandra/schema/TableMetadata.java
@@ -26,8 +26,6 @@ import javax.annotation.Nullable;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.auth.DataResource;
 import org.apache.cassandra.config.DatabaseDescriptor;
@@ -56,7 +54,6 @@ import static org.apache.cassandra.schema.SchemaConstants.isValidName;
 @Unmetered
 public class TableMetadata implements SchemaElement
 {
-    private static final Logger logger = LoggerFactory.getLogger(TableMetadata.class);
 
     // Please note that currently the only one truly useful flag is COUNTER, as the rest of the flags were about
     // differencing between CQL tables and the various types of COMPACT STORAGE tables (pre-4.0). As those "compact"

--- a/test/microbench/org/apache/cassandra/test/microbench/index/sai/VectorCompactionBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/index/sai/VectorCompactionBench.java
@@ -23,8 +23,6 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
@@ -119,7 +117,7 @@ public class VectorCompactionBench extends SAITester
      * index from scratch each time.
      */
     @Benchmark
-    public void compactVectorIndex() throws Throwable
+    public void compactVectorIndex()
     {
         compact();
     }

--- a/test/unit/org/apache/cassandra/index/sai/SAITester.java
+++ b/test/unit/org/apache/cassandra/index/sai/SAITester.java
@@ -359,9 +359,7 @@ public class SAITester extends CQLTester
     protected void simulateNodeRestart(boolean wait)
     {
         ColumnFamilyStore cfs = Keyspace.open(KEYSPACE).getColumnFamilyStore(currentTable());
-        cfs.indexManager.listIndexes().forEach(index -> {
-            ((StorageAttachedIndexGroup)cfs.indexManager.getIndexGroup(index)).reset();
-        });
+        cfs.indexManager.listIndexes().forEach(index -> ((StorageAttachedIndexGroup)cfs.indexManager.getIndexGroup(index)).reset());
         cfs.indexManager.listIndexes().forEach(cfs.indexManager::buildIndex);
         cfs.indexManager.executePreJoinTasksBlocking(true);
         if (wait)

--- a/test/unit/org/apache/cassandra/index/sai/cql/CompositePartitionKeyIndexTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/CompositePartitionKeyIndexTest.java
@@ -51,7 +51,7 @@ public class CompositePartitionKeyIndexTest extends SAITester
     }
 
     @Test
-    public void queryFromMemtable() throws Throwable
+    public void queryFromMemtable()
     {
         insertData1();
         insertData2();
@@ -59,7 +59,7 @@ public class CompositePartitionKeyIndexTest extends SAITester
     }
 
     @Test
-    public void queryFromSingleSSTable() throws Throwable
+    public void queryFromSingleSSTable()
     {
         insertData1();
         insertData2();
@@ -68,7 +68,7 @@ public class CompositePartitionKeyIndexTest extends SAITester
     }
 
     @Test
-    public void queryFromMultipleSSTables() throws Throwable
+    public void queryFromMultipleSSTables()
     {
         insertData1();
         flush();
@@ -78,7 +78,7 @@ public class CompositePartitionKeyIndexTest extends SAITester
     }
 
     @Test
-    public void queryFromMemtableAndSSTables() throws Throwable
+    public void queryFromMemtableAndSSTables()
     {
         insertData1();
         flush();
@@ -87,7 +87,7 @@ public class CompositePartitionKeyIndexTest extends SAITester
     }
 
     @Test
-    public void queryFromCompactedSSTable() throws Throwable
+    public void queryFromCompactedSSTable()
     {
         insertData1();
         flush();
@@ -101,7 +101,7 @@ public class CompositePartitionKeyIndexTest extends SAITester
         return row(index, Integer.toString(index), index);
     }
 
-    private void runQueries() throws Throwable
+    private void runQueries()
     {
         assertRowsIgnoringOrder(execute("SELECT * FROM %s WHERE pk1 = 2"),
                 expectedRow(2));

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorCompactionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorCompactionTest.java
@@ -369,7 +369,7 @@ abstract public class VectorCompactionTest extends VectorTester
                 for (long i = segment.metadata.minSSTableRowId; i <= segment.metadata.maxSSTableRowId; i++)
                 {
                     var primaryKey = pkm.primaryKeyFromRowId(i);
-                    assertTrue("The subsequent logic assumes that we have no clustering columns", !primaryKey.hasClustering());
+                    assertFalse("The subsequent logic assumes that we have no clustering columns", primaryKey.hasClustering());
                     try (var sstableIter = segment.sstableContext
                                            .sstable()
                                            .iterator(primaryKey.partitionKey(), Slices.ALL, columnFilter, false, SSTableReadsListener.NOOP_LISTENER))

--- a/test/unit/org/apache/cassandra/index/sai/disk/NodeStartupTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/NodeStartupTest.java
@@ -271,7 +271,7 @@ public class NodeStartupTest extends SAITester
     }
 
     @Test
-    public void startupOrderingTest() throws Throwable
+    public void startupOrderingTest()
     {
         populator.populate(this);
 

--- a/test/unit/org/apache/cassandra/index/sai/functional/IndexBuildDeciderTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/functional/IndexBuildDeciderTest.java
@@ -128,7 +128,7 @@ public class IndexBuildDeciderTest extends SAITester
         assertTrue(sstableContext.contains(secondSSTable));
 
         // SAI#canFlushFromMemtableIndex should be true
-        StorageAttachedIndex sai = (StorageAttachedIndex) group.getIndexes().iterator().next();
+        StorageAttachedIndex sai = group.getIndexes().iterator().next();
         assertTrue(sai.canFlushFromMemtableIndex());
 
         // flush another memtable: it should be flushed with MemtableIndexWriter

--- a/test/unit/org/apache/cassandra/index/sai/metrics/SegmentFlushingFailureTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/metrics/SegmentFlushingFailureTest.java
@@ -224,25 +224,25 @@ public abstract class SegmentFlushingFailureTest extends SAITester
         assertEquals("Segment buffer memory tracker should start at zero!", 0L, getSegmentBufferUsedBytes());
         assertEquals("There should be no segment builders in progress.", 0L, getColumnIndexBuildsInProgress());
 
-        execute("INSERT INTO " + KEYSPACE + "." + table1 + "(id1, v1, v2) VALUES ('0', 0, '0')");
+        execute("INSERT INTO " + KEYSPACE + '.' + table1 + "(id1, v1, v2) VALUES ('0', 0, '0')");
         flush(KEYSPACE, table1);
-        execute("INSERT INTO " + KEYSPACE + "." + table1 + "(id1, v1, v2) VALUES ('1', 1, '1')");
+        execute("INSERT INTO " + KEYSPACE + '.' + table1 + "(id1, v1, v2) VALUES ('1', 1, '1')");
         flush(KEYSPACE, table1);
         Collection<SSTableReader> sstablesTable1 = getColumnFamilyStore(KEYSPACE, table1).getLiveSSTables();
 
-        execute("INSERT INTO " + KEYSPACE + "." + table2 + "(id1, v1, v2) VALUES ('0', 0, '0')");
+        execute("INSERT INTO " + KEYSPACE + '.' + table2 + "(id1, v1, v2) VALUES ('0', 0, '0')");
         flush(KEYSPACE, table2);
-        execute("INSERT INTO " + KEYSPACE + "." + table2 + "(id1, v1, v2) VALUES ('1', 1, '1')");
+        execute("INSERT INTO " + KEYSPACE + '.' + table2 + "(id1, v1, v2) VALUES ('1', 1, '1')");
         flush(KEYSPACE, table2);
         Collection<SSTableReader> sstablesTable2 = getColumnFamilyStore(KEYSPACE, table2).getLiveSSTables();
 
         // Start compaction against both tables/indexes and verify that they are aborted safely:
         verifyCompactionIndexBuilds(2, segmentFlushFailure, table1, table2);
 
-        executeNet(String.format("SELECT * FROM %s WHERE v1 = 0", KEYSPACE + "." + table1));
+        executeNet(String.format("SELECT * FROM %s WHERE v1 = 0", KEYSPACE + '.' + table1));
         assertThat(getColumnFamilyStore(KEYSPACE, table1).getLiveSSTables()).isEqualTo(sstablesTable1);
 
-        executeNet(String.format("SELECT * FROM %s WHERE v1 = 0", KEYSPACE + "." + table2));
+        executeNet(String.format("SELECT * FROM %s WHERE v1 = 0", KEYSPACE + '.' + table2));
         assertThat(getColumnFamilyStore(KEYSPACE, table2).getLiveSSTables()).isEqualTo(sstablesTable2);
     }
 
@@ -258,25 +258,25 @@ public abstract class SegmentFlushingFailureTest extends SAITester
         assertEquals("Segment buffer memory tracker should start at zero!", 0L, getSegmentBufferUsedBytes());
         assertEquals("There should be no segment builders in progress.", 0L, getColumnIndexBuildsInProgress());
 
-        execute("INSERT INTO " + KEYSPACE + "." + table1 + "(id1, v1, v2) VALUES ('0', 0, '0')");
+        execute("INSERT INTO " + KEYSPACE + '.' + table1 + "(id1, v1, v2) VALUES ('0', 0, '0')");
         flush(KEYSPACE, table1);
-        execute("INSERT INTO " + KEYSPACE + "." + table1 + "(id1, v1, v2) VALUES ('1', 1, '1')");
+        execute("INSERT INTO " + KEYSPACE + '.' + table1 + "(id1, v1, v2) VALUES ('1', 1, '1')");
         flush(KEYSPACE, table1);
         Collection<SSTableReader> sstablesTable1 = getColumnFamilyStore(KEYSPACE, table1).getLiveSSTables();
 
-        execute("INSERT INTO " + KEYSPACE + "." + table2 + "(id1, v1, v2) VALUES ('0', 0, '0')");
+        execute("INSERT INTO " + KEYSPACE + '.' + table2 + "(id1, v1, v2) VALUES ('0', 0, '0')");
         flush(KEYSPACE, table2);
-        execute("INSERT INTO " + KEYSPACE + "." + table2 + "(id1, v1, v2) VALUES ('1', 1, '1')");
+        execute("INSERT INTO " + KEYSPACE + '.' + table2 + "(id1, v1, v2) VALUES ('1', 1, '1')");
         flush(KEYSPACE, table2);
 
         // Start compaction against both tables/indexes, and verify only the numeric index is aborted:
         verifyCompactionIndexBuilds(1, kdTreeSegmentFlushFailure, table1, table2);
 
         // index is still queryable and sstables remain the same
-        executeNet(String.format("SELECT * FROM %s WHERE v1 = 0", KEYSPACE + "." + table1));
+        executeNet(String.format("SELECT * FROM %s WHERE v1 = 0", KEYSPACE + '.' + table1));
         assertThat(getColumnFamilyStore(KEYSPACE, table1).getLiveSSTables()).isEqualTo(sstablesTable1);
 
-        ResultSet rows = executeNet(String.format("SELECT * FROM %s WHERE v2 = '0'", KEYSPACE + "." + table2));
+        ResultSet rows = executeNet(String.format("SELECT * FROM %s WHERE v2 = '0'", KEYSPACE + '.' + table2));
         assertEquals(1, rows.all().size());
 
         // table2 succeeded compaction


### PR DESCRIPTION
Fixes https://github.com/riptano/cndb/issues/18137

Fixes IntelliJ linter warnings in files affected during work on
CNDB-15608 to reduce warning noise:
- Fix single character strings to character constants
- Remove unused imports 
- Remove unnecessary throw in method declarations
- Simplify assert in a test
- Remove undocumented fields from javadoc
- Remove unnecessary resource suppression
- Simplify string join
- Remove unused logger field
- Remove unnecessary curly braces in lambda expression
- Remove unnecessary cast