### PR TITLE
CNDB-17505: Added eviction policy to cache in NoSpamLogger (#2373)

### DIFF
--- a/.build/checkstyle_suppressions.xml
+++ b/.build/checkstyle_suppressions.xml
@@ -22,5 +22,4 @@
 
 <suppressions>
   <suppress checks="RegexpSinglelineJava" files="Semaphore\.java"/>
-  <suppress checks="RegexpSinglelineJava" id="blockSystemPropertyUsage" files="NoSpamLogger\.java"/>
 </suppressions>

--- a/.build/checkstyle_suppressions.xml
+++ b/.build/checkstyle_suppressions.xml
@@ -22,4 +22,5 @@
 
 <suppressions>
   <suppress checks="RegexpSinglelineJava" files="Semaphore\.java"/>
+  <suppress checks="RegexpSinglelineJava" id="blockSystemPropertyUsage" files="NoSpamLogger\.java"/>
 </suppressions>

--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -633,6 +633,12 @@ public enum CassandraRelevantProperties
     NON_GRACEFUL_CLOSE("cassandra.messagingService.nonGracefulClose"),
     NON_GRACEFUL_SHUTDOWN("cassandra.test.messagingService.nonGracefulShutdown"),
     /**
+     * Maximum number of log statements cached per NoSpamLogger instance.
+     * This prevents unbounded memory growth when log messages contain dynamic content.
+     * Defaults to MAX_VALUE as a default behavior since we rely on the cache time-based expiration.
+     */
+    NOSPAM_LOGGER_MAX_STATEMENTS_PER_LOGGER("cassandra.nospam_logger.max_statements_per_logger", String.valueOf(Long.MAX_VALUE)),
+    /**
      * Allows custom implementation of {@link OperationContext.Factory} to optionally create and configure custom
      * {@link OperationContext} instances.
      */
@@ -1046,7 +1052,7 @@ public enum CassandraRelevantProperties
      *
      * This is a dev/CI only property. Do not use otherwise.
      */
-    TEST_STORAGE_COMPATIBILITY_MODE("cassandra.test.storage_compatibility_mode", StorageCompatibilityMode.HCD_1.toString()),
+    TEST_STORAGE_COMPATIBILITY_MODE("cassandra.test.storage_compatibility_mode", "HCD_1"),
     TEST_STRICT_LCS_CHECKS("cassandra.test.strict_lcs_checks"),
     /** Turns some warnings into exceptions for testing. */
     TEST_STRICT_RUNTIME_CHECKS("cassandra.strict.runtime.checks"),

--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -633,6 +633,18 @@ public enum CassandraRelevantProperties
     NON_GRACEFUL_CLOSE("cassandra.messagingService.nonGracefulClose"),
     NON_GRACEFUL_SHUTDOWN("cassandra.test.messagingService.nonGracefulShutdown"),
     /**
+     * Maximum number of log statements cached per NoSpamLogger instance.
+     * This prevents unbounded memory growth when log messages contain dynamic content.
+     * Note: This property is accessed manually in NoSpamLogger via Long.getLong() to avoid circular dependencies.
+     * The circular dependency occurs because some classes referenced in CassandraRelevantProperties use NoSpamLogger.
+     * For example, {@link StorageCompatibilityMode} has a NoSpamLogger instance and is referenced in
+     * TEST_STORAGE_COMPATIBILITY_MODE, which would create a circular dependency if NoSpamLogger tried to
+     * access CassandraRelevantProperties during initialization.
+     *
+     * @see org.apache.cassandra.utils.NoSpamLogger
+     */
+    NOSPAM_LOGGER_MAX_STATEMENTS_PER_LOGGER("cassandra.nospam_logger.max_statements_per_logger", convertToString(Long.MAX_VALUE)),
+    /**
      * Allows custom implementation of {@link OperationContext.Factory} to optionally create and configure custom
      * {@link OperationContext} instances.
      */

--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -41,6 +41,8 @@ import org.apache.cassandra.service.reads.range.EndpointGroupingRangeCommandIter
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.StorageCompatibilityMode;
 
+import static org.apache.cassandra.utils.NoSpamLogger.NOSPAM_LOGGER_MAX_STATEMENTS_PER_LOGGER_PROPERTY;
+
 // checkstyle: suppress below 'blockSystemPropertyUsage'
 
 /** A class that extracts system properties for the cassandra node it runs within. */
@@ -643,7 +645,7 @@ public enum CassandraRelevantProperties
      *
      * @see org.apache.cassandra.utils.NoSpamLogger
      */
-    NOSPAM_LOGGER_MAX_STATEMENTS_PER_LOGGER("cassandra.nospam_logger.max_statements_per_logger", convertToString(Long.MAX_VALUE)),
+    NOSPAM_LOGGER_MAX_STATEMENTS_PER_LOGGER(NOSPAM_LOGGER_MAX_STATEMENTS_PER_LOGGER_PROPERTY, convertToString(Long.MAX_VALUE)),
     /**
      * Allows custom implementation of {@link OperationContext.Factory} to optionally create and configure custom
      * {@link OperationContext} instances.

--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -633,12 +633,6 @@ public enum CassandraRelevantProperties
     NON_GRACEFUL_CLOSE("cassandra.messagingService.nonGracefulClose"),
     NON_GRACEFUL_SHUTDOWN("cassandra.test.messagingService.nonGracefulShutdown"),
     /**
-     * Maximum number of log statements cached per NoSpamLogger instance.
-     * This prevents unbounded memory growth when log messages contain dynamic content.
-     * Defaults to MAX_VALUE as a default behavior since we rely on the cache time-based expiration.
-     */
-    NOSPAM_LOGGER_MAX_STATEMENTS_PER_LOGGER("cassandra.nospam_logger.max_statements_per_logger", String.valueOf(Long.MAX_VALUE)),
-    /**
      * Allows custom implementation of {@link OperationContext.Factory} to optionally create and configure custom
      * {@link OperationContext} instances.
      */
@@ -1052,7 +1046,7 @@ public enum CassandraRelevantProperties
      *
      * This is a dev/CI only property. Do not use otherwise.
      */
-    TEST_STORAGE_COMPATIBILITY_MODE("cassandra.test.storage_compatibility_mode", "HCD_1"),
+    TEST_STORAGE_COMPATIBILITY_MODE("cassandra.test.storage_compatibility_mode", StorageCompatibilityMode.HCD_1.toString()),
     TEST_STRICT_LCS_CHECKS("cassandra.test.strict_lcs_checks"),
     /** Turns some warnings into exceptions for testing. */
     TEST_STRICT_RUNTIME_CHECKS("cassandra.strict.runtime.checks"),

--- a/src/java/org/apache/cassandra/utils/NoSpamLogger.java
+++ b/src/java/org/apache/cassandra/utils/NoSpamLogger.java
@@ -73,8 +73,13 @@ public class NoSpamLogger
         CLOCK = clock;
     }
 
+    private static Ticker TICKER = Ticker.systemTicker();
+
     @VisibleForTesting
-    static Ticker TICKER = Ticker.systemTicker();
+    public static void unsafeSetTicker(Ticker ticker)
+    {
+        TICKER = ticker;
+    }
 
     public class NoSpamLogStatement extends AtomicLong
     {

--- a/src/java/org/apache/cassandra/utils/NoSpamLogger.java
+++ b/src/java/org/apache/cassandra/utils/NoSpamLogger.java
@@ -266,6 +266,34 @@ public class NoSpamLogger
 
     private final Logger wrapped;
     private final long minIntervalNanos;
+
+    /**
+     * Custom expiry policy for NoSpamLogStatement cache entries.
+     * Each entry expires based on its own minIntervalNanos value.
+     */
+    private static class StatementExpiry implements Expiry<String, NoSpamLogStatement>
+    {
+        @Override
+        public long expireAfterCreate(String key, NoSpamLogStatement value, long currentTime)
+        {
+            return value.expiry();
+        }
+
+        @Override
+        public long expireAfterUpdate(String key, NoSpamLogStatement value,
+                                      long currentTime, long currentDuration)
+        {
+            return value.expiry();
+        }
+
+        @Override
+        public long expireAfterRead(String key, NoSpamLogStatement value,
+                                    long currentTime, long currentDuration)
+        {
+            return currentDuration;
+        }
+    }
+
     /**
      * Cache of NoSpamLogStatement instances per NoSpamLogger instance.
      * Bounded by size and time to prevent memory exhaustion from dynamic log messages.
@@ -274,28 +302,7 @@ public class NoSpamLogger
      */
     private final Cache<String, NoSpamLogStatement> lastMessage = Caffeine.newBuilder()
                                                                           .maximumSize(NOSPAM_LOGGER_MAX_STATEMENTS_PER_LOGGER.getLong())
-                                                                          .expireAfter(new Expiry<String, NoSpamLogStatement>()
-                                                                          {
-                                                                              @Override
-                                                                              public long expireAfterCreate(String key, NoSpamLogStatement value, long currentTime)
-                                                                              {
-                                                                                  return value.expiry();
-                                                                              }
-
-                                                                              @Override
-                                                                              public long expireAfterUpdate(String key, NoSpamLogStatement value,
-                                                                                                            long currentTime, long currentDuration)
-                                                                              {
-                                                                                  return value.expiry();
-                                                                              }
-
-                                                                              @Override
-                                                                              public long expireAfterRead(String key, NoSpamLogStatement value,
-                                                                                                          long currentTime, long currentDuration)
-                                                                              {
-                                                                                  return currentDuration;
-                                                                              }
-                                                                          })
+                                                                          .expireAfter(new StatementExpiry())
                                                                           .ticker(TICKER)
                                                                           .executor(ForkJoinPool.commonPool())
                                                                           .recordStats()

--- a/src/java/org/apache/cassandra/utils/NoSpamLogger.java
+++ b/src/java/org/apache/cassandra/utils/NoSpamLogger.java
@@ -17,6 +17,7 @@
  */
 package org.apache.cassandra.utils;
 
+import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
@@ -24,8 +25,13 @@ import java.util.function.Supplier;
 import org.cliffc.high_scale_lib.NonBlockingHashMap;
 import org.slf4j.Logger;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.Expiry;
+import com.github.benmanes.caffeine.cache.Ticker;
 import com.google.common.annotations.VisibleForTesting;
 
+import static org.apache.cassandra.config.CassandraRelevantProperties.*;
 import static org.apache.cassandra.utils.Clock.Global;
 
 /**
@@ -36,8 +42,11 @@ import static org.apache.cassandra.utils.Clock.Global;
  * result in the original time being used. No warning is provided if there is a mismatch.
  *
  * If the statement is cached and used to log directly then only a volatile read will be required in the common case.
- * If the Logger is cached then there is a single concurrent hash map lookup + the volatile read.
- * If neither the logger nor the statement is cached then it is two concurrent hash map lookups + the volatile read.
+ * If the Logger is cached then there is a single Caffeine cache lookup + the volatile read.
+ * If neither the logger nor the statement is cached then it is a NonBlockingHashMap lookup + a Caffeine cache lookup + the volatile read.
+ *
+ * The implementation uses Caffeine cache with time-based expiration to automatically evict log statements
+ * after their minimum interval has passed, preventing unbounded memory growth from dynamic log messages.
  *
  */
 public class NoSpamLogger
@@ -63,6 +72,9 @@ public class NoSpamLogger
     {
         CLOCK = clock;
     }
+
+    @VisibleForTesting
+    static Ticker TICKER = Ticker.systemTicker();
 
     public class NoSpamLogStatement extends AtomicLong
     {
@@ -157,6 +169,11 @@ public class NoSpamLogger
         {
             return NoSpamLogStatement.this.error(CLOCK.nanoTime(), objects);
         }
+
+        public long expiry()
+        {
+            return minIntervalNanos;
+        }
     }
 
     private static final NonBlockingHashMap<Logger, NoSpamLogger> wrappedLoggers = new NonBlockingHashMap<>();
@@ -165,6 +182,28 @@ public class NoSpamLogger
     static void clearWrappedLoggersForTest()
     {
         wrappedLoggers.clear();
+    }
+
+    /**
+     * Forces eviction of entries from the {@link NoSpamLogStatement} cache for this logger instance.
+     * This is useful for testing to ensure cache size limits are enforced immediately.
+     */
+    @VisibleForTesting
+    void cleanUpStatementsForTest()
+    {
+        lastMessage.cleanUp();
+    }
+
+    /**
+     * Returns the current size of the lastMessage cache for this logger instance.
+     * This is useful for testing cache eviction behavior.
+     *
+     * @return the number of log statements currently cached for this logger
+     */
+    @VisibleForTesting
+    long getStatementsCount()
+    {
+        return lastMessage.estimatedSize();
     }
 
     public static NoSpamLogger getLogger(Logger logger, long minInterval, TimeUnit unit)
@@ -222,7 +261,40 @@ public class NoSpamLogger
 
     private final Logger wrapped;
     private final long minIntervalNanos;
-    private final NonBlockingHashMap<String, NoSpamLogStatement> lastMessage = new NonBlockingHashMap<>();
+    /**
+     * Cache of NoSpamLogStatement instances per NoSpamLogger instance.
+     * Bounded by size and time to prevent memory exhaustion from dynamic log messages.
+     * Uses Caffeine with W-TinyLFU eviction policy.
+     * Uses custom per-entry expiry based on each statement's minIntervalNanos.
+     */
+    private final Cache<String, NoSpamLogStatement> lastMessage = Caffeine.newBuilder()
+                                                                          .maximumSize(NOSPAM_LOGGER_MAX_STATEMENTS_PER_LOGGER.getLong())
+                                                                          .expireAfter(new Expiry<String, NoSpamLogStatement>()
+                                                                          {
+                                                                              @Override
+                                                                              public long expireAfterCreate(String key, NoSpamLogStatement value, long currentTime)
+                                                                              {
+                                                                                  return value.expiry();
+                                                                              }
+
+                                                                              @Override
+                                                                              public long expireAfterUpdate(String key, NoSpamLogStatement value,
+                                                                                                            long currentTime, long currentDuration)
+                                                                              {
+                                                                                  return value.expiry();
+                                                                              }
+
+                                                                              @Override
+                                                                              public long expireAfterRead(String key, NoSpamLogStatement value,
+                                                                                                          long currentTime, long currentDuration)
+                                                                              {
+                                                                                  return currentDuration;
+                                                                              }
+                                                                          })
+                                                                          .ticker(TICKER)
+                                                                          .executor(ForkJoinPool.commonPool())
+                                                                          .recordStats()
+                                                                          .build();
 
     private NoSpamLogger(Logger wrapped, long minInterval, TimeUnit timeUnit)
     {
@@ -297,14 +369,6 @@ public class NoSpamLogger
 
     public NoSpamLogStatement getStatement(String key, String s, long minIntervalNanos)
     {
-        NoSpamLogStatement statement = lastMessage.get(key);
-        if (statement == null)
-        {
-            statement = new NoSpamLogStatement(s, minIntervalNanos);
-            NoSpamLogStatement temp = lastMessage.putIfAbsent(key, statement);
-            if (temp != null)
-                statement = temp;
-        }
-        return statement;
+        return lastMessage.get(key, k -> new NoSpamLogStatement(s, minIntervalNanos));
     }
 }

--- a/src/java/org/apache/cassandra/utils/NoSpamLogger.java
+++ b/src/java/org/apache/cassandra/utils/NoSpamLogger.java
@@ -99,9 +99,11 @@ public class NoSpamLogger
         noSpamLoggerMaxStatementsPerLogger = getOrDefaultNoSpamLoggerMaxStatementsPerLogger();
     }
 
+    public static final String NOSPAM_LOGGER_MAX_STATEMENTS_PER_LOGGER_PROPERTY = "cassandra.nospam_logger.max_statements_per_logger";
+
     private static long getOrDefaultNoSpamLoggerMaxStatementsPerLogger()
     {
-        return Long.getLong("cassandra.nospam_logger.max_statements_per_logger", Long.MAX_VALUE);
+        return Long.getLong(NOSPAM_LOGGER_MAX_STATEMENTS_PER_LOGGER_PROPERTY, Long.MAX_VALUE);
     }
 
     public class NoSpamLogStatement extends AtomicLong

--- a/src/java/org/apache/cassandra/utils/NoSpamLogger.java
+++ b/src/java/org/apache/cassandra/utils/NoSpamLogger.java
@@ -103,6 +103,7 @@ public class NoSpamLogger
 
     private static long getOrDefaultNoSpamLoggerMaxStatementsPerLogger()
     {
+        // checkstyle: suppress below 'blockSystemPropertyUsage'
         return Long.getLong(NOSPAM_LOGGER_MAX_STATEMENTS_PER_LOGGER_PROPERTY, Long.MAX_VALUE);
     }
 

--- a/src/java/org/apache/cassandra/utils/NoSpamLogger.java
+++ b/src/java/org/apache/cassandra/utils/NoSpamLogger.java
@@ -31,7 +31,6 @@ import com.github.benmanes.caffeine.cache.Expiry;
 import com.github.benmanes.caffeine.cache.Ticker;
 import com.google.common.annotations.VisibleForTesting;
 
-import static org.apache.cassandra.config.CassandraRelevantProperties.*;
 import static org.apache.cassandra.utils.Clock.Global;
 
 /**
@@ -79,6 +78,30 @@ public class NoSpamLogger
     public static void unsafeSetTicker(Ticker ticker)
     {
         TICKER = ticker;
+    }
+
+    /**
+     * Maximum number of log statements cached per NoSpamLogger instance.
+     * This prevents unbounded memory growth when log messages contain dynamic content.
+     * Defaults to MAX_VALUE as a default behavior since we rely on the cache time-based expiration.
+     */
+    private static long noSpamLoggerMaxStatementsPerLogger = getOrDefaultNoSpamLoggerMaxStatementsPerLogger();
+
+    @VisibleForTesting
+    public static void setNospamLoggerMaxStatementsPerLoggerUnsafe(long maxStatementsPerLogger)
+    {
+        noSpamLoggerMaxStatementsPerLogger = maxStatementsPerLogger;
+    }
+
+    @VisibleForTesting
+    public static void resetNospamLoggerMaxStatementsPerLoggerUnsafe()
+    {
+        noSpamLoggerMaxStatementsPerLogger = getOrDefaultNoSpamLoggerMaxStatementsPerLogger();
+    }
+
+    private static long getOrDefaultNoSpamLoggerMaxStatementsPerLogger()
+    {
+        return Long.getLong("cassandra.nospam_logger.max_statements_per_logger", Long.MAX_VALUE);
     }
 
     public class NoSpamLogStatement extends AtomicLong
@@ -301,7 +324,7 @@ public class NoSpamLogger
      * Uses custom per-entry expiry based on each statement's minIntervalNanos.
      */
     private final Cache<String, NoSpamLogStatement> lastMessage = Caffeine.newBuilder()
-                                                                          .maximumSize(NOSPAM_LOGGER_MAX_STATEMENTS_PER_LOGGER.getLong())
+                                                                          .maximumSize(noSpamLoggerMaxStatementsPerLogger)
                                                                           .expireAfter(new StatementExpiry())
                                                                           .ticker(TICKER)
                                                                           .executor(ForkJoinPool.commonPool())

--- a/test/unit/org/apache/cassandra/config/DatabaseDescriptorRefTest.java
+++ b/test/unit/org/apache/cassandra/config/DatabaseDescriptorRefTest.java
@@ -212,6 +212,7 @@ public class DatabaseDescriptorRefTest
     "org.apache.cassandra.utils.FBUtilities",
     "org.apache.cassandra.utils.NoSpamLogger",
     "org.apache.cassandra.utils.NoSpamLogger$Clock",
+    "org.apache.cassandra.utils.NoSpamLogger$StatementExpiry",
     "org.apache.cassandra.utils.Pair",
     "org.apache.cassandra.utils.StorageCompatibilityMode",
     "org.apache.cassandra.utils.binlog.BinLogOptions",

--- a/test/unit/org/apache/cassandra/utils/NoSpamLoggerTest.java
+++ b/test/unit/org/apache/cassandra/utils/NoSpamLoggerTest.java
@@ -76,11 +76,13 @@ public class NoSpamLoggerTest
     static final String statement = "swizzle{}";
     static final String param = "";
     static long now;
+    static long tickerTime;
 
     @BeforeClass
     public static void setUpClass() throws Exception
     {
         NoSpamLogger.unsafeSetClock(() -> now);
+        NoSpamLogger.TICKER = () -> tickerTime;
     }
 
     @Before
@@ -305,5 +307,251 @@ public class NoSpamLoggerTest
         loggedMsg = logged.get(Level.INFO).remove();
         assertEquals("TESTING {}", loggedMsg.left);
         assertArrayEquals(params, loggedMsg.right);
+    }
+
+    /**
+     * Test that the {@link NoSpamLogStatement} cache is bounded and doesn't grow beyond max_statements_per_logger.
+     * This prevents memory exhaustion from dynamic log messages (e.g., queries with unique strings).
+     */
+    @Test
+    public void testNoSpamLogStatementCacheBounded()
+    {
+        int maxStatementsPerLogger = 10;
+        System.setProperty("cassandra.nospam_logger.max_statements_per_logger", String.valueOf(maxStatementsPerLogger));
+        try
+        {
+            NoSpamLogger.clearWrappedLoggersForTest();
+            now = 5;
+            NoSpamLogger logger = NoSpamLogger.getLogger(mock, 5, TimeUnit.NANOSECONDS);
+
+            // Create more unique log statements than the cache can hold
+            int numberOfLogStatements = (int) (maxStatementsPerLogger * 1.5);
+            for (int i = 0; i < numberOfLogStatements; i++)
+            {
+                String uniqueStatement = "statement" + i + "{}";
+                assertTrue("First occurrence of statement " + i + " should succeed",
+                           logger.info(uniqueStatement, param));
+                now += 10; // Advance time so each statement can log
+            }
+
+            assertEquals(numberOfLogStatements, logged.get(Level.INFO).size());
+
+            // Force cache cleanup to ensure eviction has completed
+            logger.cleanUpStatementsForTest();
+
+            // Verify the cache size is bounded to the configured maximum
+            assertTrue("Cache size should be at most " + maxStatementsPerLogger, logger.getStatementsCount() <= maxStatementsPerLogger);
+        }
+        finally
+        {
+            System.clearProperty("cassandra.nospam_logger.max_statements_per_logger");
+            NoSpamLogger.clearWrappedLoggersForTest();
+        }
+    }
+
+    /**
+     * Test that log statements expire after the configured inactivity period.
+     */
+    @Test
+    public void testNoSpamLogStatementsCacheTimeBasedEviction()
+    {
+        try
+        {
+            int minIntervalInseconds = 10;
+            NoSpamLogger.clearWrappedLoggersForTest();
+            now = 0;
+            tickerTime = 0;
+            NoSpamLogger logger = NoSpamLogger.getLogger(mock, minIntervalInseconds, TimeUnit.SECONDS);
+
+            assertTrue(logger.info("test{}", param));
+            assertEquals(1, logged.get(Level.INFO).size());
+            assertEquals("Cache should contain 1 statement", 1, logger.getStatementsCount());
+
+            // Try to log again immediately - should be rate-limited
+            assertFalse(logger.info("test{}", param));
+            assertEquals(1, logged.get(Level.INFO).size());
+            assertEquals("Cache should still contain 1 statement", 1, logger.getStatementsCount());
+
+            // Advance BOTH clocks by more than `minIntervalInseconds` seconds
+            // `now` is used for rate limiting (NoSpamLogger.CLOCK)
+            // `tickerTime` is used for cache expiration (Caffeine's Ticker)
+            long advanceTime = TimeUnit.SECONDS.toNanos(minIntervalInseconds + 1);
+            now += advanceTime;
+            tickerTime += advanceTime;
+
+            // Trigger cache cleanup to process expired entries
+            logger.cleanUpStatementsForTest();
+
+            // Verify the statement was evicted from cache
+            assertEquals("Cache should be empty after expiration", 0, logger.getStatementsCount());
+
+            // The statement should have expired from cache, so it should log again
+            assertTrue("Statement should have expired and can log again",
+                       logger.info("test{}", param));
+            assertEquals(2, logged.get(Level.INFO).size());
+            assertEquals("Cache should contain 1 statement again", 1, logger.getStatementsCount());
+        }
+        finally
+        {
+            NoSpamLogger.clearWrappedLoggersForTest();
+        }
+    }
+
+    /**
+     * Test that NoSpamLogger instances are cached and reused.
+     * This test verifies that getting the same logger returns the cached instance,
+     * and that clearing the cache creates new instances.
+     */
+    @Test
+    public void testNoSpamLoggerCaching()
+    {
+        NoSpamLogger.clearWrappedLoggersForTest();
+        now = 0;
+
+        // Create multiple unique logger instances
+        Logger logger1 = new SubstituteLogger("testLogger1", null, true)
+        {
+            @Override
+            public void info(String statement, Object... args)
+            {
+                logged.get(Level.INFO).offer(Pair.create(statement, args));
+            }
+
+            @Override
+            public int hashCode()
+            {
+                return System.identityHashCode(this);
+            }
+
+            @Override
+            public boolean equals(Object o)
+            {
+                return this == o;
+            }
+        };
+
+        Logger logger2 = new SubstituteLogger("testLogger2", null, true)
+        {
+            @Override
+            public void info(String statement, Object... args)
+            {
+                logged.get(Level.INFO).offer(Pair.create(statement, args));
+            }
+
+            @Override
+            public int hashCode()
+            {
+                return System.identityHashCode(this);
+            }
+
+            @Override
+            public boolean equals(Object o)
+            {
+                return this == o;
+            }
+        };
+
+        // Get NoSpamLogger instances - these should be cached
+        NoSpamLogger nsl1 = NoSpamLogger.getLogger(logger1, 5, TimeUnit.NANOSECONDS);
+        NoSpamLogger nsl2 = NoSpamLogger.getLogger(logger2, 5, TimeUnit.NANOSECONDS);
+
+        assertTrue(nsl1.info("test{}", param));
+        assertTrue(nsl2.info("test{}", param));
+        assertEquals(2, logged.get(Level.INFO).size());
+
+        // Verify that getting the same logger returns the cached instance
+        NoSpamLogger nsl1Again = NoSpamLogger.getLogger(logger1, 5, TimeUnit.NANOSECONDS);
+        assertSame("Should return cached instance", nsl1, nsl1Again);
+
+        // Forcefully clear all cached loggers
+        NoSpamLogger.clearWrappedLoggersForTest();
+
+        // Getting the logger again should create a new instance
+        NoSpamLogger nsl1New = NoSpamLogger.getLogger(logger1, 5, TimeUnit.NANOSECONDS);
+        assertNotSame("Should create new instance after cache clear", nsl1, nsl1New);
+
+        // Verify the new instance works correctly
+        assertTrue("New logger instance should log immediately", nsl1New.info("test{}", param));
+        assertEquals(3, logged.get(Level.INFO).size());
+    }
+
+    /**
+     * Test that the NoSpamLogStatement cache uses custom per-entry expiry based on each logger's minIntervalNanos.
+     * This test verifies that different NoSpamLogger instances with different intervals result in
+     * different expiry times for their cached statements.
+     */
+    @Test
+    public void testNoSpamLogStatementCacheCustomExpiry()
+    {
+        NoSpamLogger.clearWrappedLoggersForTest();
+        now = 0;
+        tickerTime = 0;
+
+        // Create three NoSpamLogger instances with different intervals
+        int[] intervals = { 2, 5, 10 };
+        NoSpamLogger[] loggers = new NoSpamLogger[intervals.length];
+        int logMessagesPerLogger = 3;
+        for (int i = 0; i < intervals.length; i++)
+        {
+            // Create a unique Logger instance for each interval to get separate NoSpamLogger instances
+            Logger testLogger = new SubstituteLogger("testLogger" + i, null, true)
+            {
+                @Override
+                public void info(String statement, Object... args)
+                {
+                    logged.get(Level.INFO).offer(Pair.create(statement, args));
+                }
+
+                @Override
+                public int hashCode()
+                {
+                    return System.identityHashCode(this);
+                }
+
+                @Override
+                public boolean equals(Object o)
+                {
+                    return this == o;
+                }
+            };
+
+            loggers[i] = NoSpamLogger.getLogger(testLogger, intervals[i], TimeUnit.SECONDS);
+
+            // Log 3 messages from each logger
+            for (int j = 1; j <= logMessagesPerLogger; j++)
+            {
+                assertTrue(loggers[i].info("message" + j));
+                now += intervals[i] * 1_000_000_000L + 1; // Advance past the interval to allow next log
+            }
+            assertEquals(logMessagesPerLogger, loggers[i].getStatementsCount());
+        }
+
+        assertEquals(logMessagesPerLogger * intervals.length, logged.get(Level.INFO).size());
+
+        // Test expiry at different time points
+        // Entries were created at tickerTime=0, so they expire at their interval time
+        int[] checkTimes = new int[intervals.length];
+        for (int i = 0; i < intervals.length; i++)
+        {
+            // Set check time to 1 second after expiry (entries expire at interval seconds)
+            checkTimes[i] = intervals[i] + 1;
+        }
+
+        for (int timeIdx = 0; timeIdx < checkTimes.length; timeIdx++)
+        {
+            tickerTime = TimeUnit.SECONDS.toNanos(checkTimes[timeIdx]);
+
+            for (int i = 0; i < loggers.length; i++)
+            {
+                loggers[i].cleanUpStatementsForTest();
+
+                // Entries expire at (creation_time + interval), created at time 0
+                // So they expire when tickerTime > interval
+                int expected = (intervals[i] < checkTimes[timeIdx]) ? 0 : logMessagesPerLogger;
+                assertEquals(String.format("After %ds, %d-second logger should have %d statements",
+                                           checkTimes[timeIdx], intervals[i], expected),
+                             expected, loggers[i].getStatementsCount());
+            }
+        }
     }
 }

--- a/test/unit/org/apache/cassandra/utils/NoSpamLoggerTest.java
+++ b/test/unit/org/apache/cassandra/utils/NoSpamLoggerTest.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
+import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.utils.NoSpamLogger.Level;
 import org.apache.cassandra.utils.NoSpamLogger.NoSpamLogStatement;
 import org.junit.Before;
@@ -317,7 +318,7 @@ public class NoSpamLoggerTest
     public void testNoSpamLogStatementCacheBounded()
     {
         int maxStatementsPerLogger = 10;
-        System.setProperty("cassandra.nospam_logger.max_statements_per_logger", String.valueOf(maxStatementsPerLogger));
+        CassandraRelevantProperties.NOSPAM_LOGGER_MAX_STATEMENTS_PER_LOGGER.setLong(maxStatementsPerLogger);
         try
         {
             NoSpamLogger.clearWrappedLoggersForTest();

--- a/test/unit/org/apache/cassandra/utils/NoSpamLoggerTest.java
+++ b/test/unit/org/apache/cassandra/utils/NoSpamLoggerTest.java
@@ -82,7 +82,7 @@ public class NoSpamLoggerTest
     public static void setUpClass() throws Exception
     {
         NoSpamLogger.unsafeSetClock(() -> now);
-        NoSpamLogger.TICKER = () -> tickerTime;
+        NoSpamLogger.unsafeSetTicker(() -> tickerTime);
     }
 
     @Before

--- a/test/unit/org/apache/cassandra/utils/NoSpamLoggerTest.java
+++ b/test/unit/org/apache/cassandra/utils/NoSpamLoggerTest.java
@@ -26,7 +26,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
-import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.utils.NoSpamLogger.Level;
 import org.apache.cassandra.utils.NoSpamLogger.NoSpamLogStatement;
 import org.junit.Before;
@@ -318,10 +317,10 @@ public class NoSpamLoggerTest
     public void testNoSpamLogStatementCacheBounded()
     {
         int maxStatementsPerLogger = 10;
-        CassandraRelevantProperties.NOSPAM_LOGGER_MAX_STATEMENTS_PER_LOGGER.setLong(maxStatementsPerLogger);
         try
         {
             NoSpamLogger.clearWrappedLoggersForTest();
+            NoSpamLogger.setNospamLoggerMaxStatementsPerLoggerUnsafe(maxStatementsPerLogger);
             now = 5;
             NoSpamLogger logger = NoSpamLogger.getLogger(mock, 5, TimeUnit.NANOSECONDS);
 
@@ -345,7 +344,7 @@ public class NoSpamLoggerTest
         }
         finally
         {
-            System.clearProperty("cassandra.nospam_logger.max_statements_per_logger");
+            NoSpamLogger.resetNospamLoggerMaxStatementsPerLoggerUnsafe();
             NoSpamLogger.clearWrappedLoggersForTest();
         }
     }


### PR DESCRIPTION
### What is the issue
NoSpamLogger uses unbounded cache that could lead to memory exhaustion

### What does this PR fix and why was it fixed
This PR replaces the previous `NonBlockingHashMap` based caching implementation in `NoSpamLogger` with Caffeine cache to prevent unbounded memory growth and improve cache management

(Syncing up changes from https://github.com/datastax/cassandra/pull/2373 to `main-5.0`)
