### PR TITLE
CNDB-18238: Update JVector to hotfix regression in recall. We flip pruning to false by default.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -747,7 +747,7 @@
           <dependency groupId="org.apache.lucene" artifactId="lucene-core" version="9.8.0" />
           <dependency groupId="org.apache.lucene" artifactId="lucene-analysis-common" version="9.8.0" />
           <dependency groupId="org.apache.lucene" artifactId="lucene-backward-codecs" version="9.8.0" />
-          <dependency groupId="io.github.jbellis" artifactId="jvector" version="4.0.0-rc.8" />
+          <dependency groupId="io.github.jbellis" artifactId="jvector" version="4.0.0-rc.8-hf1" />
           <dependency groupId="com.bpodgursky" artifactId="jbool_expressions" version="1.14" scope="test"/>
 
           <dependency groupId="com.carrotsearch.randomizedtesting" artifactId="randomizedtesting-runner" version="2.1.2" scope="test">

--- a/src/java/org/apache/cassandra/index/sai/disk/v3/V3OnDiskFormat.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v3/V3OnDiskFormat.java
@@ -49,7 +49,7 @@ public class V3OnDiskFormat extends V2OnDiskFormat
     public static volatile boolean WRITE_JVECTOR3_FORMAT = Boolean.parseBoolean(System.getProperty("cassandra.sai.write_jv3_format", "false"));
     public static final boolean ENABLE_LTM_CONSTRUCTION = Boolean.parseBoolean(System.getProperty("cassandra.sai.ltm_construction", "true"));
     // JVector doesn't give us a way to access its default, so we set it here, but allow it to be overridden.
-    public static boolean JVECTOR_USE_PRUNING_DEFAULT = Boolean.parseBoolean(System.getProperty("cassandra.sai.jvector.use_pruning_default", "true"));
+    public static boolean JVECTOR_USE_PRUNING_DEFAULT = Boolean.parseBoolean(System.getProperty("cassandra.sai.jvector.use_pruning_default", "false"));
 
     // We allow the version to be configured via a system property because of some legacy use cases, but it is
     // generally not recommended to change this directly. Instead, use the cassandra.sai.latest.version system property

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorSiftSmallTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorSiftSmallTest.java
@@ -38,7 +38,6 @@ import org.apache.cassandra.cql3.UntypedResultSet;
 import org.apache.cassandra.index.sai.StorageAttachedIndex;
 import org.apache.cassandra.index.sai.disk.v1.SegmentBuilder;
 import org.apache.cassandra.index.sai.disk.v2.V2VectorIndexSearcher;
-import org.apache.cassandra.index.sai.disk.vector.CompactionGraph;
 import org.apache.cassandra.index.sai.disk.vector.JVectorVersionUtil;
 
 import static org.junit.Assert.assertEquals;
@@ -73,8 +72,8 @@ public class VectorSiftSmallTest extends VectorTester.Versioned
         // Run a few queries with increasing rerank_k to validate that recall increases
         ensureIncreasingRerankKIncreasesRecall(queryVectors, groundTruth);
 
-        // Run queries with and without pruning to validate recall improves
-        ensureDisablingPruningIncreasesRecall(queryVectors, groundTruth);
+        // Test that use_pruning option works (even though JVector ignores it)
+        testUsePruningOptionCompatibility(queryVectors, groundTruth);
 
         flush();
         var diskRecall = testRecall(100, queryVectors, groundTruth);
@@ -115,19 +114,30 @@ public class VectorSiftSmallTest extends VectorTester.Versioned
                    strictlyIncreasedCount > 3);
     }
 
-    private void ensureDisablingPruningIncreasesRecall(List<float[]> queryVectors, List<List<Integer>> groundTruth)
+    /**
+     * Tests that the use_pruning option is accepted and works without errors.
+     * <p>
+     * IMPORTANT: As of JVector PR #682, pruning is deprecated and always disabled.
+     * JVector's usePruning() method now always sets pruneSearch = false regardless of input.
+     * This test verifies API compatibility - the option is accepted but has no effect on recall
+     * since JVector ignores it for top-K queries.
+     */
+    private void testUsePruningOptionCompatibility(List<float[]> queryVectors, List<List<Integer>> groundTruth)
     {
         int limit = 10;
-        // Test with pruning enabled
-        double recallWithPruning = testRecall(limit, queryVectors, groundTruth, null, true);
+        
+        // Test with pruning "enabled" (actually disabled by JVector)
+        double recallWithPruningTrue = testRecall(limit, queryVectors, groundTruth, null, true);
 
-        // Test with pruning disabled
-        double recallWithoutPruning = testRecall(limit, queryVectors, groundTruth, null, false);
+        // Test with pruning explicitly disabled
+        double recallWithPruningFalse = testRecall(limit, queryVectors, groundTruth, null, false);
 
-        // Recall should be at least as good when pruning is disabled
-        assertTrue("Recall without pruning (" + recallWithoutPruning +
-                  ") should be at least as good as recall with pruning (" + recallWithPruning + ')',
-                  recallWithoutPruning >= recallWithPruning);
+        // Since JVector always disables pruning, recall should be identical
+        // (allowing for minor floating point differences)
+        assertTrue("Recall with use_pruning=true (" + recallWithPruningTrue +
+                  ") should equal recall with use_pruning=false (" + recallWithPruningFalse +
+                  ") since JVector always disables pruning for top-K queries",
+                  Math.abs(recallWithPruningTrue - recallWithPruningFalse) < 0.001);
     }
 
     // Note: test only fails when scores are sent from replica to coordinator.


### PR DESCRIPTION
### What is the issue
...
4.0.0-rc.8 has a regression in recall when we run queries with pruning set to true. This is the default behavior in our vector queries - we use pruning.

### What does this PR fix and why was it fixed
...

This hotfix changes the defaults of pruning being set to False. JVector testing shows that no pruning produces similar latencies but better recall, so this was the simplest way to fix recall in a hotfix release in JVector.

**EDIT:
Below was a wrong statement, the pruning option is ignored and no matter what a user sets pruning will be always pointing to FALSE, according to Ted.** 
> Anyone who still runs queries with pruning explicitly set to TRUE in their ANN OPTIONS will see the regression, but default queries where there is no pruning set in ANN OPTIONS will be fixed. We do not have a metric to say if anyone was using pruning set to true explicitly, but considering this was the default option - I'd say it is highly unlikely. 

NOTE: It is a known issue that currently `VectorCompactionTest` and `VectorSiftSmallTest` are timing out in CI so I reran them locally and they still pass.