### PR TITLE
CNDB-8756: Keep all the SAI components of a sstable in the same version

### DIFF
--- a/src/java/org/apache/cassandra/exceptions/RequestFailureReason.java
+++ b/src/java/org/apache/cassandra/exceptions/RequestFailureReason.java
@@ -49,7 +49,12 @@ public enum RequestFailureReason
     UNKNOWN_TABLE            (501),
     REMOTE_STORAGE_FAILURE   (502),
     INDEX_BUILD_IN_PROGRESS  (503),
-    FEATURE_NEEDS_INDEX_REBUILD(504); // The index uses an old version that doesn't support the requested feature
+    /**
+     * The index uses an old version that doesn't support the requested feature.
+     * The problematic old index version can be being used by either the entire index or only some sstables.
+     * Enabling the feature requires setting the right index version and running a sstable upgrade.
+     */
+    FEATURE_NEEDS_INDEX_REBUILD(504);
 
     public static final Serializer serializer = new Serializer();
 

--- a/src/java/org/apache/cassandra/index/FeatureNeedsIndexRebuildException.java
+++ b/src/java/org/apache/cassandra/index/FeatureNeedsIndexRebuildException.java
@@ -16,13 +16,29 @@
 
 package org.apache.cassandra.index;
 
+import java.util.Set;
+
+import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.exceptions.InternalRequestExecutionException;
 import org.apache.cassandra.exceptions.RequestFailureReason;
+import org.apache.cassandra.service.StorageServiceMBean;
 
 /**
- * Thrown if a secondary index is still in an old version that doesn't support the requested feature.
+ * Thrown if a secondary index or any of its components is still in an old version that doesn't support the requested
+ * feature.
  * </p>
- * Users hitting this exception should probably rebuild their index to a newer version.
+ * Users hitting this exception should probably set the right index version and upgrade their sstables. That way, the
+ * new replacement sstables will use that new version.
+ * </p>
+ * Please note that rebuilding the index with {@code nodetool rebuild_index},
+ * {@link StorageServiceMBean#rebuildSecondaryIndex(String, String, String...)},
+ * {@link ColumnFamilyStore#rebuildSecondaryIndex(String, String, String...)},
+ * {@link SecondaryIndexManager#rebuildIndexesBlocking(Set)}, etc. will not be enough to upgrade the index version,
+ * because sstables are fixed to the index version active when they were first indexed. See CNDB-8756 for details.
+ * </p>
+ * If this error is hit during an index build, when the index has been recorded in the schema, and before it's marked
+ * as queryable, it means that the index also needs to be rebuilt after upgrading the sstables, so it gets marked as
+ * queryable. CNDB-16824 is meant to simplify that.
  */
 public final class FeatureNeedsIndexRebuildException extends RuntimeException implements InternalRequestExecutionException
 {

--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndex.java
@@ -96,6 +96,7 @@ import org.apache.cassandra.io.sstable.SSTableFlushObserver;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.schema.IndexMetadata;
+import org.apache.cassandra.schema.Schema;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.service.ClientState;
 import org.apache.cassandra.service.ClientWarn;
@@ -357,7 +358,22 @@ public class StorageAttachedIndex implements Index
         else if (type.isVector())
         {
             if (!Version.current(metadata.keyspace).onOrAfter(Version.JVECTOR_EARLIEST))
-                throw new InvalidRequestException(vectorUnsupportedByVersionError(Version.current(metadata.keyspace)));
+            {
+                throw new InvalidRequestException(vectorUnsupportedByCurrentVersionError(Version.current(metadata.keyspace)));
+            }
+
+            // Also, any pre-existing indexes must be in a version compatible with vectors.
+            ColumnFamilyStore baseCfs = Schema.instance.getColumnFamilyStoreInstance(metadata.id);
+            if (baseCfs != null)
+            {
+                StorageAttachedIndexGroup indexGroup = StorageAttachedIndexGroup.getIndexGroup(baseCfs);
+                if (indexGroup != null)
+                {
+                    Version version = indexGroup.getMinVersion();
+                    if (!version.onOrAfter(Version.JVECTOR_EARLIEST))
+                        throw new InvalidRequestException(vectorUnsupportedByExistingVersionError(version));
+                }
+            }
 
             if (type.valueLengthIfFixed() == 4 && config.getSimilarityFunction() == VectorSimilarityFunction.COSINE)
                 throw new InvalidRequestException("Cosine similarity is not supported for single-dimension vectors");
@@ -453,9 +469,25 @@ public class StorageAttachedIndex implements Index
             return ImmediateFuture.success(null);
         }
 
-        if (indexContext.isVector() && indexContext.version().compareTo(Version.JVECTOR_EARLIEST) < 0)
+        StorageAttachedIndexGroup indexGroup = StorageAttachedIndexGroup.getIndexGroup(baseCfs);
+        assert indexGroup != null;
+
+        // verify the compatibility of the on-disk format version with the vector index
+        if (indexContext.isVector())
         {
-            throw new FeatureNeedsIndexRebuildException(vectorUnsupportedByVersionError(indexContext.version()));
+            // The current version must support vectors
+            Version currentVersion = indexContext.version();
+            if (currentVersion.compareTo(Version.JVECTOR_EARLIEST) < 0)
+            {
+                throw new FeatureNeedsIndexRebuildException(vectorUnsupportedByCurrentVersionError(currentVersion));
+            }
+
+            // Also, any pre-existing indexes must be in a version compatible with vectors
+            Version minVersion = indexGroup.getMinVersion();
+            if (minVersion.compareTo(Version.JVECTOR_EARLIEST) < 0)
+            {
+                throw new FeatureNeedsIndexRebuildException(vectorUnsupportedByExistingVersionError(minVersion));
+            }
         }
 
         // stop in-progress compaction tasks to prevent compacted sstables not being indexed.
@@ -476,7 +508,6 @@ public class StorageAttachedIndex implements Index
         // From now on, all memtable will have attached memtable index. It is now safe to flush indexes directly from flushing Memtables.
         canFlushFromMemtableIndex = true;
 
-        StorageAttachedIndexGroup indexGroup = StorageAttachedIndexGroup.getIndexGroup(baseCfs);
         List<SSTableReader> nonIndexed = findNonIndexedSSTables(baseCfs, indexGroup, validate);
 
         if (nonIndexed.isEmpty())
@@ -501,12 +532,26 @@ public class StorageAttachedIndex implements Index
     }
 
     @VisibleForTesting
-    public static String vectorUnsupportedByVersionError(Version currentVersion)
+    public static String vectorUnsupportedByCurrentVersionError(Version currentVersion)
     {
         return String.format("The current configured on-disk format version %s does not support vector indexes. " +
                              "The minimum version that supports vectors is %s. " +
                              "The on-disk format version can be set via the -D%s system property.",
                              currentVersion,
+                             Version.JVECTOR_EARLIEST,
+                             CassandraRelevantProperties.SAI_CURRENT_VERSION.name());
+    }
+
+    @VisibleForTesting
+    public static String vectorUnsupportedByExistingVersionError(Version existingVersion)
+    {
+        return String.format("The current sstables have other indexes using the on-disk format version %s, " +
+                             "which is not compatible with vector indexes. " +
+                             "The minimum version that supports vectors is %s. " +
+                             "The on-disk format version can be set via the -D%s system property, " +
+                             "and the indexes on the sstables can be upgraded via nodetool upgradesstables." +
+                             "Then it will be needed to rebuild the index after the upgrade.",
+                             existingVersion,
                              Version.JVECTOR_EARLIEST,
                              CassandraRelevantProperties.SAI_CURRENT_VERSION.name());
     }

--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndexGroup.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndexGroup.java
@@ -588,4 +588,25 @@ public class StorageAttachedIndexGroup implements Index.Group, INotificationCons
             contexts.add(index.getIndexContext());
         return contexts;
     }
+
+    /**
+     * @return the minimum index version among all the per-sstable index components of this group,
+     * or the current version if there are no sstable indexes.
+     */
+    public Version getMinVersion()
+    {
+        StorageAttachedIndexGroup indexGroup = StorageAttachedIndexGroup.getIndexGroup(baseCfs);
+        assert indexGroup != null;
+        Version minVersion = null;
+        for (SSTableReader sstable : baseCfs.getLiveSSTables())
+        {
+            IndexDescriptor indexDescriptor = indexGroup.descriptorFor(sstable);
+            assert indexDescriptor != null;
+
+            Version version = indexDescriptor.perSSTableComponents().version();
+            if (minVersion == null || version.compareTo(minVersion) < 0)
+                minVersion = version;
+        }
+        return minVersion == null ? Version.current(baseCfs.metadata.keyspace) : minVersion;
+    }
 }

--- a/src/java/org/apache/cassandra/index/sai/disk/StorageAttachedIndexWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/StorageAttachedIndexWriter.java
@@ -37,7 +37,7 @@ import org.apache.cassandra.db.rows.Unfiltered;
 import org.apache.cassandra.db.tries.TrieSpaceExhaustedException;
 import org.apache.cassandra.index.sai.StorageAttachedIndex;
 import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
-import org.apache.cassandra.index.sai.disk.format.Version;
+import org.apache.cassandra.index.sai.disk.format.OnDiskFormat;
 import org.apache.cassandra.index.sai.memory.RowMapping;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
 import org.apache.cassandra.io.sstable.SSTableFlushObserver;
@@ -89,8 +89,9 @@ public class StorageAttachedIndexWriter implements SSTableFlushObserver
                                       boolean perIndexComponentsOnly,
                                       TableMetrics tableMetrics) throws IOException
     {
-        // We always write at the latest version (through what that version is can be configured for specific cases)
-        var onDiskFormat = Version.current(indexDescriptor.descriptor.ksname).onDiskFormat();
+        // We always use the version of the existing per-sstable components, if any, or the configured current version
+        // if there are no previously existing per-sstable components.
+        OnDiskFormat onDiskFormat = indexDescriptor.versionForNewComponents().onDiskFormat();
         this.indexDescriptor = indexDescriptor;
         // Note: I think there is a silent assumption here. That is, the PK factory we use here must be for the current
         // format version, because that is what `IndexContext.keyFactory` always uses (see ctor)

--- a/src/java/org/apache/cassandra/index/sai/disk/format/IndexDescriptor.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/IndexDescriptor.java
@@ -80,10 +80,13 @@ public class IndexDescriptor
     private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private static final NoSpamLogger noSpamLogger = NoSpamLogger.getLogger(logger, 1, TimeUnit.MINUTES);
 
-    // TODO Because indexes can be added at any time to existing data, the Version of a column index
-    // may not match the Version of the base sstable.  OnDiskFormat + IndexFeatureSet + IndexDescriptor
-    // was not designed with this in mind, leading to some awkwardness, notably in IFS where some features
-    // are per-sstable (`isRowAware`) and some are per-column (`hasTermsHistogram`).
+    /*
+    TODO: New indexes can be added at any time to existing data. Since CNDB-8756 we keep all new column indexes in the
+     same version as the existing per-sstable index components, making sstable upgrade the only way to move to a newer
+     version. However, prior to that fix the Version of a column index may not match the Version of the base sstable.
+     OnDiskFormat + IndexFeatureSet + IndexDescriptor was not designed with this in mind, leading to some awkwardness,
+     notably in IFS where some features are per-sstable (`isRowAware`) and some are per-column (`hasTermsHistogram`).
+    */
 
     public final Descriptor descriptor;
     private final ComponentsBuildId emptyGroupMarker;
@@ -262,6 +265,16 @@ public class IndexDescriptor
         return this;
     }
 
+    /**
+     * Returns the version that should be used for new components for the sstable of this descriptor.
+     * It is the version of the per-sstable components, which is either the version of the existing per-sstable
+     * components if any, or the current version if there is no existing components.
+     */
+    public Version versionForNewComponents()
+    {
+        return perSSTableComponents().version();
+    }
+
     public IndexComponents.ForRead perSSTableComponents()
     {
         return perSSTable;
@@ -290,7 +303,7 @@ public class IndexDescriptor
 
     private IndexComponents.ForWrite newComponentsForWrite(@Nullable IndexContext context, IndexComponentsImpl currentComponents)
     {
-        Version version = context != null ? context.version() : Version.current(descriptor.ksname);
+        Version version = versionForNewComponents();
         var currentBuildId = currentComponents == null ? null : currentComponents.buildId;
         return new IndexComponentsImpl(context, ComponentsBuildId.forNewBuild(version, currentBuildId, candidateId -> {
             // This checks that there is no existing files on disk we would overwrite by using `candidateId` for our

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/features/FeaturesVersionSupportTester.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/features/FeaturesVersionSupportTester.java
@@ -22,6 +22,7 @@ import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.Test;
 
 import org.apache.cassandra.distributed.Cluster;
@@ -29,12 +30,12 @@ import org.apache.cassandra.distributed.api.ICoordinator;
 import org.apache.cassandra.distributed.test.TestBaseImpl;
 import org.apache.cassandra.distributed.test.sai.SAIUtil;
 import org.apache.cassandra.exceptions.RequestFailureReason;
+import org.apache.cassandra.index.FeatureNeedsIndexRebuildException;
 import org.apache.cassandra.index.sai.disk.format.Version;
 import org.assertj.core.api.Assertions;
 
 import org.apache.cassandra.config.CassandraRelevantProperties;
 import static org.apache.cassandra.distributed.api.ConsistencyLevel.ALL;
-import static org.apache.cassandra.distributed.api.ConsistencyLevel.ONE;
 import static org.apache.cassandra.distributed.api.Feature.GOSSIP;
 import static org.apache.cassandra.distributed.api.Feature.NETWORK;
 
@@ -79,6 +80,13 @@ public abstract class FeaturesVersionSupportTester extends TestBaseImpl
                               .withConfig(config -> config.with(GOSSIP).with(NETWORK))
                               .start(), 1);
 
+        for (String keyspace : VERSIONS_PER_KEYSPACE.keySet())
+            cluster.schemaChange("CREATE KEYSPACE " + keyspace + " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}");
+    }
+
+    @Before
+    public void before()
+    {
         // The first node, which will be the coordinator in all tests, uses the latest version for all keyspaces
         cluster.get(1).runOnInstance(() -> org.apache.cassandra.index.sai.SAIUtil.setCurrentVersion(Version.LATEST));
 
@@ -86,31 +94,30 @@ public abstract class FeaturesVersionSupportTester extends TestBaseImpl
         String versionString = version.toString();
         cluster.get(2).runOnInstance(() -> org.apache.cassandra.index.sai.SAIUtil.setCurrentVersion(Version.parse(versionString), VERSIONS_PER_KEYSPACE));
 
-        for (String keyspace : VERSIONS_PER_KEYSPACE.keySet())
-            cluster.schemaChange("CREATE KEYSPACE " + keyspace + " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}");
 
-        // Set a comprehensive exception filter that covers all expected exceptions
-        // When testing with older SAI versions, index build failures can occur on either node
+        // Set a comprehensive exception filter that covers all expected exceptions.
+        // When testing with older SAI versions, index build failures can occur on either node.
         cluster.setUncaughtExceptionsFilter((i, t) -> {
             String className = t.getClass().getName();
             String message = t.getMessage() != null ? t.getMessage() : "";
-            
-            // Also check the cause if the exception is wrapped
+
+            // Also check the cause if the exception is wrapped.
             Throwable cause = t.getCause();
             String causeMessage = cause != null && cause.getMessage() != null ? cause.getMessage() : "";
-            
-            // Filter index build failures wrapped in RuntimeException or ExecutionException
-            if ((t instanceof RuntimeException || t instanceof java.util.concurrent.ExecutionException) && 
+
+            // Filter index build failures wrapped in RuntimeException or ExecutionException.
+            if ((t instanceof RuntimeException || t instanceof java.util.concurrent.ExecutionException) &&
                 (message.contains("Failed to update views on column indexes") ||
                  causeMessage.contains("Failed to update views on column indexes")))
                 return true;
-                
-            // Filter FeatureNeedsIndexRebuildException for both vector and BM25
+
+            // Filter FeatureNeedsIndexRebuildException for both vector and BM25.
             if (className.contains("FeatureNeedsIndexRebuildException") &&
                 (message.contains("does not support vector indexes") ||
-                 message.contains("does not support BM25 scoring")))
+                 message.contains("does not support BM25 scoring") ||
+                 message.contains("The current sstables have other indexes using the on-disk format version")))
                 return true;
-                
+
             return false;
         });
     }
@@ -129,6 +136,8 @@ public abstract class FeaturesVersionSupportTester extends TestBaseImpl
     /**
      * Test that vector indexes are supported with on-disk format versions from {@link Version#CA}.
      * Nodes using older versions should fail their index build, although the index will still exist.
+     * This includes nodes set to use a version that supports ANN, but with a pre-existing index in a version that
+     * doesn't support ANN.
      */
     @Test
     public void testANN()
@@ -138,15 +147,31 @@ public abstract class FeaturesVersionSupportTester extends TestBaseImpl
 
     private void testANN(String keyspace, Version version)
     {
-        cluster.schemaChange("CREATE TABLE " + keyspace + ".ann (k int PRIMARY KEY, v vector<float, 2>)");
+        cluster.schemaChange("CREATE TABLE " + keyspace + ".ann (k int PRIMARY KEY, x int, v vector<float, 2>)");
 
         ICoordinator coordinator = cluster.coordinator(1);
-        coordinator.execute("INSERT INTO " + keyspace + ".ann (k, v) VALUES (0, [1.0, 2.0])", ALL);
-        coordinator.execute("INSERT INTO " + keyspace + ".ann (k, v) VALUES (1, [2.0, 3.0])", ALL);
-        coordinator.execute("INSERT INTO " + keyspace + ".ann (k, v) VALUES (2, [3.0, 4.0])", ALL);
-        coordinator.execute("INSERT INTO " + keyspace + ".ann (k, v) VALUES (3, [4.0, 5.0])", ALL);
+        coordinator.execute("INSERT INTO " + keyspace + ".ann (k, x, v) VALUES (0, 0, [1.0, 2.0])", ALL);
+        coordinator.execute("INSERT INTO " + keyspace + ".ann (k, x, v) VALUES (1, 1, [2.0, 3.0])", ALL);
+        coordinator.execute("INSERT INTO " + keyspace + ".ann (k, x, v) VALUES (2, 2, [3.0, 4.0])", ALL);
+        coordinator.execute("INSERT INTO " + keyspace + ".ann (k, x, v) VALUES (3, 3, [4.0, 5.0])", ALL);
         cluster.forEach(node -> node.flush(keyspace));
 
+        // The second node is on the tested version, so it would accept or reject the index creation depending on
+        // whether that version supports it.
+        testANN(coordinator, keyspace, "does not support vector indexes");
+
+        // Create a non-vector index with the tested version, so there are some per-sstable components around
+        cluster.schemaChange("CREATE CUSTOM INDEX ON " + keyspace + ".ann(x) USING 'StorageAttachedIndex'");
+        SAIUtil.waitForIndexQueryableOnAllNodes(cluster, keyspace);
+
+        // Set the version of the second node to the latest version, so all nodes are in the latest version,
+        // but there is still a non-vector index with components on the tested version.
+        cluster.get(2).runOnInstance(() -> org.apache.cassandra.index.sai.SAIUtil.setCurrentVersion(Version.LATEST));
+        testANN(coordinator, keyspace, "The current sstables have other indexes using the on-disk format version");
+    }
+
+    private void testANN(ICoordinator coordinator, String keyspace, String expectedErrorMessage)
+    {
         String createIndexQuery = "CREATE CUSTOM INDEX ann_idx ON " + keyspace + ".ann(v) USING 'StorageAttachedIndex' " +
                                   "WITH OPTIONS = {'similarity_function' : 'euclidean'}";
         String annSelectQuery = "SELECT k FROM " + keyspace + ".ann ORDER BY v ANN OF [2.5, 3.5] LIMIT 3";
@@ -155,16 +180,22 @@ public abstract class FeaturesVersionSupportTester extends TestBaseImpl
         if (version.onOrAfter(Version.JVECTOR_EARLIEST))
         {
             cluster.schemaChange(createIndexQuery);
-            SAIUtil.waitForIndexQueryableOnFirstNode(cluster, keyspace, "ann_idx");
-            Assertions.assertThat(coordinator.execute(annSelectQuery, ONE)).hasNumberOfRows(3);
-            Assertions.assertThat(coordinator.execute(geoSelectQuery, ONE)).hasNumberOfRows(2);
+            SAIUtil.waitForIndexQueryableOnAllNodes(cluster, keyspace);
+            Assertions.assertThat(coordinator.execute(annSelectQuery, ALL)).hasNumberOfRows(3);
+            Assertions.assertThat(coordinator.execute(geoSelectQuery, ALL)).hasNumberOfRows(2);
         }
         else
         {
             // The on-disk format version in node 2 is too old to support indexes on vector columns.
+            // That can be due to either the default version for new indexes in node 2 for the keyspace, or the
+            // existence of other indexes using an old version that forces the new index to use that same old version.
+            cluster.setUncaughtExceptionsFilter((i, t) -> i == 2 &&
+                                                          t.getClass().getName().contains(FeatureNeedsIndexRebuildException.class.getName()) &&
+                                                          t.getMessage().contains(expectedErrorMessage));
             cluster.schemaChange(createIndexQuery);
             SAIUtil.assertIndexBuildFailed(cluster.get(1), cluster.get(2), keyspace, "ann_idx");
         }
+        cluster.schemaChange("DROP INDEX IF EXISTS " + keyspace + ".ann_idx");
     }
 
     /**
@@ -194,17 +225,17 @@ public abstract class FeaturesVersionSupportTester extends TestBaseImpl
                              "'index_analyzer': '{" +
                              "\"tokenizer\" : {\"name\" : \"standard\"}, " +
                              "\"filters\" : [{\"name\" : \"porterstem\"}]}'}");
-        SAIUtil.waitForIndexQueryableOnFirstNode(cluster, keyspace, "bm25_idx");
+        SAIUtil.waitForIndexQueryableOnAllNodes(cluster, keyspace);
 
         String query = "SELECT k FROM " + keyspace + ".bm25 ORDER BY v BM25 OF 'apple' LIMIT 3";
 
         if (version.onOrAfter(Version.BM25_EARLIEST))
         {
-            Assertions.assertThat(coordinator.execute(query, ONE)).hasNumberOfRows(1);
+            Assertions.assertThat(coordinator.execute(query, ALL)).hasNumberOfRows(1);
         }
         else
         {
-            Assertions.assertThatThrownBy(() -> coordinator.execute(query, ONE))
+            Assertions.assertThatThrownBy(() -> coordinator.execute(query, ALL))
                       .hasMessageContaining(RequestFailureReason.FEATURE_NEEDS_INDEX_REBUILD.name());
         }
     }
@@ -230,9 +261,9 @@ public abstract class FeaturesVersionSupportTester extends TestBaseImpl
         cluster.schemaChange("CREATE CUSTOM INDEX analyzer_idx ON " + keyspace + ".analyzer(v)" +
                              " USING 'org.apache.cassandra.index.sai.StorageAttachedIndex'" +
                              "WITH OPTIONS = { 'index_analyzer': 'standard' }");
-        SAIUtil.waitForIndexQueryableOnFirstNode(cluster, keyspace, "analyzer_idx");
+        SAIUtil.waitForIndexQueryableOnAllNodes(cluster, keyspace);
 
-        Assertions.assertThat(coordinator.execute("SELECT * FROM " + keyspace + ".analyzer WHERE v = 'dogs'", ONE))
+        Assertions.assertThat(coordinator.execute("SELECT * FROM " + keyspace + ".analyzer WHERE v = 'dogs'", ALL))
                   .hasNumberOfRows(1);
     }
 
@@ -265,14 +296,14 @@ public abstract class FeaturesVersionSupportTester extends TestBaseImpl
                              "'query_analyzer': '{" +
                              "  \"tokenizer\" : { \"name\" : \"whitespace\", \"args\" : {} }," +
                              "  \"filters\" : [ {\"name\" : \"lowercase\",\"args\": {}} ]}'}");
-        SAIUtil.waitForIndexQueryableOnFirstNode(cluster, keyspace, "q_analyzer_idx");
+        SAIUtil.waitForIndexQueryableOnAllNodes(cluster, keyspace);
 
         String query = "SELECT k FROM " + keyspace + ".q_analyzer WHERE v : ";
-        Assertions.assertThat(coordinator.execute(query + "'ast'", ONE)).hasNumberOfRows(3);
-        Assertions.assertThat(coordinator.execute(query + "'astra'", ONE)).hasNumberOfRows(3);
-        Assertions.assertThat(coordinator.execute(query + "'astra2'", ONE)).hasNumberOfRows(1);
-        Assertions.assertThat(coordinator.execute(query + "'fox'", ONE)).hasNumberOfRows(3);
-        Assertions.assertThat(coordinator.execute(query + "'foxes'", ONE)).hasNumberOfRows(1);
+        Assertions.assertThat(coordinator.execute(query + "'ast'", ALL)).hasNumberOfRows(3);
+        Assertions.assertThat(coordinator.execute(query + "'astra'", ALL)).hasNumberOfRows(3);
+        Assertions.assertThat(coordinator.execute(query + "'astra2'", ALL)).hasNumberOfRows(1);
+        Assertions.assertThat(coordinator.execute(query + "'fox'", ALL)).hasNumberOfRows(3);
+        Assertions.assertThat(coordinator.execute(query + "'foxes'", ALL)).hasNumberOfRows(1);
     }
 
     private static void test(BiConsumer<String, Version> testMethod)

--- a/test/unit/org/apache/cassandra/cql3/CQLTester.java
+++ b/test/unit/org/apache/cassandra/cql3/CQLTester.java
@@ -1352,7 +1352,7 @@ public abstract class CQLTester
     {
         String formattedQuery = formatQuery(keyspace, query);
         Pair<String, String> qualifiedIndexName = createFormattedIndex(keyspace, formattedQuery);
-        waitForIndexQueryableOnFirstNode(qualifiedIndexName.left, qualifiedIndexName.right);
+        waitForIndexQueryable(qualifiedIndexName.left, qualifiedIndexName.right);
         return qualifiedIndexName.right;
     }
 
@@ -1459,7 +1459,7 @@ public abstract class CQLTester
 
     public void waitForIndexQueryable(String index)
     {
-        waitForIndexQueryableOnFirstNode(KEYSPACE, index);
+        waitForIndexQueryable(KEYSPACE, index);
     }
 
     /**
@@ -1468,9 +1468,14 @@ public abstract class CQLTester
      * @param keyspace the index keyspace name
      * @param index the index name
      */
-    public void waitForIndexQueryableOnFirstNode(String keyspace, String index)
+    public void waitForIndexQueryable(String keyspace, String index)
     {
         waitForIndexQueryable(keyspace, index, 1, TimeUnit.MINUTES);
+    }
+
+    public void waitForIndexQueryableOnFirstNode(String keyspace, String index)
+    {
+        waitForIndexQueryable(keyspace, index);
     }
 
     /**

--- a/test/unit/org/apache/cassandra/index/sai/SAITester.java
+++ b/test/unit/org/apache/cassandra/index/sai/SAITester.java
@@ -422,39 +422,75 @@ public class SAITester extends CQLTester
         return true;
     }
 
-    protected void verifySAIVersionInUse(Version expectedVersion)
+    protected void verifySAIVersionInUse(Version... expectedVersions)
     {
-        verifySAIVersionInUse(expectedVersion, KEYSPACE, currentTable());
+        verifySAIVersionInUse(KEYSPACE, currentTable(), expectedVersions);
     }
 
-    protected void verifySAIVersionInUse(Version expectedVersion, String keyspace, String table)
+    protected void verifySAIVersionInUse(String keyspace,
+                                         String table,
+                                         Version... expectedVersions)
+    {
+        verifySAIVersionInUse(keyspace, table, true, expectedVersions);
+    }
+
+    protected void verifySAIVersionInUse(String keyspace,
+                                         String table,
+                                         boolean uniqueVersionPerSSTable,
+                                         Version... expectedVersions)
     {
         ColumnFamilyStore cfs = Keyspace.open(keyspace).getColumnFamilyStore(table);
         StorageAttachedIndexGroup group = StorageAttachedIndexGroup.getIndexGroup(cfs);
+        Assert.assertNotNull(group);
+        Set<Version> versions = Set.copyOf(Arrays.asList(expectedVersions)); // there might be duplicate expected versions
 
         for (SSTableReader sstable : cfs.getLiveSSTables())
         {
-            IndexDescriptor indexDescriptor = loadDescriptor(sstable, cfs);
+            verifySAIVersionInUse(cfs, group, sstable, versions, uniqueVersionPerSSTable);
+        }
+    }
 
-            assertEquals(expectedVersion, indexDescriptor.perSSTableComponents().version());
-            SSTableContext ssTableContext = group.sstableContextManager().getContext(sstable);
-            // This is to make sure the context uses the actual files we think
-            assertEquals(expectedVersion, ssTableContext.usedPerSSTableComponents().version());
+    private void verifySAIVersionInUse(ColumnFamilyStore cfs,
+                                       StorageAttachedIndexGroup group,
+                                       SSTableReader sstable,
+                                       Set<Version> expectedVersions,
+                                       boolean uniqueVersionPerSSTable)
+    {
+        Set<Version> foundVersions = new HashSet<>();
 
-            for (IndexContext indexContext : getIndexContexts(keyspace, table))
+        IndexDescriptor indexDescriptor = loadDescriptor(sstable, cfs);
+        Version perSSTableVersion = indexDescriptor.perSSTableComponents().version();
+        foundVersions.add(perSSTableVersion);
+        Assertions.assertThat(perSSTableVersion).isIn(expectedVersions);
+
+        // This is to make sure the context uses the actual files we think
+        SSTableContext sstableContext = group.sstableContextManager().getContext(sstable);
+        perSSTableVersion = sstableContext.usedPerSSTableComponents().version();
+        Assertions.assertThat(perSSTableVersion).isIn(expectedVersions);
+
+        for (IndexContext indexContext : getIndexContexts(cfs.keyspace.getName(), cfs.name))
+        {
+            Version perIndexVersion = indexDescriptor.perIndexComponents(indexContext).version();
+            Assertions.assertThat(perIndexVersion).isIn(expectedVersions);
+
+            // Make sure the per-index version is the same as the per-sstable version.
+            if (uniqueVersionPerSSTable && !perIndexVersion.equals(perSSTableVersion))
+                Assert.fail("Per-index version " + perIndexVersion +
+                            " is not equals to the per-sstable version " + perSSTableVersion);
+
+            for (SSTableIndex sstableIndex : indexContext.getView())
             {
-                assertEquals(indexDescriptor.perIndexComponents(indexContext).version(), expectedVersion);
+                if (sstableIndex.isEmpty())
+                    continue;
 
-                for (SSTableIndex sstableIndex : indexContext.getView())
-                {
-                    if (sstableIndex.isEmpty())
-                        continue;
-
-                    // Make sure the index does use components of the proper version.
-                    assertEquals(sstableIndex.usedPerIndexComponents().version(), expectedVersion);
-                }
+                // Make sure the index does use components of the proper version.
+                perIndexVersion = sstableIndex.usedPerIndexComponents().version();
+                foundVersions.add(perIndexVersion);
+                Assertions.assertThat(perIndexVersion).isIn(expectedVersions);
             }
         }
+
+        Assertions.assertThat(foundVersions).isEqualTo(expectedVersions);
     }
 
     /**
@@ -613,9 +649,14 @@ public class SAITester extends CQLTester
 
     protected void upgradeSSTables()
     {
+        upgradeSSTables(KEYSPACE, currentTable());
+    }
+
+    protected void upgradeSSTables(String keyspace, String table)
+    {
         try
         {
-            StorageService.instance.upgradeSSTables(KEYSPACE, false, currentTable());
+            StorageService.instance.upgradeSSTables(keyspace, false, table);
         }
         catch (Throwable e)
         {

--- a/test/unit/org/apache/cassandra/index/sai/cql/CreateIndexWithNewVersionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/CreateIndexWithNewVersionTest.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.cql;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.index.sai.SAITester;
+import org.apache.cassandra.index.sai.SAIUtil;
+import org.apache.cassandra.index.sai.StorageAttachedIndexGroup;
+import org.apache.cassandra.index.sai.disk.format.Version;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests that creating a new index with a different version than an existing index works as expected:
+ * <ul>
+ *     <li>If the sstable doesn't have any other index components, the index should be created with the current
+ *     version.</li>
+ *     <li>If the sstable already has other index components belonging to another index, the new index should be created
+ *     with the version of those already existing components, regardless of the current version.</li>
+ * </ul>
+ * As a result:
+ * <ul>
+ *     <li>Rebuilding an index won't change its version.</li>
+ *     <li>Upgrading sstables will upgrade the version of their indexes, since the upgraded sstables are new sstables.</li>
+ *     <li>Compacting sstables will upgrade the version of their indexes, since the compacted sstables are new sstable.</li>
+ * </ul>
+ * See CNDB-8756 for further details.
+ * See {@link FeaturesVersionSupportTest} and {@link VersionSelectorTest} for related tests.
+ */
+@RunWith(Parameterized.class)
+public class CreateIndexWithNewVersionTest extends SAITester
+{
+    @Parameterized.Parameter
+    public boolean useImmutableComponents;
+
+    @Parameterized.Parameter(1)
+    public Version initialVersion;
+
+    @Parameterized.Parameter(2)
+    public Version upgradeVersion;
+
+    // The smallest between initialVersion and upgradeVersion, since we're testing both upgrades and downgrades.
+    private Version oldestVersion;
+
+    @Parameterized.Parameters(name = "immutable={0} initial={1} upgrade={2}")
+    public static Collection<Object[]> data()
+    {
+        List<Object[]> data = new ArrayList<>();
+        for (boolean useImmutableComponents : new boolean[]{ true, false })
+        {
+            for (Version oldVersion : Version.ALL)
+            {
+                for (Version newVersion : Version.ALL)
+                {
+                    if (oldVersion == newVersion)
+                        continue;
+
+                    data.add(new Object[]{ useImmutableComponents, oldVersion, newVersion });
+                }
+            }
+        }
+        return data;
+    }
+
+    @Before
+    public void setup()
+    {
+        SAIUtil.setCurrentVersion(initialVersion);
+        CassandraRelevantProperties.IMMUTABLE_SAI_COMPONENTS.setBoolean(useImmutableComponents);
+        oldestVersion = initialVersion.after(upgradeVersion) ? upgradeVersion : initialVersion;
+    }
+
+    @Test
+    public void testCreateIndexWithNewVersion()
+    {
+        // Create a table and insert some data.
+        createTable("CREATE TABLE %s (k int, c int, a int, b int, PRIMARY KEY (k, c))");
+        execute("INSERT INTO %s (k, c, a, b) VALUES (?, ?, ?, ?)", 0, 0, 0, 0);
+        execute("INSERT INTO %s (k, c, a, b) VALUES (?, ?, ?, ?)", 0, 1, 0, 1);
+        execute("INSERT INTO %s (k, c, a, b) VALUES (?, ?, ?, ?)", 0, 2, 1, 0);
+        execute("INSERT INTO %s (k, c, a, b) VALUES (?, ?, ?, ?)", 0, 3, 1, 1);
+        execute("INSERT INTO %s (k, c, a, b) VALUES (?, ?, ?, ?)", 1, 0, 0, 0);
+        execute("INSERT INTO %s (k, c, a, b) VALUES (?, ?, ?, ?)", 1, 1, 0, 1);
+        execute("INSERT INTO %s (k, c, a, b) VALUES (?, ?, ?, ?)", 1, 2, 1, 0);
+        execute("INSERT INTO %s (k, c, a, b) VALUES (?, ?, ?, ?)", 1, 3, 1, 1);
+        flush();
+
+        // Create an index with the initial version.
+        createIndex("CREATE CUSTOM INDEX ON %s(a) USING 'StorageAttachedIndex'");
+        verifySAIVersionInUse(initialVersion);
+        StorageAttachedIndexGroup group = StorageAttachedIndexGroup.getIndexGroup(getCurrentColumnFamilyStore());
+        assertThat(group).isNotNull();
+        assertThat(group.getMinVersion()).isEqualTo(initialVersion);
+
+        // Create a new index with a different version.
+        // The per-sstable components and the existing per-index components will remain in the initial version.
+        // The new per-index components will be created in the new version only if it's the same as the initial version.
+        // Otherwise, they will use the old version, so all the index components of a sstable are in the same version.
+        SAIUtil.setCurrentVersion(upgradeVersion);
+        createIndex("CREATE CUSTOM INDEX ON %s(b) USING 'StorageAttachedIndex'");
+        verifySAIVersionInUse(initialVersion);
+        assertThat(group.getMinVersion()).isEqualTo(initialVersion);
+
+        // Add some more data, and flush it to a new sstable.
+        execute("INSERT INTO %s (k, c, a, b) VALUES (?, ?, ?, ?)", 2, 0, 0, 0);
+        execute("INSERT INTO %s (k, c, a, b) VALUES (?, ?, ?, ?)", 2, 1, 0, 1);
+        execute("INSERT INTO %s (k, c, a, b) VALUES (?, ?, ?, ?)", 2, 2, 1, 0);
+        execute("INSERT INTO %s (k, c, a, b) VALUES (?, ?, ?, ?)", 2, 3, 1, 1);
+        flush();
+
+        // The new sstable should create new per-sstable components in the new version, for both indexes.
+        // The old sstable should keep their components in the old version.
+        verifySAIVersionInUse(initialVersion, upgradeVersion);
+        assertThat(group.getMinVersion()).isEqualTo(oldestVersion);
+        verifyQueries();
+
+        // Rebuild should rebuild the sstable indexes keeping the exact same versions we were using.
+        rebuildTableIndexes();
+        verifySAIVersionInUse(initialVersion, upgradeVersion);
+        assertThat(group.getMinVersion()).isEqualTo(oldestVersion);
+        verifyQueries();
+
+        // Upgrade sstables should upgrade all sstable indexes to the new version.
+        upgradeSSTables();
+        verifySAIVersionInUse(upgradeVersion);
+        assertThat(group.getMinVersion()).isEqualTo(upgradeVersion);
+        verifyQueries();
+
+        // Add another sstable with the initial version again
+        SAIUtil.setCurrentVersion(initialVersion);
+        execute("INSERT INTO %s (k, c, a, b) VALUES (?, ?, ?, ?) USING TIMESTAMP 1", 3, 0, 0, 0);
+        flush();
+        verifySAIVersionInUse(initialVersion, upgradeVersion);
+        assertThat(execute("SELECT * FROM %s WHERE a = 0").size()).isEqualTo(7);
+
+        // change the version again and verify that compaction effectively upgrades the index
+        SAIUtil.setCurrentVersion(upgradeVersion);
+        compact();
+        verifySAIVersionInUse(upgradeVersion);
+        assertThat(execute("SELECT * FROM %s WHERE a = 0").size()).isEqualTo(7);
+    }
+
+    private void verifyQueries()
+    {
+        // test old index on column a
+        assertRowsIgnoringOrder(execute("SELECT * FROM %s WHERE a = 0"),
+                                row(0, 0, 0, 0),
+                                row(0, 1, 0, 1),
+                                row(1, 0, 0, 0),
+                                row(1, 1, 0, 1),
+                                row(2, 0, 0, 0),
+                                row(2, 1, 0, 1));
+        assertRowsIgnoringOrder(execute("SELECT * FROM %s WHERE a = 1"),
+                                row(0, 2, 1, 0),
+                                row(0, 3, 1, 1),
+                                row(1, 2, 1, 0),
+                                row(1, 3, 1, 1),
+                                row(2, 2, 1, 0),
+                                row(2, 3, 1, 1));
+
+        // test new index on column b
+        assertRowsIgnoringOrder(execute("SELECT * FROM %s WHERE b = 0"),
+                                row(0, 0, 0, 0),
+                                row(0, 2, 1, 0),
+                                row(1, 0, 0, 0),
+                                row(1, 2, 1, 0),
+                                row(2, 0, 0, 0),
+                                row(2, 2, 1, 0));
+        assertRowsIgnoringOrder(execute("SELECT * FROM %s WHERE b = 1"),
+                                row(0, 1, 0, 1),
+                                row(0, 3, 1, 1),
+                                row(1, 1, 0, 1),
+                                row(1, 3, 1, 1),
+                                row(2, 1, 0, 1),
+                                row(2, 3, 1, 1));
+
+        // test both indexes combined
+        assertRowsIgnoringOrder(execute("SELECT * FROM %s WHERE a = 0 AND b = 0"),
+                                row(0, 0, 0, 0),
+                                row(1, 0, 0, 0),
+                                row(2, 0, 0, 0));
+        assertRowsIgnoringOrder(execute("SELECT * FROM %s WHERE a = 0 AND b = 1"),
+                                row(0, 1, 0, 1),
+                                row(1, 1, 0, 1),
+                                row(2, 1, 0, 1));
+        assertRowsIgnoringOrder(execute("SELECT * FROM %s WHERE a = 1 AND b = 0"),
+                                row(0, 2, 1, 0),
+                                row(1, 2, 1, 0),
+                                row(2, 2, 1, 0));
+        assertRowsIgnoringOrder(execute("SELECT * FROM %s WHERE a = 1 AND b = 1"),
+                                row(0, 3, 1, 1),
+                                row(1, 3, 1, 1),
+                                row(2, 3, 1, 1));
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/FeaturesVersionSupportTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/FeaturesVersionSupportTest.java
@@ -99,12 +99,13 @@ public class FeaturesVersionSupportTest extends VectorTester
         else
         {
             Assertions.assertThatThrownBy(() -> createIndex(createIndexQuery))
-                      .hasMessageContaining(StorageAttachedIndex.vectorUnsupportedByVersionError(version));
+                      .hasMessageContaining(StorageAttachedIndex.vectorUnsupportedByCurrentVersionError(version));
         }
 
-        // vector index creation will be accepted on newer versions, even if there is still another index in the older version
-        SAIUtil.setCurrentVersion(Version.LATEST);
-        createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
+        // Vector index creation will be accepted on newer versions, unless there are other indexes using a version
+        // that doesn't support jvector. In that case, the vector index will fail until the old sstables are
+        // upgraded, so the old indexes are upgraded too.
+        assertIndexCreationChecksCurrentPerTableVersion(createIndexQuery);
 
         // once the index has been created, we can query it
         assertRows(execute("SELECT k FROM %s ORDER BY v ANN OF [2.5, 3.5, 4.5] LIMIT 3"), row(2), row(1), row(3));
@@ -148,16 +149,35 @@ public class FeaturesVersionSupportTest extends VectorTester
         else
         {
             Assertions.assertThatThrownBy(() -> createIndex(createIndexQuery))
-                      .hasMessageContaining(StorageAttachedIndex.vectorUnsupportedByVersionError(version));
+                      .hasMessageContaining(StorageAttachedIndex.vectorUnsupportedByCurrentVersionError(version));
         }
 
-        // vector index creation will be accepted on newer versions, even if there is still an index in the older version
-        SAIUtil.setCurrentVersion(Version.LATEST);
-        createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
+        // Geospatial index creation will be accepted on newer versions, unless there are other indexes using a version
+        // that doesn't support jvector. In that case, the geospatial index will fail until the old sstables are
+        // upgraded, so the old indexes are upgraded too.
+        assertIndexCreationChecksCurrentPerTableVersion(createIndexQuery);
 
         // once the index has been created, we can query it
         assertRowsIgnoringOrder(execute("SELECT k FROM %s WHERE GEO_DISTANCE(v, [5,5]) < 157000"), row(2), row(3));
         assertRowsIgnoringOrder(execute("SELECT k FROM %s WHERE GEO_DISTANCE(v, [5,5]) < 157011"), row(1), row(2), row(3));
+    }
+
+    private void assertIndexCreationChecksCurrentPerTableVersion(String createIndexQuery)
+    {
+        SAIUtil.setCurrentVersion(Version.LATEST);
+        if (version.onOrAfter(Version.JVECTOR_EARLIEST))
+        {
+            createIndex(createIndexQuery);
+        }
+        else
+        {
+            Assertions.assertThatThrownBy(() -> createIndex(createIndexQuery))
+                      .hasMessageContaining(StorageAttachedIndex.vectorUnsupportedByExistingVersionError(version));
+
+            upgradeSSTables();
+            createIndex(createIndexQuery);
+            verifySAIVersionInUse(KEYSPACE, currentTable(), Version.LATEST);
+        }
     }
 
     /**

--- a/test/unit/org/apache/cassandra/index/sai/cql/MixedVersionsInSSTableTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/MixedVersionsInSSTableTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.apache.cassandra.index.sai.SAITester;
+import org.apache.cassandra.index.sai.SAIUtil;
+import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
+import org.apache.cassandra.index.sai.disk.format.Version;
+import org.apache.cassandra.inject.ActionBuilder;
+import org.apache.cassandra.inject.Expression;
+import org.apache.cassandra.inject.Injection;
+import org.apache.cassandra.inject.Injections;
+import org.apache.cassandra.inject.InvokePointBuilder;
+import org.assertj.core.api.Assertions;
+
+import static org.apache.cassandra.inject.Expression.expr;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test to verify that we can query a sstable with multiple indexes on different versions.
+ * </p>
+ * We shouldn't generate such a scenario after CNDB-8756, which makes all the indexes of a sstable use the same version.
+ * However, we can have old sstables created before that fix was introduced, and we should be able to deal with them
+ * when possible.
+ *
+ * @see CreateIndexWithNewVersionTest
+ */
+@RunWith(Parameterized.class)
+public class MixedVersionsInSSTableTest extends SAITester
+{
+    @Parameterized.Parameter
+    public Version initialVersion;
+
+    @Parameterized.Parameter(1)
+    public Version upgradeVersion;
+
+    private Version oldestVersion;
+    private Injection injection;
+
+    @Parameterized.Parameters(name = "initial={0} upgrade={1}")
+    public static Collection<Object[]> data()
+    {
+        List<Object[]> data = new ArrayList<>();
+        for (Version oldVersion : Version.ALL)
+        {
+            for (Version newVersion : Version.ALL)
+            {
+                if (oldVersion == newVersion)
+                    continue;
+
+                data.add(new Object[]{ oldVersion, newVersion });
+            }
+        }
+        return data;
+    }
+
+    @Before
+    public void before() throws Throwable
+    {
+        oldestVersion = initialVersion.after(upgradeVersion) ? upgradeVersion : initialVersion;
+
+        // Inject a rule to skip CNDB-8756, so new indexes are created with the new version regardless of having an
+        // index using the old version.
+        Expression expression = expr("org.apache.cassandra.index.sai.disk.format.Version." + upgradeVersion.toString().toUpperCase());
+        injection = Injections.newCustom("use_current_version")
+                              .add(InvokePointBuilder.newInvokePoint()
+                                                     .onClass(IndexDescriptor.class)
+                                                     .onMethod("versionForNewComponents")
+                                                     .atEntry())
+                              .add(ActionBuilder.newActionBuilder().actions().doReturn(expression))
+                              .build();
+        Injections.inject(injection);
+        injection.disable();
+    }
+
+    @After
+    public void after()
+    {
+        injection.disable();
+    }
+
+    @Test
+    public void testMixedVersionsInSSTable()
+    {
+        createTable("CREATE TABLE %s(k int, c int, a int, b int, v vector<float, 2>, PRIMARY KEY(k, c))");
+
+        execute("INSERT INTO %s (k, c, a, b, v) VALUES (0, 0, 0, 0, [0, 1])");
+        execute("INSERT INTO %s (k, c, a, b, v) VALUES (0, 1, 1, 0, [0, 2])");
+        execute("INSERT INTO %s (k, c, a, b, v) VALUES (0, 2, 0, 0, [0, 3])");
+        execute("INSERT INTO %s (k, c, a, b, v) VALUES (1, 0, 1, 0, [0, 4])");
+        execute("INSERT INTO %s (k, c, a, b, v) VALUES (1, 1, 0, 1, [0, 5])");
+        execute("INSERT INTO %s (k, c, a, b, v) VALUES (1, 2, 1, 1, [0, 6])");
+        execute("INSERT INTO %s (k, c, a, b, v) VALUES (2, 0, 0, 1, [0, 7])");
+        execute("INSERT INTO %s (k, c, a, b, v) VALUES (2, 1, 1, 1, [0, 8])");
+        execute("INSERT INTO %s (k, c, a, b, v) VALUES (2, 2, 0, 1, [0, 9])");
+        flush();
+
+        SAIUtil.setCurrentVersion(initialVersion);
+        createIndex("CREATE CUSTOM INDEX ON %s(a) USING 'StorageAttachedIndex'");
+        verifySAIVersionInUse(initialVersion);
+
+        injection.enable();
+
+        SAIUtil.setCurrentVersion(upgradeVersion);
+        createIndex("CREATE CUSTOM INDEX ON %s(b) USING 'StorageAttachedIndex'");
+        if (oldestVersion.onOrAfter(Version.JVECTOR_EARLIEST))
+        {
+            createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
+        }
+        verifySAIVersionInUse(KEYSPACE, currentTable(), false, initialVersion, upgradeVersion);
+
+        assertEquals(5, execute("SELECT * FROM %s WHERE a = 0").size());
+        assertEquals(4, execute("SELECT * FROM %s WHERE a = 1").size());
+
+        // queries only for the index on the new version break when the older index is in AA if they find results
+        if (initialVersion == Version.AA)
+        {
+            assertFailsDueToPrimaryKey("SELECT * FROM %s WHERE b = 0");
+            assertFailsDueToPrimaryKey("SELECT * FROM %s WHERE b = 1");
+        }
+        else
+        {
+            assertEquals(4, execute("SELECT * FROM %s WHERE b = 0").size());
+            assertEquals(5, execute("SELECT * FROM %s WHERE b = 1").size());
+        }
+        assertEmpty(execute("SELECT * FROM %s WHERE b = 2"));
+
+        assertEquals(2, execute("SELECT * FROM %s WHERE a = 0 AND b = 0").size());
+        assertEquals(3, execute("SELECT * FROM %s WHERE a = 0 AND b = 1").size());
+        assertEquals(2, execute("SELECT * FROM %s WHERE a = 1 AND b = 0").size());
+        assertEquals(2, execute("SELECT * FROM %s WHERE a = 1 AND b = 1").size());
+        assertEquals(7, execute("SELECT * FROM %s WHERE a = 0 OR b = 0").size());
+        assertEquals(7, execute("SELECT * FROM %s WHERE a = 0 OR b = 1").size());
+        assertEquals(6, execute("SELECT * FROM %s WHERE a = 1 OR b = 0").size());
+        assertEquals(7, execute("SELECT * FROM %s WHERE a = 1 OR b = 1").size());
+
+        if (oldestVersion.onOrAfter(Version.JVECTOR_EARLIEST))
+        {
+            assertEquals(2, execute("SELECT k, c FROM %s ORDER BY v ANN OF [0, 1] LIMIT 2").size());
+            assertEquals(9, execute("SELECT k, c FROM %s ORDER BY v ANN OF [0, 1] LIMIT 10").size());
+        }
+    }
+
+    private void assertFailsDueToPrimaryKey(String query)
+    {
+        Assertions.assertThatThrownBy(() -> executeInternal(query))
+                  .isInstanceOf(AssertionError.class)
+                  .hasMessageContaining("PrimaryKey");
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/NativeIndexDDLTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/NativeIndexDDLTest.java
@@ -1335,8 +1335,12 @@ public class NativeIndexDDLTest extends SAITester
         assertEquals(rowCount, rows.all().size());
     }
 
+    /**
+     * Tests that we can rebuild and reload in place to a newer version only after upgrading sstables.
+     * More exhaustive testing is done in {@link CreateIndexWithNewVersionTest}.
+     */
     @Test
-    public void verifyCanRebuildAndReloadInPlaceToNewerVersion()
+    public void verifyCanRebuildAndReloadInPlaceToNewerVersionOnlyAfterSSTableUpgrade()
     {
         Version current = Version.current(KEYSPACE);
         try
@@ -1354,24 +1358,32 @@ public class NativeIndexDDLTest extends SAITester
             flush();
 
             // Sanity check first
-            ResultSet rows = executeNet("SELECT id1 FROM %s WHERE v1>=0");
-            assertEquals(rowCount, rows.all().size());
-            rows = executeNet("SELECT id1 FROM %s WHERE v2='0'");
-            assertEquals(rowCount, rows.all().size());
-
+            Runnable queryTester = () -> {
+                ResultSet rows = executeNet("SELECT id1 FROM %s WHERE v1>=0");
+                assertEquals(rowCount, rows.all().size());
+                rows = executeNet("SELECT id1 FROM %s WHERE v2='0'");
+                assertEquals(rowCount, rows.all().size());
+            };
+            queryTester.run();
             verifySAIVersionInUse(Version.AA);
 
             SAIUtil.setCurrentVersion(current);
 
+            // The queries should still work, but the version should not have changed.
             rebuildTableIndexes();
             reloadSSTableIndexInPlace();
+            queryTester.run();
+            verifySAIVersionInUse(Version.AA);
 
-            // This should still work
-            rows = executeNet("SELECT id1 FROM %s WHERE v1>=0");
-            assertEquals(rowCount, rows.all().size());
-            rows = executeNet("SELECT id1 FROM %s WHERE v2='0'");
-            assertEquals(rowCount, rows.all().size());
+            // Now upgrade sstables and try again
+            upgradeSSTables();
+            queryTester.run();
+            verifySAIVersionInUse(current);
 
+            // Rebuild once again
+            rebuildTableIndexes();
+            reloadSSTableIndexInPlace();
+            queryTester.run();
             verifySAIVersionInUse(current);
         }
         finally

--- a/test/unit/org/apache/cassandra/index/sai/cql/VersionSelectorTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VersionSelectorTest.java
@@ -16,22 +16,22 @@
 
 package org.apache.cassandra.index.sai.cql;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
+import java.util.function.Function;
 
-import org.junit.Assume;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.cql3.UntypedResultSet;
 import org.apache.cassandra.index.sai.SAITester;
 import org.apache.cassandra.index.sai.SAIUtil;
+import org.apache.cassandra.index.sai.StorageAttachedIndex;
 import org.apache.cassandra.index.sai.disk.format.Version;
 import org.assertj.core.api.Assertions;
 
@@ -46,15 +46,37 @@ import static java.lang.String.format;
 public class VersionSelectorTest extends SAITester
 {
     public static final String TABLE = "tbl";
-    private static final Logger logger = LoggerFactory.getLogger(VersionSelectorTest.class);
 
     @Parameterized.Parameter
     public Version globalCurrentVersion;
 
-    @Parameterized.Parameters(name = "globalCurrentVersion={0}")
+    @Parameterized.Parameter(1)
+    public Operation operation;
+
+    public enum Operation
+    {
+        CREATE,
+        REBUILD
+    }
+
+    @Parameterized.Parameters(name = "globalCurrentVersion={0} operation={1}")
     public static Collection<Object[]> data()
     {
-        return Version.ALL.stream().map(v -> new Object[]{ v }).collect(Collectors.toList());
+        Collection<Object[]> params = new ArrayList<>();
+        for (Operation operation : Operation.values())
+        {
+            for (Version version : Version.ALL)
+            {
+                params.add(new Object[]{ version, operation });
+            }
+        }
+        return params;
+    }
+
+    @Before
+    public void before()
+    {
+        SAIUtil.setCurrentVersion(globalCurrentVersion);
     }
 
     @Test
@@ -62,13 +84,13 @@ public class VersionSelectorTest extends SAITester
     {
         test(keyspace -> {
             createTable(keyspace, "CREATE TABLE %s (k int PRIMARY KEY, v int)");
-            createIndex(keyspace, "CREATE CUSTOM INDEX IF NOT EXISTS ON %s(v) USING 'StorageAttachedIndex'");
             execute(keyspace, "INSERT INTO %s (k, v) VALUES (0, 0)");
             execute(keyspace, "INSERT INTO %s (k, v) VALUES (1, 1)");
-        }).withQueries(keyspace -> {
-            assertRowCount(keyspace, "SELECT * FROM %s WHERE v>=0", 2);
-            assertRowCount(keyspace, "SELECT * FROM %s WHERE v>0", 1);
-        });
+        }).withIndex(keyspace -> createIndex(keyspace, "CREATE CUSTOM INDEX IF NOT EXISTS ON %s(v) USING 'StorageAttachedIndex'"))
+          .withQueries(keyspace -> {
+              assertRowCount(keyspace, "SELECT * FROM %s WHERE v>=0", 2);
+              assertRowCount(keyspace, "SELECT * FROM %s WHERE v>0", 1);
+          });
     }
 
     @Test
@@ -76,17 +98,17 @@ public class VersionSelectorTest extends SAITester
     {
         test(keyspace -> {
             createTable(keyspace, "CREATE TABLE %s (k int, c int, v int, PRIMARY KEY (k, c))");
-            createIndex(keyspace, "CREATE CUSTOM INDEX IF NOT EXISTS ON %s(v) USING 'StorageAttachedIndex'");
             execute(keyspace, "INSERT INTO %s (k, c, v) VALUES (0, 0, 0)");
             execute(keyspace, "INSERT INTO %s (k, c, v) VALUES (0, 1, 1)");
             execute(keyspace, "INSERT INTO %s (k, c, v) VALUES (1, 0, 0)");
             execute(keyspace, "INSERT INTO %s (k, c, v) VALUES (1, 1, 2)");
-        }).withQueries(keyspace -> {
-            assertRowCount(keyspace, "SELECT * FROM %s WHERE v>=0", 4);
-            assertRowCount(keyspace, "SELECT * FROM %s WHERE v>0", 2);
-            assertRowCount(keyspace, "SELECT * FROM %s WHERE k = 0 AND v>=0", 2);
-            assertRowCount(keyspace, "SELECT * FROM %s WHERE k = 0 AND v>0", 1);
-        });
+        }).withIndex(keyspace -> createIndex(keyspace, "CREATE CUSTOM INDEX IF NOT EXISTS ON %s(v) USING 'StorageAttachedIndex'"))
+          .withQueries(keyspace -> {
+              assertRowCount(keyspace, "SELECT * FROM %s WHERE v>=0", 4);
+              assertRowCount(keyspace, "SELECT * FROM %s WHERE v>0", 2);
+              assertRowCount(keyspace, "SELECT * FROM %s WHERE k = 0 AND v>=0", 2);
+              assertRowCount(keyspace, "SELECT * FROM %s WHERE k = 0 AND v>0", 1);
+          });
     }
 
     @Test
@@ -94,15 +116,15 @@ public class VersionSelectorTest extends SAITester
     {
         test(keyspace -> {
             createTable(keyspace, "CREATE TABLE %s (k int PRIMARY KEY, v text)");
-            createIndex(keyspace, "CREATE CUSTOM INDEX IF NOT EXISTS ON %s(v) USING 'StorageAttachedIndex'");
             execute(keyspace, "INSERT INTO %s (k, v) VALUES (0, '0')");
             execute(keyspace, "INSERT INTO %s (k, v) VALUES (1, '0')");
             execute(keyspace, "INSERT INTO %s (k, v) VALUES (2, '1')");
-        }).withQueries(keyspace -> {
-            assertRowCount(keyspace, "SELECT * FROM %s WHERE v='0'", 2);
-            assertRowCount(keyspace, "SELECT * FROM %s WHERE v='1'", 1);
-            assertRowCount(keyspace, "SELECT * FROM %s WHERE v='2'", 0);
-        });
+        }).withIndex(keyspace -> createIndex(keyspace, "CREATE CUSTOM INDEX IF NOT EXISTS ON %s(v) USING 'StorageAttachedIndex'"))
+          .withQueries(keyspace -> {
+              assertRowCount(keyspace, "SELECT * FROM %s WHERE v='0'", 2);
+              assertRowCount(keyspace, "SELECT * FROM %s WHERE v='1'", 1);
+              assertRowCount(keyspace, "SELECT * FROM %s WHERE v='2'", 0);
+          });
     }
 
     @Test
@@ -110,21 +132,21 @@ public class VersionSelectorTest extends SAITester
     {
         test(keyspace -> {
             createTable(keyspace, "CREATE TABLE %s (k int, c int, v text, PRIMARY KEY (k, c))");
-            createIndex(keyspace, "CREATE CUSTOM INDEX IF NOT EXISTS ON %s(v) USING 'StorageAttachedIndex'");
             execute(keyspace, "INSERT INTO %s (k, c, v) VALUES (0, 0, '0')");
             execute(keyspace, "INSERT INTO %s (k, c, v) VALUES (0, 1, '0')");
             execute(keyspace, "INSERT INTO %s (k, c, v) VALUES (0, 2, '1')");
             execute(keyspace, "INSERT INTO %s (k, c, v) VALUES (1, 0, '0')");
             execute(keyspace, "INSERT INTO %s (k, c, v) VALUES (1, 1, '0')");
             execute(keyspace, "INSERT INTO %s (k, c, v) VALUES (1, 2, '1')");
-        }).withQueries(keyspace -> {
-            assertRowCount(keyspace, "SELECT * FROM %s WHERE v='0'", 4);
-            assertRowCount(keyspace, "SELECT * FROM %s WHERE v='1'", 2);
-            assertRowCount(keyspace, "SELECT * FROM %s WHERE v='2'", 0);
-            assertRowCount(keyspace, "SELECT * FROM %s WHERE k = 0 AND v='0'", 2);
-            assertRowCount(keyspace, "SELECT * FROM %s WHERE k = 0 AND v='1'", 1);
-            assertRowCount(keyspace, "SELECT * FROM %s WHERE k = 0 AND v='2'", 0);
-        });
+        }).withIndex(keyspace -> createIndex(keyspace, "CREATE CUSTOM INDEX IF NOT EXISTS ON %s(v) USING 'StorageAttachedIndex'"))
+          .withQueries(keyspace -> {
+              assertRowCount(keyspace, "SELECT * FROM %s WHERE v='0'", 4);
+              assertRowCount(keyspace, "SELECT * FROM %s WHERE v='1'", 2);
+              assertRowCount(keyspace, "SELECT * FROM %s WHERE v='2'", 0);
+              assertRowCount(keyspace, "SELECT * FROM %s WHERE k = 0 AND v='0'", 2);
+              assertRowCount(keyspace, "SELECT * FROM %s WHERE k = 0 AND v='1'", 1);
+              assertRowCount(keyspace, "SELECT * FROM %s WHERE k = 0 AND v='2'", 0);
+          });
     }
 
     @Test
@@ -132,26 +154,27 @@ public class VersionSelectorTest extends SAITester
     {
         test(keyspace -> {
             createTable(keyspace, "CREATE TABLE %s (k int PRIMARY KEY, v text)");
-            createIndex(keyspace, "CREATE CUSTOM INDEX IF NOT EXISTS ON %s(v) USING 'StorageAttachedIndex' " +
-                               "WITH OPTIONS = {" +
-                               "'index_analyzer': '{" +
-                               "  \"tokenizer\" : { \"name\" : \"whitespace\", \"args\" : {} }," +
-                               "  \"filters\" : [ { \"name\" : \"lowercase\", \"args\": {} }, " +
-                               "                  { \"name\" : \"edgengram\", \"args\": { \"minGramSize\":\"1\", \"maxGramSize\":\"30\" } }]," +
-                               "  \"charFilters\" : []}', " +
-                               "'query_analyzer': '{" +
-                               "  \"tokenizer\" : { \"name\" : \"whitespace\", \"args\" : {} }," +
-                               "  \"filters\" : [ {\"name\" : \"lowercase\",\"args\": {}} ]}'}");
             execute(keyspace, "INSERT INTO %s (k, v) VALUES (1, 'astra quick fox')");
             execute(keyspace, "INSERT INTO %s (k, v) VALUES (2, 'astra2 quick fox')");
             execute(keyspace, "INSERT INTO %s (k, v) VALUES (3, 'astra3 quick foxes')");
-        }).withQueries(keyspace -> {
-            assertRowCount(keyspace, "SELECT * FROM %s WHERE v='ast'", 3);
-            assertRowCount(keyspace, "SELECT * FROM %s WHERE v='astra'", 3);
-            assertRowCount(keyspace, "SELECT * FROM %s WHERE v='astra2'", 1);
-            assertRowCount(keyspace, "SELECT * FROM %s WHERE v='fox'", 3);
-            assertRowCount(keyspace, "SELECT * FROM %s WHERE v='foxes'", 1);
-        });
+        }).withIndex(keyspace -> createIndex(keyspace,
+                                             "CREATE CUSTOM INDEX IF NOT EXISTS ON %s(v) USING 'StorageAttachedIndex' " +
+                                             "WITH OPTIONS = {" +
+                                             "'index_analyzer': '{" +
+                                             "  \"tokenizer\" : { \"name\" : \"whitespace\", \"args\" : {} }," +
+                                             "  \"filters\" : [ { \"name\" : \"lowercase\", \"args\": {} }, " +
+                                             "                  { \"name\" : \"edgengram\", \"args\": { \"minGramSize\":\"1\", \"maxGramSize\":\"30\" } }]," +
+                                             "  \"charFilters\" : []}', " +
+                                             "'query_analyzer': '{" +
+                                             "  \"tokenizer\" : { \"name\" : \"whitespace\", \"args\" : {} }," +
+                                             "  \"filters\" : [ {\"name\" : \"lowercase\",\"args\": {}} ]}'}"))
+          .withQueries(keyspace -> {
+              assertRowCount(keyspace, "SELECT * FROM %s WHERE v='ast'", 3);
+              assertRowCount(keyspace, "SELECT * FROM %s WHERE v='astra'", 3);
+              assertRowCount(keyspace, "SELECT * FROM %s WHERE v='astra2'", 1);
+              assertRowCount(keyspace, "SELECT * FROM %s WHERE v='fox'", 3);
+              assertRowCount(keyspace, "SELECT * FROM %s WHERE v='foxes'", 1);
+          });
     }
 
     @Test
@@ -159,34 +182,35 @@ public class VersionSelectorTest extends SAITester
     {
         test(keyspace -> {
             createTable(keyspace, "CREATE TABLE %s (k int, c int, v text, PRIMARY KEY (k, c))");
-            createIndex(keyspace, "CREATE CUSTOM INDEX IF NOT EXISTS ON %s(v) USING 'StorageAttachedIndex' " +
-                               "WITH OPTIONS = {" +
-                               "'index_analyzer': '{" +
-                               "  \"tokenizer\" : { \"name\" : \"whitespace\", \"args\" : {} }," +
-                               "  \"filters\" : [ { \"name\" : \"lowercase\", \"args\": {} }, " +
-                               "                  { \"name\" : \"edgengram\", \"args\": { \"minGramSize\":\"1\", \"maxGramSize\":\"30\" } }]," +
-                               "  \"charFilters\" : []}', " +
-                               "'query_analyzer': '{" +
-                               "  \"tokenizer\" : { \"name\" : \"whitespace\", \"args\" : {} }," +
-                               "  \"filters\" : [ {\"name\" : \"lowercase\",\"args\": {}} ]}'}");
             execute(keyspace, "INSERT INTO %s (k, c, v) VALUES (0, 1, 'astra quick fox')");
             execute(keyspace, "INSERT INTO %s (k, c, v) VALUES (0, 2, 'astra2 quick fox')");
             execute(keyspace, "INSERT INTO %s (k, c, v) VALUES (0, 3, 'astra3 quick foxes')");
             execute(keyspace, "INSERT INTO %s (k, c, v) VALUES (1, 1, 'astra quick fox')");
             execute(keyspace, "INSERT INTO %s (k, c, v) VALUES (1, 2, 'astra2 quick fox')");
             execute(keyspace, "INSERT INTO %s (k, c, v) VALUES (1, 3, 'astra3 quick foxes')");
-        }).withQueries(keyspace -> {
-            assertRowCount(keyspace, "SELECT * FROM %s WHERE v='ast'", 6);
-            assertRowCount(keyspace, "SELECT * FROM %s WHERE v='astra'", 6);
-            assertRowCount(keyspace, "SELECT * FROM %s WHERE v='astra2'", 2);
-            assertRowCount(keyspace, "SELECT * FROM %s WHERE v='fox'", 6);
-            assertRowCount(keyspace, "SELECT * FROM %s WHERE v='foxes'", 2);
-            assertRowCount(keyspace, "SELECT * FROM %s WHERE k = 0 AND v='ast'", 3);
-            assertRowCount(keyspace, "SELECT * FROM %s WHERE k = 0 AND v='astra'", 3);
-            assertRowCount(keyspace, "SELECT * FROM %s WHERE k = 0 AND v='astra2'", 1);
-            assertRowCount(keyspace, "SELECT * FROM %s WHERE k = 0 AND v='fox'", 3);
-            assertRowCount(keyspace, "SELECT * FROM %s WHERE k = 0 AND v='foxes'", 1);
-        });
+        }).withIndex(keyspace -> createIndex(keyspace,
+                                             "CREATE CUSTOM INDEX IF NOT EXISTS ON %s(v) USING 'StorageAttachedIndex' " +
+                                             "WITH OPTIONS = {" +
+                                             "'index_analyzer': '{" +
+                                             "  \"tokenizer\" : { \"name\" : \"whitespace\", \"args\" : {} }," +
+                                             "  \"filters\" : [ { \"name\" : \"lowercase\", \"args\": {} }, " +
+                                             "                  { \"name\" : \"edgengram\", \"args\": { \"minGramSize\":\"1\", \"maxGramSize\":\"30\" } }]," +
+                                             "  \"charFilters\" : []}', " +
+                                             "'query_analyzer': '{" +
+                                             "  \"tokenizer\" : { \"name\" : \"whitespace\", \"args\" : {} }," +
+                                             "  \"filters\" : [ {\"name\" : \"lowercase\",\"args\": {}} ]}'}"))
+          .withQueries(keyspace -> {
+              assertRowCount(keyspace, "SELECT * FROM %s WHERE v='ast'", 6);
+              assertRowCount(keyspace, "SELECT * FROM %s WHERE v='astra'", 6);
+              assertRowCount(keyspace, "SELECT * FROM %s WHERE v='astra2'", 2);
+              assertRowCount(keyspace, "SELECT * FROM %s WHERE v='fox'", 6);
+              assertRowCount(keyspace, "SELECT * FROM %s WHERE v='foxes'", 2);
+              assertRowCount(keyspace, "SELECT * FROM %s WHERE k = 0 AND v='ast'", 3);
+              assertRowCount(keyspace, "SELECT * FROM %s WHERE k = 0 AND v='astra'", 3);
+              assertRowCount(keyspace, "SELECT * FROM %s WHERE k = 0 AND v='astra2'", 1);
+              assertRowCount(keyspace, "SELECT * FROM %s WHERE k = 0 AND v='fox'", 3);
+              assertRowCount(keyspace, "SELECT * FROM %s WHERE k = 0 AND v='foxes'", 1);
+          });
     }
 
     @Test
@@ -194,16 +218,19 @@ public class VersionSelectorTest extends SAITester
     {
         test(keyspace -> {
             createTable(keyspace, "CREATE TABLE %s (k int PRIMARY KEY, v vector<float, 2>)");
-            createIndex(keyspace, "CREATE CUSTOM INDEX IF NOT EXISTS ON %s(v) USING 'StorageAttachedIndex' " +
-                               "WITH OPTIONS = {'similarity_function' : 'euclidean'}");
             execute(keyspace, "INSERT INTO %s (k, v) VALUES (0, [1.0, 2.0])");
             execute(keyspace, "INSERT INTO %s (k, v) VALUES (1, [2.0, 3.0])");
             execute(keyspace, "INSERT INTO %s (k, v) VALUES (2, [3.0, 4.0])");
             execute(keyspace, "INSERT INTO %s (k, v) VALUES (3, [4.0, 5.0])");
-        }, Version.JVECTOR_EARLIEST, "JVector is not supported in V2OnDiskFormat").withQueries(keyspace -> {
-            assertRowCount(keyspace, "SELECT k FROM %s ORDER BY v ANN OF [2.5, 3.5] LIMIT 3", 3);
-            assertRowCount(keyspace, "SELECT k FROM %s WHERE GEO_DISTANCE(v, [2.5, 3.5]) < 157000", 2);
-        }, Version.JVECTOR_EARLIEST, "INDEX_NOT_AVAILABLE");
+        }).withIndex(keyspace -> createIndex(keyspace, "CREATE CUSTOM INDEX IF NOT EXISTS ON %s(v) USING 'StorageAttachedIndex' " +
+                                                       "WITH OPTIONS = {'similarity_function' : 'euclidean'}"),
+                     Version.JVECTOR_EARLIEST,
+                     StorageAttachedIndex::vectorUnsupportedByCurrentVersionError,
+                     "JVector is not supported in V2OnDiskFormat")
+          .withQueries(keyspace -> {
+              assertRowCount(keyspace, "SELECT k FROM %s ORDER BY v ANN OF [2.5, 3.5] LIMIT 3", 3);
+              assertRowCount(keyspace, "SELECT k FROM %s WHERE GEO_DISTANCE(v, [2.5, 3.5]) < 157000", 2);
+          }, Version.JVECTOR_EARLIEST, "INDEX_NOT_AVAILABLE");
     }
 
     @Test
@@ -211,8 +238,6 @@ public class VersionSelectorTest extends SAITester
     {
         test(keyspace -> {
             createTable(keyspace, "CREATE TABLE %s (k int, c int, v vector<float, 2>, PRIMARY KEY (k, c))");
-            createIndex(keyspace, "CREATE CUSTOM INDEX IF NOT EXISTS ON %s(v) USING 'StorageAttachedIndex' " +
-                               "WITH OPTIONS = {'similarity_function' : 'euclidean'}");
             execute(keyspace, "INSERT INTO %s (k, c, v) VALUES (0, 0, [1.0, 2.0])");
             execute(keyspace, "INSERT INTO %s (k, c, v) VALUES (0, 1, [2.0, 3.0])");
             execute(keyspace, "INSERT INTO %s (k, c, v) VALUES (0, 2, [3.0, 4.0])");
@@ -221,12 +246,17 @@ public class VersionSelectorTest extends SAITester
             execute(keyspace, "INSERT INTO %s (k, c, v) VALUES (1, 1, [2.0, 3.0])");
             execute(keyspace, "INSERT INTO %s (k, c, v) VALUES (1, 2, [3.0, 4.0])");
             execute(keyspace, "INSERT INTO %s (k, c, v) VALUES (1, 3, [4.0, 5.0])");
-        }, Version.JVECTOR_EARLIEST, "JVector is not supported in V2OnDiskFormat").withQueries(keyspace -> {
-            assertRowCount(keyspace, "SELECT k FROM %s ORDER BY v ANN OF [2.5, 3.5] LIMIT 3", 3);
-            assertRowCount(keyspace, "SELECT k FROM %s WHERE GEO_DISTANCE(v, [2.5, 3.5]) < 157000", 4);
-            assertRowCount(keyspace, "SELECT k FROM %s WHERE k=0 ORDER BY v ANN OF [2.5, 3.5] LIMIT 3", 3);
-            assertRowCount(keyspace, "SELECT k FROM %s WHERE k=0 AND GEO_DISTANCE(v, [2.5, 3.5]) < 157000", 2);
-        }, Version.JVECTOR_EARLIEST, "INDEX_NOT_AVAILABLE");
+        }).withIndex(keyspace -> createIndex(keyspace, "CREATE CUSTOM INDEX IF NOT EXISTS ON %s(v) USING 'StorageAttachedIndex' " +
+                                                       "WITH OPTIONS = {'similarity_function' : 'euclidean'}"),
+                     Version.JVECTOR_EARLIEST,
+                     StorageAttachedIndex::vectorUnsupportedByCurrentVersionError,
+                     "JVector is not supported in V2OnDiskFormat")
+          .withQueries(keyspace -> {
+              assertRowCount(keyspace, "SELECT k FROM %s ORDER BY v ANN OF [2.5, 3.5] LIMIT 3", 3);
+              assertRowCount(keyspace, "SELECT k FROM %s WHERE GEO_DISTANCE(v, [2.5, 3.5]) < 157000", 4);
+              assertRowCount(keyspace, "SELECT k FROM %s WHERE k=0 ORDER BY v ANN OF [2.5, 3.5] LIMIT 3", 3);
+              assertRowCount(keyspace, "SELECT k FROM %s WHERE k=0 AND GEO_DISTANCE(v, [2.5, 3.5]) < 157000", 2);
+          }, Version.JVECTOR_EARLIEST, "INDEX_NOT_AVAILABLE");
     }
 
     @Test
@@ -234,20 +264,20 @@ public class VersionSelectorTest extends SAITester
     {
         test(keyspace -> {
             createTable(keyspace, "CREATE TABLE %s (k int PRIMARY KEY, v text)");
-            createIndex(keyspace, "CREATE CUSTOM INDEX IF NOT EXISTS ON %s(v) USING 'StorageAttachedIndex' " +
-                               "WITH OPTIONS = {" +
-                               "'index_analyzer': '{" +
-                               "\"tokenizer\" : {\"name\" : \"standard\"}, " +
-                               "\"filters\" : [{\"name\" : \"porterstem\"}]}'}");
             execute(keyspace, "INSERT INTO %s (k, v) VALUES (1, 'apple')");
             execute(keyspace, "INSERT INTO %s (k, v) VALUES (2, 'orange')");
             execute(keyspace, "INSERT INTO %s (k, v) VALUES (3, 'banana')");
             execute(keyspace, "INSERT INTO %s (k, v) VALUES (4, 'apple')");
-        }).withQueries(keyspace -> {
-            assertRowCount(keyspace, "SELECT k FROM %s ORDER BY v BM25 OF 'apple' LIMIT 3", 2);
-            assertRowCount(keyspace, "SELECT k FROM %s ORDER BY v BM25 OF 'orange' LIMIT 3", 1);
-            assertRowCount(keyspace, "SELECT k FROM %s ORDER BY v BM25 OF 'kiwi' LIMIT 3", 0);
-        }, Version.BM25_EARLIEST, "FEATURE_NEEDS_INDEX_REBUILD");
+        }).withIndex(keyspace -> createIndex(keyspace, "CREATE CUSTOM INDEX IF NOT EXISTS ON %s(v) USING 'StorageAttachedIndex' " +
+                                                       "WITH OPTIONS = {" +
+                                                       "'index_analyzer': '{" +
+                                                       "\"tokenizer\" : {\"name\" : \"standard\"}, " +
+                                                       "\"filters\" : [{\"name\" : \"porterstem\"}]}'}"))
+          .withQueries(keyspace -> {
+              assertRowCount(keyspace, "SELECT k FROM %s ORDER BY v BM25 OF 'apple' LIMIT 3", 2);
+              assertRowCount(keyspace, "SELECT k FROM %s ORDER BY v BM25 OF 'orange' LIMIT 3", 1);
+              assertRowCount(keyspace, "SELECT k FROM %s ORDER BY v BM25 OF 'kiwi' LIMIT 3", 0);
+          }, Version.BM25_EARLIEST, "FEATURE_NEEDS_INDEX_REBUILD");
     }
 
     @Test
@@ -255,11 +285,6 @@ public class VersionSelectorTest extends SAITester
     {
         test(keyspace -> {
             createTable(keyspace, "CREATE TABLE %s (k int, c int, v text, PRIMARY KEY (k, c))");
-            createIndex(keyspace, "CREATE CUSTOM INDEX IF NOT EXISTS ON %s(v) USING 'StorageAttachedIndex' " +
-                               "WITH OPTIONS = {" +
-                               "'index_analyzer': '{" +
-                               "\"tokenizer\" : {\"name\" : \"standard\"}, " +
-                               "\"filters\" : [{\"name\" : \"porterstem\"}]}'}");
             execute(keyspace, "INSERT INTO %s (k, c, v) VALUES (0, 1, 'apple')");
             execute(keyspace, "INSERT INTO %s (k, c, v) VALUES (0, 2, 'orange')");
             execute(keyspace, "INSERT INTO %s (k, c, v) VALUES (0, 3, 'banana')");
@@ -268,14 +293,19 @@ public class VersionSelectorTest extends SAITester
             execute(keyspace, "INSERT INTO %s (k, c, v) VALUES (1, 2, 'orange')");
             execute(keyspace, "INSERT INTO %s (k, c, v) VALUES (1, 3, 'banana')");
             execute(keyspace, "INSERT INTO %s (k, c, v) VALUES (1, 4, 'apple')");
-        }).withQueries(keyspace -> {
-            assertRowCount(keyspace, "SELECT k FROM %s ORDER BY v BM25 OF 'apple' LIMIT 3", 3);
-            assertRowCount(keyspace, "SELECT k FROM %s ORDER BY v BM25 OF 'orange' LIMIT 3", 2);
-            assertRowCount(keyspace, "SELECT k FROM %s ORDER BY v BM25 OF 'kiwi' LIMIT 3", 0);
-            assertRowCount(keyspace, "SELECT k FROM %s WHERE k=0 ORDER BY v BM25 OF 'apple' LIMIT 3", 2);
-            assertRowCount(keyspace, "SELECT k FROM %s WHERE k=0 ORDER BY v BM25 OF 'orange' LIMIT 3", 1);
-            assertRowCount(keyspace, "SELECT k FROM %s WHERE k=0 ORDER BY v BM25 OF 'kiwi' LIMIT 3", 0);
-        }, Version.BM25_EARLIEST, "FEATURE_NEEDS_INDEX_REBUILD");
+        }).withIndex(keyspace -> createIndex(keyspace, "CREATE CUSTOM INDEX IF NOT EXISTS ON %s(v) USING 'StorageAttachedIndex' " +
+                                                       "WITH OPTIONS = {" +
+                                                       "'index_analyzer': '{" +
+                                                       "\"tokenizer\" : {\"name\" : \"standard\"}, " +
+                                                       "\"filters\" : [{\"name\" : \"porterstem\"}]}'}"))
+          .withQueries(keyspace -> {
+              assertRowCount(keyspace, "SELECT k FROM %s ORDER BY v BM25 OF 'apple' LIMIT 3", 3);
+              assertRowCount(keyspace, "SELECT k FROM %s ORDER BY v BM25 OF 'orange' LIMIT 3", 2);
+              assertRowCount(keyspace, "SELECT k FROM %s ORDER BY v BM25 OF 'kiwi' LIMIT 3", 0);
+              assertRowCount(keyspace, "SELECT k FROM %s WHERE k=0 ORDER BY v BM25 OF 'apple' LIMIT 3", 2);
+              assertRowCount(keyspace, "SELECT k FROM %s WHERE k=0 ORDER BY v BM25 OF 'orange' LIMIT 3", 1);
+              assertRowCount(keyspace, "SELECT k FROM %s WHERE k=0 ORDER BY v BM25 OF 'kiwi' LIMIT 3", 0);
+          }, Version.BM25_EARLIEST, "FEATURE_NEEDS_INDEX_REBUILD");
     }
 
     @Override
@@ -300,45 +330,62 @@ public class VersionSelectorTest extends SAITester
         assertRowCount(execute(keyspace, query), expected);
     }
 
-    /**
-     * @param schemaCreator the initial schema and data
-     */
-    private Tester test(Consumer<String> schemaCreator)
+    private TestCase test(Consumer<String> tableCreator)
     {
-        return test(schemaCreator, Version.AA, null);
+        return Operation.CREATE == operation
+               ? new CreateIndexTestCase(tableCreator)
+               : new RebuildIndexTestCase(tableCreator);
     }
 
-    /**
-     * @param schemaCreator the initial schema and data
-     * @param minVersionForIndexing the minimum index version required to support creating an index with the tested features
-     * @param indexingErrorIfUnsupported the error message expected during indexing if the index version does not support the tested features
-     */
-    private Tester test(Consumer<String> schemaCreator, Version minVersionForIndexing, String indexingErrorIfUnsupported)
+    private abstract class TestCase
     {
-        return new Tester(schemaCreator, minVersionForIndexing, indexingErrorIfUnsupported);
-    }
-
-    private class Tester
-    {
-        private final Consumer<String> schemaCreator;
-        private final Version minVersionForIndexing;
-        private final String indexingErrorIfUnsupported;
+        protected final Map<String, Version> versionsPerKeyspace;
+        protected Consumer<String> indexCreator;
+        protected Version minVersionForIndexing;
+        protected Function<Version, String> createIndexErrorIfUnsupported;
+        protected String rebuildIndexErrorIfUnsupported;
 
         /**
-         * @param schemaCreator the initial schema and data
-         * @param minVersionForIndexing the minimum index version required to support creating an index with the tested features
-         * @param indexingErrorIfUnsupported the error message expected during indexing if the index version does not support the tested features
+         * @param tableCreator the initial schema and data
          */
-        Tester(Consumer<String> schemaCreator,
-               Version minVersionForIndexing,
-               String indexingErrorIfUnsupported)
+        TestCase(Consumer<String> tableCreator)
         {
-            // we can skip the test case if the starting version does not support the tested index
-            Assume.assumeTrue(globalCurrentVersion.onOrAfter(minVersionForIndexing));
+            tableCreator.accept(KEYSPACE);
 
+            // create one keyspace, table and dataset per index version
+            versionsPerKeyspace = new HashMap<>();
+            for (Version version : Version.ALL)
+            {
+                String keyspace = "ks_" + version;
+                createKeyspace("CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}", keyspace);
+                tableCreator.accept(keyspace);
+                disableCompaction(keyspace, TABLE);
+                flush(keyspace, TABLE);
+                versionsPerKeyspace.put(keyspace, version);
+            }
+        }
+
+        TestCase withIndex(Consumer<String> indexCreator)
+        {
+            return withIndex(indexCreator, Version.AA, null, null);
+        }
+
+        /**
+         * @param indexCreator the index creation statement
+         * @param minVersionForIndexing the minimum index version required to create or rebuild the index
+         * @param createIndexErrorIfUnsupported the error message expected if the index version does not support the tested index
+         * @param rebuildIndexErrorIfUnsupported the error message expected if the index version does not support index rebuild
+         */
+        TestCase withIndex(Consumer<String> indexCreator,
+                           Version minVersionForIndexing,
+                           Function<Version, String> createIndexErrorIfUnsupported,
+                           String rebuildIndexErrorIfUnsupported)
+        {
+            this.indexCreator = indexCreator;
             this.minVersionForIndexing = minVersionForIndexing;
-            this.indexingErrorIfUnsupported = indexingErrorIfUnsupported;
-            this.schemaCreator = schemaCreator;
+            this.createIndexErrorIfUnsupported = createIndexErrorIfUnsupported;
+            this.rebuildIndexErrorIfUnsupported = rebuildIndexErrorIfUnsupported;
+            return this;
         }
 
         /**
@@ -354,65 +401,145 @@ public class VersionSelectorTest extends SAITester
          * @param minVersionForQuerying the minimum index version required to support the tested queries
          * @param queryingErrorIfUnsupported the error message expected if the index version does not support the tested queries
          */
+        abstract void withQueries(Consumer<String> queryResultsVerifier,
+                                  Version minVersionForQuerying,
+                                  String queryingErrorIfUnsupported);
+
+        protected void verifyQueries(Consumer<String> queryResultsVerifier,
+                                     String keyspace,
+                                     Version currentVersion,
+                                     Version minVersion,
+                                     String errorMessage)
+        {
+            if (currentVersion.onOrAfter(minVersion))
+                queryResultsVerifier.accept(keyspace);
+            else
+                Assertions.assertThatThrownBy(() -> queryResultsVerifier.accept(keyspace))
+                          .hasMessageContaining(errorMessage);
+        }
+    }
+
+    /**
+     * Test case for index creation.
+     */
+    private class CreateIndexTestCase extends TestCase
+    {
+        CreateIndexTestCase(Consumer<String> tableCreator)
+        {
+            super(tableCreator);
+        }
+
+        @Override
         void withQueries(Consumer<String> queryResultsVerifier,
                          Version minVersionForQuerying,
                          String queryingErrorIfUnsupported)
         {
-            // we can skip the test case if the starting version does not support the tested queries
-            Assume.assumeTrue(globalCurrentVersion.onOrAfter(minVersionForQuerying));
+            // set the per-keyspace current versions
+            SAIUtil.setCurrentVersion(globalCurrentVersion, versionsPerKeyspace);
+
+            // verify whether we can create the index in each keyspace,
+            // depending on whether the tested version supports it,
+            // and whether we can run the tested queries in case the index creation succeeds
+            versionsPerKeyspace.forEach((keyspace, version) -> {
+                if (version.onOrAfter(minVersionForIndexing))
+                {
+                    indexCreator.accept(keyspace);
+                    verifySAIVersionInUse(keyspace, TABLE, version);
+                    verifyQueries(queryResultsVerifier,
+                                  keyspace,
+                                  version,
+                                  minVersionForQuerying,
+                                  queryingErrorIfUnsupported);
+                }
+                else
+                {
+                    Assertions.assertThatThrownBy(() -> indexCreator.accept(keyspace))
+                              .hasMessageContaining(createIndexErrorIfUnsupported.apply(version));
+                    verifyNoIndexFiles(keyspace, TABLE);
+                }
+            });
+        }
+    }
+
+    /**
+     * Test case for index rebuild.
+     */
+    private class RebuildIndexTestCase extends TestCase
+    {
+        RebuildIndexTestCase(Consumer<String> tableCreator)
+        {
+            super(tableCreator);
+        }
+
+        @Override
+        void withQueries(Consumer<String> queryResultsVerifier,
+                         Version minVersionForQuerying,
+                         String queryingErrorIfUnsupported)
+        {
+            // if the starting version does not support the tested queries then we cannot even create the index
+            if (!globalCurrentVersion.onOrAfter(minVersionForIndexing))
+            {
+                Assertions.assertThatThrownBy(() -> indexCreator.accept(KEYSPACE))
+                          .hasMessageContaining(createIndexErrorIfUnsupported.apply(globalCurrentVersion));
+                verifyNoIndexFiles(KEYSPACE, TABLE);
+                return;
+            }
 
             // set the default current version, without any per-keyspace overrides
             SAIUtil.setCurrentVersion(globalCurrentVersion);
 
-            // create a series of keyspaces, all of them using the initial default current version,
-            // and verify the queries and the version of the index
-            Map<String, Version> versionsPerKeyspace = new HashMap<>();
-            for (Version version : Version.ALL)
-            {
-                // create and track the keyspace for the index version we will later upgrade to
-                String keyspace = "ks_" + version;
-                createKeyspace("CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}", keyspace);
-                versionsPerKeyspace.put(keyspace, version);
+            // create the index for each keyspace, which should use the default current version
+            versionsPerKeyspace.keySet().forEach(keyspace -> {
+                indexCreator.accept(keyspace);
+                verifySAIVersionInUse(keyspace, TABLE, globalCurrentVersion);
+                verifyQueries(queryResultsVerifier,
+                              keyspace,
+                              globalCurrentVersion,
+                              minVersionForQuerying,
+                              queryingErrorIfUnsupported);
+            });
 
-                // create the schema and data, still using the initial version, and verify the queries
-                schemaCreator.accept(keyspace);
-                disableCompaction(keyspace, TABLE);
-                flush(keyspace, TABLE);
-                verifySAIVersionInUse(globalCurrentVersion, keyspace, TABLE);
-                queryResultsVerifier.accept(keyspace);
-            }
-
-            // assign a new version to each tested keyspace, so we end up with a different version for each keyspace,
+            // assign a new version to each tested keyspace,
+            // so we end up with a different version for each keyspace,
             // although their index files are still in the initial version
             SAIUtil.setCurrentVersion(globalCurrentVersion, versionsPerKeyspace);
 
-            // try to rebuild the indexes of each keyspace, which should leave them in their new version,
+            // try to rebuild the indexes of each keyspace,
+            // which should leave them in their new version if it's supported,
             // and verify the queries and the version of the index
             versionsPerKeyspace.forEach((keyspace, version) -> {
-                logger.debug("Testing index rebuild from {} to {} in keyspace {}", globalCurrentVersion, version, keyspace);
 
-                verifySAIVersionInUse(globalCurrentVersion, keyspace, TABLE);
+                verifySAIVersionInUse(keyspace, TABLE, globalCurrentVersion);
 
                 // Verify if we can rebuild the index, depending on whether the new version supports it
-                passOrFail(() -> {
+                if (version.onOrAfter(minVersionForIndexing))
+                {
+                    // If the new version per-sstable components is different from the old version,
+                    // we need to upgrade the sstables first. Otherwise, the index rebuild would ignore the new version.
+                    if (!version.equals(globalCurrentVersion))
+                    {
+                        rebuildTableIndexes(keyspace, TABLE);
+                        verifySAIVersionInUse(keyspace, TABLE, globalCurrentVersion);
+                        upgradeSSTables(keyspace, TABLE);
+                    }
+
                     rebuildTableIndexes(keyspace, TABLE);
                     reloadSSTableIndexInPlace(keyspace, TABLE);
-                    verifySAIVersionInUse(version, keyspace, TABLE);
-                }, version.onOrAfter(minVersionForIndexing), indexingErrorIfUnsupported);
+                    verifySAIVersionInUse(keyspace, TABLE, version);
+                }
+                else
+                {
+                    Assertions.assertThatThrownBy(() -> rebuildTableIndexes(keyspace, TABLE))
+                              .hasMessageContaining(rebuildIndexErrorIfUnsupported);
+                }
 
                 // Verify if we can query the index, depending on whether the new version supports the queries
-                passOrFail(() -> queryResultsVerifier.accept(keyspace),
-                           version.onOrAfter(minVersionForQuerying),
-                           queryingErrorIfUnsupported);
+                verifyQueries(queryResultsVerifier,
+                              keyspace,
+                              version,
+                              minVersionForQuerying,
+                              queryingErrorIfUnsupported);
             });
-        }
-
-        private void passOrFail(Runnable r, boolean shouldPass, String message)
-        {
-            if (shouldPass)
-                r.run();
-            else
-                Assertions.assertThatThrownBy(r::run).hasMessageContaining(message);
         }
     }
 }


### PR DESCRIPTION

New per-index components for a sstable will use the version of any existing per-sstable components in that same sstable. If there aren't any previous per-sstable components then the configured current version will be used. A sstable can have per-sstable components if they have been added by another index. New sstables will always use the current version.

This means that all the index components of a sstable will always use the same index version, even though different sstables can have different versions.

Rebuilding indexes after changing the current version won't change the version of the existing sstable indexes, although new sstables will use the new current version. However, sstableupgrade will rewrite the tables with the new version. Thus, the procedure to upgrade indexes is first setting the current version and then running sstableupgrade.

Creating a new index will fail if there is any sstable in the indexed table using a version that doesn't support the type of index we are creating. For example, creating a vector index will fail if there is still some sstable using the aa format, even in the current version supports indexes. If an index creation fails for this reason, the index will be added to the schema but marked as failed. Running sstableupgrade will upgrade the index version, but it won't mark the index as queryable, so it will be needed to also rebuild the index so it becomes queryable.
