### PR TITLE
CNDB-17573-main: expose lazy bloom filter metrics

### DIFF
--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -3610,6 +3610,21 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
         return bloomFilterTracker.getRecentTrueNegativeRate();
     }
 
+    public long getLazyBloomFilterHitCount()
+    {
+        return bloomFilterTracker.getLazyBloomFilterHitCount();
+    }
+
+    public long getLoadedBloomFilterHitCount()
+    {
+        return bloomFilterTracker.getLoadedBloomFilterHitCount();
+    }
+
+    public long getPassThroughBloomFilterHitCount()
+    {
+        return bloomFilterTracker.getPassThroughBloomFilterHitCount();
+    }
+
     public long getReadRequests()
     {
         return metric == null ? 0 : metric.readRequests.getCount();

--- a/src/java/org/apache/cassandra/io/sstable/filter/BloomFilterMetrics.java
+++ b/src/java/org/apache/cassandra/io/sstable/filter/BloomFilterMetrics.java
@@ -70,6 +70,51 @@ public class BloomFilterMetrics<R extends SSTableReaderWithFilter> extends Abstr
                                                                                      SSTableReaderWithFilter::getFilterOffHeapSize,
                                                                                      Long::sum);
 
+    public final GaugeProvider<Long> approximateBloomFilterOffHeapMemoryUsed = newGaugeProvider("ApproximateBloomFilterOffHeapMemoryUsed",
+                                                                                                0L,
+                                                                                                SSTableReaderWithFilter::getApproximateBloomFilterMemorySize,
+                                                                                                Long::sum);
+
+    public final GaugeProvider<Long> loadedBloomFilter = newGaugeProvider("LoadedBloomFilter",
+                                                                          0L,
+                                                                          r -> r.isBloomFilterLoaded() ? 1L : 0L,
+                                                                          Long::sum);
+
+    public final GaugeProvider<Long> lazyBloomFilter = newGaugeProvider("LazyBloomFilter",
+                                                                        0L,
+                                                                        r -> r.isLazyBloomFilter() ? 1L : 0L,
+                                                                        Long::sum);
+
+    public final GaugeProvider<Long> passThroughBloomFilter = newGaugeProvider("PassThroughBloomFilter",
+                                                                               0L,
+                                                                               r -> r.isPassThroughBloomFilter() ? 1L : 0L,
+                                                                               Long::sum);
+
+    public final GaugeProvider<Long> lazyBloomFilterByRequestRate = newGaugeProvider("LazyBloomFilterByRequestRate",
+                                                                                     0L,
+                                                                                     r -> r.isLazyBloomFilterByRequestRateCriteria() ? 1L : 0L,
+                                                                                     Long::sum);
+
+    public final GaugeProvider<Long> lazyBloomFilterByRequestCount = newGaugeProvider("LazyBloomFilterByRequestCount",
+                                                                                      0L,
+                                                                                      r -> r.isLazyBloomFilterByRequestCountCriteria() ? 1L : 0L,
+                                                                                      Long::sum);
+
+    public final GaugeProvider<Long> lazyBloomFilterHits = newGaugeProvider("LazyBloomFilterHits",
+                                                                            0L,
+                                                                            r -> r.getFilterTracker().getLazyBloomFilterHitCount(),
+                                                                            Long::sum);
+
+    public final GaugeProvider<Long> loadedBloomFilterHits = newGaugeProvider("LoadedBloomFilterHits",
+                                                                              0L,
+                                                                              r -> r.getFilterTracker().getLoadedBloomFilterHitCount(),
+                                                                              Long::sum);
+
+    public final GaugeProvider<Long> passThroughBloomFilterHits = newGaugeProvider("PassThroughBloomFilterHits",
+                                                                                   0L,
+                                                                                   r -> r.getFilterTracker().getPassThroughBloomFilterHitCount(),
+                                                                                   Long::sum);
+
     /**
      * False positive ratio of bloom filter
      */
@@ -110,6 +155,15 @@ public class BloomFilterMetrics<R extends SSTableReaderWithFilter> extends Abstr
                                                                         recentBloomFilterFalsePositives,
                                                                         bloomFilterDiskSpaceUsed,
                                                                         bloomFilterOffHeapMemoryUsed,
+                                                                        approximateBloomFilterOffHeapMemoryUsed,
+                                                                        loadedBloomFilter,
+                                                                        lazyBloomFilter,
+                                                                        passThroughBloomFilter,
+                                                                        lazyBloomFilterByRequestRate,
+                                                                        lazyBloomFilterByRequestCount,
+                                                                        lazyBloomFilterHits,
+                                                                        loadedBloomFilterHits,
+                                                                        passThroughBloomFilterHits,
                                                                         bloomFilterFalseRatio,
                                                                         recentBloomFilterFalseRatio);
 

--- a/src/java/org/apache/cassandra/io/sstable/filter/BloomFilterTracker.java
+++ b/src/java/org/apache/cassandra/io/sstable/filter/BloomFilterTracker.java
@@ -20,6 +20,8 @@ package org.apache.cassandra.io.sstable.filter;
 import com.codahale.metrics.Meter;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.utils.BloomFilter;
+import org.apache.cassandra.utils.FilterFactory;
 
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -28,6 +30,19 @@ public abstract class BloomFilterTracker
     public abstract void addFalsePositive();
     public abstract void addTruePositive();
     public abstract void addTrueNegative();
+    /**
+     * Count a lookup that uses {@link FilterFactory#AlwaysPresentForLazyLoading}.
+     */
+    public abstract void addLazyBloomFilterHit();
+    /**
+     * Count a lookup that uses a loaded {@link BloomFilter}.
+     */
+    public abstract void addLoadedBloomFilterHit();
+    /**
+     * Count a lookup that uses {@link FilterFactory#AlwaysPresent} due to lazy bloom filter
+     * loading failure or due to reaching bloom filter memory limit.
+     */
+    public abstract void addPassThroughBloomFilterHit();
     public abstract long getFalsePositiveCount();
     public abstract long getRecentFalsePositiveCount();
     public abstract double getRecentFalsePositiveRate();
@@ -37,6 +52,9 @@ public abstract class BloomFilterTracker
     public abstract long getTrueNegativeCount();
     public abstract long getRecentTrueNegativeCount();
     public abstract double getRecentTrueNegativeRate();
+    public abstract long getLazyBloomFilterHitCount();
+    public abstract long getLoadedBloomFilterHitCount();
+    public abstract long getPassThroughBloomFilterHitCount();
 
     public static BloomFilterTracker createNoopTracker()
     {
@@ -53,6 +71,9 @@ public abstract class BloomFilterTracker
         private final Meter falsePositiveCount = new Meter();
         private final Meter truePositiveCount = new Meter();
         private final Meter trueNegativeCount = new Meter();
+        private final Meter lazyBloomFilterHitCount = new Meter();
+        private final Meter loadedBloomFilterHitCount = new Meter();
+        private final Meter passThroughBloomFilterHitCount = new Meter();
         private final AtomicLong lastFalsePositiveCount = new AtomicLong();
         private final AtomicLong lastTruePositiveCount = new AtomicLong();
         private final AtomicLong lastTrueNegativeCount = new AtomicLong();
@@ -73,6 +94,24 @@ public abstract class BloomFilterTracker
         public void addTrueNegative()
         {
             trueNegativeCount.mark();
+        }
+
+        @Override
+        public void addLazyBloomFilterHit()
+        {
+            lazyBloomFilterHitCount.mark();
+        }
+
+        @Override
+        public void addLoadedBloomFilterHit()
+        {
+            loadedBloomFilterHitCount.mark();
+        }
+
+        @Override
+        public void addPassThroughBloomFilterHit()
+        {
+            passThroughBloomFilterHitCount.mark();
         }
 
         @Override
@@ -130,6 +169,24 @@ public abstract class BloomFilterTracker
         {
             return trueNegativeCount.getFifteenMinuteRate();
         }
+
+        @Override
+        public long getLazyBloomFilterHitCount()
+        {
+            return lazyBloomFilterHitCount.getCount();
+        }
+
+        @Override
+        public long getLoadedBloomFilterHitCount()
+        {
+            return loadedBloomFilterHitCount.getCount();
+        }
+
+        @Override
+        public long getPassThroughBloomFilterHitCount()
+        {
+            return passThroughBloomFilterHitCount.getCount();
+        }
     }
 
     /**
@@ -151,6 +208,15 @@ public abstract class BloomFilterTracker
 
         @Override
         public void addTrueNegative() {}
+
+        @Override
+        public void addLazyBloomFilterHit() {}
+
+        @Override
+        public void addLoadedBloomFilterHit() {}
+
+        @Override
+        public void addPassThroughBloomFilterHit() {}
 
         @Override
         public long getFalsePositiveCount()
@@ -201,6 +267,24 @@ public abstract class BloomFilterTracker
 
         @Override
         public double getRecentTrueNegativeRate()
+        {
+            return 0;
+        }
+
+        @Override
+        public long getLazyBloomFilterHitCount()
+        {
+            return 0;
+        }
+
+        @Override
+        public long getLoadedBloomFilterHitCount()
+        {
+            return 0;
+        }
+
+        @Override
+        public long getPassThroughBloomFilterHitCount()
         {
             return 0;
         }

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableReaderWithFilter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableReaderWithFilter.java
@@ -36,6 +36,7 @@ import org.apache.cassandra.io.sstable.SSTableReadsListener;
 import org.apache.cassandra.io.sstable.filter.BloomFilterTracker;
 import org.apache.cassandra.utils.BloomFilter;
 import org.apache.cassandra.utils.FilterFactory;
+import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.IFilter;
 import org.apache.cassandra.utils.concurrent.Ref;
 
@@ -48,6 +49,7 @@ public abstract class SSTableReaderWithFilter extends SSTableReader
     private final boolean bloomFilterLazyLoading = BloomFilter.lazyLoading();
     private final int bloomFilterLazyLoadingWindow = BloomFilter.lazyLoadingWindow();
     private final long bloomFilterLazyLoadingThreshold = BloomFilter.lazyLoadingThreshold();
+    protected volatile long approximateBloomFilterMemorySize;
 
     private final BloomFilterTracker filterTracker;
 
@@ -84,15 +86,98 @@ public abstract class SSTableReaderWithFilter extends SSTableReader
     public boolean mayContainAssumingKeyIsInRange(DecoratedKey key)
     {
         maybeDeserializeLazyBloomFilter();
-        // if we don't have bloom filter(bf_fp_chance=1.0 or filter file is missing),
-        // we check index file instead.
-        return !filter.isInformative() && getPosition(key, Operator.EQ, false) >= 0 || filter.isPresent(key);
+
+        if (filter.isInformative())
+        {
+            recordBloomFilterHit();
+            return filter.isPresent(key);
+        }
+
+        if (isPassThroughBloomFilter())
+        {
+            recordBloomFilterHit();
+            return true;
+        }
+
+        // Lazy bloom filters must check the index both to answer accurately and to drive the lazy-loading threshold.
+        return getPosition(key, Operator.EQ, false) >= 0 || filter.isPresent(key);
     }
 
     protected boolean inBloomFilter(DecoratedKey dk)
     {
+        recordBloomFilterHit();
         maybeDeserializeLazyBloomFilter();
         return filter.isPresent(dk);
+    }
+
+    private void recordBloomFilterHit()
+    {
+        // There could be a race where async BF loading completes before calling filter.isPresent(key).
+        // That is acceptable because the counter records the state observed before this lookup.
+        if (isLazyBloomFilter())
+            filterTracker.addLazyBloomFilterHit();
+        else if (isPassThroughBloomFilter())
+            filterTracker.addPassThroughBloomFilterHit();
+        else
+            filterTracker.addLoadedBloomFilterHit();
+    }
+
+    /**
+     * If underlying bloom filter is {@link BloomFilter}.
+     */
+    public boolean isBloomFilterLoaded()
+    {
+        return !isLazyBloomFilter() && !isPassThroughBloomFilter();
+    }
+
+    /**
+     * If underlying filter is {@link FilterFactory#AlwaysPresentForLazyLoading}.
+     */
+    public boolean isLazyBloomFilter()
+    {
+        return filter == FilterFactory.AlwaysPresentForLazyLoading;
+    }
+
+    /**
+     * If underlying filter is {@link FilterFactory#AlwaysPresent}:
+     *   - BF file was not written when hitting BF memory limit during flush
+     *   - BF deserialization hits BF memory limit
+     *   - Lazy BF failed to load
+     */
+    public boolean isPassThroughBloomFilter()
+    {
+        return filter == FilterFactory.AlwaysPresent;
+    }
+
+    protected long computeExpectedBloomFilterMemorySize()
+    {
+        return FilterFactory.getFilterOffHeapSize(estimatedKeys(), metadata().params.bloomFilterFpChance);
+    }
+
+    /**
+     * Returns the approximate off-heap memory size in bytes that the bloom filter for this SSTable would occupy when
+     * fully loaded based on estimated keys and false-positive chance, regardless of the current bloom filter state
+     * (either lazy BF or no BF due to memory limit or loading failure).
+     */
+    public long getApproximateBloomFilterMemorySize()
+    {
+        return approximateBloomFilterMemorySize;
+    }
+
+    @VisibleForTesting
+    public boolean isLazyBloomFilterByRequestRateCriteria()
+    {
+        return isLazyBloomFilter()
+               && bloomFilterLazyLoadingWindow > 0
+               && bloomFilterLazyLoadingThreshold > 0
+               && !partitionIndexHitRateExceedsThreshold();
+    }
+
+    public boolean isLazyBloomFilterByRequestCountCriteria()
+    {
+        return isLazyBloomFilter()
+               && (bloomFilterLazyLoadingThreshold == 0
+                   || bloomFilterLazyLoadingWindow <= 0 && !partitionIndexHitCountExceedsThreshold());
     }
 
     /**
@@ -110,14 +195,14 @@ public abstract class SSTableReaderWithFilter extends SSTableReader
 
         boolean loadBloomFilter = false;
 
-        // If the threshold was set to zero we always want to deserialize
+        // If the threshold was set to zero we always want to deserialize on first access
         if (bloomFilterLazyLoadingThreshold == 0)
             loadBloomFilter = true;
-            // otherwise, if window is <= 0 we use the threshold as an absolute count
-        else if (bloomFilterLazyLoadingWindow <= 0 && partitionIndexReadMeter.get().count() >= bloomFilterLazyLoadingThreshold)
+        // otherwise, if window is <= 0 we use the threshold as an absolute count
+        else if (bloomFilterLazyLoadingWindow <= 0 && partitionIndexHitCountExceedsThreshold())
             loadBloomFilter = true;
-            // otherwise we look at the count in the specified window
-        else if (bloomFilterLazyLoadingWindow > 0 && partitionIndexReadMeter.get().rate(bloomFilterLazyLoadingWindow) >= bloomFilterLazyLoadingThreshold)
+        // otherwise we look at the count in the specified window
+        else if (bloomFilterLazyLoadingWindow > 0 && partitionIndexHitRateExceedsThreshold())
             loadBloomFilter = true;
 
         if (!loadBloomFilter)
@@ -152,7 +237,8 @@ public abstract class SSTableReaderWithFilter extends SSTableReader
                                      }
                                      else
                                      {
-                                         logger.debug("Successfuly loaded lazy bloom filter for {}", descriptor.baseFileURI());
+                                         logger.debug("Successfuly loaded lazy bloom filter for {} with offheap size {}", descriptor.baseFileURI(),
+                                                      FBUtilities.prettyPrintMemory(loaded.offHeapSize()));
 
                                          filter = loaded;
                                          tidy.addCloseable(loaded); // close newly created bloom filter on sstable close
@@ -170,6 +256,16 @@ public abstract class SSTableReaderWithFilter extends SSTableReader
                          });
 
         return true;
+    }
+
+    private boolean partitionIndexHitRateExceedsThreshold()
+    {
+        return partitionIndexReadMeter.map(meter -> meter.rate(bloomFilterLazyLoadingWindow) >= bloomFilterLazyLoadingThreshold).orElse(false);
+    }
+
+    private boolean partitionIndexHitCountExceedsThreshold()
+    {
+        return partitionIndexReadMeter.map(meter -> meter.count() >= bloomFilterLazyLoadingThreshold).orElse(false);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/io/sstable/format/big/BigTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/BigTableReader.java
@@ -103,6 +103,7 @@ public class BigTableReader extends SSTableReaderWithFilter implements IndexSumm
         this.indexSummary = builder.getIndexSummary();
         this.rowIndexEntrySerializer = new RowIndexEntry.Serializer(descriptor.version, header, owner != null ? owner.getMetrics() : null);
         this.keyCache = Objects.requireNonNull(builder.getKeyCache());
+        this.approximateBloomFilterMemorySize = isBloomFilterLoaded() ? filter.offHeapSize() : computeExpectedBloomFilterMemorySize();
     }
 
     @Override
@@ -513,7 +514,9 @@ public class BigTableReader extends SSTableReaderWithFilter implements IndexSumm
     @Override
     public SSTableReaderWithFilter cloneAndReplace(IFilter filter)
     {
-        return unbuildTo(new Builder(descriptor).setFilter(filter), true).build(owner().orElse(null), true, true);
+        BigTableReader replacement = unbuildTo(new Builder(descriptor).setFilter(filter), true).build(owner().orElse(null), true, true);
+        replacement.approximateBloomFilterMemorySize = approximateBloomFilterMemorySize;
+        return replacement;
     }
 
     /**
@@ -526,10 +529,12 @@ public class BigTableReader extends SSTableReaderWithFilter implements IndexSumm
      */
     private SSTableReader cloneAndReplace(DecoratedKey newFirst, OpenReason reason)
     {
-        return unbuildTo(new Builder(descriptor), true)
+        BigTableReader replacement = unbuildTo(new Builder(descriptor), true)
                .setFirst(newFirst)
                .setOpenReason(reason)
                .build(owner().orElse(null), true, true);
+        replacement.approximateBloomFilterMemorySize = approximateBloomFilterMemorySize;
+        return replacement;
     }
 
     /**
@@ -543,11 +548,13 @@ public class BigTableReader extends SSTableReaderWithFilter implements IndexSumm
      */
     private BigTableReader cloneAndReplace(DecoratedKey newFirst, OpenReason reason, IndexSummary newSummary)
     {
-        return unbuildTo(new Builder(descriptor).setIndexSummary(newSummary), true)
+        BigTableReader replacement = unbuildTo(new Builder(descriptor).setIndexSummary(newSummary), true)
                     .setIndexSummary(newSummary)
                     .setFirst(newFirst)
                     .setOpenReason(reason)
                     .build(owner().orElse(null), true, true);
+        replacement.approximateBloomFilterMemorySize = approximateBloomFilterMemorySize;
+        return replacement;
     }
 
     public SSTableReader cloneWithRestoredStart(DecoratedKey restoredStart)

--- a/src/java/org/apache/cassandra/io/sstable/format/bti/BtiTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/bti/BtiTableReader.java
@@ -81,6 +81,7 @@ public class BtiTableReader extends SSTableReaderWithFilter
         super(builder, owner);
         this.rowIndexFile = builder.getRowIndexFile();
         this.partitionIndex = builder.getPartitionIndex();
+        this.approximateBloomFilterMemorySize = isBloomFilterLoaded() ? filter.offHeapSize() : computeExpectedBloomFilterMemorySize();
     }
 
     protected final Builder unbuildTo(Builder builder, boolean sharedCopy)
@@ -461,7 +462,9 @@ public class BtiTableReader extends SSTableReaderWithFilter
     @Override
     public BtiTableReader cloneAndReplace(IFilter filter)
     {
-        return unbuildTo(new Builder(descriptor).setFilter(filter), true).build(owner().orElse(null), true, true);
+        BtiTableReader replacement = unbuildTo(new Builder(descriptor).setFilter(filter), true).build(owner().orElse(null), true, true);
+        replacement.approximateBloomFilterMemorySize = approximateBloomFilterMemorySize;
+        return replacement;
     }
 
     @Override
@@ -495,10 +498,12 @@ public class BtiTableReader extends SSTableReaderWithFilter
      */
     private BtiTableReader cloneAndReplace(DecoratedKey newFirst, OpenReason reason)
     {
-        return unbuildTo(new Builder(descriptor), true)
+        BtiTableReader replacement = unbuildTo(new Builder(descriptor), true)
                .setFirst(newFirst)
                .setOpenReason(reason)
                .build(owner().orElse(null), true, true);
+        replacement.approximateBloomFilterMemorySize = approximateBloomFilterMemorySize;
+        return replacement;
     }
 
     @Override

--- a/src/java/org/apache/cassandra/utils/FilterFactory.java
+++ b/src/java/org/apache/cassandra/utils/FilterFactory.java
@@ -103,11 +103,9 @@ public class FilterFactory
 
     private static IFilter createFilter(long numElements, double maxFalsePosProbability, MemoryLimiter memoryLimiter, boolean failOnExceedingLimit)
     {
-        assert maxFalsePosProbability <= 1.0 : "Invalid probability";
-        if (maxFalsePosProbability == 1.0)
+        BloomCalculations.BloomSpecification spec = getBloomSpecification(numElements, maxFalsePosProbability);
+        if (spec == null)
             return FilterFactory.AlwaysPresent;
-        int bucketsPerElement = BloomCalculations.maxBucketsPerElement(numElements);
-        BloomCalculations.BloomSpecification spec = BloomCalculations.computeBloomSpec(bucketsPerElement, maxFalsePosProbability);
         return createFilter(spec.K, numElements, spec.bucketsPerElement, memoryLimiter, failOnExceedingLimit);
     }
 
@@ -129,6 +127,27 @@ public class FilterFactory
             metrics.incrementOOMError();
             return AlwaysPresent;
         }
+    }
+
+    public static long getFilterOffHeapSize(long numElements, double maxFalsePosProbability)
+    {
+        BloomCalculations.BloomSpecification spec = getBloomSpecification(numElements, maxFalsePosProbability);
+        if (spec == null)
+            return 0;
+
+        long numBits = (numElements * spec.bucketsPerElement) + BITSET_EXCESS;
+        long wordCount = (((numBits - 1) >>> 6) + 1);
+        return wordCount * 8L;
+    }
+
+    private static BloomCalculations.BloomSpecification getBloomSpecification(long numElements, double maxFalsePosProbability)
+    {
+        assert maxFalsePosProbability <= 1.0 : "Invalid probability";
+        if (maxFalsePosProbability == 1.0)
+            return null;
+
+        int bucketsPerElement = BloomCalculations.maxBucketsPerElement(numElements);
+        return BloomCalculations.computeBloomSpec(bucketsPerElement, maxFalsePosProbability);
     }
 
     private static class AlwaysPresentFilter implements IFilter

--- a/test/unit/org/apache/cassandra/io/sstable/SSTableReaderTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/SSTableReaderTest.java
@@ -156,7 +156,7 @@ public class SSTableReaderTest
     public static final String CF_INDEXED = "Indexed1";
     public static final String CF_STANDARD_LOW_INDEX_INTERVAL = "StandardLowIndexInterval";
     public static final String CF_STANDARD_SMALL_BLOOM_FILTER = "StandardSmallBloomFilter";
-    public static final String CF_STANDARD_NO_BLOOM_FILTER = "StandardNoBloomFilter";
+    public static final String CF_STANDARD_PASS_THROUGH_BLOOM_FILTER = "StandardPassThroughBloomFilter";
 
     private final List<Ref<?>> refsToRelease = new ArrayList<>();
     private IPartitioner partitioner;
@@ -188,7 +188,7 @@ public class SSTableReaderTest
                                                 .minIndexInterval(4)
                                                 .maxIndexInterval(4)
                                                 .bloomFilterFpChance(0.99),
-                                    SchemaLoader.standardCFMD(KEYSPACE1, CF_STANDARD_NO_BLOOM_FILTER)
+                                    SchemaLoader.standardCFMD(KEYSPACE1, CF_STANDARD_PASS_THROUGH_BLOOM_FILTER)
                                                 .bloomFilterFpChance(1));
 
         // All tests in this class assume auto-compaction is disabled.
@@ -1849,7 +1849,7 @@ public class SSTableReaderTest
 
         final int numKeys = 100;
         final Keyspace keyspace = Keyspace.open(KEYSPACE1);
-        final ColumnFamilyStore cfs = keyspace.getColumnFamilyStore(CF_STANDARD_NO_BLOOM_FILTER);
+        final ColumnFamilyStore cfs = keyspace.getColumnFamilyStore(CF_STANDARD_PASS_THROUGH_BLOOM_FILTER);
 
         SSTableReader sstable = getNewSSTable(cfs, numKeys, 1);
         Assert.assertTrue(getFilterSize(sstable) == 0);

--- a/test/unit/org/apache/cassandra/io/sstable/filter/BloomFilterTrackerTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/filter/BloomFilterTrackerTest.java
@@ -78,4 +78,40 @@ public class BloomFilterTrackerTest
         assertEquals(1L, bft.getFalsePositiveCount());
         assertEquals(0.2d, bft.getRecentFalsePositiveRate(), 0.0);
     }
+
+    @Test
+    public void testAddingLazyBloomFilterHits()
+    {
+        BloomFilterTracker bft = BloomFilterTracker.createMeterTracker();
+        assertEquals(0L, bft.getLazyBloomFilterHitCount());
+        bft.addLazyBloomFilterHit();
+        bft.addLazyBloomFilterHit();
+        assertEquals(2L, bft.getLazyBloomFilterHitCount());
+        assertEquals(0L, bft.getLoadedBloomFilterHitCount());
+        assertEquals(0L, bft.getPassThroughBloomFilterHitCount());
+    }
+
+    @Test
+    public void testAddingLoadedBloomFilterHits()
+    {
+        BloomFilterTracker bft = BloomFilterTracker.createMeterTracker();
+        assertEquals(0L, bft.getLoadedBloomFilterHitCount());
+        bft.addLoadedBloomFilterHit();
+        bft.addLoadedBloomFilterHit();
+        assertEquals(2L, bft.getLoadedBloomFilterHitCount());
+        assertEquals(0L, bft.getLazyBloomFilterHitCount());
+        assertEquals(0L, bft.getPassThroughBloomFilterHitCount());
+    }
+
+    @Test
+    public void testAddingPassThroughBloomFilterHits()
+    {
+        BloomFilterTracker bft = BloomFilterTracker.createMeterTracker();
+        assertEquals(0L, bft.getPassThroughBloomFilterHitCount());
+        bft.addPassThroughBloomFilterHit();
+        bft.addPassThroughBloomFilterHit();
+        assertEquals(2L, bft.getPassThroughBloomFilterHitCount());
+        assertEquals(0L, bft.getLazyBloomFilterHitCount());
+        assertEquals(0L, bft.getLoadedBloomFilterHitCount());
+    }
 }

--- a/test/unit/org/apache/cassandra/io/sstable/format/LazyBloomFilterTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/format/LazyBloomFilterTest.java
@@ -33,6 +33,7 @@ import com.google.common.util.concurrent.Uninterruptibles;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -69,8 +70,6 @@ public class LazyBloomFilterTest
     @BeforeClass
     public static void defineSchema()
     {
-        CassandraRelevantProperties.BLOOM_FILTER_LAZY_LOADING.setBoolean(true);
-
         SchemaLoader.prepareServer();
         SchemaLoader.createKeyspace(KEYSPACE1,
                                     KeyspaceParams.simple(1),
@@ -88,11 +87,24 @@ public class LazyBloomFilterTest
         CassandraRelevantProperties.BLOOM_FILTER_LAZY_LOADING.reset();
     }
 
+    @Before
+    public void init()
+    {
+        CassandraRelevantProperties.BLOOM_FILTER_LAZY_LOADING.setBoolean(true);
+    }
+
     @After
     public void cleanup()
     {
-        store.loadNewSSTables();
-        store.truncateBlocking();
+        try
+        {
+            store.loadNewSSTables();
+            store.truncateBlocking();
+        }
+        finally
+        {
+            CassandraRelevantProperties.BLOOM_FILTER_LAZY_LOADING.reset();
+        }
     }
 
     @Test
@@ -101,6 +113,11 @@ public class LazyBloomFilterTest
         CassandraRelevantProperties.BLOOM_FILTER_LAZY_LOADING_THRESHOLD.setInt(0);
 
         SSTableReaderWithFilter sstable = reopenFlushedSSTable();
+        assertThat(sstable.isBloomFilterLoaded()).isFalse();
+        assertThat(sstable.isLazyBloomFilter()).isTrue();
+        assertThat(sstable.isLazyBloomFilterByRequestRateCriteria()).isFalse();
+        assertThat(sstable.isLazyBloomFilterByRequestCountCriteria()).isTrue();
+        assertThat(sstable.isPassThroughBloomFilter()).isFalse();
 
         // first read will trigger bloom filter deserialization
         assertTrue(sstable.mayContainAssumingKeyIsInRange(Util.dk(String.valueOf(10))));
@@ -196,11 +213,26 @@ public class LazyBloomFilterTest
 
         SSTableReaderWithFilter sstable = reopenFlushedSSTable();
         DecoratedKey key = Util.dk(String.valueOf(keyInt));
+        long lazyBloomFilterHits = store.getLazyBloomFilterHitCount();
 
         // first read will NOT trigger bloom filter deserialization because of threshold not reached
         sstable.mayContainAssumingKeyIsInRange(key);
         assertSame(FilterFactory.AlwaysPresentForLazyLoading, sstable.getFilter());
         assertThat(sstable.getFilter().offHeapSize()).isEqualTo(0);
+        assertThat(store.getLazyBloomFilterHitCount()).isEqualTo(lazyBloomFilterHits + 1);
+        assertThat(sstable.isBloomFilterLoaded()).isFalse();
+        assertThat(sstable.isLazyBloomFilter()).isTrue();
+        assertThat(sstable.isPassThroughBloomFilter()).isFalse();
+        if (window > 0)
+        {
+            assertThat(sstable.isLazyBloomFilterByRequestRateCriteria()).isTrue();
+            assertThat(sstable.isLazyBloomFilterByRequestCountCriteria()).isFalse();
+        }
+        else
+        {
+            assertThat(sstable.isLazyBloomFilterByRequestRateCriteria()).isFalse();
+            assertThat(sstable.isLazyBloomFilterByRequestCountCriteria()).isTrue();
+        }
 
         // make the sstable access the index
         SinglePartitionReadCommand command = createCommand(key);
@@ -221,6 +253,12 @@ public class LazyBloomFilterTest
 
         assertThat(sstable.getFilter()).isNotSameAs(FilterFactory.AlwaysPresent);
         assertThat(sstable.getFilter().offHeapSize()).isGreaterThan(0);
+        assertThat(sstable.isBloomFilterLoaded()).isTrue();
+        assertThat(sstable.isLazyBloomFilter()).isFalse();
+        assertThat(sstable.isLazyBloomFilterByRequestRateCriteria()).isFalse();
+        assertThat(sstable.isLazyBloomFilterByRequestCountCriteria()).isFalse();
+        assertThat(sstable.isPassThroughBloomFilter()).isFalse();
+        assertThat(store.getLazyBloomFilterHitCount()).isGreaterThan(lazyBloomFilterHits);
 
         releaseSSTables(sstable);
     }
@@ -231,6 +269,7 @@ public class LazyBloomFilterTest
         CassandraRelevantProperties.BLOOM_FILTER_LAZY_LOADING_THRESHOLD.setInt(0);
 
         SSTableReaderWithFilter sstable = reopenFlushedSSTable();
+        long passThroughBloomFilterHits = store.getPassThroughBloomFilterHitCount();
 
         // release sstable
         store.getLiveSSTables().forEach(s -> s.selfRef().release()); // ColumnFamilyStore#clearUnsafe won't release sstable reference
@@ -244,6 +283,67 @@ public class LazyBloomFilterTest
                   .until(() -> sstable.filter == FilterFactory.AlwaysPresent);
 
         assertThat(sstable.getFilter()).isSameAs(FilterFactory.AlwaysPresent);
+        assertThat(sstable.isBloomFilterLoaded()).isFalse();
+        assertThat(sstable.isLazyBloomFilter()).isFalse();
+        assertThat(sstable.isLazyBloomFilterByRequestRateCriteria()).isFalse();
+        assertThat(sstable.isLazyBloomFilterByRequestCountCriteria()).isFalse();
+        assertThat(sstable.isPassThroughBloomFilter()).isTrue();
+        assertThat(sstable.mayContainAssumingKeyIsInRange(Util.dk(String.valueOf(10)))).isTrue();
+        assertThat(store.getPassThroughBloomFilterHitCount()).isEqualTo(passThroughBloomFilterHits + 1);
+    }
+
+    @Test
+    public void testApproximateMemorySizeForLoadedBF()
+    {
+        CassandraRelevantProperties.BLOOM_FILTER_LAZY_LOADING.setBoolean(false);
+
+        SSTableReaderWithFilter sstable = reopenFlushedSSTable();
+        assertThat(sstable.estimatedKeys()).isGreaterThan(0);
+
+        long approximateMemorySize = FilterFactory.getFilterOffHeapSize(sstable.estimatedKeys(), store.metadata().params.bloomFilterFpChance);
+        assertThat(sstable.getFilter().offHeapSize()).isGreaterThan(0);
+        assertThat(sstable.getApproximateBloomFilterMemorySize()).isEqualTo(sstable.getFilter().offHeapSize());
+        assertThat(sstable.getApproximateBloomFilterMemorySize()).isEqualTo(approximateMemorySize);
+    }
+
+    @Test
+    public void testApproximateMemorySizeForLazyBF()
+    {
+        SSTableReaderWithFilter sstable = reopenFlushedSSTable();
+        assertThat(sstable.estimatedKeys()).isGreaterThan(0);
+
+        long approximateMemorySize = FilterFactory.getFilterOffHeapSize(sstable.estimatedKeys(), store.metadata().params.bloomFilterFpChance);
+        assertThat(sstable.getFilter().offHeapSize()).isEqualTo(0);
+        assertThat(sstable.getFilter()).isSameAs(FilterFactory.AlwaysPresentForLazyLoading);
+        assertThat(sstable.getApproximateBloomFilterMemorySize()).isEqualTo(approximateMemorySize);
+    }
+
+    @Test
+    public void testApproximateMemorySizePreservedWhenLazyBFBecomesNoFilter()
+    {
+        CassandraRelevantProperties.BLOOM_FILTER_LAZY_LOADING_THRESHOLD.setInt(0);
+
+        SSTableReaderWithFilter sstable = reopenFlushedSSTable();
+
+        // approximateBloomFilterMemorySize is computed at open time, before any deserialization attempt
+        long approximateMemorySize = sstable.getApproximateBloomFilterMemorySize();
+        assertThat(approximateMemorySize).isGreaterThan(0);
+        assertThat(sstable.isLazyBloomFilter()).isTrue();
+
+        // Release the sstable to fail lazy BF loading
+        store.getLiveSSTables().forEach(s -> s.selfRef().release());
+        store.clearUnsafe();
+        assertThat(sstable.selfRef().globalCount()).isEqualTo(0);
+
+        assertThat(sstable.maybeDeserializeLazyBloomFilter()).isTrue();
+        Awaitility.await("lazy BF deserialization falls back to AlwaysPresent")
+                  .atMost(10, TimeUnit.SECONDS)
+                  .until(() -> sstable.getFilter() == FilterFactory.AlwaysPresent);
+
+        // filter is now the pass-through filter
+        assertThat(sstable.isPassThroughBloomFilter()).isTrue();
+        assertThat(sstable.isBloomFilterLoaded()).isFalse();
+        assertThat(sstable.getApproximateBloomFilterMemorySize()).isEqualTo(approximateMemorySize);
     }
 
     private void releaseSSTables(SSTableReaderWithFilter sstable)
@@ -285,8 +385,11 @@ public class LazyBloomFilterTest
         SSTableReader newlyOpenedSSTable = Iterables.getOnlyElement(store.getLiveSSTables());
         assertThat(newlyOpenedSSTable).isInstanceOf(SSTableReaderWithFilter.class);
         sstable = (SSTableReaderWithFilter) newlyOpenedSSTable;
-        assertSame(FilterFactory.AlwaysPresentForLazyLoading, sstable.getFilter());
-        assertThat(sstable.getFilter().offHeapSize()).isEqualTo(0);
+        if (CassandraRelevantProperties.BLOOM_FILTER_LAZY_LOADING.getBoolean())
+        {
+            assertSame(FilterFactory.AlwaysPresentForLazyLoading, sstable.getFilter());
+            assertThat(sstable.getFilter().offHeapSize()).isEqualTo(0);
+        }
 
         return sstable;
     }

--- a/test/unit/org/apache/cassandra/utils/BloomFilterTest.java
+++ b/test/unit/org/apache/cassandra/utils/BloomFilterTest.java
@@ -409,6 +409,32 @@ public class BloomFilterTest
     }
 
     @Test
+    public void testGetFilterOffHeapSize()
+    {
+        long numElements = 100_000;
+        double fpChance = 0.01;
+
+        long actualOffHeapSize;
+        try (IFilter filter = FilterFactory.getFilter(numElements, fpChance, memoryLimiter))
+        {
+            assertTrue(filter instanceof BloomFilter);
+            actualOffHeapSize = filter.offHeapSize();
+        }
+        assertNotEquals(0, actualOffHeapSize);
+        assertEquals(actualOffHeapSize, FilterFactory.getFilterOffHeapSize(numElements, fpChance));
+    }
+
+    @Test
+    public void testGetFilterOffHeapSizeForBoundaries()
+    {
+        // fp_chance=1.0 maps to AlwaysPresent — no memory is needed
+        assertEquals(0, FilterFactory.getFilterOffHeapSize(100_000, 1.0));
+
+        // 0 elements: the Math.max(1, numElements) guard keeps the calculation valid
+        assertTrue(FilterFactory.getFilterOffHeapSize(0, 0.01) > 0);
+    }
+
+    @Test
     @Ignore // this is a test that can be used to print out the sizes of BFs
     public void testBloomFilterSize()
     {


### PR DESCRIPTION
0. Expose approximate BF memory size

1. Add bloom filter state metrics:
   - LoadedBloomFilter: SSTables with a real bloom filter loaded
   - LazyBloomFilter: SSTables still waiting for lazy bloom filter loading
   - PassThroughBloomFilter: SSTables using pass-through filtering after lazy loading could not complete or due to BF memory limit

2. Add lazy loading criteria metrics:
   - LazyBloomFilterByRequestRate: num of lazy bloom filters waiting because the request rate threshold is not met
   - LazyBloomFilterByRequestCount: num of lazy bloom filters waiting because the request count threshold is not met

3. Add hit metrics for pass-through bloom filter states:
   - LazyBloomFilterHits: reads against lazy bloom filters waiting to load
   - PassThroughBloomFilterHits: reads against SSTables with no bloom filter - AlwaysPresent

Fixes #17573
