### PR TITLE
CNDB-18195: Upgrade Netty to 4.1.135.Final

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -172,7 +172,7 @@
     <property name="chronicle-threads.version" value="2.24ea14" />
     <property name="chronicle-map.version" value="3.24ea4" />
 
-    <property name="netty.version" value="4.1.133.Final" />
+    <property name="netty.version" value="4.1.135.Final" />
 
     <condition property="maven-ant-tasks.jar.exists">
       <available file="${build.dir}/maven-ant-tasks-${maven-ant-tasks.version}.jar" />


### PR DESCRIPTION
### What is the issue
...
CNDB-18195: Upgrade Netty to 4.1.135.Final because of SNYK found vulnerability [SNYK-JAVA-IONETTY-17254120](https://security.snyk.io/vuln/SNYK-JAVA-IONETTY-17254120)

### What does this PR fix and why was it fixed
...
