### PR TITLE
CNDB-16394: Add tests for SAI that use a larger amount of random data

### DIFF
--- a/src/java/org/apache/cassandra/utils/RandomPlus.java
+++ b/src/java/org/apache/cassandra/utils/RandomPlus.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.utils;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Random;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * Extension of {@link Random} with additional utility methods for generating random values
+ * within specified ranges for various numeric types.
+ */
+public class RandomPlus extends Random
+{
+    public RandomPlus()
+    {
+        super();
+    }
+
+    public RandomPlus(long seed)
+    {
+        super(seed);
+    }
+
+    public int nextInt(int min, int max)
+    {
+        return (int) nextDouble(min, max);
+    }
+
+    public long nextLong(long min, long max)
+    {
+        return (long) nextDouble(min, max);
+    }
+
+    public byte[] nextBytes(int minLength, int maxLength)
+    {
+        int length = nextInt(minLength, maxLength);
+        byte[] bytes = new byte[length];
+        nextBytes(bytes);
+        return bytes;
+    }
+
+    public double nextDouble(double min, double max)
+    {
+        Preconditions.checkArgument(min < max, "max must be greater than min");
+        return min + (max - min) * nextDouble();
+    }
+
+    public float nextFloat(float min, float max)
+    {
+        Preconditions.checkArgument(min < max, "max must be greater than min");
+        return min + (max - min) * nextFloat();
+    }
+
+    public BigInteger nextBigInteger(BigInteger min, BigInteger max)
+    {
+        Preconditions.checkArgument(min.compareTo(max) < 0, "max must be greater than min");
+        BigInteger range = max.subtract(min);
+        int len = range.bitLength();
+        BigInteger res;
+        do
+        {
+            res = new BigInteger(len, this).add(min);
+        }
+        while (res.compareTo(max) >= 0);
+        return res;
+    }
+
+    public BigDecimal nextBigDecimal(BigDecimal min, BigDecimal max)
+    {
+        return BigDecimal.valueOf(nextDouble(min.doubleValue(), max.doubleValue()));
+    }
+
+    public String nextAlphanumeric(int length)
+    {
+        return ints(48, 123)
+               .filter(i -> (i <= 57 || i >= 65) && (i <= 90 || i >= 97))
+               .limit(length)
+               .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+               .toString();
+    }
+}

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/datamodels/MultiNodeQueryTester.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/datamodels/MultiNodeQueryTester.java
@@ -73,9 +73,8 @@ abstract class MultiNodeQueryTester extends TestBaseImpl
         cluster = Cluster.build(3)
                          .withConfig(config -> config.with(NETWORK, GOSSIP)
                                                      .set("hinted_handoff_enabled", false))
-                         .withInstanceInitializer((cl, nodeNumber) -> {
-                             Byteman.createFromText(INJECTION_SCRIPT).install(cl);
-                         })
+                         .withInstanceInitializer((cl, nodeNumber) ->
+                                                  Byteman.createFromText(INJECTION_SCRIPT).install(cl))
                          .start();
 
         cluster.schemaChange("CREATE KEYSPACE " + DataModel.KEYSPACE + " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 2}");

--- a/test/long/org/apache/cassandra/distributed/test/sai/datamodels/LongMultiNodeQueryTester.java
+++ b/test/long/org/apache/cassandra/distributed/test/sai/datamodels/LongMultiNodeQueryTester.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test.sai.datamodels;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.function.Supplier;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.runners.Parameterized;
+
+import org.apache.cassandra.index.sai.cql.datamodels.DataModel;
+import org.apache.cassandra.index.sai.cql.datamodels.IndexQuerySupport;
+
+/**
+ * Long-running variant of {@link MultiNodeQueryTester} that uses larger and random datasets
+ * to test SAI with more realistic data volumes.
+ */
+abstract class LongMultiNodeQueryTester extends MultiNodeQueryTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params() throws Throwable
+    {
+        List<Object[]> scenarios = new LinkedList<>();
+
+        scenarios.add(new Object[]{ "BaseDataModel",
+                                    (Supplier<DataModel>) () -> new DataModel.BaseDataModel(DataModel.NORMAL_COLUMNS, DataModel.NORMAL_COLUMN_DATA_LARGE),
+                                    IndexQuerySupport.BASE_QUERY_SETS });
+
+        scenarios.add(new Object[]{ "CompoundKeyDataModel",
+                                    (Supplier<DataModel>) () -> new DataModel.CompoundKeyDataModel(DataModel.NORMAL_COLUMNS, DataModel.NORMAL_COLUMN_DATA_LARGE),
+                                    IndexQuerySupport.BASE_QUERY_SETS });
+
+        scenarios.add(new Object[]{ "CompoundKeyWithStaticsDataModel",
+                                    (Supplier<DataModel>) () -> new DataModel.CompoundKeyWithStaticsDataModel(DataModel.STATIC_COLUMNS, DataModel.STATIC_COLUMN_DATA_LARGE),
+                                    IndexQuerySupport.STATIC_QUERY_SETS });
+
+        scenarios.add(new Object[]{ "CompositePartitionKeyDataModel",
+                                    (Supplier<DataModel>) () -> new DataModel.CompositePartitionKeyDataModel(DataModel.NORMAL_COLUMNS, DataModel.NORMAL_COLUMN_DATA_LARGE),
+                                    ImmutableList.builder().addAll(IndexQuerySupport.BASE_QUERY_SETS).addAll(IndexQuerySupport.COMPOSITE_PARTITION_QUERY_SETS).build() });
+
+        return scenarios;
+    }
+}

--- a/test/long/org/apache/cassandra/distributed/test/sai/datamodels/LongQueryCellDeletionsTest.java
+++ b/test/long/org/apache/cassandra/distributed/test/sai/datamodels/LongQueryCellDeletionsTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test.sai.datamodels;
+
+import org.junit.Test;
+
+import org.apache.cassandra.index.sai.cql.datamodels.IndexQuerySupport;
+
+public class LongQueryCellDeletionsTest extends LongMultiNodeQueryTester
+{
+    @Test
+    public void testCellDeletions() throws Throwable
+    {
+        IndexQuerySupport.cellDeletions(executor, dataModel.get(), sets);
+    }
+}

--- a/test/long/org/apache/cassandra/distributed/test/sai/datamodels/LongQueryCellDeletionsUpgradeTest.java
+++ b/test/long/org/apache/cassandra/distributed/test/sai/datamodels/LongQueryCellDeletionsUpgradeTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test.sai.datamodels;
+
+import org.junit.Test;
+
+import org.apache.cassandra.index.sai.cql.datamodels.IndexQuerySupport;
+
+public class LongQueryCellDeletionsUpgradeTest extends LongMultiNodeQueryTester
+{
+    @Test
+    public void testCellDeletionsAfterUpgrade() throws Throwable
+    {
+        IndexQuerySupport.cellDeletionsAfterUpgrade(executor, dataModel.get(), sets);
+    }
+}

--- a/test/long/org/apache/cassandra/distributed/test/sai/datamodels/LongQueryRowDeletionsTest.java
+++ b/test/long/org/apache/cassandra/distributed/test/sai/datamodels/LongQueryRowDeletionsTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test.sai.datamodels;
+
+import org.junit.Test;
+
+import org.apache.cassandra.index.sai.cql.datamodels.IndexQuerySupport;
+
+public class LongQueryRowDeletionsTest extends LongMultiNodeQueryTester
+{
+    @Test
+    public void testRowDeletions() throws Throwable
+    {
+        IndexQuerySupport.rowDeletions(executor, dataModel.get(), sets);
+    }
+}

--- a/test/long/org/apache/cassandra/distributed/test/sai/datamodels/LongQueryRowDeletionsUpgradeTest.java
+++ b/test/long/org/apache/cassandra/distributed/test/sai/datamodels/LongQueryRowDeletionsUpgradeTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test.sai.datamodels;
+
+import org.junit.Test;
+
+import org.apache.cassandra.index.sai.cql.datamodels.IndexQuerySupport;
+
+public class LongQueryRowDeletionsUpgradeTest extends LongMultiNodeQueryTester
+{
+    @Test
+    public void testRowDeletionsAfterUpgrade() throws Throwable
+    {
+        IndexQuerySupport.rowDeletionsAfterUpgrade(executor, dataModel.get(), sets);
+    }
+}

--- a/test/long/org/apache/cassandra/distributed/test/sai/datamodels/LongQueryTimeToLiveTest.java
+++ b/test/long/org/apache/cassandra/distributed/test/sai/datamodels/LongQueryTimeToLiveTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test.sai.datamodels;
+
+import org.junit.Test;
+
+import org.apache.cassandra.index.sai.cql.datamodels.IndexQuerySupport;
+
+public class LongQueryTimeToLiveTest extends LongMultiNodeQueryTester
+{
+    @Test
+    public void testTimeToLive() throws Throwable
+    {
+        IndexQuerySupport.timeToLive(executor, dataModel.get(), sets);
+    }
+}

--- a/test/long/org/apache/cassandra/distributed/test/sai/datamodels/LongQueryTimeToLiveUpgradeTest.java
+++ b/test/long/org/apache/cassandra/distributed/test/sai/datamodels/LongQueryTimeToLiveUpgradeTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test.sai.datamodels;
+
+import org.junit.Test;
+
+import org.apache.cassandra.index.sai.cql.datamodels.IndexQuerySupport;
+
+public class LongQueryTimeToLiveUpgradeTest extends LongMultiNodeQueryTester
+{
+    @Test
+    public void testTimeToLiveAfterUpgrade() throws Throwable
+    {
+        IndexQuerySupport.timeToLiveAfterUpgrade(executor, dataModel.get(), sets);
+    }
+}

--- a/test/long/org/apache/cassandra/distributed/test/sai/datamodels/LongQueryWriteLifecycleTest.java
+++ b/test/long/org/apache/cassandra/distributed/test/sai/datamodels/LongQueryWriteLifecycleTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test.sai.datamodels;
+
+import org.junit.Test;
+
+import org.apache.cassandra.index.sai.cql.datamodels.IndexQuerySupport;
+
+public class LongQueryWriteLifecycleTest extends LongMultiNodeQueryTester
+{
+    @Test
+    public void testWriteLifecycle() throws Throwable
+    {
+        IndexQuerySupport.writeLifecycle(executor, dataModel.get(), sets);
+    }
+}

--- a/test/long/org/apache/cassandra/distributed/test/sai/datamodels/LongQueryWriteLifecycleUpgradeTest.java
+++ b/test/long/org/apache/cassandra/distributed/test/sai/datamodels/LongQueryWriteLifecycleUpgradeTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test.sai.datamodels;
+
+import org.junit.Test;
+
+import org.apache.cassandra.index.sai.cql.datamodels.IndexQuerySupport;
+
+public class LongQueryWriteLifecycleUpgradeTest extends LongMultiNodeQueryTester
+{
+    @Test
+    public void testWriteLifecycleAfterUpgrade() throws Throwable
+    {
+        IndexQuerySupport.writeLifecycleAfterUpgrade(executor, dataModel.get(), sets);
+    }
+}

--- a/test/long/org/apache/cassandra/index/sai/cql/datamodels/LongQueryCellDeletionsWithBaseDataModelTest.java
+++ b/test/long/org/apache/cassandra/index/sai/cql/datamodels/LongQueryCellDeletionsWithBaseDataModelTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class LongQueryCellDeletionsWithBaseDataModelTest extends QueryCellDeletionsTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(SingleNodeQueryTester::baseDataModelParamsLarge);
+    }
+}

--- a/test/long/org/apache/cassandra/index/sai/cql/datamodels/LongQueryCellDeletionsWithBaseDataModelUpgradeTest.java
+++ b/test/long/org/apache/cassandra/index/sai/cql/datamodels/LongQueryCellDeletionsWithBaseDataModelUpgradeTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class LongQueryCellDeletionsWithBaseDataModelUpgradeTest extends QueryCellDeletionsUpgradeTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(SingleNodeQueryTester::baseDataModelParamsLarge);
+    }
+}

--- a/test/long/org/apache/cassandra/index/sai/cql/datamodels/LongQueryCellDeletionsWithCompositePartitionKeyTest.java
+++ b/test/long/org/apache/cassandra/index/sai/cql/datamodels/LongQueryCellDeletionsWithCompositePartitionKeyTest.java
@@ -1,0 +1,31 @@
+
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class LongQueryCellDeletionsWithCompositePartitionKeyTest extends QueryCellDeletionsTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(SingleNodeQueryTester::compositePartitionKeyParamsLarge);
+    }
+}
+

--- a/test/long/org/apache/cassandra/index/sai/cql/datamodels/LongQueryCellDeletionsWithCompoundKeyTest.java
+++ b/test/long/org/apache/cassandra/index/sai/cql/datamodels/LongQueryCellDeletionsWithCompoundKeyTest.java
@@ -1,0 +1,31 @@
+
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class LongQueryCellDeletionsWithCompoundKeyTest extends QueryCellDeletionsTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(SingleNodeQueryTester::compoundKeyParamsLarge);
+    }
+}
+

--- a/test/long/org/apache/cassandra/index/sai/cql/datamodels/LongQueryCellDeletionsWithCompoundKeyWithStaticsTest.java
+++ b/test/long/org/apache/cassandra/index/sai/cql/datamodels/LongQueryCellDeletionsWithCompoundKeyWithStaticsTest.java
@@ -1,0 +1,31 @@
+
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class LongQueryCellDeletionsWithCompoundKeyWithStaticsTest extends QueryCellDeletionsTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(SingleNodeQueryTester::compoundKeyWithStaticsParamsLarge);
+    }
+}
+

--- a/test/long/org/apache/cassandra/index/sai/cql/datamodels/LongQueryRowDeletionsWithBaseModelTest.java
+++ b/test/long/org/apache/cassandra/index/sai/cql/datamodels/LongQueryRowDeletionsWithBaseModelTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class LongQueryRowDeletionsWithBaseModelTest extends QueryRowDeletionsTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(SingleNodeQueryTester::baseDataModelParamsLarge);
+    }
+}

--- a/test/long/org/apache/cassandra/index/sai/cql/datamodels/LongQueryRowDeletionsWithBaseModelUpgradeTest.java
+++ b/test/long/org/apache/cassandra/index/sai/cql/datamodels/LongQueryRowDeletionsWithBaseModelUpgradeTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class LongQueryRowDeletionsWithBaseModelUpgradeTest extends QueryRowDeletionsUpgradeTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(SingleNodeQueryTester::baseDataModelParamsLarge);
+    }
+}

--- a/test/long/org/apache/cassandra/index/sai/cql/datamodels/LongQueryRowDeletionsWithCompositePartitionKeyTest.java
+++ b/test/long/org/apache/cassandra/index/sai/cql/datamodels/LongQueryRowDeletionsWithCompositePartitionKeyTest.java
@@ -1,0 +1,31 @@
+
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class LongQueryRowDeletionsWithCompositePartitionKeyTest extends QueryRowDeletionsTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(SingleNodeQueryTester::compositePartitionKeyParamsLarge);
+    }
+}
+

--- a/test/long/org/apache/cassandra/index/sai/cql/datamodels/LongQueryRowDeletionsWithCompoundKeyTest.java
+++ b/test/long/org/apache/cassandra/index/sai/cql/datamodels/LongQueryRowDeletionsWithCompoundKeyTest.java
@@ -1,0 +1,31 @@
+
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class LongQueryRowDeletionsWithCompoundKeyTest extends QueryRowDeletionsTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(SingleNodeQueryTester::compoundKeyParamsLarge);
+    }
+}
+

--- a/test/long/org/apache/cassandra/index/sai/cql/datamodels/LongQueryRowDeletionsWithCompoundKeyWithStaticsTest.java
+++ b/test/long/org/apache/cassandra/index/sai/cql/datamodels/LongQueryRowDeletionsWithCompoundKeyWithStaticsTest.java
@@ -1,0 +1,31 @@
+
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class LongQueryRowDeletionsWithCompoundKeyWithStaticsTest extends QueryRowDeletionsTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(SingleNodeQueryTester::compoundKeyWithStaticsParamsLarge);
+    }
+}
+

--- a/test/long/org/apache/cassandra/index/sai/cql/datamodels/LongQueryTimeToLiveWithBaseModelTest.java
+++ b/test/long/org/apache/cassandra/index/sai/cql/datamodels/LongQueryTimeToLiveWithBaseModelTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class LongQueryTimeToLiveWithBaseModelTest extends QueryTimeToLiveTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(SingleNodeQueryTester::baseDataModelParamsLarge);
+    }
+}

--- a/test/long/org/apache/cassandra/index/sai/cql/datamodels/LongQueryTimeToLiveWithBaseModelUpgradeTest.java
+++ b/test/long/org/apache/cassandra/index/sai/cql/datamodels/LongQueryTimeToLiveWithBaseModelUpgradeTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class LongQueryTimeToLiveWithBaseModelUpgradeTest extends QueryTimeToLiveUpgradeTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(SingleNodeQueryTester::baseDataModelParamsLarge);
+    }
+}

--- a/test/long/org/apache/cassandra/index/sai/cql/datamodels/LongQueryTimeToLiveWithCompositePartitionKeyTest.java
+++ b/test/long/org/apache/cassandra/index/sai/cql/datamodels/LongQueryTimeToLiveWithCompositePartitionKeyTest.java
@@ -1,0 +1,31 @@
+
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class LongQueryTimeToLiveWithCompositePartitionKeyTest extends QueryTimeToLiveTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(SingleNodeQueryTester::compositePartitionKeyParamsLarge);
+    }
+}
+

--- a/test/long/org/apache/cassandra/index/sai/cql/datamodels/LongQueryTimeToLiveWithCompoundKeyTest.java
+++ b/test/long/org/apache/cassandra/index/sai/cql/datamodels/LongQueryTimeToLiveWithCompoundKeyTest.java
@@ -1,0 +1,31 @@
+
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class LongQueryTimeToLiveWithCompoundKeyTest extends QueryTimeToLiveTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(SingleNodeQueryTester::compoundKeyParamsLarge);
+    }
+}
+

--- a/test/long/org/apache/cassandra/index/sai/cql/datamodels/LongQueryTimeToLiveWithCompoundKeyWithStaticsTest.java
+++ b/test/long/org/apache/cassandra/index/sai/cql/datamodels/LongQueryTimeToLiveWithCompoundKeyWithStaticsTest.java
@@ -1,0 +1,31 @@
+
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class LongQueryTimeToLiveWithCompoundKeyWithStaticsTest extends QueryTimeToLiveTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(SingleNodeQueryTester::compoundKeyWithStaticsParamsLarge);
+    }
+}
+

--- a/test/long/org/apache/cassandra/index/sai/cql/datamodels/LongQueryWriteLifecycleWithBaseModelTest.java
+++ b/test/long/org/apache/cassandra/index/sai/cql/datamodels/LongQueryWriteLifecycleWithBaseModelTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class LongQueryWriteLifecycleWithBaseModelTest extends QueryWriteLifecycleTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(SingleNodeQueryTester::baseDataModelParamsLarge);
+    }
+}

--- a/test/long/org/apache/cassandra/index/sai/cql/datamodels/LongQueryWriteLifecycleWithBaseModelUpgradeTest.java
+++ b/test/long/org/apache/cassandra/index/sai/cql/datamodels/LongQueryWriteLifecycleWithBaseModelUpgradeTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class LongQueryWriteLifecycleWithBaseModelUpgradeTest extends QueryWriteLifecycleUpgradeTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(SingleNodeQueryTester::baseDataModelParamsLarge);
+    }
+}

--- a/test/long/org/apache/cassandra/index/sai/cql/datamodels/LongQueryWriteLifecycleWithCompositePartitionKeyTest.java
+++ b/test/long/org/apache/cassandra/index/sai/cql/datamodels/LongQueryWriteLifecycleWithCompositePartitionKeyTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class LongQueryWriteLifecycleWithCompositePartitionKeyTest extends QueryWriteLifecycleTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(SingleNodeQueryTester::compositePartitionKeyParamsLarge);
+    }
+}

--- a/test/long/org/apache/cassandra/index/sai/cql/datamodels/LongQueryWriteLifecycleWithCompoundKeyTest.java
+++ b/test/long/org/apache/cassandra/index/sai/cql/datamodels/LongQueryWriteLifecycleWithCompoundKeyTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class LongQueryWriteLifecycleWithCompoundKeyTest extends QueryWriteLifecycleTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(SingleNodeQueryTester::compoundKeyParamsLarge);
+    }
+}

--- a/test/long/org/apache/cassandra/index/sai/cql/datamodels/LongQueryWriteLifecycleWithCompoundKeyUpgradeTest.java
+++ b/test/long/org/apache/cassandra/index/sai/cql/datamodels/LongQueryWriteLifecycleWithCompoundKeyUpgradeTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class LongQueryWriteLifecycleWithCompoundKeyUpgradeTest extends QueryWriteLifecycleUpgradeTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(SingleNodeQueryTester::compoundKeyParamsLarge);
+    }
+}

--- a/test/long/org/apache/cassandra/index/sai/cql/datamodels/LongQueryWriteLifecycleWithCompoundKeyWithStaticsTest.java
+++ b/test/long/org/apache/cassandra/index/sai/cql/datamodels/LongQueryWriteLifecycleWithCompoundKeyWithStaticsTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class LongQueryWriteLifecycleWithCompoundKeyWithStaticsTest extends QueryWriteLifecycleTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(SingleNodeQueryTester::compoundKeyWithStaticsParamsLarge);
+    }
+}

--- a/test/long/org/apache/cassandra/index/sai/cql/datamodels/LongQueryWriteLifecycleWithCompoundKeyWithStaticsUpgradeTest.java
+++ b/test/long/org/apache/cassandra/index/sai/cql/datamodels/LongQueryWriteLifecycleWithCompoundKeyWithStaticsUpgradeTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.index.sai.cql.datamodels;
+
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+public class LongQueryWriteLifecycleWithCompoundKeyWithStaticsUpgradeTest extends QueryWriteLifecycleUpgradeTester
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static List<Object[]> params()
+    {
+        return allIndexVersionsParams(SingleNodeQueryTester::compoundKeyWithStaticsParamsLarge);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/DataModel.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/DataModel.java
@@ -32,11 +32,20 @@ import com.google.common.collect.Sets;
 
 import org.apache.cassandra.cql3.CQL3Type;
 import org.apache.cassandra.index.sai.disk.format.Version;
+import org.apache.cassandra.index.sai.utils.CqlDataGenerator;
 import org.apache.cassandra.utils.Pair;
+import org.apache.cassandra.utils.RandomPlus;
 
 public interface DataModel
 {
     static final String KEYSPACE = "sai_query_keyspace";
+
+    /**
+     * Number of rows to generate for large dataset tests. These tests use randomly generated data
+     * to provide more comprehensive coverage with realistic data volumes. The random seed is logged
+     * at the start of data generation to allow reproduction of any test failures.
+     */
+    int LARGE_DATA_SET_ROW_COUNT = 1000;
 
     String SIMPLE_SELECT_TEMPLATE = "SELECT %s FROM %%s WHERE %s %s ? LIMIT ?";
     String SIMPLE_SELECT_WITH_FILTERING_TEMPLATE = "SELECT %s FROM %%s WHERE %s %s ? LIMIT ? ALLOW FILTERING";
@@ -108,6 +117,26 @@ public interface DataModel
                     .add("'WY', 10000000000, false, '2015-06-17', 550.25,  97093.14,  2.7,  '192.146.215.91',   586107,   57,   5,       'Wyoming', '00:15:50', '2015-06-17T00:00:00', e8a3c287-78cf-46b5-b554-42562e7dcfb3, 2576612e-d17d-11e8-a8d5-f2801f1b9fd1, 2")
                     .build();
 
+    List<String> NORMAL_COLUMN_DATA_LARGE =
+        generateRows(NORMAL_COLUMNS.stream().map(p -> p.right).collect(Collectors.toList()), LARGE_DATA_SET_ROW_COUNT);
+
+    static List<String> generateRows(List<String> columnTypes, int count)
+    {
+        long seed = System.currentTimeMillis();
+        System.err.println("Generating " + count + " random rows with seed: " + seed);
+        
+        RandomPlus random = new RandomPlus(seed);
+        CqlDataGenerator.Factory factory = new CqlDataGenerator.Factory(random);
+        CqlDataGenerator.RowGenerator rowGenerator =
+            new CqlDataGenerator.RowGenerator(columnTypes.stream()
+                                                         .map(factory::forType)
+                                                         .toArray(CqlDataGenerator[]::new));
+
+        return IntStream.range(0, count)
+                        .mapToObj(i -> rowGenerator.generateRow())
+                        .collect(Collectors.toList());
+    }
+
     String STATIC_INT_COLUMN = "entered";
 
     List<Pair<String, String>> STATIC_COLUMNS =
@@ -131,6 +160,9 @@ public interface DataModel
                                                        "1845, " + NORMAL_COLUMN_DATA.get(14),
                                                        "1845, " + NORMAL_COLUMN_DATA.get(15),
                                                        "1905, " + NORMAL_COLUMN_DATA.get(16));
+
+    List<String> STATIC_COLUMN_DATA_LARGE =
+        generateRows(STATIC_COLUMNS.stream().map(p -> p.right).collect(Collectors.toList()), LARGE_DATA_SET_ROW_COUNT);
 
     static AtomicInteger seq = new AtomicInteger();
 

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/IndexQuerySupport.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/IndexQuerySupport.java
@@ -126,6 +126,8 @@ public class IndexQuerySupport
         dataModel.compact(executor);
         executeQueries(dataModel, executor, sets);
 
+        // truncate to decrease memory pressure and release open file descriptors
+        // might be needed when running multiple tests one after another in the same JVM
         dataModel.truncateTables(executor);
     }
 
@@ -174,6 +176,10 @@ public class IndexQuerySupport
         // queries after compacting to a single SSTable index of the current version
         dataModel.compact(executor);
         executeQueries(dataModel, executor, sets);
+
+        // truncate to decrease memory pressure and release open file descriptors
+        // might be needed when running multiple tests one after another in the same JVM
+        dataModel.truncateTables(executor);
     }
 
     public static void rowDeletions(DataModel.Executor executor, DataModel dataModel, List<BaseQuerySet> sets) throws Throwable 
@@ -206,6 +212,10 @@ public class IndexQuerySupport
         dataModel.truncateTables(executor);
         dataModel.insertRows(executor);
         executeQueries(dataModel, executor, sets);
+
+        // truncate to decrease memory pressure and release open file descriptors
+        // might be needed when running multiple tests one after another in the same JVM
+        dataModel.truncateTables(executor);
     }
 
     /**
@@ -257,6 +267,10 @@ public class IndexQuerySupport
         dataModel.truncateTables(executor);
         dataModel.insertRows(executor);
         executeQueries(dataModel, executor, sets);
+
+        // truncate to decrease memory pressure and release open file descriptors
+        // might be needed when running multiple tests one after another in the same JVM
+        dataModel.truncateTables(executor);
     }
 
     public static void cellDeletions(DataModel.Executor executor, DataModel dataModel, List<BaseQuerySet> sets) throws Throwable 
@@ -284,6 +298,10 @@ public class IndexQuerySupport
         // queries after compacting deletes into to a single SSTable index
         dataModel.compact(executor);
         executeQueries(dataModel, executor, sets);
+
+        // truncate to decrease memory pressure and release open file descriptors
+        // might be needed when running multiple tests one after another in the same JVM
+        dataModel.truncateTables(executor);
     }
 
     /**
@@ -325,6 +343,10 @@ public class IndexQuerySupport
         // queries after compacting to a single SSTable index of the current version
         dataModel.compact(executor);
         executeQueries(dataModel, executor, sets);
+
+        // truncate to decrease memory pressure and release open file descriptors
+        // might be needed when running multiple tests one after another in the same JVM
+        dataModel.truncateTables(executor);
     }
 
     public static void timeToLive(DataModel.Executor executor, DataModel dataModel, List<BaseQuerySet> sets) throws Throwable
@@ -349,6 +371,10 @@ public class IndexQuerySupport
         // Make sure fresh overwrites invalidate TTLs:
         dataModel.insertRows(executor);
         executeQueries(dataModel, executor, sets);
+
+        // truncate to decrease memory pressure and release open file descriptors
+        // might be needed when running multiple tests one after another in the same JVM
+        dataModel.truncateTables(executor);
     }
 
     /**
@@ -394,6 +420,10 @@ public class IndexQuerySupport
         // Make sure fresh overwrites invalidate TTLs:
         dataModel.insertRows(executor);
         executeQueries(dataModel, executor, sets);
+
+        // Truncate to decrease memory pressure and release open file descriptors.
+        // Might be needed when running multiple tests one after another in the same JVM.
+        dataModel.truncateTables(executor);
     }
 
     private static void executeQueries(DataModel dataModel, DataModel.Executor executor, List<BaseQuerySet> sets) throws Throwable

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/SingleNodeQueryTester.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/SingleNodeQueryTester.java
@@ -109,6 +109,13 @@ abstract class SingleNodeQueryTester extends SAITester
                              IndexQuerySupport.BASE_QUERY_SETS};
     }
 
+    protected static Object[] baseDataModelParamsLarge(Version version)
+    {
+        return new Object[]{ version,
+                             new DataModel.BaseDataModel(DataModel.NORMAL_COLUMNS, DataModel.NORMAL_COLUMN_DATA_LARGE),
+                             IndexQuerySupport.BASE_QUERY_SETS};
+    }
+
     protected static Object[] compoundKeyParams(Version version)
     {
         return new Object[]{ version,
@@ -116,10 +123,24 @@ abstract class SingleNodeQueryTester extends SAITester
                              IndexQuerySupport.BASE_QUERY_SETS};
     }
 
+    protected static Object[] compoundKeyParamsLarge(Version version)
+    {
+        return new Object[]{ version,
+                             new DataModel.CompoundKeyDataModel(DataModel.NORMAL_COLUMNS, DataModel.NORMAL_COLUMN_DATA_LARGE),
+                             IndexQuerySupport.BASE_QUERY_SETS};
+    }
+
     protected static Object[] compoundKeyWithStaticsParams(Version version)
     {
         return new Object[]{ version,
                              new DataModel.CompoundKeyWithStaticsDataModel(DataModel.STATIC_COLUMNS, DataModel.STATIC_COLUMN_DATA),
+                             IndexQuerySupport.STATIC_QUERY_SETS};
+    }
+
+    protected static Object[] compoundKeyWithStaticsParamsLarge(Version version)
+    {
+        return new Object[]{ version,
+                             new DataModel.CompoundKeyWithStaticsDataModel(DataModel.STATIC_COLUMNS, DataModel.STATIC_COLUMN_DATA_LARGE),
                              IndexQuerySupport.STATIC_QUERY_SETS};
     }
 
@@ -132,4 +153,15 @@ abstract class SingleNodeQueryTester extends SAITester
                                           .addAll(IndexQuerySupport.COMPOSITE_PARTITION_QUERY_SETS)
                                      .build() };
     }
+
+    protected static Object[] compositePartitionKeyParamsLarge(Version version)
+    {
+        return new Object[]{ version,
+                             new DataModel.CompositePartitionKeyDataModel(DataModel.NORMAL_COLUMNS, DataModel.NORMAL_COLUMN_DATA_LARGE),
+                             ImmutableList.<IndexQuerySupport.BaseQuerySet>builder()
+                                          .addAll(IndexQuerySupport.BASE_QUERY_SETS)
+                                          .addAll(IndexQuerySupport.COMPOSITE_PARTITION_QUERY_SETS)
+                             .build() };
+    }
+
 }

--- a/test/unit/org/apache/cassandra/index/sai/utils/CqlDataGenerator.java
+++ b/test/unit/org/apache/cassandra/index/sai/utils/CqlDataGenerator.java
@@ -1,0 +1,571 @@
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.utils;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.net.InetAddress;
+import java.util.Arrays;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.apache.cassandra.cql3.Duration;
+import org.apache.cassandra.utils.Hex;
+import org.apache.cassandra.utils.RandomPlus;
+import org.apache.cassandra.utils.TimeUUID;
+
+public interface CqlDataGenerator
+{
+    /**
+     * Generates a random value and returns it as a CQL literal string (e.g. 'abc', 123, 0xdeadbeef)
+     */
+    String generateCqlValue();
+
+    /**
+     * Factory for creating {@link CqlDataGenerator}s for different CQL types
+     */
+    class Factory
+    {
+        private final RandomPlus random;
+
+        public Factory()
+        {
+            this.random = new RandomPlus();
+        }
+
+        public Factory(RandomPlus random)
+        {
+            this.random = random;
+        }
+
+        public CqlDataGenerator ascii(int minLength, int maxLength)
+        {
+            return new AsciiGenerator(random, minLength, maxLength);
+        }
+
+        public CqlDataGenerator utf8(int minLength, int maxLength)
+        {
+            return new UTF8Generator(random, minLength, maxLength);
+        }
+
+        public CqlDataGenerator bool()
+        {
+            return new BooleanGenerator(random);
+        }
+
+        public CqlDataGenerator tinyint()
+        {
+            return new ByteGenerator(random);
+        }
+
+        public CqlDataGenerator blob(int minLength, int maxLength)
+        {
+            return new BytesGenerator(random, minLength, maxLength);
+        }
+
+        public CqlDataGenerator smallint(short min, short max)
+        {
+            return new ShortGenerator(random, min, max);
+        }
+
+        public CqlDataGenerator cint(int min, int max)
+        {
+            return new IntGenerator(random, min, max);
+        }
+
+        public CqlDataGenerator bigint(long min, long max)
+        {
+            return new LongGenerator(random, min, max);
+        }
+
+        public CqlDataGenerator varint(BigInteger min, BigInteger max)
+        {
+            return new BigIntegerGenerator(random, min, max);
+        }
+
+        public CqlDataGenerator cfloat(float min, float max)
+        {
+            return new FloatGenerator(random, min, max);
+        }
+
+        public CqlDataGenerator cdouble(double min, double max)
+        {
+            return new DoubleGenerator(random, min, max);
+        }
+
+        public CqlDataGenerator decimal(BigDecimal min, BigDecimal max)
+        {
+            return new DecimalGenerator(random, min, max);
+        }
+
+        public CqlDataGenerator inet()
+        {
+            return new InetAddressGenerator(random);
+        }
+
+        public CqlDataGenerator uuid()
+        {
+            return new UUIDGenerator(random);
+        }
+
+        public CqlDataGenerator timeuuid()
+        {
+            return new TimeUUIDGenerator(random);
+        }
+
+        public CqlDataGenerator timestamp()
+        {
+            return new TimestampGenerator(random);
+        }
+
+        public CqlDataGenerator time(long min, long max)
+        {
+            return new TimeGenerator(random, min, max);
+        }
+
+        public CqlDataGenerator date()
+        {
+            return new DateGenerator(random);
+        }
+
+        public CqlDataGenerator duration(long minSeconds, long maxSeconds)
+        {
+            return new DurationGenerator(random, minSeconds, maxSeconds);
+        }
+
+        public CqlDataGenerator forType(String cqlTypeName)
+        {
+            // The type can come with a modifier like `static` e.g. `int static`, so drop any modifiers after space.
+            String baseType = cqlTypeName.split(" ")[0];
+            switch (baseType.toLowerCase())
+            {
+                case "ascii":
+                    return ascii(5, 20);
+                case "text":
+                case "varchar":
+                    return utf8(5, 20);
+                case "boolean":
+                    return bool();
+                case "tinyint":
+                    return tinyint();
+                case "blob":
+                    return blob(16, 64);
+                case "smallint":
+                    return smallint(Short.MIN_VALUE, Short.MAX_VALUE);
+                case "int":
+                    return cint(Integer.MIN_VALUE, Integer.MAX_VALUE);
+                case "bigint":
+                    return bigint(Long.MIN_VALUE, Long.MAX_VALUE);
+                case "varint":
+                    return varint(BigInteger.valueOf(Long.MIN_VALUE), BigInteger.valueOf(Long.MAX_VALUE));
+                case "float":
+                    return cfloat(-1000.0f, 1000.0f);
+                case "double":
+                    return cdouble(-1000.0, 1000.0);
+                case "decimal":
+                    return decimal(BigDecimal.valueOf(-1000), BigDecimal.valueOf(1000));
+                case "inet":
+                    return inet();
+                case "uuid":
+                    return uuid();
+                case "timeuuid":
+                    return timeuuid();
+                case "timestamp":
+                    return timestamp();
+                case "time":
+                    return time(0, 24 * Duration.NANOS_PER_HOUR);
+                case "date":
+                    return date();
+                case "duration":
+                    return duration(0, 1000);
+                default:
+                    throw new IllegalArgumentException("Unsupported type: " + cqlTypeName);
+            }
+        }
+    }
+
+    abstract class AbstractCqlDataGenerator implements CqlDataGenerator
+    {
+        final RandomPlus random;
+
+        public AbstractCqlDataGenerator(RandomPlus random)
+        {
+            this.random = random;
+        }
+    }
+
+    class AsciiGenerator extends AbstractCqlDataGenerator
+    {
+        private final int minLength;
+        private final int maxLength;
+
+        public AsciiGenerator(RandomPlus random, int minLength, int maxLength)
+        {
+            super(random);
+            this.minLength = minLength;
+            this.maxLength = maxLength;
+        }
+
+        @Override
+        public String generateCqlValue()
+        {
+            int length = random.nextInt(minLength, maxLength + 1);
+            return String.format("'%s'", random.nextAlphanumeric(length));
+        }
+    }
+
+    class UTF8Generator extends AbstractCqlDataGenerator
+    {
+        private final int minLength;
+        private final int maxLength;
+
+        public UTF8Generator(RandomPlus random, int minLength, int maxLength)
+        {
+            super(random);
+            this.minLength = minLength;
+            this.maxLength = maxLength;
+        }
+
+        @Override
+        public String generateCqlValue()
+        {
+            int length = random.nextInt(minLength, maxLength + 1);
+            return String.format("'%s'", random.nextAlphanumeric(length));
+        }
+    }
+
+    class BooleanGenerator extends AbstractCqlDataGenerator
+    {
+        public BooleanGenerator(RandomPlus random)
+        {
+            super(random);
+        }
+
+        @Override
+        public String generateCqlValue()
+        {
+            return String.valueOf(random.nextBoolean());
+        }
+    }
+
+    class ByteGenerator extends AbstractCqlDataGenerator
+    {
+        public ByteGenerator(RandomPlus random)
+        {
+            super(random);
+        }
+
+        @Override
+        public String generateCqlValue()
+        {
+            return String.valueOf((byte) random.nextInt());
+        }
+    }
+
+    class BytesGenerator extends AbstractCqlDataGenerator
+    {
+        private final int minLength;
+        private final int maxLength;
+
+        public BytesGenerator(RandomPlus random, int minLength, int maxLength)
+        {
+            super(random);
+            this.minLength = minLength;
+            this.maxLength = maxLength;
+        }
+
+        @Override
+        public String generateCqlValue()
+        {
+            return Hex.bytesToHex(random.nextBytes(minLength, maxLength));
+        }
+    }
+
+    class ShortGenerator extends AbstractCqlDataGenerator
+    {
+        private final short min;
+        private final short max;
+
+        public ShortGenerator(RandomPlus random, short min, short max)
+        {
+            super(random);
+            this.min = min;
+            this.max = max;
+        }
+
+        @Override
+        public String generateCqlValue()
+        {
+            return String.valueOf((short) random.nextInt(min, max));
+        }
+    }
+
+    class IntGenerator extends AbstractCqlDataGenerator
+    {
+        private final int min;
+        private final int max;
+
+        public IntGenerator(RandomPlus random, int min, int max)
+        {
+            super(random);
+            this.min = min;
+            this.max = max;
+        }
+
+        @Override
+        public String generateCqlValue()
+        {
+            return String.valueOf(random.nextInt(min, max));
+        }
+    }
+
+    class LongGenerator extends AbstractCqlDataGenerator
+    {
+        private final long min;
+        private final long max;
+
+        public LongGenerator(RandomPlus random, long min, long max)
+        {
+            super(random);
+            this.min = min;
+            this.max = max;
+        }
+
+        @Override
+        public String generateCqlValue()
+        {
+            return String.valueOf(random.nextLong(min, max));
+        }
+    }
+
+    class BigIntegerGenerator extends AbstractCqlDataGenerator
+    {
+        private final BigInteger min;
+        private final BigInteger max;
+
+        public BigIntegerGenerator(RandomPlus random, BigInteger min, BigInteger max)
+        {
+            super(random);
+            this.min = min;
+            this.max = max;
+        }
+
+        @Override
+        public String generateCqlValue()
+        {
+            return random.nextBigInteger(min, max).toString();
+        }
+    }
+
+    class FloatGenerator extends AbstractCqlDataGenerator
+    {
+        private final float min;
+        private final float max;
+
+        public FloatGenerator(RandomPlus random, float min, float max)
+        {
+            super(random);
+            this.min = min;
+            this.max = max;
+        }
+
+        @Override
+        public String generateCqlValue()
+        {
+            return String.valueOf(random.nextFloat(min, max));
+        }
+    }
+
+    class DoubleGenerator extends AbstractCqlDataGenerator
+    {
+        private final double min;
+        private final double max;
+
+        public DoubleGenerator(RandomPlus random, double min, double max)
+        {
+            super(random);
+            this.min = min;
+            this.max = max;
+        }
+
+        @Override
+        public String generateCqlValue()
+        {
+            return String.valueOf(random.nextDouble(min, max));
+        }
+    }
+
+    class DecimalGenerator extends AbstractCqlDataGenerator
+    {
+        private final BigDecimal min;
+        private final BigDecimal max;
+
+        public DecimalGenerator(RandomPlus random, BigDecimal min, BigDecimal max)
+        {
+            super(random);
+            this.min = min;
+            this.max = max;
+        }
+
+        @Override
+        public String generateCqlValue()
+        {
+            return random.nextBigDecimal(min, max).toString();
+        }
+    }
+
+    class InetAddressGenerator extends AbstractCqlDataGenerator
+    {
+        public InetAddressGenerator(RandomPlus random)
+        {
+            super(random);
+        }
+
+        @Override
+        public String generateCqlValue()
+        {
+            try
+            {
+                InetAddress address = InetAddress.getByAddress(new byte[]{
+                    (byte) random.nextInt(1, 256),
+                    (byte) random.nextInt(0, 256),
+                    (byte) random.nextInt(0, 256),
+                    (byte) random.nextInt(1, 256)
+                });
+                return String.format("'%s'", address.getHostAddress());
+            }
+            catch (Exception e)
+            {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    class UUIDGenerator extends AbstractCqlDataGenerator
+    {
+        public UUIDGenerator(RandomPlus random)
+        {
+            super(random);
+        }
+
+        @Override
+        public String generateCqlValue()
+        {
+            return new UUID(random.nextLong(), random.nextLong()).toString();
+        }
+    }
+
+    class TimeUUIDGenerator extends AbstractCqlDataGenerator
+    {
+        public TimeUUIDGenerator(RandomPlus random)
+        {
+            super(random);
+        }
+
+        @Override
+        public String generateCqlValue()
+        {
+            return TimeUUID.Generator.atUnixMillis(random.nextInt()).toString();
+        }
+    }
+
+    class TimestampGenerator extends AbstractCqlDataGenerator
+    {
+        public TimestampGenerator(RandomPlus random)
+        {
+            super(random);
+        }
+
+        @Override
+        public String generateCqlValue()
+        {
+            return String.valueOf(random.nextLong());
+        }
+    }
+
+    class TimeGenerator extends AbstractCqlDataGenerator
+    {
+        private final long min;
+        private final long max;
+
+        public TimeGenerator(RandomPlus random, long min, long max)
+        {
+            super(random);
+            this.min = min;
+            this.max = max;
+        }
+
+        @Override
+        public String generateCqlValue()
+        {
+            return String.valueOf(random.nextLong(min, max));
+        }
+    }
+
+    class DateGenerator extends AbstractCqlDataGenerator
+    {
+        public DateGenerator(RandomPlus random)
+        {
+            super(random);
+        }
+
+        @Override
+        public String generateCqlValue()
+        {
+            return String.format("'%d-%02d-%02d'",
+                                 random.nextInt(1970, 2070),
+                                 random.nextInt(1, 13),
+                                 random.nextInt(1, 29));
+        }
+    }
+
+    class DurationGenerator extends AbstractCqlDataGenerator
+    {
+        private final long minMilliseconds;
+        private final long maxMilliseconds;
+
+        public DurationGenerator(RandomPlus random, long minSeconds, long maxSeconds)
+        {
+            super(random);
+            this.minMilliseconds = minSeconds * 1000;
+            this.maxMilliseconds = maxSeconds * 1000;
+        }
+
+        @Override
+        public String generateCqlValue()
+        {
+            return String.format("%dms", random.nextLong(minMilliseconds, maxMilliseconds));
+        }
+    }
+
+    class RowGenerator
+    {
+        final CqlDataGenerator[] columnValueGenerators;
+
+        public RowGenerator(CqlDataGenerator[] columnValueGenerators)
+        {
+            this.columnValueGenerators = columnValueGenerators;
+        }
+
+        public String generateRow()
+        {
+            return Arrays.stream(columnValueGenerators)
+                         .map(CqlDataGenerator::generateCqlValue)
+                         .collect(Collectors.joining(","));
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/utils/CqlDataGeneratorTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/utils/CqlDataGeneratorTest.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.utils;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+
+import org.junit.Test;
+
+import org.apache.cassandra.cql3.CQL3Type;
+import org.apache.cassandra.db.marshal.AbstractType;
+import org.apache.cassandra.db.marshal.AsciiType;
+import org.apache.cassandra.db.marshal.BooleanType;
+import org.apache.cassandra.db.marshal.ByteType;
+import org.apache.cassandra.db.marshal.BytesType;
+import org.apache.cassandra.db.marshal.DecimalType;
+import org.apache.cassandra.db.marshal.DoubleType;
+import org.apache.cassandra.db.marshal.DurationType;
+import org.apache.cassandra.db.marshal.FloatType;
+import org.apache.cassandra.db.marshal.InetAddressType;
+import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.db.marshal.IntegerType;
+import org.apache.cassandra.db.marshal.LongType;
+import org.apache.cassandra.db.marshal.ShortType;
+import org.apache.cassandra.db.marshal.SimpleDateType;
+import org.apache.cassandra.db.marshal.TimeType;
+import org.apache.cassandra.db.marshal.TimeUUIDType;
+import org.apache.cassandra.db.marshal.TimestampType;
+import org.apache.cassandra.db.marshal.UTF8Type;
+import org.apache.cassandra.db.marshal.UUIDType;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class CqlDataGeneratorTest
+{
+    private final CqlDataGenerator.Factory factory = new CqlDataGenerator.Factory();
+
+    @Test
+    public void testAscii()
+    {
+        testGenerator(factory.ascii(0, 20), AsciiType.instance);
+    }
+
+    @Test
+    public void testUtf8()
+    {
+        testGenerator(factory.utf8(0, 20), UTF8Type.instance);
+    }
+
+    @Test
+    public void testBoolean()
+    {
+        testGenerator(factory.bool(), BooleanType.instance);
+    }
+
+    @Test
+    public void testTinyint()
+    {
+        testGenerator(factory.tinyint(), ByteType.instance);
+    }
+
+    @Test
+    public void testBlob()
+    {
+        testGenerator(factory.blob(0, 64), BytesType.instance);
+    }
+
+    @Test
+    public void testSmallint()
+    {
+        short min = Short.MIN_VALUE;
+        short max = Short.MAX_VALUE;
+        testGenerator(factory.smallint(min, max), ShortType.instance, min, max);
+    }
+
+    @Test
+    public void testInt()
+    {
+        int min = 0;
+        int max = 100;
+        testGenerator(factory.cint(min, max), Int32Type.instance, min, max);
+    }
+
+    @Test
+    public void testBigint()
+    {
+        long min = 0L;
+        long max = 100L;
+        testGenerator(factory.bigint(min, max), LongType.instance, min, max);
+    }
+
+    @Test
+    public void testVarint()
+    {
+        BigInteger min1 = BigInteger.valueOf(Long.MIN_VALUE);
+        BigInteger max1 = BigInteger.valueOf(Long.MAX_VALUE);
+        testGenerator(factory.varint(min1, max1), IntegerType.instance, min1, max1);
+
+        BigInteger min2 = BigInteger.valueOf(-7);
+        BigInteger max2 = BigInteger.valueOf(7);
+        testGenerator(factory.varint(min2, max2), IntegerType.instance, min2, max2);
+    }
+
+    @Test
+    public void testFloat()
+    {
+        float min = -1000.0f;
+        float max = 1000.0f;
+        testGenerator(factory.cfloat(min, max), FloatType.instance, min, max);
+    }
+
+    @Test
+    public void testDouble()
+    {
+        double min = -1000.0;
+        double max = 1000.0;
+        testGenerator(factory.cdouble(min, max), DoubleType.instance, min, max);
+    }
+
+    @Test
+    public void testDecimal()
+    {
+        BigDecimal min = BigDecimal.valueOf(-1000);
+        BigDecimal max = BigDecimal.valueOf(1000);
+        testGenerator(factory.decimal(min, max), DecimalType.instance, min, max);
+    }
+
+    @Test
+    public void testInet()
+    {
+        testGenerator(factory.inet(), InetAddressType.instance);
+    }
+
+    @Test
+    public void testUuid()
+    {
+        testGenerator(factory.uuid(), UUIDType.instance);
+    }
+
+    @Test
+    public void testTimeuuid()
+    {
+        testGenerator(factory.timeuuid(), TimeUUIDType.instance);
+    }
+
+    @Test
+    public void testTimestamp()
+    {
+        testGenerator(factory.timestamp(), TimestampType.instance);
+    }
+
+    @Test
+    public void testTime()
+    {
+        long min = 0;
+        long max = 1000;
+        testGenerator(factory.time(min, max), TimeType.instance, min, max);
+    }
+
+    @Test
+    public void testDate()
+    {
+        testGenerator(factory.date(), SimpleDateType.instance);
+    }
+
+    @Test
+    public void testDuration()
+    {
+        testGenerator(factory.duration(0, 1000), DurationType.instance);
+    }
+
+    private <T> void testGenerator(CqlDataGenerator generator, AbstractType<T> type)
+    {
+        for (int i = 0; i < 10000; i++)
+        {
+            String rawValue = generateUnquotedCqlValue(generator);
+            type.fromString(rawValue);
+        }
+    }
+
+    /**
+     * Test generator with bounds validation using Comparable types.
+     * Uses the Cassandra type to parse the CQL string into a ByteBuffer and then compose it into a Java object.
+     *
+     * @param generator the CQL data generator
+     * @param type the Cassandra type
+     * @param min the minimum expected value (inclusive)
+     * @param max the maximum expected value (inclusive)
+     */
+    private <T extends Comparable<T>> void testGenerator(CqlDataGenerator generator,
+                                                          AbstractType<T> type,
+                                                          T min,
+                                                          T max)
+    {
+        for (int i = 0; i < 10000; i++)
+        {
+            String rawValue = generateUnquotedCqlValue(generator);
+            ByteBuffer valueBytes = type.fromString(rawValue);
+            T value = type.compose(valueBytes);
+            assertThat(value).isBetween(min, max);
+        }
+    }
+
+    private static @NonNull String generateUnquotedCqlValue(CqlDataGenerator generator)
+    {
+        String maybeQuotedValue = generator.generateCqlValue();
+        return (maybeQuotedValue.startsWith("'") && maybeQuotedValue.endsWith("'"))
+               ? maybeQuotedValue.substring(1, maybeQuotedValue.length() - 1)
+               : maybeQuotedValue;
+    }
+
+    @Test
+    public void testExhaustiveness()
+    {
+        for (CQL3Type.Native type : CQL3Type.Native.values())
+        {
+            String name = type.name();
+            if (type == CQL3Type.Native.COUNTER || type == CQL3Type.Native.EMPTY)
+            {
+                assertThatThrownBy(() -> factory.forType(name))
+                .hasMessageContaining("Unsupported type: " + name);
+            }
+            else
+            {
+                assertThat(factory.forType(name)).isNotNull();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Some issues can never be found when testing SAI on a few manually inserted rows we had until now.

During adding this set of tests it was already found that:
- flushes could deadlock under specific failure scenarios (CNDB-17110)
- SAI tests were not cleaning the data after themselves which caused running out of file descriptors
- some query optimizer code was computing incorrect estimates for some query bounds (CNDB-17012)
- rows could be missing when mixing static and non-static column predicates in a single query (CNDB-17666)
