### PR TITLE
CNDB-18063 test RowAwarePrimaryKeyFactory with static clustering (#2445)

### DIFF
--- a/src/java/org/apache/cassandra/db/marshal/AbstractType.java
+++ b/src/java/org/apache/cassandra/db/marshal/AbstractType.java
@@ -32,6 +32,7 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Streams;
@@ -191,6 +192,8 @@ public abstract class AbstractType<T> implements Comparator<ByteBuffer>, Assignm
         return getSerializer().deserialize(value, accessor);
     }
 
+    @SuppressWarnings("unchecked")
+    @VisibleForTesting
     public ByteBuffer decomposeUntyped(Object value)
     {
         return decompose((T) value);

--- a/test/unit/org/apache/cassandra/index/sai/utils/AbstractPrimaryKeyTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/utils/AbstractPrimaryKeyTest.java
@@ -49,6 +49,13 @@ public class AbstractPrimaryKeyTest extends SaiRandomizedTest
                                                                            .addClusteringColumn("ck1", UTF8Type.instance)
                                                                            .build();
 
+    static final TableMetadata simplePartitionStaticAndSingleClusteringAsc = TableMetadata.builder("test", "test")
+                                                                                          .partitioner(Murmur3Partitioner.instance)
+                                                                                          .addPartitionKeyColumn("pk1", Int32Type.instance)
+                                                                                          .addStaticColumn("sk1", Int32Type.instance)
+                                                                                          .addClusteringColumn("ck1", UTF8Type.instance)
+                                                                                          .build();
+
     static TableMetadata simplePartitionMultipleClusteringAsc = TableMetadata.builder("test", "test")
                                                                              .partitioner(Murmur3Partitioner.instance)
                                                                              .addPartitionKeyColumn("pk1", Int32Type.instance)
@@ -146,20 +153,20 @@ public class AbstractPrimaryKeyTest extends SaiRandomizedTest
         if (TypeUtil.isComposite(table.partitionKeyType))
             key = ((CompositeType)table.partitionKeyType).decompose(partitionKeys);
         else
-            key = table.partitionKeyType.fromString((String)partitionKeys[0]);
+            key = table.partitionKeyType.decomposeUntyped(partitionKeys[0]);
         return table.partitioner.decorateKey(key);
     }
 
-    Clustering makeClustering(TableMetadata table, String...clusteringKeys)
+    Clustering<?> makeClustering(TableMetadata table, String...clusteringKeys)
     {
-        Clustering clustering;
+        Clustering<?> clustering;
         if (table.comparator.size() == 0)
             clustering = Clustering.EMPTY;
         else
         {
             ByteBuffer[] values = new ByteBuffer[clusteringKeys.length];
             for (int index = 0; index < table.comparator.size(); index++)
-                values[index] = table.comparator.subtype(index).fromString(clusteringKeys[index]);
+                values[index] = table.comparator.subtype(index).decomposeUntyped(clusteringKeys[index]);
             clustering = Clustering.make(values);
         }
         return clustering;

--- a/test/unit/org/apache/cassandra/index/sai/utils/RowAwarePrimaryKeyFactoryTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/utils/RowAwarePrimaryKeyFactoryTest.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 import org.apache.cassandra.db.Clustering;
 import org.apache.cassandra.index.sai.disk.v2.RowAwarePrimaryKeyFactory;
 
-public class RowAwarePrimaryKeyTest extends AbstractPrimaryKeyTest
+public class RowAwarePrimaryKeyFactoryTest extends AbstractPrimaryKeyTest
 {
     @Test
     public void singlePartitionTest()
@@ -34,12 +34,12 @@ public class RowAwarePrimaryKeyTest extends AbstractPrimaryKeyTest
         int rows = nextInt(10, 100);
         PrimaryKey[] keys = new PrimaryKey[rows];
         for (int index = 0; index < rows; index++)
-            keys[index] = factory.create(makeKey(simplePartition, Integer.toString(index)), Clustering.EMPTY);
+            keys[index] = factory.create(makeKey(simplePartition, index), Clustering.EMPTY);
 
         Arrays.sort(keys);
 
-        byteComparisonTests(factory, keys);
-        compareToAndEqualsTests(factory, keys);
+        verifyTokenOnlyByteComparableRepresentations(factory, keys);
+        compareToAndEquals(factory, keys);
     }
 
     @Test
@@ -53,8 +53,8 @@ public class RowAwarePrimaryKeyTest extends AbstractPrimaryKeyTest
 
         Arrays.sort(keys);
 
-        byteComparisonTests(factory, keys);
-        compareToAndEqualsTests(factory, keys);
+        verifyTokenOnlyByteComparableRepresentations(factory, keys);
+        compareToAndEquals(factory, keys);
     }
 
     @Test
@@ -67,7 +67,7 @@ public class RowAwarePrimaryKeyTest extends AbstractPrimaryKeyTest
         int clustering = 0;
         for (int index = 0; index < rows; index++)
         {
-            keys[index] = factory.create(makeKey(simplePartitionSingleClusteringAsc, Integer.toString(partition)),
+            keys[index] = factory.create(makeKey(simplePartitionSingleClusteringAsc, partition),
                                          makeClustering(simplePartitionSingleClusteringAsc, Integer.toString(clustering++)));
             if (clustering == 5)
             {
@@ -78,8 +78,8 @@ public class RowAwarePrimaryKeyTest extends AbstractPrimaryKeyTest
 
         Arrays.sort(keys);
 
-        byteComparisonTests(factory, keys);
-        compareToAndEqualsTests(factory, keys);
+        verifyTokenOnlyByteComparableRepresentations(factory, keys);
+        compareToAndEquals(factory, keys);
     }
 
     @Test
@@ -93,7 +93,7 @@ public class RowAwarePrimaryKeyTest extends AbstractPrimaryKeyTest
         int clustering2 = 0;
         for (int index = 0; index < rows; index++)
         {
-            keys[index] = factory.create(makeKey(simplePartitionMultipleClusteringAsc, Integer.toString(partition)),
+            keys[index] = factory.create(makeKey(simplePartitionMultipleClusteringAsc, partition),
                                          makeClustering(simplePartitionMultipleClusteringAsc, Integer.toString(clustering1), Integer.toString(clustering2++)));
             if (clustering2 == 5)
             {
@@ -109,8 +109,8 @@ public class RowAwarePrimaryKeyTest extends AbstractPrimaryKeyTest
 
         Arrays.sort(keys);
 
-        byteComparisonTests(factory, keys);
-        compareToAndEqualsTests(factory, keys);
+        verifyTokenOnlyByteComparableRepresentations(factory, keys);
+        compareToAndEquals(factory, keys);
     }
 
     @Test
@@ -123,7 +123,7 @@ public class RowAwarePrimaryKeyTest extends AbstractPrimaryKeyTest
         int clustering = 0;
         for (int index = 0; index < rows; index++)
         {
-            keys[index] = factory.create(makeKey(simplePartitionSingleClusteringDesc, Integer.toString(partition)),
+            keys[index] = factory.create(makeKey(simplePartitionSingleClusteringDesc, partition),
                                          makeClustering(simplePartitionSingleClusteringDesc, Integer.toString(clustering++)));
             if (clustering == 5)
             {
@@ -134,8 +134,8 @@ public class RowAwarePrimaryKeyTest extends AbstractPrimaryKeyTest
 
         Arrays.sort(keys);
 
-        byteComparisonTests(factory, keys);
-        compareToAndEqualsTests(factory, keys);
+        verifyTokenOnlyByteComparableRepresentations(factory, keys);
+        compareToAndEquals(factory, keys);
     }
 
     @Test
@@ -149,7 +149,7 @@ public class RowAwarePrimaryKeyTest extends AbstractPrimaryKeyTest
         int clustering2 = 0;
         for (int index = 0; index < rows; index++)
         {
-            keys[index] = factory.create(makeKey(simplePartitionMultipleClusteringDesc, Integer.toString(partition)),
+            keys[index] = factory.create(makeKey(simplePartitionMultipleClusteringDesc, partition),
                                          makeClustering(simplePartitionMultipleClusteringDesc, Integer.toString(clustering1), Integer.toString(clustering2++)));
             if (clustering2 == 5)
             {
@@ -165,8 +165,8 @@ public class RowAwarePrimaryKeyTest extends AbstractPrimaryKeyTest
 
         Arrays.sort(keys);
 
-        byteComparisonTests(factory, keys);
-        compareToAndEqualsTests(factory, keys);
+        verifyTokenOnlyByteComparableRepresentations(factory, keys);
+        compareToAndEquals(factory, keys);
     }
 
     @Test
@@ -190,8 +190,8 @@ public class RowAwarePrimaryKeyTest extends AbstractPrimaryKeyTest
 
         Arrays.sort(keys);
 
-        byteComparisonTests(factory, keys);
-        compareToAndEqualsTests(factory, keys);
+        verifyTokenOnlyByteComparableRepresentations(factory, keys);
+        compareToAndEquals(factory, keys);
     }
 
     @Test
@@ -221,8 +221,8 @@ public class RowAwarePrimaryKeyTest extends AbstractPrimaryKeyTest
 
         Arrays.sort(keys);
 
-        byteComparisonTests(factory, keys);
-        compareToAndEqualsTests(factory, keys);
+        verifyTokenOnlyByteComparableRepresentations(factory, keys);
+        compareToAndEquals(factory, keys);
     }
 
     @Test
@@ -246,8 +246,8 @@ public class RowAwarePrimaryKeyTest extends AbstractPrimaryKeyTest
 
         Arrays.sort(keys);
 
-        byteComparisonTests(factory, keys);
-        compareToAndEqualsTests(factory, keys);
+        verifyTokenOnlyByteComparableRepresentations(factory, keys);
+        compareToAndEquals(factory, keys);
     }
 
     @Test
@@ -277,8 +277,8 @@ public class RowAwarePrimaryKeyTest extends AbstractPrimaryKeyTest
 
         Arrays.sort(keys);
 
-        byteComparisonTests(factory, keys);
-        compareToAndEqualsTests(factory, keys);
+        verifyTokenOnlyByteComparableRepresentations(factory, keys);
+        compareToAndEquals(factory, keys);
     }
 
     @Test
@@ -292,7 +292,7 @@ public class RowAwarePrimaryKeyTest extends AbstractPrimaryKeyTest
         int clustering2 = 0;
         for (int index = 0; index < rows; index++)
         {
-            keys[index] = factory.create(makeKey(simplePartitionMultipleClusteringMixed, Integer.toString(partition)),
+            keys[index] = factory.create(makeKey(simplePartitionMultipleClusteringMixed, partition),
                                          makeClustering(simplePartitionMultipleClusteringMixed, Integer.toString(clustering1), Integer.toString(clustering2++)));
             if (clustering2 == 5)
             {
@@ -308,8 +308,8 @@ public class RowAwarePrimaryKeyTest extends AbstractPrimaryKeyTest
 
         Arrays.sort(keys);
 
-        byteComparisonTests(factory, keys);
-        compareToAndEqualsTests(factory, keys);
+        verifyTokenOnlyByteComparableRepresentations(factory, keys);
+        compareToAndEquals(factory, keys);
     }
 
     @Test
@@ -339,11 +339,41 @@ public class RowAwarePrimaryKeyTest extends AbstractPrimaryKeyTest
 
         Arrays.sort(keys);
 
-        byteComparisonTests(factory, keys);
-        compareToAndEqualsTests(factory, keys);
+        verifyTokenOnlyByteComparableRepresentations(factory, keys);
+        compareToAndEquals(factory, keys);
     }
 
-    private void compareToAndEqualsTests(PrimaryKey.Factory factory, PrimaryKey... keys)
+    @Test
+    public void simplePartitonStaticAndSingleClusteringAscTest()
+    {
+        PrimaryKey.Factory factory = new RowAwarePrimaryKeyFactory(simplePartitionStaticAndSingleClusteringAsc.comparator);
+        int rows = nextInt(10, 100);
+        PrimaryKey[] keys = new PrimaryKey[rows];
+        int partition = 0;
+        int clustering = 0;
+        for (int index = 0; index < rows; index++)
+        {
+            if (clustering == 0)
+            {
+                keys[index] = factory.create(makeKey(simplePartitionSingleClusteringAsc, partition), Clustering.STATIC_CLUSTERING);
+                clustering++;
+            }
+            else
+                keys[index] = factory.create(makeKey(simplePartitionSingleClusteringAsc, partition),
+                                             makeClustering(simplePartitionSingleClusteringAsc, Integer.toString(clustering++)));
+            if (clustering == 5)
+            {
+                clustering = 0;
+                partition++;
+            }
+        }
+
+        Arrays.sort(keys);
+
+        verifyTokenOnlyByteComparableRepresentations(factory, keys);
+    }
+
+    private void compareToAndEquals(PrimaryKey.Factory factory, PrimaryKey... keys)
     {
         for (int index = 0; index < keys.length - 1; index++)
         {
@@ -362,7 +392,7 @@ public class RowAwarePrimaryKeyTest extends AbstractPrimaryKeyTest
         }
     }
 
-    private void byteComparisonTests(PrimaryKey.Factory factory, PrimaryKey... keys)
+    private void verifyTokenOnlyByteComparableRepresentations(PrimaryKey.Factory factory, PrimaryKey... keys)
     {
         for (int index = 0; index < keys.length - 1; index++)
         {

--- a/test/unit/org/apache/cassandra/index/sai/utils/TokenAwarePrimaryKeyTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/utils/TokenAwarePrimaryKeyTest.java
@@ -29,9 +29,9 @@ public class TokenAwarePrimaryKeyTest extends AbstractPrimaryKeyTest
     {
         PrimaryKey.Factory factory = new PartitionAwarePrimaryKeyFactory();
 
-        PrimaryKey first = factory.createTokenOnly(makeKey(simplePartition, "1").getToken());
+        PrimaryKey first = factory.createTokenOnly(makeKey(simplePartition, 1).getToken());
         PrimaryKey firstToken = factory.createTokenOnly(first.token());
-        PrimaryKey second = factory.createTokenOnly(makeKey(simplePartition, "2").getToken());
+        PrimaryKey second = factory.createTokenOnly(makeKey(simplePartition, 2).getToken());
         PrimaryKey secondToken = factory.createTokenOnly(second.token());
 
         assertCompareToAndEquals(first, second, -1);


### PR DESCRIPTION
Fixes https://github.com/riptano/cndb/issues/18063

Static clustering is special case, which is good to have additional testing, and will help to prevent regressions with changes to implementations like in #2122.

This commit adds a test for `RowAwarePrimaryKeyFactory` with static clustering.
Introduces decomposeUntyped to simplify the test code. Improves a name of test help method.
Fixes warnings on `Clustering` in an affected file that could be part of in #2433.
