### PR TITLE
CNDB-17469: Allow compaction tasks to override their execution executor

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/AbstractCompactionTask.java
+++ b/src/java/org/apache/cassandra/db/compaction/AbstractCompactionTask.java
@@ -21,8 +21,11 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
+
+import javax.annotation.Nullable;
 
 import com.google.common.base.Preconditions;
 
@@ -315,6 +318,15 @@ public abstract class AbstractCompactionTask extends WrappedRunnable
      * by CNDB.
      */
     public abstract long getSpaceOverhead();
+
+    /**
+     * Allows subclasses to route the task to a dedicated executor instead of the shared compaction executor.
+     */
+    @Nullable
+    public Executor getCustomExecutor()
+    {
+        return null;
+    }
 
     /**
      * @return The compaction observers for this task. Used by CNDB.

--- a/src/java/org/apache/cassandra/db/compaction/BackgroundCompactionRunner.java
+++ b/src/java/org/apache/cassandra/db/compaction/BackgroundCompactionRunner.java
@@ -31,6 +31,7 @@ import java.util.concurrent.CompletableFuture; // checkstyle: permit this import
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -406,6 +407,7 @@ public class BackgroundCompactionRunner implements Runnable
         ongoingCompactions.incrementAndGet();
         try
         {
+            Executor executor = task.getCustomExecutor() == null ? compactionExecutor : task.getCustomExecutor();
             return CompletableFuture.runAsync(
             () -> {
                 try
@@ -421,7 +423,7 @@ public class BackgroundCompactionRunner implements Runnable
                     //  - a thread has freed up, and a new compaction task (from any CFS) can be scheduled on it
                     markForCompactionCheck(cfs);
                 }
-            }, compactionExecutor);
+            }, executor);
         }
         catch (RejectedExecutionException ex)
         {


### PR DESCRIPTION
Fixes riptano/cndb#17860