### PR TITLE
Port CNDB-14041 65107f5 & 344b02b & de95aff to main-5.0

### DIFF
--- a/src/java/org/apache/cassandra/io/compress/AdaptiveCompressor.java
+++ b/src/java/org/apache/cassandra/io/compress/AdaptiveCompressor.java
@@ -459,11 +459,12 @@ public class AdaptiveCompressor implements ICompressor
         // 0.0 if actualRate >= rateLimit
         // 1.0 if actualRate <= 0.8 * rateLimit;
         double rateLimitFactor = Math.min(1.0, Math.max(0.0, (rateLimit - actualRate) / (0.2 * rateLimit)));
+        assert rateLimitFactor >= 0.0 : "rateLimitFactor (" + rateLimitFactor + " out of valid range [0.0, 1.0]";
 
         long pendingCompactions = compactionManager.getPendingTasks();
-        long activeCompactions = compactionManager.getActiveCompactions();
-        long queuedCompactions = pendingCompactions - activeCompactions;
-        double compactionQueuePressure = Math.min(1.0, (double) queuedCompactions / (maxCompactionQueueLength * DatabaseDescriptor.getConcurrentCompactors()));
+        double compactionQueuePressure = Math.min(1.0, (double) pendingCompactions / (maxCompactionQueueLength * DatabaseDescriptor.getConcurrentCompactors()));
+        assert compactionQueuePressure >= 0.0 && compactionQueuePressure <= 1.0
+            : "compactionQueuePressure (" + compactionQueuePressure + ") out of valid range [0.0, 1.0]";
         return compactionQueuePressure * rateLimitFactor;
     }
 

--- a/src/java/org/apache/cassandra/metrics/CompactionMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/CompactionMetrics.java
@@ -36,6 +36,7 @@ import org.apache.cassandra.db.compaction.CompactionAggregateStatistics;
 import org.apache.cassandra.db.compaction.CompactionManager;
 import org.apache.cassandra.db.compaction.CompactionStrategyStatistics;
 import org.apache.cassandra.db.compaction.TableOperation;
+import org.apache.cassandra.exceptions.UnknownKeyspaceException;
 import org.apache.cassandra.schema.Schema;
 import org.apache.cassandra.schema.TableMetadata;
 
@@ -115,7 +116,7 @@ public class CompactionMetrics
             // add estimate number of compactions need to be done
             for (String keyspaceName : Schema.instance.getKeyspaces())
             {
-                for (ColumnFamilyStore cfs : Keyspace.open(keyspaceName).getColumnFamilyStores())
+                for (ColumnFamilyStore cfs : getColumnFamilyStores(keyspaceName))
                     n += cfs.getCompactionStrategy().getEstimatedRemainingTasks();
             }
             // add number of currently running compactions
@@ -127,7 +128,7 @@ public class CompactionMetrics
             // estimation of compactions need to be done
             for (String keyspaceName : Schema.instance.getKeyspaces())
             {
-                for (ColumnFamilyStore cfs : Keyspace.open(keyspaceName).getColumnFamilyStores())
+                for (ColumnFamilyStore cfs : getColumnFamilyStores(keyspaceName))
                 {
                     int taskNumber = cfs.getCompactionStrategy().getEstimatedRemainingTasks();
                     if (taskNumber > 0)
@@ -177,7 +178,7 @@ public class CompactionMetrics
             {
                 Map<String, Double> ksMap = new HashMap<>();
                 resultMap.put(keyspaceName, ksMap);
-                for (ColumnFamilyStore cfs : Keyspace.open(keyspaceName).getColumnFamilyStores())
+                for (ColumnFamilyStore cfs : getColumnFamilyStores(keyspaceName))
                     ksMap.put(cfs.getTableName(), cfs.getWA());
             }
 
@@ -220,7 +221,7 @@ public class CompactionMetrics
                                                         for (String keyspaceName : Schema.instance.getKeyspaces())
                                                         {
                                                             // Scan all the compactions strategies of all tables and find those that have compactions in progress.
-                                                            for (ColumnFamilyStore cfs : Keyspace.open(keyspaceName).getColumnFamilyStores())
+                                                            for (ColumnFamilyStore cfs : getColumnFamilyStores(keyspaceName))
                                                                 // For those return the statistics.
                                                                 ret.addAll(cfs.getCompactionStrategy().getStatistics());
                                                         }
@@ -239,7 +240,7 @@ public class CompactionMetrics
                                             {
                                                 Map<String, Map<String, String>> ksMap = new HashMap<>();
                                                 ret.put(keyspaceName, ksMap);
-                                                for (ColumnFamilyStore cfs : Keyspace.open(keyspaceName).getColumnFamilyStores())
+                                                for (ColumnFamilyStore cfs : getColumnFamilyStores(keyspaceName))
                                                 {
                                                     Map<String, String> overlaps = cfs.getCompactionStrategy().getMaxOverlapsMap();
                                                     ksMap.put(cfs.getTableName(), overlaps);
@@ -310,6 +311,23 @@ public class CompactionMetrics
                        .sum();
             }
         });
+    }
+
+    /**
+     * Returns a list of all ColumnFamilyStores in a keyspace if it exists.
+     * If the keyspace does not exist, returns an empty list.
+     * This is useful to avoid throwing when a keyspace gets dropped while we are iterating all keyspaces.
+     */
+    private static Collection<ColumnFamilyStore> getColumnFamilyStores(String keyspaceName)
+    {
+        try
+        {
+            return Keyspace.open(keyspaceName).getColumnFamilyStores();
+        }
+        catch (UnknownKeyspaceException e)
+        {
+            return Collections.emptyList();
+        }
     }
 
     /**

--- a/test/unit/org/apache/cassandra/cql3/CQLTester.java
+++ b/test/unit/org/apache/cassandra/cql3/CQLTester.java
@@ -69,6 +69,9 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+
+import org.apache.cassandra.io.compress.AdaptiveCompressor;
+import org.apache.cassandra.io.compress.LZ4Compressor;
 import org.apache.cassandra.service.ClientWarn;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -3579,5 +3582,12 @@ public abstract class CQLTester
             Assert.assertEquals(1, warnings.size());
             Assert.assertEquals(expectedWarning, warnings.get(0));
         }
+    }
+
+    public static String defaultCompressor()
+    {
+        return DatabaseDescriptor.shouldUseAdaptiveCompressionByDefault()
+               ? AdaptiveCompressor.class.getName()
+               : LZ4Compressor.class.getName();
     }
 }

--- a/test/unit/org/apache/cassandra/cql3/statements/DescribeStatementTest.java
+++ b/test/unit/org/apache/cassandra/cql3/statements/DescribeStatementTest.java
@@ -1098,7 +1098,7 @@ public class  DescribeStatementTest extends CQLTester
                "    AND cdc = false\n" +
                "    AND comment = ''\n" +
                "    AND compaction = " + cqlQuoted(CompactionParams.DEFAULT.asMap()) + "\n" +
-               "    AND compression = {'chunk_length_in_kb': '16', 'class': 'org.apache.cassandra.io.compress.LZ4Compressor'}\n" +
+               "    AND compression = {'chunk_length_in_kb': '16', 'class': '" + defaultCompressor() + "'}\n" +
                memtableFormat +
                "    AND crc_check_chance = 1.0\n" +
                "    AND default_time_to_live = 0\n" +
@@ -1138,7 +1138,7 @@ public class  DescribeStatementTest extends CQLTester
                "    AND cdc = false\n" +
                "    AND comment = ''\n" +
                "    AND compaction = " + cqlQuoted(CompactionParams.DEFAULT.asMap()) + "\n" +
-               "    AND compression = {'chunk_length_in_kb': '16', 'class': 'org.apache.cassandra.io.compress.LZ4Compressor'}\n" +
+               "    AND compression = {'chunk_length_in_kb': '16', 'class': '" + defaultCompressor() + "'}\n" +
                memtableFormat +
                "    AND crc_check_chance = 1.0\n" +
                "    AND extensions = {}\n" +

--- a/test/unit/org/apache/cassandra/cql3/validation/operations/AlterTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/operations/AlterTest.java
@@ -741,7 +741,7 @@ public class AlterTest extends CQLTester
     public void testAlterTableWithCompression() throws Throwable
     {
         createTable("CREATE TABLE %s (a text, b int, c int, primary key (a, b))");
-        assertSchemaOption("compression", map("chunk_length_in_kb", "16", "class", "org.apache.cassandra.io.compress.LZ4Compressor"));
+        assertSchemaOption("compression", map("chunk_length_in_kb", "16", "class", defaultCompressor()));
 
         alterTable("ALTER TABLE %s WITH compression = { 'class' : 'SnappyCompressor', 'chunk_length_in_kb' : 32 };");
         assertSchemaOption("compression", map("chunk_length_in_kb", "32", "class", "org.apache.cassandra.io.compress.SnappyCompressor"));

--- a/test/unit/org/apache/cassandra/cql3/validation/operations/CreateTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/operations/CreateTest.java
@@ -765,7 +765,7 @@ public class CreateTest extends CQLTester
     public void testCreateTableWithCompression() throws Throwable
     {
         createTable("CREATE TABLE %s (a text, b int, c int, primary key (a, b))");
-        assertSchemaOption("compression", map("chunk_length_in_kb", "16", "class", "org.apache.cassandra.io.compress.LZ4Compressor"));
+        assertSchemaOption("compression", map("chunk_length_in_kb", "16", "class", defaultCompressor()));
 
         createTable("CREATE TABLE %s (a text, b int, c int, primary key (a, b))"
                 + " WITH compression = { 'class' : 'SnappyCompressor', 'chunk_length_in_kb' : 32 };");


### PR DESCRIPTION
https://github.com/riptano/cndb/issues/18140

```
CNDB-18140: CNDB-14041 Fix UnknownKeyspaceException in CompactionMetrics, compaction pressure calculation, and revert table default

Commit 1: CNDB-14041: Fix UnknownKeyspaceException in CompactionMetrics

Fixes:

org.apache.cassandra.exceptions.UnknownKeyspaceException: Could not find a keyspace xxxxx
	at org.apache.cassandra.db.Keyspace.<init>(Keyspace.java:368)
	at org.apache.cassandra.db.Keyspace.lambda$open$0(Keyspace.java:168)
	at org.apache.cassandra.utils.concurrent.LoadingMap.lambda$blockingLoadIfAbsent$1(LoadingMap.java:273)
	at org.apache.cassandra.utils.concurrent.LoadingMap.lambda$computeIfAbsent$0(LoadingMap.java:98)
	at org.apache.cassandra.utils.concurrent.LoadingMap.updateOrRemoveEntry(LoadingMap.java:178)
	at org.apache.cassandra.utils.concurrent.LoadingMap.computeIfAbsent(LoadingMap.java:98)
	at org.apache.cassandra.utils.concurrent.LoadingMap.blockingLoadIfAbsent(LoadingMap.java:272)
	at org.apache.cassandra.schema.Schema.maybeAddKeyspaceInstance(Schema.java:246)
	at org.apache.cassandra.db.Keyspace.open(Keyspace.java:166)
	at org.apache.cassandra.db.Keyspace.open(Keyspace.java:155)
	at org.apache.cassandra.metrics.CompactionMetrics.lambda$new$0(CompactionMetrics.java:115)
	at org.apache.cassandra.db.compaction.CompactionManager.getPendingTasks(CompactionManager.java:2180)

Commit 2: CNDB-14041: Fix compaction pressure calculation in AdaptiveCompressor

Compaction pressure is not allowed to get below 0.

Commit 3: CNDB-14041: Revert enable Adaptive Compression by default for new tables (#2449)

Disable adaptive compression by default, while keeping the fixes and improvements in the patch that enabled it, https://github.com/datastax/cassandra/pull/2415.

We've decided to revert it in July release, as we do not want this change to happen on all tenants at the same time.

Forward merging of
 - https://github.com/datastax/cassandra/commit/41a3cea193b1beb64a1a4919f1ffd6d27bbf2d42
 - https://github.com/datastax/cassandra/commit/65107f528d89da610c791363ff37e58c89377018
 - https://github.com/datastax/cassandra/commit/344b02bf6c50e02800c3c006093f370d5b0760c2
```