### PR TITLE
CNDB-18143: Port CNDB-18001 a5871b2 to main-5.0

### DIFF
--- a/src/java/org/apache/cassandra/db/ReadCommand.java
+++ b/src/java/org/apache/cassandra/db/ReadCommand.java
@@ -315,6 +315,14 @@ public abstract class ReadCommand extends AbstractReadQuery
     }
 
     /**
+     * @return {@code true} if this command is a BM25 request, {@code false} otherwise
+     */
+    public boolean isBM25()
+    {
+        return indexQueryPlan != null && indexQueryPlan.isBM25();
+    }
+
+    /**
      * @return {@code true} if this command only queries a single partition, {@code false} otherwise.
      */
     public abstract boolean isSinglePartition();

--- a/src/java/org/apache/cassandra/index/Index.java
+++ b/src/java/org/apache/cassandra/index/Index.java
@@ -1232,6 +1232,14 @@ public interface Index
         }
 
         /**
+         * @return {@code true} if this plan is a BM25 request, {@code false} otherwise
+         */
+        default boolean isBM25()
+        {
+            return false;
+        }
+
+        /**
          * @return {@code true} if this plan uses index-based filtering, {@code false} otherwise
          */
         default boolean usesIndexFiltering()

--- a/src/java/org/apache/cassandra/index/sai/metrics/TableQueryMetrics.java
+++ b/src/java/org/apache/cassandra/index/sai/metrics/TableQueryMetrics.java
@@ -96,11 +96,19 @@ public class TableQueryMetrics
 
     private void addMetrics(TableMetadata table, QueryKind queryKind, Predicate<ReadCommand> filter)
     {
-        if (queryKind == QueryKind.ALL || CassandraRelevantProperties.SAI_QUERY_KIND_PER_TABLE_METRICS_ENABLED.getBoolean())
-            perTableMetrics.put(queryKind, new PerTable(table, queryKind, filter));
-
-        if (queryKind == QueryKind.ALL || CassandraRelevantProperties.SAI_QUERY_KIND_PER_QUERY_METRICS_ENABLED.getBoolean())
+        if (queryKind == QueryKind.ALL)
+        {
+            perTableMetrics.put(queryKind, new PerTableAll(table, queryKind, filter));
             perQueryMetrics.put(queryKind, new PerQuery(table, queryKind, filter));
+        }
+        else
+        {
+            if (CassandraRelevantProperties.SAI_QUERY_KIND_PER_TABLE_METRICS_ENABLED.getBoolean())
+                perTableMetrics.put(queryKind, new PerTable(table, queryKind, filter));
+
+            if (CassandraRelevantProperties.SAI_QUERY_KIND_PER_QUERY_METRICS_ENABLED.getBoolean())
+                perQueryMetrics.put(queryKind, new PerQuery(table, queryKind, filter));
+        }
     }
 
     /**
@@ -172,7 +180,7 @@ public class TableQueryMetrics
             this.filter = filter;
         }
 
-        public final void record(QueryContext.Snapshot snapshot, ReadCommand command)
+        public void record(QueryContext.Snapshot snapshot, ReadCommand command)
         {
             if (filter.test(command))
                 record(snapshot);
@@ -283,6 +291,32 @@ public class TableQueryMetrics
                 sortThenFilterQueriesCompleted = Metrics.counter(createMetricName("SortThenFilterQueriesCompleted"));
                 filterThenSortQueriesCompleted = Metrics.counter(createMetricName("FilterThenSortQueriesCompleted"));
             }
+        }
+    }
+
+    public static class PerTableAll extends PerTable
+    {
+        public final Counter totalBM25QueriesCompleted;
+
+        public PerTableAll(TableMetadata table, QueryKind queryKind, Predicate<ReadCommand> filter)
+        {
+            super(table, queryKind, filter);
+            totalBM25QueriesCompleted = Metrics.counter(createMetricName("TotalBM25QueriesCompleted"));
+        }
+
+        @Override
+        public void record(QueryContext.Snapshot snapshot)
+        {
+            super.record(snapshot);
+        }
+
+        @Override
+        public final void record(QueryContext.Snapshot snapshot, ReadCommand command)
+        {
+            super.record(snapshot, command);
+
+            if (command.isBM25())
+                totalBM25QueriesCompleted.inc();
         }
     }
 

--- a/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexQueryPlan.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexQueryPlan.java
@@ -256,6 +256,12 @@ public class StorageAttachedIndexQueryPlan implements Index.QueryPlan
     }
 
     @Override
+    public boolean isBM25()
+    {
+        return orderer != null && orderer.isBM25();
+    }
+
+    @Override
     public boolean usesIndexFiltering()
     {
         return usesIndexFiltering;

--- a/test/unit/org/apache/cassandra/index/sai/metrics/QueryMetricsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/metrics/QueryMetricsTest.java
@@ -436,36 +436,40 @@ public class QueryMetricsTest extends AbstractMetricsTest
     @Test
     public void testQueryKindFlags()
     {
-        createTable("CREATE TABLE %s (k int, c int, n int, s text, v vector<float, 2>, PRIMARY KEY(k, c))");
+        createTable("CREATE TABLE %s (k int, c int, n int, s text, t text, v vector<float, 2>, PRIMARY KEY(k, c))");
 
         // test without indexes
-        assertQueryTypeFlags("SELECT * FROM %s", false, false);
-        assertQueryTypeFlags("SELECT * FROM %s WHERE n = 1 ALLOW FILTERING", false, false);
+        assertQueryTypeFlags("SELECT * FROM %s", false, false, false);
+        assertQueryTypeFlags("SELECT * FROM %s WHERE n = 1 ALLOW FILTERING", false, false, false);
 
         // test with legacy indexes
         String idx = createIndex("CREATE INDEX ON %s(n)");
-        assertQueryTypeFlags("SELECT * FROM %s", false, false);
-        assertQueryTypeFlags("SELECT * FROM %s WHERE n = 1", false, true);
-        assertQueryTypeFlags("SELECT * FROM %s WHERE n = 1 AND s = 'a' ALLOW FILTERING", false, true);
-        assertQueryTypeFlags("SELECT * FROM %s WHERE n = 1 OR s = 'a' ALLOW FILTERING", false, false);
+        assertQueryTypeFlags("SELECT * FROM %s", false, false, false);
+        assertQueryTypeFlags("SELECT * FROM %s WHERE n = 1", false, true, false);
+        assertQueryTypeFlags("SELECT * FROM %s WHERE n = 1 AND s = 'a' ALLOW FILTERING", false, true, false);
+        assertQueryTypeFlags("SELECT * FROM %s WHERE n = 1 OR s = 'a' ALLOW FILTERING", false, false, false);
 
         // test with SAI indexes
         dropIndex("DROP INDEX %s." + idx);
         createIndex("CREATE CUSTOM INDEX ON %s(n) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
-        assertQueryTypeFlags("SELECT * FROM %s", false, false);
-        assertQueryTypeFlags("SELECT * FROM %s WHERE n = 1", false, true);
-        assertQueryTypeFlags("SELECT * FROM %s WHERE n = 1 AND s = 'a' ALLOW FILTERING", false, true);
-        assertQueryTypeFlags("SELECT * FROM %s WHERE n = 1 OR s = 'a' ALLOW FILTERING", false, false);
-        assertQueryTypeFlags("SELECT * FROM %s ORDER BY v ANN OF [1, 1] LIMIT 10", true, false);
-        assertQueryTypeFlags("SELECT * FROM %s WHERE n=1 ORDER BY v ANN OF [1, 1] LIMIT 10", true, true);
+        createIndex("CREATE CUSTOM INDEX ON %s(t) USING 'StorageAttachedIndex' WITH OPTIONS = {'index_analyzer': 'standard', 'query_analyzer': 'standard'}");
+        assertQueryTypeFlags("SELECT * FROM %s", false, false, false);
+        assertQueryTypeFlags("SELECT * FROM %s WHERE n = 1", false, true, false);
+        assertQueryTypeFlags("SELECT * FROM %s WHERE n = 1 AND s = 'a' ALLOW FILTERING", false, true, false);
+        assertQueryTypeFlags("SELECT * FROM %s WHERE n = 1 OR s = 'a' ALLOW FILTERING", false, false, false);
+        assertQueryTypeFlags("SELECT * FROM %s ORDER BY v ANN OF [1, 1] LIMIT 10", true, false, false);
+        assertQueryTypeFlags("SELECT * FROM %s WHERE n=1 ORDER BY v ANN OF [1, 1] LIMIT 10", true, true, false);
+        assertQueryTypeFlags("SELECT * FROM %s ORDER BY t BM25 OF 'foo' LIMIT 10", true, false, true);
+        assertQueryTypeFlags("SELECT * FROM %s WHERE n = 1 ORDER BY t BM25 OF 'foo' LIMIT 10", true, true, true);
     }
 
-    private void assertQueryTypeFlags(String query, boolean expectedIsTopK, boolean expectedUsesIndexFiltering)
+    private void assertQueryTypeFlags(String query, boolean expectedIsTopK, boolean expectedUsesIndexFiltering, boolean expectedIsBM25)
     {
         ReadCommand command = parseReadCommand(query);
         Assert.assertEquals(expectedIsTopK, command.isTopK());
         Assert.assertEquals(expectedUsesIndexFiltering, command.usesIndexFiltering());
+        Assert.assertEquals(expectedIsBM25, command.isBM25());
     }
 
     /**
@@ -662,6 +666,38 @@ public class QueryMetricsTest extends AbstractMetricsTest
         waitForHistogramCountEqualsIfExists(hasPerQueryKindMetrics, objectName(name, PER_MP_TOPK_QUERY_METRIC_TYPE), 1);
         waitForHistogramCountEqualsIfExists(hasPerQueryKindMetrics, objectName(name, PER_SP_HYBRID_QUERY_METRIC_TYPE), 2);
         waitForHistogramCountEqualsIfExists(hasPerQueryKindMetrics, objectName(name, PER_MP_HYBRID_QUERY_METRIC_TYPE), 2);
+    }
+
+    @Test
+    public void testBM25Metrics()
+    {
+        createTable("CREATE TABLE %s (k int, c int, n int, s text, v vector<float, 2>, PRIMARY KEY(k, c))");
+        createIndex("CREATE CUSTOM INDEX ON %s(n) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX ON %s(s) USING 'StorageAttachedIndex' WITH OPTIONS = {'index_analyzer': 'standard', 'query_analyzer': 'standard'}");
+
+        for (int k = 0; k < 3; k++)
+            for (int c = 0; c < 4; c++)
+                execute("INSERT INTO %s (k, c, n, s, v) VALUES (?, ?, ?, ?, [1, 1])", k, c, 1, "foo bar baz");
+
+        UntypedResultSet rows = execute("SELECT k, c FROM %s ORDER BY s BM25 OF 'foo' LIMIT 100");
+        assertEquals(12, rows.size());
+
+        rows = execute("SELECT k, c FROM %s WHERE k = 0 ORDER BY s BM25 OF 'foo' LIMIT 100");
+        assertEquals(4, rows.size());
+
+        rows = execute("SELECT k, c FROM %s WHERE n = 1 ORDER BY s BM25 OF 'foo' LIMIT 100");
+        assertEquals(12, rows.size());
+
+        rows = execute("SELECT k, c FROM %s WHERE k = 0 AND n = 1 ORDER BY s BM25 OF 'foo' LIMIT 100");
+        assertEquals(4, rows.size());
+
+        rows = execute("SELECT k, c FROM %s ORDER BY v ANN OF [1, 1] LIMIT 100");
+        assertEquals(12, rows.size());
+
+        waitForEquals(objectName("TotalBM25QueriesCompleted", TABLE_QUERY_METRIC_TYPE), 4);
+        waitForEquals(objectName("TotalQueriesCompleted", TABLE_QUERY_METRIC_TYPE), 5);
+        waitForEquals(objectName("TotalQueryTimeouts", TABLE_QUERY_METRIC_TYPE), 0);
     }
 
     @Test


### PR DESCRIPTION
https://github.com/riptano/cndb/issues/18143

```
CNDB-18143: CNDB-18001: BM25 per table counter metric for completed BM25 queries (#2443)


We want to have visibility on the BM25 queries - where and how much they are executed.

This commit forward merges https://github.com/datastax/cassandra/commit/a5871b27986886ef01b55f763bdc4e36ad5de866
```