### PR TITLE
CNDB-16886: Reject BM25 queries in validation when the coordinator is…

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/IndexContext.java
+++ b/src/java/org/apache/cassandra/index/sai/IndexContext.java
@@ -90,6 +90,7 @@ import org.apache.cassandra.utils.concurrent.OpOrder;
 import static org.apache.cassandra.config.CassandraRelevantProperties.SAI_INDEX_READS_DISABLED;
 import static org.apache.cassandra.config.CassandraRelevantProperties.SAI_INDEX_METRICS_ENABLED;
 import static org.apache.cassandra.config.CassandraRelevantProperties.VALIDATE_MAX_TERM_SIZE_AT_COORDINATOR;
+import static org.apache.cassandra.index.sai.plan.QueryController.INDEX_VERSION_DOES_NOT_SUPPORT_BM25;
 
 /**
  * Manage metadata for each column index.
@@ -853,20 +854,25 @@ public class IndexContext
 
     public void validate(RowFilter rowFilter)
     {
-        // Only vector indexes have requirements to validate right now.
-        if (!isVector())
-            return;
-        // Only iterate over the top level expressions because that is where the ANN expression is located.
+        // Only iterate over the top level expressions because that is where the ANN and BM25 expressions are located.
         for (RowFilter.Expression expression : rowFilter.root.expressions())
-            if (expression.operator() == Operator.ANN && expression.column().equals(column))
-            {
-                float[] value = TypeUtil.decomposeVector(getValidator(), expression.getIndexValue());
-                VectorValidation.validateIndexable(value, vectorSimilarityFunction);
-                // There is only one ANN expression per query.
-                return;
-            }
-    }
+        {
+            if (!expression.column().equals(column))
+                continue;
 
+            switch (expression.operator())
+            {
+                case ANN:
+                    float[] value = TypeUtil.decomposeVector(getValidator(), expression.getIndexValue());
+                    VectorValidation.validateIndexable(value, vectorSimilarityFunction);
+                    return;
+                case BM25:
+                    if (version().onOrAfter(Version.BM25_EARLIEST))
+                        return;
+                    throw new InvalidRequestException(String.format(INDEX_VERSION_DOES_NOT_SUPPORT_BM25, getIndexName()));
+            }
+        }
+    }
 
     public boolean equals(Object obj)
     {

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/features/FeaturesVersionSupportTester.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/features/FeaturesVersionSupportTester.java
@@ -32,6 +32,7 @@ import org.apache.cassandra.distributed.test.sai.SAIUtil;
 import org.apache.cassandra.exceptions.RequestFailureReason;
 import org.apache.cassandra.index.FeatureNeedsIndexRebuildException;
 import org.apache.cassandra.index.sai.disk.format.Version;
+import org.apache.cassandra.index.sai.plan.QueryController;
 import org.assertj.core.api.Assertions;
 
 import static org.apache.cassandra.distributed.api.ConsistencyLevel.ALL;
@@ -170,7 +171,8 @@ public abstract class FeaturesVersionSupportTester extends TestBaseImpl
         coordinator.execute("INSERT INTO " + keyspace + ".bm25 (k, v) VALUES (4, 'kiwi')", ALL);
         cluster.forEach(node -> node.flush(keyspace));
 
-        cluster.schemaChange("CREATE CUSTOM INDEX bm25_idx ON " + keyspace + ".bm25(v) " +
+        String index = "bm25_idx";
+        cluster.schemaChange("CREATE CUSTOM INDEX " + index + " ON " + keyspace + ".bm25(v) " +
                              "USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' " +
                              "WITH OPTIONS = {" +
                              "'index_analyzer': '{" +
@@ -189,6 +191,21 @@ public abstract class FeaturesVersionSupportTester extends TestBaseImpl
             Assertions.assertThatThrownBy(() -> coordinator.execute(query, ALL))
                       .hasMessageContaining(RequestFailureReason.FEATURE_NEEDS_INDEX_REBUILD.name());
         }
+
+        // Test with the coordinator also using the tested version.
+        // In this case the query will fail with a meaningful error message, instead of generic per-node error codes.
+        String versionString = version.toString();
+        cluster.get(1).runOnInstance(() -> org.apache.cassandra.index.sai.SAIUtil.setCurrentVersion(Version.parse(versionString), VERSIONS_PER_KEYSPACE));
+        if (version.onOrAfter(Version.BM25_EARLIEST))
+        {
+            Assertions.assertThat(coordinator.execute(query, ALL)).hasNumberOfRows(1);
+        }
+        else
+        {
+            Assertions.assertThatThrownBy(() -> coordinator.execute(query, ALL))
+                      .hasMessageContaining(String.format(QueryController.INDEX_VERSION_DOES_NOT_SUPPORT_BM25, index));
+        }
+        cluster.get(1).runOnInstance(() -> org.apache.cassandra.index.sai.SAIUtil.setCurrentVersion(Version.LATEST));
     }
 
     /**

--- a/test/unit/org/apache/cassandra/index/sai/cql/FeaturesVersionSupportTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/FeaturesVersionSupportTest.java
@@ -27,7 +27,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import org.apache.cassandra.cql3.UntypedResultSet;
-import org.apache.cassandra.exceptions.ReadFailureException;
+import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.exceptions.RequestFailureReason;
 import org.apache.cassandra.index.sai.SAIUtil;
 import org.apache.cassandra.index.sai.SSTableIndex;
@@ -35,6 +35,7 @@ import org.apache.cassandra.index.sai.StorageAttachedIndex;
 import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.index.sai.memory.MemtableIndex;
 import org.apache.cassandra.index.sai.memory.TrieMemtableIndex;
+import org.apache.cassandra.index.sai.plan.QueryController;
 import org.assertj.core.api.Assertions;
 
 import static org.apache.cassandra.index.sai.cql.BM25Test.*;
@@ -188,12 +189,12 @@ public class FeaturesVersionSupportTest extends VectorTester
     public void testBM25() throws Throwable
     {
         createTable("CREATE TABLE %s (k int PRIMARY KEY, v text)");
-        createIndex("CREATE CUSTOM INDEX ON %s(v) " +
-                    "USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' " +
-                    "WITH OPTIONS = {" +
-                    "'index_analyzer': '{" +
-                    "\"tokenizer\" : {\"name\" : \"standard\"}, " +
-                    "\"filters\" : [{\"name\" : \"porterstem\"}]}'}");
+        String index = createIndex("CREATE CUSTOM INDEX ON %s(v) " +
+                                   "USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' " +
+                                   "WITH OPTIONS = {" +
+                                   "'index_analyzer': '{" +
+                                   "\"tokenizer\" : {\"name\" : \"standard\"}, " +
+                                   "\"filters\" : [{\"name\" : \"porterstem\"}]}'}");
         execute("INSERT INTO %s (k, v) VALUES (1, 'apple')");
         String query = "SELECT k FROM %s WHERE v : 'apple' ORDER BY v BM25 OF 'apple' LIMIT 3";
         beforeAndAfterFlush(() -> {
@@ -204,8 +205,8 @@ public class FeaturesVersionSupportTest extends VectorTester
             else
             {
                 Assertions.assertThatThrownBy(() -> execute(query))
-                          .isInstanceOf(ReadFailureException.class)
-                          .hasMessageContaining(RequestFailureReason.FEATURE_NEEDS_INDEX_REBUILD.name());
+                          .isInstanceOf(InvalidRequestException.class)
+                          .hasMessageContaining(String.format(QueryController.INDEX_VERSION_DOES_NOT_SUPPORT_BM25, index));
             }
         });
     }

--- a/test/unit/org/apache/cassandra/index/sai/cql/VersionSelectorTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VersionSelectorTest.java
@@ -33,6 +33,7 @@ import org.apache.cassandra.index.sai.SAITester;
 import org.apache.cassandra.index.sai.SAIUtil;
 import org.apache.cassandra.index.sai.StorageAttachedIndex;
 import org.apache.cassandra.index.sai.disk.format.Version;
+import org.apache.cassandra.index.sai.plan.QueryController;
 import org.assertj.core.api.Assertions;
 
 import static java.lang.String.format;
@@ -268,7 +269,7 @@ public class VersionSelectorTest extends SAITester
             execute(keyspace, "INSERT INTO %s (k, v) VALUES (2, 'orange')");
             execute(keyspace, "INSERT INTO %s (k, v) VALUES (3, 'banana')");
             execute(keyspace, "INSERT INTO %s (k, v) VALUES (4, 'apple')");
-        }).withIndex(keyspace -> createIndex(keyspace, "CREATE CUSTOM INDEX IF NOT EXISTS ON %s(v) USING 'StorageAttachedIndex' " +
+        }).withIndex(keyspace -> createIndex(keyspace, "CREATE CUSTOM INDEX bm25_skinny ON %s(v) USING 'StorageAttachedIndex' " +
                                                        "WITH OPTIONS = {" +
                                                        "'index_analyzer': '{" +
                                                        "\"tokenizer\" : {\"name\" : \"standard\"}, " +
@@ -277,7 +278,7 @@ public class VersionSelectorTest extends SAITester
               assertRowCount(keyspace, "SELECT k FROM %s ORDER BY v BM25 OF 'apple' LIMIT 3", 2);
               assertRowCount(keyspace, "SELECT k FROM %s ORDER BY v BM25 OF 'orange' LIMIT 3", 1);
               assertRowCount(keyspace, "SELECT k FROM %s ORDER BY v BM25 OF 'kiwi' LIMIT 3", 0);
-          }, Version.BM25_EARLIEST, "FEATURE_NEEDS_INDEX_REBUILD");
+          }, Version.BM25_EARLIEST, String.format(QueryController.INDEX_VERSION_DOES_NOT_SUPPORT_BM25, "bm25_skinny"));
     }
 
     @Test
@@ -293,7 +294,7 @@ public class VersionSelectorTest extends SAITester
             execute(keyspace, "INSERT INTO %s (k, c, v) VALUES (1, 2, 'orange')");
             execute(keyspace, "INSERT INTO %s (k, c, v) VALUES (1, 3, 'banana')");
             execute(keyspace, "INSERT INTO %s (k, c, v) VALUES (1, 4, 'apple')");
-        }).withIndex(keyspace -> createIndex(keyspace, "CREATE CUSTOM INDEX IF NOT EXISTS ON %s(v) USING 'StorageAttachedIndex' " +
+        }).withIndex(keyspace -> createIndex(keyspace, "CREATE CUSTOM INDEX bm25_wide ON %s(v) USING 'StorageAttachedIndex' " +
                                                        "WITH OPTIONS = {" +
                                                        "'index_analyzer': '{" +
                                                        "\"tokenizer\" : {\"name\" : \"standard\"}, " +
@@ -305,7 +306,7 @@ public class VersionSelectorTest extends SAITester
               assertRowCount(keyspace, "SELECT k FROM %s WHERE k=0 ORDER BY v BM25 OF 'apple' LIMIT 3", 2);
               assertRowCount(keyspace, "SELECT k FROM %s WHERE k=0 ORDER BY v BM25 OF 'orange' LIMIT 3", 1);
               assertRowCount(keyspace, "SELECT k FROM %s WHERE k=0 ORDER BY v BM25 OF 'kiwi' LIMIT 3", 0);
-          }, Version.BM25_EARLIEST, "FEATURE_NEEDS_INDEX_REBUILD");
+          }, Version.BM25_EARLIEST, String.format(QueryController.INDEX_VERSION_DOES_NOT_SUPPORT_BM25, "bm25_wide"));
     }
 
     @Override


### PR DESCRIPTION
### What is the issue

Writers reject BM25 queries when the index version if before `Version.BM25_EARLIEST`, or when the index doesn't have the needed components. They do that by sending `RequestFailureReason.FEATURE_NEEDS_INDEX_UPGRADE`. If the query succeeds in the writers, there are still more version checks in the coordinator, so everything should be in the right version.

While that behaviour is correct and manages index version issues in a controlled manner, we could also check the current index version at the query validation step done by the coordinator, before actually executing the query. That would allow us to throw a better error message than the obscure `ReadFailureException` with named error codes, and save us some round trips, in case the coordinator is in the wrong version. The `ReadFailureException` with named error codes would still be used for cases when only some of the writers or the sstables is in the wrong version.

### What does this PR fix and why was it fixed

Reject BM25 queries on `Index.validate(ReadCommand)` if the current index version doesn't support them. That way they would be rejected on the coordinator before execution, which is faster and produces a descriptive error message, rather than the generic per-replica error codes. The replicas still will do their own validation if the query gets past the coordinator.
