### PR TITLE
CNDB-18233: Add repro test from DSP-25161

### DIFF
--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorSegmentationTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorSegmentationTest.java
@@ -127,4 +127,27 @@ public class VectorSegmentationTest extends VectorTester
 
         return vectors;
     }
+
+    /**
+     * See DSP-25161 and <a href="https://github.com/datastax/cassandra/pull/1189">this PR</a>.
+     */
+    @Test
+    public void testCompactionWithLowRowCountEstimate()
+    {
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v vector<float, 2>)");
+        createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
+
+        for (int k = 0; k < 2000; k++)
+        {
+            execute("INSERT INTO %s (k, v) VALUES (?, ?)", k, randomVectorBoxed(2));
+        }
+        flush();
+
+        execute("DELETE FROM %s WHERE k = 0");
+        flush();
+
+        compact();
+
+        assertThat(areAllTableIndexesQueryable()).isTrue();
+    }
 }


### PR DESCRIPTION
### What is the issue

https://github.com/datastax/cassandra/pull/1189 fixed a bug in vector index building without adding any reproduction test. That fix has been ported to BDP by [DSP-25161](https://datastax.jira.com/browse/DSP-25161), after hitting the same bug. 

The patch for DSP-25161 contains a repro test that we should port back to CC.

### What does this PR fix and why was it fixed

Add a repro test for https://github.com/datastax/cassandra/pull/1189

[DSP-25161]: https://datastax.jira.com/browse/DSP-25161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ