### PR TITLE
CNDB-17444: Use xxHash3 for hashing ChunkCache.Key

### DIFF
--- a/.build/build-rat.xml
+++ b/.build/build-rat.xml
@@ -58,7 +58,8 @@
                  <exclude name="test/conf/unit-test-conf/test-native-port.yaml"/>
                  <exclude name="test/resources/data/config/YamlConfigurationLoaderTest/*.yaml"/>
                  <exclude name="test/resources/mockito-extensions/org.mockito.plugins.MockMaker"/>
-                 <exclude name="test/resources/schema/schema_validation_tests/*.crc32"/>
+                 <exclude name="test/resources/schema/schema_validation_tests/**/*.crc32"/>
+                 <exclude name="test/resources/schema/schema_validation_tests/**/*.db"/>
                  <exclude name="tools/cqlstress-*.yaml"/>
                  <!-- test data -->
                  <exclude name="pylib/cqlshlib/test/test_authproviderhandling_config/*"/>

--- a/.build/cassandra-deps-template.xml
+++ b/.build/cassandra-deps-template.xml
@@ -337,6 +337,10 @@
       <artifactId>HdrHistogram</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.dynatrace.hash4j</groupId>
+      <artifactId>hash4j</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.googlecode.concurrent-trees</groupId>
       <artifactId>concurrent-trees</artifactId>
     </dependency>

--- a/.build/parent-pom-template.xml
+++ b/.build/parent-pom-template.xml
@@ -346,6 +346,11 @@
         <version>2.1.12</version>
       </dependency>
       <dependency>
+        <groupId>com.dynatrace.hash4j</groupId>
+        <artifactId>hash4j</artifactId>
+        <version>0.30.0</version>
+      </dependency>
+      <dependency>
         <groupId>commons-cli</groupId>
         <artifactId>commons-cli</artifactId>
         <version>1.5.0</version>

--- a/src/java/org/apache/cassandra/cache/ChunkCache.java
+++ b/src/java/org/apache/cassandra/cache/ChunkCache.java
@@ -31,6 +31,9 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 import javax.annotation.Nullable;
 
+import com.dynatrace.hash4j.hashing.Hasher64;
+import com.dynatrace.hash4j.hashing.Hashing;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
@@ -299,12 +302,16 @@ public class ChunkCache
         synchronousCache.invalidateAll(Iterables.filter(cache.asMap().keySet(), x -> (x.readerId & mask) == fileId));
     }
 
-    static class Key
+    @VisibleForTesting
+    public static class Key
     {
+        private static final Hasher64 hasher = Hashing.metroHash64();
+
         final long readerId;
         final long position;
 
-        private Key(long readerId, long position)
+        @VisibleForTesting
+        public Key(long readerId, long position)
         {
             super();
             this.position = position;
@@ -314,11 +321,7 @@ public class ChunkCache
         @Override
         public int hashCode()
         {
-            final int prime = 31;
-            int result = 1;
-            result = prime * result + Long.hashCode(readerId);
-            result = prime * result + Long.hashCode(position);
-            return result;
+            return hasher.hashLongLongToInt(readerId, position);
         }
 
         @Override
@@ -326,7 +329,7 @@ public class ChunkCache
         {
             if (this == obj)
                 return true;
-            if (obj == null)
+            if (obj == null || getClass() != obj.getClass())
                 return false;
 
             Key other = (Key) obj;

--- a/test/microbench/org/apache/cassandra/test/microbench/ChunkCacheKeyBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/ChunkCacheKeyBench.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.test.microbench;
+
+import org.apache.cassandra.cache.ChunkCache;
+import org.openjdk.jmh.annotations.*;
+
+import java.util.concurrent.TimeUnit;
+import java.util.Random;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 2, time = 1) // seconds
+@Measurement(iterations = 5, time = 1) // seconds
+@Fork(value = 1)
+@State(Scope.Benchmark)
+public class ChunkCacheKeyBench
+{
+    private ChunkCache.Key[] keys;
+    private int index;
+
+
+    private static final int KEY_COUNT = 1 << 20;
+    private static final int KEY_COUNT_MASK = KEY_COUNT - 1;
+
+    @Setup(Level.Trial)
+    public void setup()
+    {
+        keys = new ChunkCache.Key[KEY_COUNT];
+        Random random = new Random(12345);
+        for (int i = 0; i < KEY_COUNT; i++)
+        {
+            long readerId = random.nextLong();
+            long position = random.nextLong();
+            keys[i] = new ChunkCache.Key(readerId, position);
+        }
+        index = 0;
+    }
+
+
+    @Benchmark
+    public int hashKey()
+    {
+        // Cycle through the array to avoid JIT constant folding
+        ChunkCache.Key key = keys[index];
+        index = (index + 1) & KEY_COUNT_MASK;
+        return key.hashCode();
+    }
+}

--- a/test/unit/org/apache/cassandra/cache/ChunkCacheKeyHashCollisionTest.java
+++ b/test/unit/org/apache/cassandra/cache/ChunkCacheKeyHashCollisionTest.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cache;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import com.google.common.base.Preconditions;
+import org.apache.commons.math3.distribution.ChiSquaredDistribution;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+
+/**
+ * Verifies that hash collisions between different ChunkCache keys are rare and nicely distributed.
+ * Unfortunately we cannot test all combinations of readerId and position values, because that would be 2^128 pairs.
+ * However, we still want to test if all bits present in the inputs are properly accounted for in the hashCode()
+ * function. Therefore, we test smaller subsets of readerIds and positions shifted by different number
+ * of bits each time and every bit is tested in at least one of the runs.
+ * The test fails if the total collision rate is above 0.1% or if any single key collides with more than 2 other keys.
+ */
+@RunWith(Parameterized.class)
+public class ChunkCacheKeyHashCollisionTest
+{
+    private final int alignment;
+    private final int readerBitShift;
+
+    public ChunkCacheKeyHashCollisionTest(int alignment, int readerBitShift) {
+        this.alignment = alignment;
+        this.readerBitShift = readerBitShift;
+    }
+
+    // Controls how many test cases to generate.
+    // Smaller step will generate more test-cases and increase the total runtime of the test suite.
+    static final int BIT_SHIFT_STEP = 8;
+    static final int NUMBER_OF_TEST_CASES = (Long.BYTES * 8 / BIT_SHIFT_STEP) * (Long.BYTES * 8 / BIT_SHIFT_STEP);
+
+    // Number of changing bits in readerId
+    static final int READER_BITS = 8;
+    // Number of changing bits in position
+    static final int POSITION_BITS = 8;
+
+    // Distinct readerIds tested in each run
+    static final int READER_COUNT = 1 << READER_BITS;
+    // Distinct positions tested in each run
+    static final int POSITION_COUNT = 1 << POSITION_BITS;
+
+    @Parameterized.Parameters(name = "alignment={0}, readerBitShift={1}")
+    public static Collection<Object[]> data() {
+        List<Object[]> params = new ArrayList<>();
+        for (int a = 0; a < Long.BYTES * 8 - POSITION_BITS; a += BIT_SHIFT_STEP) {
+            for (int r = 0; r < Long.BYTES * 8 - READER_BITS; r += BIT_SHIFT_STEP) {
+                params.add(new Object[]{a, r});
+            }
+        }
+        return params;
+    }
+
+    @Test
+    public void testEquals()
+    {
+        assertFalse(new ChunkCache.Key(0, 0).equals(null));
+        assertFalse(new ChunkCache.Key(0, 0).equals(new Object()));
+
+        ChunkCache.Key prevKey =  null;
+        for (long readerId = 0; readerId < READER_COUNT; readerId++)
+        {
+            for (long position = 0; position < POSITION_COUNT; position++)
+            {
+                ChunkCache.Key key1 = new ChunkCache.Key(readerId << readerBitShift, position << alignment);
+                ChunkCache.Key key2 = new ChunkCache.Key(readerId << readerBitShift, position << alignment);
+                assertEquals(key1, key1);
+                assertEquals(key1, key2);
+                assertEquals(key1.hashCode(), key2.hashCode());
+                assertNotEquals(key1, prevKey);
+                prevKey = key1;
+            }
+        }
+    }
+
+    @Test
+    public void testCollisions()
+    {
+        final int totalHashesCount = READER_COUNT * POSITION_COUNT;
+        int[] hashes = new int[totalHashesCount];
+
+        int i = 0;
+        for (long readerId = 0; readerId < READER_COUNT; readerId++)
+        {
+            for (long position = 0; position < POSITION_COUNT; position++)
+            {
+                ChunkCache.Key key = new ChunkCache.Key(readerId << readerBitShift, position << alignment);
+                hashes[i++] = key.hashCode();
+            }
+        }
+
+        // That might look counterintuitive, but sorting is actually significantly faster for this size of data than
+        // counting duplicates in a HashSet or HashMap, due to better cache locality and parallelism.
+        // And the array uses much less memory, especially compared to
+        // a HashMap that otherwise would be needed to track max per-key collisions.
+        Arrays.parallelSort(hashes);
+
+        int totalCollisions = 0;
+        int maxPerKeyCollisions = 0;
+        int currentKeyCollisions = 0;
+        for (int j = 1; j < hashes.length; j++) {
+            if (hashes[j] == hashes[j - 1]) {
+                totalCollisions++;
+                currentKeyCollisions++;
+            }
+            else
+            {
+                maxPerKeyCollisions = Math.max(maxPerKeyCollisions, currentKeyCollisions);
+                currentKeyCollisions = 0;
+            }
+        }
+        maxPerKeyCollisions = Math.max(maxPerKeyCollisions, currentKeyCollisions);
+
+        // The total actual number of collisions should be close to the theoretical expected number of collisions
+        // as if the hashes were distributed perfectly at random. For small number of hashes, the theoretical
+        // probability of collision gets very low, but the sampling error gets higher, therefore we relax
+        // the requirement and clamp it at 0.0001 (which can be still considered a very low collision rate).
+        var actualCollisionRate = (double) totalCollisions / totalHashesCount;
+        var M = (double) (1L << Integer.SIZE);
+        var expectedCollisions = totalHashesCount - M * (1.0 - Math.pow((M - 1.0) / M, totalHashesCount));
+        var expectedCollisionRate = expectedCollisions / totalHashesCount;
+        assertThat(actualCollisionRate).describedAs("Collision rate is too high: total %d collisions out of %d keys (%.4f%%)",
+                                              totalCollisions, totalHashesCount, actualCollisionRate * 100)
+                                       .isLessThan(expectedCollisionRate * 1.2 + 0.0001);
+
+        // Even when the total number of collisions is low, check that collisions are uniformly distributed.
+        // We don't want a single key to have a large number of collisions.
+        assertThat(maxPerKeyCollisions).describedAs("Max number of collisions for a single key is too large: %d collisions", maxPerKeyCollisions)
+                                       .isLessThanOrEqualTo(3);
+
+        // Test slices of the hash. A good hashing function should distribute values uniformly, regardless of
+        // which subset of bits of the hash we take. Slices of various sizes are taken from various positions.
+        // Many hash-map implementations often use only some number of lower bits of the hash value, so this test
+        // has direct relationship to how well given hashing function can work in hash-map-like structures.
+        for (int bitCount = 8; bitCount <= READER_BITS + POSITION_BITS - 4; bitCount += 2)
+            for (int bitShift = 0; bitShift <= Integer.BYTES * 8 - bitCount; bitShift += BIT_SHIFT_STEP)
+                assertHashSlicesAreUniformlyDistributed(hashes, bitCount, bitShift);
+
+    }
+
+    private static void assertHashSlicesAreUniformlyDistributed(int[] hashes, int bitCount, int bitShift)
+    {
+        // The test doesn't work well if we have too few keys per bin
+        Preconditions.checkArgument(hashes.length >= 16 * (1 << bitCount));
+
+        int numBins = 1 << bitCount;
+        int mask = (numBins - 1) << bitShift;
+        long[] counts = new long[numBins];
+        for (int hash : hashes)
+            counts[(hash & mask) >>> bitShift]++;
+
+        double expectedCount = (double) hashes.length / numBins;
+        double pValue = probabilityOfDataComingFromUniformDistribution(counts, expectedCount);
+
+        // The problem with a statistical test is that it can fail by chance if we're unlucky even if the code under
+        // test is good. This parameter controls how much risk of failing the whole test suite by accident we are ok with.
+        // The lower the value, the weaker the test gets, and more likely a bad hashing function gets undetected.
+        final double PROBABILITY_OF_TEST_SUITE_FAILURE = 0.01;
+        assertThat(pValue).describedAs("Bits %d..%d failed uniform distribution test", bitShift, bitShift + bitCount)
+                          .isGreaterThan(PROBABILITY_OF_TEST_SUITE_FAILURE / NUMBER_OF_TEST_CASES);
+    }
+
+    /**
+     * Calculates the probability that the data are uniformly distributed between a fixed number of bins.
+     * @param counts the count in each bin
+     * @param expectedCount the expected count in every bin if data were distributed ideally uniformly
+     */
+    private static double probabilityOfDataComingFromUniformDistribution(long[] counts, double expectedCount)
+    {
+        double chiSquare = 0;
+        for (long count : counts)
+        {
+            double deviation = count - expectedCount;
+            chiSquare += deviation * deviation;
+        }
+        chiSquare /= expectedCount;
+
+        // We are testing if the observed counts of hash values (for lower bits) conform to a uniform distribution.
+        // A chi-squared test is appropriate for this "goodness of fit" test.
+        // The null hypothesis is that the observed data follows the uniform distribution.
+        // A low p-value would lead us to reject the null hypothesis,
+        // indicating that the distribution is not uniform.
+        // Degrees of freedom = number of bins - 1
+        ChiSquaredDistribution chiSquaredDistribution = new ChiSquaredDistribution(counts.length - 1);
+        return 1 - chiSquaredDistribution.cumulativeProbability(chiSquare);
+    }
+}

--- a/test/unit/org/apache/cassandra/cache/ChunkCacheKeyThreadSafetyTest.java
+++ b/test/unit/org/apache/cassandra/cache/ChunkCacheKeyThreadSafetyTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cache;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Attempts to catch potential bugs in the implementation of ChunkCache.Key.hashCode() that could cause
+ * it to return incorrect values when called concurrently on the same or different keys.
+ * This test is not exhaustive and is not intended to be, but it should catch some common mistakes such
+ * as accidentally sharing data buffers or sharing instances of library objects that are not meant to be shared
+ * across threads (e.g. HashStreams).
+ */
+public class ChunkCacheKeyThreadSafetyTest
+{
+    @Test
+    public void testCallingHashCodeOnDistinctKeysIsThreadSafe() throws InterruptedException, ExecutionException
+    {
+        final int numThreads = 4;
+        final int count = 1_000_000;
+
+        class Task implements Runnable
+        {
+            final Random rnd = new Random(0);
+            final int[] hashes = new int[count];
+
+            @Override
+            public void run()
+            {
+                for (int i = 0; i < count; i++)
+                {
+                    long readerId = rnd.nextLong();
+                    long position = rnd.nextLong();
+                    ChunkCache.Key key = new ChunkCache.Key(readerId, position);
+                    hashes[i] = key.hashCode();
+                }
+            }
+        }
+
+        ExecutorService executor = Executors.newFixedThreadPool(numThreads);
+        try
+        {
+            List<Future<?>> futures = new ArrayList<>(numThreads);
+            Task[] tasks = new Task[numThreads];
+
+            for (int i = 0; i < numThreads; i++)
+            {
+                tasks[i] = new Task();
+                futures.add(executor.submit(tasks[i]));
+            }
+
+            for (Future<?> future : futures)
+                future.get(); // Wait for completion and propagate exceptions
+
+            for (int i = 1; i < numThreads; i++)
+                assertArrayEquals(tasks[0].hashes, tasks[i].hashes);
+        }
+        finally
+        {
+            executor.shutdown();
+        }
+    }
+
+    @Test
+    public void testCallingHashCodeOnSameKeyIsThreadSafe() throws InterruptedException, ExecutionException
+    {
+        final int numThreads = 4;
+        final int callsPerThread = 100_000_000;
+        final ChunkCache.Key key = new ChunkCache.Key(123L, 456L);
+        final int expectedHashCode = key.hashCode();
+
+        class Task implements Runnable
+        {
+            @Override
+            public void run()
+            {
+                for (int i = 0; i < callsPerThread; i++)
+                    assertEquals("hashCode is not stable under concurrent access", expectedHashCode, key.hashCode());
+            }
+        }
+
+        ExecutorService executor = Executors.newFixedThreadPool(numThreads);
+        try
+        {
+            List<Future<?>> futures = new ArrayList<>(numThreads);
+            for (int i = 0; i < numThreads; i++)
+                futures.add(executor.submit(new Task()));
+            for (Future<?> future : futures)
+                future.get(); // This will re-throw any exception from the worker thread
+        }
+        finally
+        {
+            executor.shutdown();
+        }
+    }
+}


### PR DESCRIPTION
The default hash function generated by IDE had poor statistical properties and high likelihood of collisions. It has been already shown in CNDB-16234 and CNDB-17275 that poor hashing can lead to performance degradation of the chunk cache due to "treeification" of entries and/or high lock contention.

ChunkCache.Key#hashCode now uses xxHash3 from hash4j. Extensive hash collisions, thread safety and performance tests were added.
