### PR TITLE
CNDB-17862 CNDB-16859 Use SinglePartitionReadCommand for index queries

### DIFF
--- a/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
@@ -505,24 +505,16 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
                               int userOffset,
                               AggregationSpecification aggregationSpec)
     {
-        boolean isPartitionRangeQuery = restrictions.isKeyRange() || restrictions.usesSecondaryIndexing() || restrictions.isDisjunction();
-
         IndexRegistry indexRegistry = IndexRegistry.obtain(table);
         RowFilter rowFilter = getRowFilter(options, state, indexRegistry);
-        DataLimits limit = getDataLimits(state, userLimit, perPartitionLimit, userOffset, aggregationSpec);
+        DataLimits dataLimits = getDataLimits(state, userLimit, perPartitionLimit, userOffset, aggregationSpec);
 
-        ReadQuery query;
-        if (isPartitionRangeQuery)
-        {
-            if (restrictions.isKeyRange() && restrictions.usesSecondaryIndexing() && !SchemaConstants.isLocalSystemKeyspace(table.keyspace))
-                Guardrails.nonPartitionRestrictedIndexQueryEnabled.ensureEnabled(state);
+        if (restrictions.isKeyRange() && restrictions.usesSecondaryIndexing() && !SchemaConstants.isLocalSystemKeyspace(table.keyspace))
+            Guardrails.nonPartitionRestrictedIndexQueryEnabled.ensureEnabled(state);
 
-            query = getRangeCommand(options, state, columnFilter, rowFilter, limit, nowInSec, indexRegistry);
-        }
-        else
-        {
-            query = getSliceCommands(options, state, columnFilter, rowFilter, limit, nowInSec, indexRegistry);
-        }
+        ReadQuery query = restrictions.isKeyRange()
+                        ? getRangeCommand(options, state, columnFilter, rowFilter, dataLimits, nowInSec, indexRegistry)
+                        : getSliceCommands(options, state, columnFilter, rowFilter, dataLimits, nowInSec, indexRegistry);
 
         // Handle additional validation for topK queries
         if (query.isTopK())
@@ -550,7 +542,7 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
             checkFalse(aggregationSpec != null, TOPK_AGGREGATION_ERROR);
         }
 
-        selectOptions.validate(state, table, userLimit, indexRegistry, query.indexQueryPlan());
+        query.validateSelectOptions(selectOptions, state);
 
         // If there's a secondary index that the command can use, have it validate the request parameters.
         query.maybeValidateIndexes();
@@ -916,9 +908,6 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
 
         SinglePartitionReadQuery.Group<? extends SinglePartitionReadQuery> group =
             SinglePartitionReadQuery.createGroup(table, nowInSec, columnFilter, rowFilter, limit, decoratedKeys, filter);
-
-        // If there's a secondary index that the commands can use, have it validate the request parameters.
-        group.maybeValidateIndexes();
 
         return group;
     }

--- a/src/java/org/apache/cassandra/db/PartitionRangeReadCommand.java
+++ b/src/java/org/apache/cassandra/db/PartitionRangeReadCommand.java
@@ -345,7 +345,6 @@ public class PartitionRangeReadCommand extends ReadCommand implements PartitionR
         metric.rangeRequests.inc();
     }
 
-    @VisibleForTesting
     public UnfilteredPartitionIterator queryStorage(final ColumnFamilyStore cfs, ReadExecutionController controller)
     {
         ColumnFamilyStore.ViewFragment view = cfs.select(View.selectLive(dataRange().keyRange()));

--- a/src/java/org/apache/cassandra/db/ReadCommand.java
+++ b/src/java/org/apache/cassandra/db/ReadCommand.java
@@ -29,6 +29,7 @@ import java.util.function.LongPredicate;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.function.Supplier;
+
 import javax.annotation.Nullable;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -42,6 +43,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.cql3.statements.SelectOptions;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.config.DataStorageSpec;
 import org.apache.cassandra.db.transform.BasePartitions;
@@ -78,6 +80,7 @@ import org.apache.cassandra.db.transform.StoppingTransformation;
 import org.apache.cassandra.db.transform.Transformation;
 import org.apache.cassandra.exceptions.UnknownIndexException;
 import org.apache.cassandra.index.Index;
+import org.apache.cassandra.index.IndexRegistry;
 import org.apache.cassandra.io.IVersionedSerializer;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.util.DataInputPlus;
@@ -94,6 +97,7 @@ import org.apache.cassandra.schema.SchemaProvider;
 import org.apache.cassandra.sensors.Context;
 import org.apache.cassandra.sensors.read.TrackingRowIterator;
 import org.apache.cassandra.service.ActiveRepairService;
+import org.apache.cassandra.service.ClientState;
 import org.apache.cassandra.tracing.Tracing;
 import org.apache.cassandra.utils.CassandraUInt;
 import org.apache.cassandra.transport.Dispatcher;
@@ -411,7 +415,8 @@ public abstract class ReadCommand extends AbstractReadQuery
 
     protected abstract ReadCommand copyAsDigestQuery();
 
-    protected abstract UnfilteredPartitionIterator queryStorage(ColumnFamilyStore cfs, ReadExecutionController executionController);
+    @VisibleForTesting
+    public abstract UnfilteredPartitionIterator queryStorage(ColumnFamilyStore cfs, ReadExecutionController executionController);
 
     /**
      * Whether the underlying {@code ClusteringIndexFilter} is reversed or not.
@@ -474,12 +479,6 @@ public abstract class ReadCommand extends AbstractReadQuery
         return cfs.indexManager.getBestIndexQueryPlanFor(rowFilter);
     }
 
-    /**
-     * If the index manager for the CFS determines that there's an applicable
-     * 2i that can be used to execute this command, call its (optional)
-     * validation method to check that nothing in this command's parameters
-     * violates the implementation specific validation rules.
-     */
     @Override
     public void maybeValidateIndexes()
     {
@@ -487,6 +486,12 @@ public abstract class ReadCommand extends AbstractReadQuery
         {
             indexQueryPlan.validate(this);
         }
+    }
+
+    @Override
+    public void validateSelectOptions(SelectOptions selectOptions, ClientState state)
+    {
+        selectOptions.validate(state, metadata(), limits().count(), IndexRegistry.obtain(metadata()), indexQueryPlan);
     }
 
     /**

--- a/src/java/org/apache/cassandra/db/ReadQuery.java
+++ b/src/java/org/apache/cassandra/db/ReadQuery.java
@@ -19,6 +19,7 @@ package org.apache.cassandra.db;
 
 import javax.annotation.Nullable;
 
+import org.apache.cassandra.cql3.statements.SelectOptions;
 import org.apache.cassandra.db.filter.ColumnFilter;
 import org.apache.cassandra.db.filter.DataLimits;
 import org.apache.cassandra.db.filter.RowFilter;
@@ -264,6 +265,13 @@ public interface ReadQuery
     }
 
     default void trackWarnings()
+    {
+    }
+
+    /**
+     * Validates the specified {@link SelectOptions} against this query.
+     */
+    default void validateSelectOptions(SelectOptions selectOptions, ClientState state)
     {
     }
 

--- a/src/java/org/apache/cassandra/db/SinglePartitionReadCommand.java
+++ b/src/java/org/apache/cassandra/db/SinglePartitionReadCommand.java
@@ -499,7 +499,7 @@ public class SinglePartitionReadCommand extends ReadCommand implements SinglePar
         metric.readRequests.inc();
     }
 
-    protected UnfilteredPartitionIterator queryStorage(final ColumnFamilyStore cfs, ReadExecutionController executionController)
+    public UnfilteredPartitionIterator queryStorage(final ColumnFamilyStore cfs, ReadExecutionController executionController)
     {
         // skip the row cache and go directly to sstables/memtable if repaired status of
         // data is being tracked. This is only requested after an initial digest mismatch
@@ -1349,6 +1349,11 @@ public class SinglePartitionReadCommand extends ReadCommand implements SinglePar
         public PartitionIterator execute(ConsistencyLevel consistency, ClientState state, Dispatcher.RequestTime requestTime) throws RequestExecutionException
         {
             return StorageProxy.read(this, consistency, state, requestTime);
+        }
+
+        public PartitionIterator postReconciliationProcessing(PartitionIterator result)
+        {
+            return queries.isEmpty() ? result : queries.get(0).postReconciliationProcessing(result);
         }
     }
 

--- a/src/java/org/apache/cassandra/db/SinglePartitionReadQuery.java
+++ b/src/java/org/apache/cassandra/db/SinglePartitionReadQuery.java
@@ -27,6 +27,7 @@ import com.google.common.collect.Iterables;
 import org.apache.commons.lang3.tuple.Pair;
 
 import org.apache.cassandra.cql3.CqlBuilder;
+import org.apache.cassandra.cql3.statements.SelectOptions;
 import org.apache.cassandra.db.filter.ClusteringIndexFilter;
 import org.apache.cassandra.db.filter.ColumnFilter;
 import org.apache.cassandra.db.filter.DataLimits;
@@ -36,6 +37,7 @@ import org.apache.cassandra.db.partitions.PartitionIterator;
 import org.apache.cassandra.db.partitions.UnfilteredPartitionIterator;
 import org.apache.cassandra.db.partitions.UnfilteredPartitionIterators;
 import org.apache.cassandra.schema.TableMetadata;
+import org.apache.cassandra.service.ClientState;
 import org.apache.cassandra.service.pager.MultiPartitionPager;
 import org.apache.cassandra.service.pager.PagingState;
 import org.apache.cassandra.service.pager.QueryPager;
@@ -178,6 +180,7 @@ public interface SinglePartitionReadQuery extends ReadQuery
         private final DataLimits limits;
         private final long nowInSec;
         private final boolean selectsFullPartitions;
+        private final boolean isTopK;
 
         public Group(List<T> queries, DataLimits limits)
         {
@@ -187,8 +190,14 @@ public interface SinglePartitionReadQuery extends ReadQuery
             T firstQuery = queries.get(0);
             this.nowInSec = firstQuery.nowInSec();
             this.selectsFullPartitions = firstQuery.selectsFullPartition();
-            for (int i = 1; i < queries.size(); i++)
-                assert queries.get(i).nowInSec() == nowInSec;
+            this.isTopK = firstQuery.isTopK();
+
+            for (T query : queries)
+            {
+                assert query.nowInSec() == nowInSec;
+                assert query.selectsFullPartition() == selectsFullPartitions;
+                assert query.isTopK() == isTopK;
+            }
         }
 
         @Override
@@ -217,6 +226,21 @@ public interface SinglePartitionReadQuery extends ReadQuery
         public boolean selectsFullPartition()
         {
             return selectsFullPartitions;
+        }
+
+        @Override
+        public boolean isTopK()
+        {
+            return isTopK;
+        }
+
+        @Override
+        public void validateSelectOptions(SelectOptions selectOptions, ClientState state)
+        {
+            for (T query : queries)
+            {
+                query.validateSelectOptions(selectOptions, state);
+            }
         }
 
         public ReadExecutionController executionController()

--- a/src/java/org/apache/cassandra/index/internal/CassandraIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/internal/CassandraIndexSearcher.java
@@ -23,9 +23,6 @@ package org.apache.cassandra.index.internal;
 import java.nio.ByteBuffer;
 import java.util.SortedSet;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import org.apache.cassandra.db.BufferClusteringBound;
 import org.apache.cassandra.db.Clustering;
 import org.apache.cassandra.db.ClusteringBound;
@@ -55,7 +52,6 @@ import org.apache.cassandra.utils.btree.BTreeSet;
 
 public abstract class CassandraIndexSearcher implements Index.Searcher
 {
-    private static final Logger logger = LoggerFactory.getLogger(CassandraIndexSearcher.class);
 
     private final RowFilter.Expression expression;
     protected final CassandraIndex index;

--- a/src/java/org/apache/cassandra/service/StorageProxy.java
+++ b/src/java/org/apache/cassandra/service/StorageProxy.java
@@ -2319,6 +2319,10 @@ public class StorageProxy implements StorageProxyMBean
         try
         {
             PartitionIterator result = fetchRows(group.queries, consistencyLevel, requestTime, readTracker);
+
+            // Let the indexes do any processing here, including reordering results, before applying the limits.
+            result = group.postReconciliationProcessing(result);
+
             // Note that the only difference between the command in a group must be the partition key on which
             // they applied.
             boolean enforceStrictLiveness = group.queries.get(0).metadata().enforceStrictLiveness();

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/IndexConsistencyTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/IndexConsistencyTest.java
@@ -187,6 +187,54 @@ public class IndexConsistencyTest extends TestBaseImpl
     }
 
     @Test
+    public void testUpdateOnWideTableWithSinglePartitionQueries() throws Exception
+    {
+        cluster.schemaChange(formatQuery("CREATE TABLE %s (k int, c int, v text, s int STATIC, PRIMARY KEY(k, c))"));
+        cluster.schemaChange(formatQuery(createIndexQuery("v")));
+        SAIUtil.waitForIndexQueryableOnFirstNode(cluster, KEYSPACE);
+        execute("INSERT INTO %s(k, s) VALUES (0, 9)",
+                "INSERT INTO %s(k, c, v) VALUES (0, -1, 'old')",
+                "INSERT INTO %s(k, c, v) VALUES (0, 0, 'old')",
+                "INSERT INTO %s(k, c, v) VALUES (0, 1, 'old')",
+                "INSERT INTO %s(k, s) VALUES (1, 9)",
+                "INSERT INTO %s(k, c, v) VALUES (1, -1, 'old')",
+                "INSERT INTO %s(k, c, v) VALUES (1, 0, 'old')",
+                "INSERT INTO %s(k, c, v) VALUES (1, 1, 'old')");
+
+        executeIsolated(1, "UPDATE %s SET v = 'new' WHERE k = 0 AND c = 0");
+
+        assertRows("SELECT * FROM %s WHERE k = 0 AND v = 'old'", row(0, -1, 9, "old"), row(0, 1, 9, "old"));
+        assertRows("SELECT * FROM %s WHERE k = 0 AND v = 'new'", row(0, 0, 9, "new"));
+    }
+
+    @Test
+    public void testUpdateOnWideTableWithSinglePartitionQueriesMultiClustering() throws Exception
+    {
+        cluster.schemaChange(formatQuery("CREATE TABLE %s (k int, c1 int, c2 int, v text, s int STATIC, PRIMARY KEY(k, c1, c2))"));
+        cluster.schemaChange(formatQuery(createIndexQuery("v")));
+        SAIUtil.waitForIndexQueryableOnFirstNode(cluster, KEYSPACE);
+        execute("INSERT INTO %s(k, s) VALUES (0, 9)",
+                "INSERT INTO %s(k, c1, c2, v) VALUES (0, -1, -1, 'old')",
+                "INSERT INTO %s(k, c1, c2, v) VALUES (0, -1, 0, 'old')",
+                "INSERT INTO %s(k, c1, c2, v) VALUES (0, -1, 1, 'old')",
+                "INSERT INTO %s(k, c1, c2, v) VALUES (0, 0, -1, 'old')",
+                "INSERT INTO %s(k, c1, c2, v) VALUES (0, 0, 0, 'old')",
+                "INSERT INTO %s(k, c1, c2, v) VALUES (0, 0, 1, 'old')",
+                "INSERT INTO %s(k, c1, c2, v) VALUES (0, 1, -1, 'old')",
+                "INSERT INTO %s(k, c1, c2, v) VALUES (0, 1, 0, 'old')",
+                "INSERT INTO %s(k, c1, c2, v) VALUES (0, 1, 1, 'old')",
+                "INSERT INTO %s(k, s) VALUES (1, 9)",
+                "INSERT INTO %s(k, c1, c2, v) VALUES (1, 0, -1, 'old')",
+                "INSERT INTO %s(k, c1, c2, v) VALUES (1, 0, 0, 'old')",
+                "INSERT INTO %s(k, c1, c2, v) VALUES (1, 0, 1, 'old')");
+
+        executeIsolated(1, "UPDATE %s SET v = 'new' WHERE k = 0 AND c1 = 0 AND c2 = 0");
+
+        assertRows("SELECT * FROM %s WHERE k = 0 AND c1 = 0 AND v = 'old'", row(0, 0, -1, 9, "old"), row(0, 0, 1, 9, "old"));
+        assertRows("SELECT * FROM %s WHERE k = 0 AND c1 = 0 AND v = 'new'", row(0, 0, 0, 9, "new"));
+    }
+
+    @Test
     public void testUpdateOnWideTableCaseInsensitiveNormalized() throws Exception
     {
         cluster.schemaChange(formatQuery("CREATE TABLE %s (k1 int, k2 int, v text, v1 text, primary key(k1, k2)) with read_repair='NONE'"));

--- a/test/microbench/org/apache/cassandra/test/microbench/ReadCommandExecutionInfoBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/ReadCommandExecutionInfoBench.java
@@ -118,7 +118,7 @@ public class ReadCommandExecutionInfoBench extends CQLTester
         int randomKey = RANDOM.nextInt(NUM_PARTITIONS);
         int randomValue = RANDOM.nextInt(NUM_VALUES);
         String query = String.format(QUERY, randomKey, randomValue);
-        ReadCommand command = parseReadCommandGroup(query).get(0);
+        ReadCommand command = parseReadCommandGroup(query).queries.get(0);
         try (UnfilteredPartitionIterator partitions = command.executeLocally(command.executionController(false)))
         {
             while (partitions.hasNext())

--- a/test/unit/org/apache/cassandra/Util.java
+++ b/test/unit/org/apache/cassandra/Util.java
@@ -82,7 +82,6 @@ import org.apache.cassandra.db.IMutation;
 import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.db.Mutation;
 import org.apache.cassandra.db.PartitionPosition;
-import org.apache.cassandra.db.PartitionRangeReadCommand;
 import org.apache.cassandra.db.ReadCommand;
 import org.apache.cassandra.db.ReadExecutionController;
 import org.apache.cassandra.db.compaction.AbstractCompactionTask;
@@ -861,7 +860,7 @@ public class Util
         }
     }
 
-    public static UnfilteredPartitionIterator executeLocally(PartitionRangeReadCommand command,
+    public static UnfilteredPartitionIterator executeLocally(ReadCommand command,
                                                              ColumnFamilyStore cfs,
                                                              ReadExecutionController controller)
     {

--- a/test/unit/org/apache/cassandra/cql3/CQLTester.java
+++ b/test/unit/org/apache/cassandra/cql3/CQLTester.java
@@ -1859,21 +1859,37 @@ public abstract class CQLTester
         return QueryProcessor.parseStatement(formattedQuery, ClientState.forInternalCalls());
     }
 
-    protected ReadCommand parseReadCommand(String query)
+    protected ReadQuery parseReadQuery(String query)
     {
         SelectStatement select = (SelectStatement) parseStatement(query);
-        ReadQuery readQuery = select.getQuery(QueryOptions.DEFAULT, FBUtilities.nowInSeconds());
-        Assertions.assertThat(readQuery).isInstanceOf(ReadCommand.class);
-        return  (ReadCommand) readQuery;
+        return select.getQuery(QueryOptions.DEFAULT, FBUtilities.nowInSeconds());
     }
 
-    protected List<SinglePartitionReadCommand> parseReadCommandGroup(String query)
+    protected ReadCommand parseReadCommand(String query)
     {
-        SelectStatement select = (SelectStatement) parseStatement(query);
-        ReadQuery readQuery = select.getQuery(QueryOptions.DEFAULT, FBUtilities.nowInSeconds());
+        ReadQuery readQuery = parseReadQuery(query);
+
+        // if it's already a ReadCommand, return it directly
+        if (readQuery instanceof ReadCommand)
+            return (ReadCommand) readQuery;
+
+        // if it's a SinglePartitionReadCommand.Group, extract the single command, or fail if it's not single-command
+        if (readQuery instanceof SinglePartitionReadCommand.Group)
+        {
+            SinglePartitionReadCommand.Group commandGroup = (SinglePartitionReadCommand.Group) readQuery;
+            List<SinglePartitionReadCommand> commands = commandGroup.queries;
+            Assertions.assertThat(commands).as("Expected exactly 1 command in query: %s", query).hasSize(1);
+            return commands.get(0);
+        }
+
+        return Assertions.fail("Unexpected query type %s for query: %s", readQuery.getClass().getName(), query);
+    }
+
+    protected SinglePartitionReadCommand.Group parseReadCommandGroup(String query)
+    {
+        ReadQuery readQuery = parseReadQuery(query);
         Assertions.assertThat(readQuery).isInstanceOf(SinglePartitionReadCommand.Group.class);
-        SinglePartitionReadCommand.Group commands = (SinglePartitionReadCommand.Group) readQuery;
-        return commands.queries;
+        return (SinglePartitionReadCommand.Group) readQuery;
     }
 
     protected ResultMessage.Prepared prepare(String query) throws Throwable

--- a/test/unit/org/apache/cassandra/db/MultiRangeReadCommandCQLTest.java
+++ b/test/unit/org/apache/cassandra/db/MultiRangeReadCommandCQLTest.java
@@ -16,6 +16,7 @@
 package org.apache.cassandra.db;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.Test;
@@ -55,12 +56,6 @@ public class MultiRangeReadCommandCQLTest extends ReadCommandCQLTester<MultiRang
                           "SELECT * FROM %s WHERE (token(k) <= -1 OR token(k) > -1) AND v = 0 ALLOW FILTERING",
                           "SELECT * FROM %s WHERE (token(k) <= ? OR token(k) > ?) AND v = ? ALLOW FILTERING",
                           multiRangeError);
-        assertToCQLString("SELECT * FROM %s WHERE k = 0 AND v = 0",
-                          "SELECT * FROM %s WHERE k = 0 AND v = 0 ALLOW FILTERING",
-                          "SELECT * FROM %s WHERE k = ? AND v = ? ALLOW FILTERING");
-        assertToCQLString("SELECT * FROM %s WHERE k = 0 AND c = 0 AND v = 0 ",
-                          "SELECT * FROM %s WHERE k = 0 AND c = 0 AND v = 0 ALLOW FILTERING",
-                          "SELECT * FROM %s WHERE k = ? AND c = ? AND v = ? ALLOW FILTERING");
         assertToCQLString("SELECT * FROM %s WHERE token(k) > token(0) AND v = 0",
                           "SELECT * FROM %s WHERE (token(k) > " + token + " AND token(k) <= " + right + " OR token(k) > " + right + ") AND v = 0 ALLOW FILTERING",
                           "SELECT * FROM %s WHERE (token(k) > ? AND token(k) <= ? OR token(k) > ?) AND v = ? ALLOW FILTERING",
@@ -92,9 +87,6 @@ public class MultiRangeReadCommandCQLTest extends ReadCommandCQLTester<MultiRang
                           "SELECT * FROM %s WHERE (token(k) <= -1 OR token(k) > -1) ORDER BY n DESC LIMIT 10 ALLOW FILTERING",
                           "SELECT * FROM %s WHERE (token(k) <= ? OR token(k) > ?) ORDER BY n DESC LIMIT 10 ALLOW FILTERING",
                           multiRangeError);
-        assertToCQLString("SELECT * FROM %s WHERE k = 0 ORDER BY n LIMIT 10",
-                          "SELECT * FROM %s WHERE k = 0 ORDER BY n ASC LIMIT 10 ALLOW FILTERING",
-                          "SELECT * FROM %s WHERE k = ? ORDER BY n ASC LIMIT 10 ALLOW FILTERING");
         assertToCQLString("SELECT * FROM %s WHERE n = 0 ORDER BY n LIMIT 10",
                           "SELECT * FROM %s WHERE (token(k) <= -1 OR token(k) > -1) AND n = 0 ORDER BY n ASC LIMIT 10 ALLOW FILTERING",
                           "SELECT * FROM %s WHERE (token(k) <= ? OR token(k) > ?) AND n = ? ORDER BY n ASC LIMIT 10 ALLOW FILTERING",
@@ -109,10 +101,6 @@ public class MultiRangeReadCommandCQLTest extends ReadCommandCQLTester<MultiRang
                           "SELECT * FROM %s WHERE (token(k) <= -1 OR token(k) > -1) ORDER BY v ANN OF [1.0, ... LIMIT 10 ALLOW FILTERING",
                           "SELECT * FROM %s WHERE (token(k) <= ? OR token(k) > ?) ORDER BY v ANN OF ? LIMIT 10 ALLOW FILTERING",
                           truncationError);
-        assertToCQLString("SELECT * FROM %s WHERE k = 0 ORDER BY v ANN OF [1, 2] LIMIT 10",
-                          "SELECT * FROM %s WHERE k = 0 ORDER BY v ANN OF [1.0, ... LIMIT 10 ALLOW FILTERING",
-                          "SELECT * FROM %s WHERE k = ? ORDER BY v ANN OF ? LIMIT 10 ALLOW FILTERING",
-                          truncationError);
         assertToCQLString("SELECT * FROM %s WHERE n = 0 ORDER BY v ANN OF [1, 2] LIMIT 10",
                           "SELECT * FROM %s WHERE (token(k) <= -1 OR token(k) > -1) AND n = 0 ORDER BY v ANN OF [1.0, ... LIMIT 10 ALLOW FILTERING",
                           "SELECT * FROM %s WHERE (token(k) <= ? OR token(k) > ?) AND n = ? ORDER BY v ANN OF ? LIMIT 10 ALLOW FILTERING",
@@ -120,7 +108,7 @@ public class MultiRangeReadCommandCQLTest extends ReadCommandCQLTester<MultiRang
     }
 
     @Override
-    protected MultiRangeReadCommand parseCommand(String query)
+    protected List<MultiRangeReadCommand> parseCommands(String query)
     {
         ReadCommand command = parseReadCommand(query);
         Assertions.assertThat(command).isInstanceOf(PartitionRangeReadCommand.class);
@@ -140,6 +128,6 @@ public class MultiRangeReadCommandCQLTest extends ReadCommandCQLTester<MultiRang
             ranges = List.of(bounds);
         }
 
-        return MultiRangeReadCommand.create(rangeCommand, ranges, true);
+        return Collections.singletonList(MultiRangeReadCommand.create(rangeCommand, ranges, true));
     }
 }

--- a/test/unit/org/apache/cassandra/db/PartitionRangeReadCommandCQLTest.java
+++ b/test/unit/org/apache/cassandra/db/PartitionRangeReadCommandCQLTest.java
@@ -15,6 +15,9 @@
  */
 package org.apache.cassandra.db;
 
+import java.util.Collections;
+import java.util.List;
+
 import org.junit.Test;
 
 import org.apache.cassandra.config.DatabaseDescriptor;
@@ -85,17 +88,9 @@ public class PartitionRangeReadCommandCQLTest extends ReadCommandCQLTester<Parti
                           "SELECT * FROM %s WHERE token(k) >= " + token + " AND token(k) <= " + token + " ALLOW FILTERING",
                           "SELECT * FROM %s WHERE token(k) >= ? AND token(k) <= ? ALLOW FILTERING");
 
-        // test with a secondary index (indexed queries are always mapped to range commands)
+        // test with a secondary index
         createIndex("CREATE INDEX ON %s(v)");
         assertToCQLString("SELECT * FROM %s WHERE v = 0", "SELECT * FROM %s WHERE v = 0 ALLOW FILTERING", "SELECT * FROM %s WHERE v = ? ALLOW FILTERING");
-        assertToCQLString("SELECT * FROM %s WHERE k = 0 AND  v = 0", "SELECT * FROM %s WHERE k = 0 AND v = 0 ALLOW FILTERING", "SELECT * FROM %s WHERE k = ? AND v = ? ALLOW FILTERING");
-        assertToCQLString("SELECT * FROM %s WHERE k = 0 AND c = 0 AND v = 0 ", "SELECT * FROM %s WHERE k = 0 AND c = 0 AND v = 0 ALLOW FILTERING", "SELECT * FROM %s WHERE k = ? AND c = ? AND v = ? ALLOW FILTERING");
-        assertToCQLString("SELECT * FROM %s WHERE k = 0 AND c > 0 AND v = 0 ", "SELECT * FROM %s WHERE k = 0 AND c > 0 AND v = 0 ALLOW FILTERING", "SELECT * FROM %s WHERE k = ? AND c > ? AND v = ? ALLOW FILTERING");
-        assertToCQLString("SELECT * FROM %s WHERE k = 0 AND c < 0 AND v = 0 ", "SELECT * FROM %s WHERE k = 0 AND c < 0 AND v = 0 ALLOW FILTERING", "SELECT * FROM %s WHERE k = ? AND c < ? AND v = ? ALLOW FILTERING");
-        assertToCQLString("SELECT * FROM %s WHERE k = 0 AND c >= 0 AND v = 0 ", "SELECT * FROM %s WHERE k = 0 AND c >= 0 AND v = 0 ALLOW FILTERING", "SELECT * FROM %s WHERE k = ? AND c >= ? AND v = ? ALLOW FILTERING");
-        assertToCQLString("SELECT * FROM %s WHERE k = 0 AND c <= 0 AND v = 0", "SELECT * FROM %s WHERE k = 0 AND c <= 0 AND v = 0 ALLOW FILTERING", "SELECT * FROM %s WHERE k = ? AND c <= ? AND v = ? ALLOW FILTERING");
-        assertToCQLString("SELECT * FROM %s WHERE k = 0 AND c IN (0) AND v = 0", "SELECT * FROM %s WHERE k = 0 AND c = 0 AND v = 0 ALLOW FILTERING", "SELECT * FROM %s WHERE k = ? AND c = ? AND v = ? ALLOW FILTERING");
-        assertToCQLString("SELECT * FROM %s WHERE k = 0 AND c IN (0, 1) AND v = 0", "SELECT * FROM %s WHERE k = 0 AND c IN (0, 1) AND v = 0 ALLOW FILTERING", "SELECT * FROM %s WHERE k = ? AND c IN (?, ?) AND v = ? ALLOW FILTERING");
         assertToCQLString("SELECT * FROM %s WHERE token(k) > token(0) AND v = 0",
                           "SELECT * FROM %s WHERE token(k) > " + token + " AND v = 0 ALLOW FILTERING",
                           "SELECT * FROM %s WHERE token(k) > ? AND v = ? ALLOW FILTERING");
@@ -105,49 +100,6 @@ public class PartitionRangeReadCommandCQLTest extends ReadCommandCQLTester<Parti
         assertToCQLString("SELECT * FROM %s WHERE token(k) >= token(0) AND token(k) <= token(0) AND v = 0",
                           "SELECT * FROM %s WHERE token(k) >= " + token + " AND token(k) <= " + token + " AND v = 0 ALLOW FILTERING",
                           "SELECT * FROM %s WHERE token(k) >= ? AND token(k) <= ? AND v = ? ALLOW FILTERING");
-
-        // test with multi-column partition key and index
-        createTable("CREATE TABLE %s (k1 int, k2 int, c int, v int, PRIMARY KEY ((k1, k2), c))");
-        createIndex("CREATE INDEX ON %s(v)");
-        assertToCQLString("SELECT * FROM %s WHERE k1 = 1 AND k2 = 2 AND v = 1", "SELECT * FROM %s WHERE k1 = 1 AND k2 = 2 AND v = 1 ALLOW FILTERING", "SELECT * FROM %s WHERE k1 = ? AND k2 = ? AND v = ? ALLOW FILTERING");
-        assertToCQLString("SELECT * FROM %s WHERE k1 = 1 AND k2 = 2 AND c = 3 AND v = 1", "SELECT * FROM %s WHERE k1 = 1 AND k2 = 2 AND c = 3 AND v = 1 ALLOW FILTERING", "SELECT * FROM %s WHERE k1 = ? AND k2 = ? AND c = ? AND v = ? ALLOW FILTERING");
-
-        // test with index and multi-column clustering
-        createTable("CREATE TABLE %s (k int, c1 int, c2 int,v int, PRIMARY KEY (k, c1, c2))");
-        createIndex("CREATE INDEX ON %s(v)");
-        assertToCQLString("SELECT * FROM %s WHERE k = 0 AND v = 0",
-                          "SELECT * FROM %s WHERE k = 0 AND v = 0 ALLOW FILTERING",
-                          "SELECT * FROM %s WHERE k = ? AND v = ? ALLOW FILTERING");
-        assertToCQLString("SELECT * FROM %s WHERE k = 0 AND c1 = 1 AND v = 0",
-                          "SELECT * FROM %s WHERE k = 0 AND c1 = 1 AND v = 0 ALLOW FILTERING",
-                          "SELECT * FROM %s WHERE k = ? AND c1 = ? AND v = ? ALLOW FILTERING");
-        assertToCQLString("SELECT * FROM %s WHERE k = 0 AND c1 > 1 AND v = 0",
-                          "SELECT * FROM %s WHERE k = 0 AND c1 > 1 AND v = 0 ALLOW FILTERING",
-                          "SELECT * FROM %s WHERE k = ? AND c1 > ? AND v = ? ALLOW FILTERING");
-        assertToCQLString("SELECT * FROM %s WHERE k = 0 AND c1 < 1 AND v = 0",
-                          "SELECT * FROM %s WHERE k = 0 AND c1 < 1 AND v = 0 ALLOW FILTERING",
-                          "SELECT * FROM %s WHERE k = ? AND c1 < ? AND v = ? ALLOW FILTERING");
-        assertToCQLString("SELECT * FROM %s WHERE k = 0 AND c1 >= 1 AND v = 0",
-                          "SELECT * FROM %s WHERE k = 0 AND c1 >= 1 AND v = 0 ALLOW FILTERING",
-                          "SELECT * FROM %s WHERE k = ? AND c1 >= ? AND v = ? ALLOW FILTERING");
-        assertToCQLString("SELECT * FROM %s WHERE k = 0 AND c1 <= 1 AND v = 0",
-                          "SELECT * FROM %s WHERE k = 0 AND c1 <= 1 AND v = 0 ALLOW FILTERING",
-                          "SELECT * FROM %s WHERE k = ? AND c1 <= ? AND v = ? ALLOW FILTERING");
-        assertToCQLString("SELECT * FROM %s WHERE k = 0 AND c1 = 1 AND c2 = 2 AND v = 0",
-                          "SELECT * FROM %s WHERE k = 0 AND (c1, c2) = (1, 2) AND v = 0 ALLOW FILTERING",
-                          "SELECT * FROM %s WHERE k = ? AND (c1, c2) = (?, ?) AND v = ? ALLOW FILTERING");
-        assertToCQLString("SELECT * FROM %s WHERE k = 0 AND c1 = 1 AND c2 > 2 AND v = 0",
-                          "SELECT * FROM %s WHERE k = 0 AND c1 = 1 AND c2 > 2 AND v = 0 ALLOW FILTERING",
-                          "SELECT * FROM %s WHERE k = ? AND c1 = ? AND c2 > ? AND v = ? ALLOW FILTERING");
-        assertToCQLString("SELECT * FROM %s WHERE k = 0 AND c1 = 1 AND c2 < 2 AND v = 0",
-                          "SELECT * FROM %s WHERE k = 0 AND c1 = 1 AND c2 < 2 AND v = 0 ALLOW FILTERING",
-                          "SELECT * FROM %s WHERE k = ? AND c1 = ? AND c2 < ? AND v = ? ALLOW FILTERING");
-        assertToCQLString("SELECT * FROM %s WHERE k = 0 AND c1 = 1 AND c2 >= 2 AND v = 0",
-                          "SELECT * FROM %s WHERE k = 0 AND c1 = 1 AND c2 >= 2 AND v = 0 ALLOW FILTERING",
-                          "SELECT * FROM %s WHERE k = ? AND c1 = ? AND c2 >= ? AND v = ? ALLOW FILTERING");
-        assertToCQLString("SELECT * FROM %s WHERE k = 0 AND c1 = 1 AND c2 <= 2 AND v = 0",
-                          "SELECT * FROM %s WHERE k = 0 AND c1 = 1 AND c2 <= 2 AND v = 0 ALLOW FILTERING",
-                          "SELECT * FROM %s WHERE k = ? AND c1 = ? AND c2 <= ? AND v = ? ALLOW FILTERING");
 
         // test generic index-based ORDER BY
         createTable("CREATE TABLE %s (k int, c int, n int, PRIMARY KEY (k, c))");
@@ -159,21 +111,9 @@ public class PartitionRangeReadCommandCQLTest extends ReadCommandCQLTester<Parti
         assertToCQLString("SELECT * FROM %s ORDER BY n DESC LIMIT 10",
                           "SELECT * FROM %s ORDER BY n DESC LIMIT 10 ALLOW FILTERING",
                           "SELECT * FROM %s ORDER BY n DESC LIMIT 10 ALLOW FILTERING");
-        assertToCQLString("SELECT * FROM %s WHERE k = 0 ORDER BY n LIMIT 10",
-                          "SELECT * FROM %s WHERE k = 0 ORDER BY n ASC LIMIT 10 ALLOW FILTERING",
-                          "SELECT * FROM %s WHERE k = ? ORDER BY n ASC LIMIT 10 ALLOW FILTERING");
-        assertToCQLString("SELECT * FROM %s WHERE k = 0 AND c = 0 ORDER BY n LIMIT 10",
-                          "SELECT * FROM %s WHERE k = 0 AND c = 0 ORDER BY n ASC LIMIT 10 ALLOW FILTERING",
-                          "SELECT * FROM %s WHERE k = ? AND c = ? ORDER BY n ASC LIMIT 10 ALLOW FILTERING");
-        assertToCQLString("SELECT * FROM %s WHERE k = 0 AND c IN (0, 1) ORDER BY n LIMIT 10",
-                          "SELECT * FROM %s WHERE k = 0 AND c IN (0, 1) ORDER BY n ASC LIMIT 10 ALLOW FILTERING",
-                          "SELECT * FROM %s WHERE k = ? AND c IN (?, ?) ORDER BY n ASC LIMIT 10 ALLOW FILTERING");
         assertToCQLString("SELECT * FROM %s WHERE n = 0 ORDER BY n LIMIT 10",
                           "SELECT * FROM %s WHERE n = 0 ORDER BY n ASC LIMIT 10 ALLOW FILTERING",
                           "SELECT * FROM %s WHERE n = ? ORDER BY n ASC LIMIT 10 ALLOW FILTERING");
-        assertToCQLString("SELECT * FROM %s WHERE k = 0 AND c > 0 ORDER BY n LIMIT 10",
-                          "SELECT * FROM %s WHERE k = 0 AND c > 0 ORDER BY n ASC LIMIT 10 ALLOW FILTERING",
-                          "SELECT * FROM %s WHERE k = ? AND c > ? ORDER BY n ASC LIMIT 10 ALLOW FILTERING");
 
         // test ANN index-based ORDER BY
         createTable("CREATE TABLE %s (k int, c int, n int, v vector<float, 2>, PRIMARY KEY (k, c))");
@@ -183,10 +123,6 @@ public class PartitionRangeReadCommandCQLTest extends ReadCommandCQLTester<Parti
         assertToCQLString("SELECT * FROM %s ORDER BY v ANN OF [1, 2] LIMIT 10",
                           "SELECT * FROM %s ORDER BY v ANN OF [1.0, ... LIMIT 10 ALLOW FILTERING",
                           "SELECT * FROM %s ORDER BY v ANN OF ? LIMIT 10 ALLOW FILTERING",
-                          truncationError);
-        assertToCQLString("SELECT * FROM %s WHERE k = 0 ORDER BY v ANN OF [1, 2] LIMIT 10",
-                          "SELECT * FROM %s WHERE k = 0 ORDER BY v ANN OF [1.0, ... LIMIT 10 ALLOW FILTERING",
-                          "SELECT * FROM %s WHERE k = ? ORDER BY v ANN OF ? LIMIT 10 ALLOW FILTERING",
                           truncationError);
         assertToCQLString("SELECT * FROM %s WHERE n = 0 ORDER BY v ANN OF [1, 2] LIMIT 10",
                           "SELECT * FROM %s WHERE n = 0 ORDER BY v ANN OF [1.0, ... LIMIT 10 ALLOW FILTERING",
@@ -287,11 +223,11 @@ public class PartitionRangeReadCommandCQLTest extends ReadCommandCQLTester<Parti
     }
 
     @Override
-    protected PartitionRangeReadCommand parseCommand(String query)
+    protected List<PartitionRangeReadCommand> parseCommands(String query)
     {
         ReadCommand command = parseReadCommand(query);
         Assertions.assertThat(command).isInstanceOf(PartitionRangeReadCommand.class);
-        return (PartitionRangeReadCommand) command;
+        return Collections.singletonList((PartitionRangeReadCommand) command);
     }
 
     public static class IndexWithLikeSupport extends StubIndex

--- a/test/unit/org/apache/cassandra/db/ReadCommandCQLTester.java
+++ b/test/unit/org/apache/cassandra/db/ReadCommandCQLTester.java
@@ -15,18 +15,19 @@
  */
 package org.apache.cassandra.db;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 
 import org.apache.cassandra.cql3.CQLTester;
-import org.apache.cassandra.db.marshal.Redaction;
 import org.assertj.core.api.Assertions;
 
 public abstract class ReadCommandCQLTester<T extends ReadCommand> extends CQLTester
 {
     private static final Pattern PATTERN = Pattern.compile("%");
 
-    protected abstract T parseCommand(String query);
+    protected abstract List<T> parseCommands(String query);
 
     protected void assertToCQLString(String query, String expectedUnredactedCQL, String expectedRedactedCQL)
     {
@@ -38,19 +39,45 @@ public abstract class ReadCommandCQLTester<T extends ReadCommand> extends CQLTes
                                      String expectedRedactedCQL,
                                      @Nullable String expectedErrorMessage)
     {
-        T command = parseCommand(query);
+        assertToCQLString(query,
+                          Collections.singletonList(expectedUnredactedCQL),
+                          Collections.singletonList(expectedRedactedCQL),
+                          expectedErrorMessage);
+    }
 
-        String actualUnredactedCQL = command.toCQLString(Redaction.NONE);
-        Assertions.assertThat(actualUnredactedCQL)
-                  .isEqualTo(formatQuery(expectedUnredactedCQL));
+    protected void assertToCQLString(String query,
+                                     List<String> expectedUnredactedCQL,
+                                     List<String> expectedRedactedCQL)
+    {
+        assertToCQLString(query, expectedUnredactedCQL, expectedRedactedCQL, null);
+    }
 
-        String actualRedactedCQL = command.toCQLString(Redaction.REDACT);
-        Assertions.assertThat(actualRedactedCQL)
-                  .isEqualTo(formatQuery(expectedRedactedCQL));
+    protected void assertToCQLString(String query,
+                                     List<String> expectedUnredactedCQL,
+                                     List<String> expectedRedactedCQL,
+                                     @Nullable String expectedErrorMessage)
+    {
+        List<T> commands = parseCommands(query);
+        Assertions.assertThat(commands)
+                  .hasSameSizeAs(expectedUnredactedCQL)
+                  .hasSameSizeAs(expectedRedactedCQL);
 
-        if (expectedErrorMessage == null)
-            execute(PATTERN.matcher(actualUnredactedCQL).replaceAll("%%"));
-        else
-            Assertions.assertThatThrownBy(() -> execute(actualUnredactedCQL)).hasMessageContaining(expectedErrorMessage);
+        for (int i = 0; i < commands.size(); i++)
+        {
+            T command = commands.get(i);
+
+            String actualUnredactedCQL = command.toUnredactedCQLString();
+            Assertions.assertThat(actualUnredactedCQL)
+                      .isEqualTo(formatQuery(expectedUnredactedCQL.get(i)));
+
+            String actualRedactedCQL = command.toRedactedCQLString();
+            Assertions.assertThat(actualRedactedCQL)
+                      .isEqualTo(formatQuery(expectedRedactedCQL.get(i)));
+
+            if (expectedErrorMessage == null)
+                execute(PATTERN.matcher(actualUnredactedCQL).replaceAll("%%"));
+            else
+                Assertions.assertThatThrownBy(() -> execute(actualUnredactedCQL)).hasMessageContaining(expectedErrorMessage);
+        }
     }
 }

--- a/test/unit/org/apache/cassandra/db/SinglePartitionReadCommandCQLTest.java
+++ b/test/unit/org/apache/cassandra/db/SinglePartitionReadCommandCQLTest.java
@@ -18,10 +18,13 @@
 
 package org.apache.cassandra.db;
 
+import java.util.List;
+
 import org.junit.Test;
 
 import org.apache.cassandra.cql3.UntypedResultSet;
 
+import static java.util.Arrays.asList;
 import static org.junit.Assert.assertTrue;
 
 public class SinglePartitionReadCommandCQLTest extends ReadCommandCQLTester<SinglePartitionReadCommand>
@@ -59,6 +62,59 @@ public class SinglePartitionReadCommandCQLTest extends ReadCommandCQLTester<Sing
         assertToCQLString("SELECT * FROM %s WHERE k = 0 AND c < 0 AND v = 1 ALLOW FILTERING", "SELECT * FROM %s WHERE k = 0 AND c < 0 AND v = 1 ALLOW FILTERING", "SELECT * FROM %s WHERE k = ? AND c < ? AND v = ? ALLOW FILTERING");
         assertToCQLString("SELECT * FROM %s WHERE k = 0 AND c >= 0 AND v = 1 ALLOW FILTERING", "SELECT * FROM %s WHERE k = 0 AND c >= 0 AND v = 1 ALLOW FILTERING", "SELECT * FROM %s WHERE k = ? AND c >= ? AND v = ? ALLOW FILTERING");
         assertToCQLString("SELECT * FROM %s WHERE k = 0 AND c <= 0 AND v = 1 ALLOW FILTERING", "SELECT * FROM %s WHERE k = 0 AND c <= 0 AND v = 1 ALLOW FILTERING", "SELECT * FROM %s WHERE k = ? AND c <= ? AND v = ? ALLOW FILTERING");
+
+        // test with IN restriction on partition key
+        assertToCQLString("SELECT * FROM %s WHERE k IN (0) ALLOW FILTERING",
+                          "SELECT * FROM %s WHERE k = 0 ALLOW FILTERING",
+                          "SELECT * FROM %s WHERE k = ? ALLOW FILTERING");
+        assertToCQLString("SELECT * FROM %s WHERE k IN (0, 1) ALLOW FILTERING",
+                          asList("SELECT * FROM %s WHERE k = 0 ALLOW FILTERING",
+                                 "SELECT * FROM %s WHERE k = 1 ALLOW FILTERING"),
+                          asList("SELECT * FROM %s WHERE k = ? ALLOW FILTERING",
+                                 "SELECT * FROM %s WHERE k = ? ALLOW FILTERING"));
+        assertToCQLString("SELECT * FROM %s WHERE k IN (0, 1) AND v = 1 ALLOW FILTERING",
+                          asList("SELECT * FROM %s WHERE k = 0 AND v = 1 ALLOW FILTERING",
+                                 "SELECT * FROM %s WHERE k = 1 AND v = 1 ALLOW FILTERING"),
+                          asList("SELECT * FROM %s WHERE k = ? AND v = ? ALLOW FILTERING",
+                                 "SELECT * FROM %s WHERE k = ? AND v = ? ALLOW FILTERING"));
+        assertToCQLString("SELECT * FROM %s WHERE k IN (0, 1) AND c = 1 ALLOW FILTERING",
+                          asList("SELECT * FROM %s WHERE k = 0 AND c = 1 ALLOW FILTERING",
+                                 "SELECT * FROM %s WHERE k = 1 AND c = 1 ALLOW FILTERING"),
+                          asList("SELECT * FROM %s WHERE k = ? AND c = ? ALLOW FILTERING",
+                                 "SELECT * FROM %s WHERE k = ? AND c = ? ALLOW FILTERING"));
+
+        // test with a secondary index
+        createIndex("CREATE INDEX ON %s(v)");
+        assertToCQLString("SELECT * FROM %s WHERE k = 0 AND  v = 0",
+                          "SELECT * FROM %s WHERE k = 0 AND v = 0 ALLOW FILTERING",
+                          "SELECT * FROM %s WHERE k = ? AND v = ? ALLOW FILTERING");
+        assertToCQLString("SELECT * FROM %s WHERE k = 0 AND c = 0 AND v = 0 ",
+                          "SELECT * FROM %s WHERE k = 0 AND c = 0 AND v = 0 ALLOW FILTERING",
+                          "SELECT * FROM %s WHERE k = ? AND c = ? AND v = ? ALLOW FILTERING");
+        assertToCQLString("SELECT * FROM %s WHERE k = 0 AND c > 0 AND v = 0 ",
+                          "SELECT * FROM %s WHERE k = 0 AND c > 0 AND v = 0 ALLOW FILTERING",
+                          "SELECT * FROM %s WHERE k = ? AND c > ? AND v = ? ALLOW FILTERING");
+        assertToCQLString("SELECT * FROM %s WHERE k = 0 AND c < 0 AND v = 0 ",
+                          "SELECT * FROM %s WHERE k = 0 AND c < 0 AND v = 0 ALLOW FILTERING",
+                          "SELECT * FROM %s WHERE k = ? AND c < ? AND v = ? ALLOW FILTERING");
+        assertToCQLString("SELECT * FROM %s WHERE k = 0 AND c >= 0 AND v = 0 ",
+                          "SELECT * FROM %s WHERE k = 0 AND c >= 0 AND v = 0 ALLOW FILTERING",
+                          "SELECT * FROM %s WHERE k = ? AND c >= ? AND v = ? ALLOW FILTERING");
+        assertToCQLString("SELECT * FROM %s WHERE k = 0 AND c <= 0 AND v = 0",
+                          "SELECT * FROM %s WHERE k = 0 AND c <= 0 AND v = 0 ALLOW FILTERING",
+                          "SELECT * FROM %s WHERE k = ? AND c <= ? AND v = ? ALLOW FILTERING");
+        assertToCQLString("SELECT * FROM %s WHERE k = 0 AND c IN (0) AND v = 0",
+                          "SELECT * FROM %s WHERE k = 0 AND c = 0 AND v = 0 ALLOW FILTERING",
+                          "SELECT * FROM %s WHERE k = ? AND c = ? AND v = ? ALLOW FILTERING");
+        assertToCQLString("SELECT * FROM %s WHERE k = 0 AND c IN (0, 1) AND v = 0",
+                          "SELECT * FROM %s WHERE k = 0 AND c IN (0, 1) AND v = 0 ALLOW FILTERING",
+                          "SELECT * FROM %s WHERE k = ? AND c IN (?, ?) AND v = ? ALLOW FILTERING");
+        assertToCQLString("SELECT * FROM %s WHERE k = 0 AND v = 0",
+                          "SELECT * FROM %s WHERE k = 0 AND v = 0 ALLOW FILTERING",
+                          "SELECT * FROM %s WHERE k = ? AND v = ? ALLOW FILTERING");
+        assertToCQLString("SELECT * FROM %s WHERE k = 0 AND c = 0 AND v = 0 ",
+                          "SELECT * FROM %s WHERE k = 0 AND c = 0 AND v = 0 ALLOW FILTERING",
+                          "SELECT * FROM %s WHERE k = ? AND c = ? AND v = ? ALLOW FILTERING");
 
         // test clustering-based ORDER BY
         createTable("CREATE TABLE %s (k int, c1 int, c2 int, PRIMARY KEY (k, c1, c2))");
@@ -101,6 +157,66 @@ public class SinglePartitionReadCommandCQLTest extends ReadCommandCQLTester<Sing
         assertToCQLString("SELECT * FROM %s WHERE k1 = 1 AND k2 = 2 AND c = 3",
                           "SELECT * FROM %s WHERE k1 = 1 AND k2 = 2 AND c = 3 ALLOW FILTERING",
                           "SELECT * FROM %s WHERE k1 = ? AND k2 = ? AND c = ? ALLOW FILTERING");
+
+        // test with multi-column partition key and index
+        createIndex("CREATE INDEX ON %s(v)");
+        assertToCQLString("SELECT * FROM %s WHERE k1 = 1 AND k2 = 2 AND v = 1",
+                          "SELECT * FROM %s WHERE k1 = 1 AND k2 = 2 AND v = 1 ALLOW FILTERING",
+                          "SELECT * FROM %s WHERE k1 = ? AND k2 = ? AND v = ? ALLOW FILTERING");
+        assertToCQLString("SELECT * FROM %s WHERE k1 = 1 AND k2 = 2 AND c = 3 AND v = 1",
+                          "SELECT * FROM %s WHERE k1 = 1 AND k2 = 2 AND c = 3 AND v = 1 ALLOW FILTERING",
+                          "SELECT * FROM %s WHERE k1 = ? AND k2 = ? AND c = ? AND v = ? ALLOW FILTERING");
+
+        // test generic index-based ORDER BY
+        createTable("CREATE TABLE %s (k int, c int, n int, PRIMARY KEY (k, c))");
+        createIndex("CREATE CUSTOM INDEX ON %s(n) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX ON %s(c) USING 'StorageAttachedIndex'");
+        assertToCQLString("SELECT * FROM %s WHERE k = 0 ORDER BY n LIMIT 10",
+                          "SELECT * FROM %s WHERE k = 0 ORDER BY n ASC LIMIT 10 ALLOW FILTERING",
+                          "SELECT * FROM %s WHERE k = ? ORDER BY n ASC LIMIT 10 ALLOW FILTERING");
+        assertToCQLString("SELECT * FROM %s WHERE k = 0 AND c = 0 ORDER BY n LIMIT 10",
+                          "SELECT * FROM %s WHERE k = 0 AND c = 0 ORDER BY n ASC LIMIT 10 ALLOW FILTERING",
+                          "SELECT * FROM %s WHERE k = ? AND c = ? ORDER BY n ASC LIMIT 10 ALLOW FILTERING");
+        assertToCQLString("SELECT * FROM %s WHERE k = 0 AND c IN (0, 1) ORDER BY n LIMIT 10",
+                          "SELECT * FROM %s WHERE k = 0 AND c IN (0, 1) ORDER BY n ASC LIMIT 10 ALLOW FILTERING",
+                          "SELECT * FROM %s WHERE k = ? AND c IN (?, ?) ORDER BY n ASC LIMIT 10 ALLOW FILTERING");
+
+        // test with index and multi-column clustering
+        createTable("CREATE TABLE %s (k int, c1 int, c2 int,v int, PRIMARY KEY (k, c1, c2))");
+        createIndex("CREATE INDEX ON %s(v)");
+        assertToCQLString("SELECT * FROM %s WHERE k = 0 AND v = 0",
+                          "SELECT * FROM %s WHERE k = 0 AND v = 0 ALLOW FILTERING",
+                          "SELECT * FROM %s WHERE k = ? AND v = ? ALLOW FILTERING");
+        assertToCQLString("SELECT * FROM %s WHERE k = 0 AND c1 = 1 AND v = 0",
+                          "SELECT * FROM %s WHERE k = 0 AND c1 = 1 AND v = 0 ALLOW FILTERING",
+                          "SELECT * FROM %s WHERE k = ? AND c1 = ? AND v = ? ALLOW FILTERING");
+        assertToCQLString("SELECT * FROM %s WHERE k = 0 AND c1 > 1 AND v = 0",
+                          "SELECT * FROM %s WHERE k = 0 AND c1 > 1 AND v = 0 ALLOW FILTERING",
+                          "SELECT * FROM %s WHERE k = ? AND c1 > ? AND v = ? ALLOW FILTERING");
+        assertToCQLString("SELECT * FROM %s WHERE k = 0 AND c1 < 1 AND v = 0",
+                          "SELECT * FROM %s WHERE k = 0 AND c1 < 1 AND v = 0 ALLOW FILTERING",
+                          "SELECT * FROM %s WHERE k = ? AND c1 < ? AND v = ? ALLOW FILTERING");
+        assertToCQLString("SELECT * FROM %s WHERE k = 0 AND c1 >= 1 AND v = 0",
+                          "SELECT * FROM %s WHERE k = 0 AND c1 >= 1 AND v = 0 ALLOW FILTERING",
+                          "SELECT * FROM %s WHERE k = ? AND c1 >= ? AND v = ? ALLOW FILTERING");
+        assertToCQLString("SELECT * FROM %s WHERE k = 0 AND c1 <= 1 AND v = 0",
+                          "SELECT * FROM %s WHERE k = 0 AND c1 <= 1 AND v = 0 ALLOW FILTERING",
+                          "SELECT * FROM %s WHERE k = ? AND c1 <= ? AND v = ? ALLOW FILTERING");
+        assertToCQLString("SELECT * FROM %s WHERE k = 0 AND c1 = 1 AND c2 = 2 AND v = 0",
+                          "SELECT * FROM %s WHERE k = 0 AND (c1, c2) = (1, 2) AND v = 0 ALLOW FILTERING",
+                          "SELECT * FROM %s WHERE k = ? AND (c1, c2) = (?, ?) AND v = ? ALLOW FILTERING");
+        assertToCQLString("SELECT * FROM %s WHERE k = 0 AND c1 = 1 AND c2 > 2 AND v = 0",
+                          "SELECT * FROM %s WHERE k = 0 AND c1 = 1 AND c2 > 2 AND v = 0 ALLOW FILTERING",
+                          "SELECT * FROM %s WHERE k = ? AND c1 = ? AND c2 > ? AND v = ? ALLOW FILTERING");
+        assertToCQLString("SELECT * FROM %s WHERE k = 0 AND c1 = 1 AND c2 < 2 AND v = 0",
+                          "SELECT * FROM %s WHERE k = 0 AND c1 = 1 AND c2 < 2 AND v = 0 ALLOW FILTERING",
+                          "SELECT * FROM %s WHERE k = ? AND c1 = ? AND c2 < ? AND v = ? ALLOW FILTERING");
+        assertToCQLString("SELECT * FROM %s WHERE k = 0 AND c1 = 1 AND c2 >= 2 AND v = 0",
+                          "SELECT * FROM %s WHERE k = 0 AND c1 = 1 AND c2 >= 2 AND v = 0 ALLOW FILTERING",
+                          "SELECT * FROM %s WHERE k = ? AND c1 = ? AND c2 >= ? AND v = ? ALLOW FILTERING");
+        assertToCQLString("SELECT * FROM %s WHERE k = 0 AND c1 = 1 AND c2 <= 2 AND v = 0",
+                          "SELECT * FROM %s WHERE k = 0 AND c1 = 1 AND c2 <= 2 AND v = 0 ALLOW FILTERING",
+                          "SELECT * FROM %s WHERE k = ? AND c1 = ? AND c2 <= ? AND v = ? ALLOW FILTERING");
 
         // test literals
         createTable("CREATE TABLE %s (k text, c text, m map<text, text>, PRIMARY KEY (k, c))");
@@ -156,8 +272,8 @@ public class SinglePartitionReadCommandCQLTest extends ReadCommandCQLTester<Sing
     }
 
     @Override
-    protected SinglePartitionReadCommand parseCommand(String query)
+    protected List<SinglePartitionReadCommand> parseCommands(String query)
     {
-        return parseReadCommandGroup(query).get(0);
+        return parseReadCommandGroup(query).queries;
     }
 }

--- a/test/unit/org/apache/cassandra/index/StubIndex.java
+++ b/test/unit/org/apache/cassandra/index/StubIndex.java
@@ -241,7 +241,7 @@ public class StubIndex implements Index
         @Override
         public UnfilteredPartitionIterator search(ReadExecutionController executionController)
         {
-            return Util.executeLocally((PartitionRangeReadCommand)command, baseCfs, executionController);
+            return Util.executeLocally(command, baseCfs, executionController);
         }
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/QueryContextTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/QueryContextTest.java
@@ -25,7 +25,7 @@ import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;
 
-import org.apache.cassandra.db.PartitionRangeReadCommand;
+import org.apache.cassandra.db.ReadCommand;
 import org.apache.cassandra.db.ReadExecutionController;
 import org.apache.cassandra.db.partitions.UnfilteredPartitionIterator;
 import org.apache.cassandra.db.rows.UnfilteredRowIterator;
@@ -1076,7 +1076,7 @@ public class QueryContextTest extends SAITester.Versioned
         assertRowsIgnoringOrder(execute(query), rows);
 
         // Get an index searcher for the query
-        PartitionRangeReadCommand command = (PartitionRangeReadCommand) parseReadCommand(query);
+        ReadCommand command = parseReadCommand(query);
         StorageAttachedIndexQueryPlan plan = (StorageAttachedIndexQueryPlan) command.indexQueryPlan();
         Assert.assertNotNull(plan);
         StorageAttachedIndexSearcher searcher = plan.searcherFor(command);

--- a/test/unit/org/apache/cassandra/index/sai/cql/GenericOrderByTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/GenericOrderByTest.java
@@ -257,4 +257,35 @@ public class GenericOrderByTest extends SAITester
                 .isInstanceOf(InvalidRequestException.class)
                 .hasMessage(SelectStatement.TOPK_AGGREGATION_ERROR);
     }
+
+    @Test
+    public void testWidePartitionWithPkPredicate() throws Throwable
+    {
+        createTable("CREATE TABLE %s (k int, c int, v int, PRIMARY KEY (k, c))");
+        createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
+
+        // write two partitions, one with increasing values and the other with decreasing values
+        execute("INSERT INTO %s (k, c, v) VALUES (0, 1, 3)");
+        execute("INSERT INTO %s (k, c, v) VALUES (0, 2, 2)");
+        execute("INSERT INTO %s (k, c, v) VALUES (0, 3, 1)");
+        execute("INSERT INTO %s (k, c, v) VALUES (1, 1, 1)");
+        execute("INSERT INTO %s (k, c, v) VALUES (1, 2, 2)");
+        execute("INSERT INTO %s (k, c, v) VALUES (1, 3, 3)");
+
+        String query = "SELECT c FROM %s WHERE k = ? ORDER BY v LIMIT ?";
+        beforeAndAfterFlush(() ->
+        {
+            // query first partition with different limits
+            assertRows(execute(query, 0, 100), row(3), row(2), row(1));
+            assertRows(execute(query, 0, 3), row(3), row(2), row(1));
+            assertRows(execute(query, 0, 2), row(3), row(2));
+            assertRows(execute(query, 0, 1), row(3));
+
+            // query second partition with different limits
+            assertRows(execute(query, 1, 100), row(1), row(2), row(3));
+            assertRows(execute(query, 1, 3), row(1), row(2), row(3));
+            assertRows(execute(query, 1, 2), row(1), row(2));
+            assertRows(execute(query, 1, 1), row(1));
+        });
+    }
 }


### PR DESCRIPTION
https://github.com/riptano/cndb/issues/17862

```
    Port of CASSANDRA-19968

    Stop transforming single-partition queries using secondary indexes into range commands,
    but use SinglePartitionReadCommand instead, as in not-indexed queries.

    Benefits of single-partition commands are:
    * They use speculative retries, which aren't supported for range queries.
    * They use digest reads, which are benficial for network usage and throughput.
    * Metrics and observability are able to distinguish between single-partition and cluster-wide SAI queries.

forward merges https://github.com/datastax/cassandra/commit/c628d7be0f11e09be981c9f4e46899c636f6df8c
```