### PR TITLE
CNDB-15818: Ignore partitionRestrictedWidePartitionBqCompressedTest (#2450)

### DIFF
--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorKeyRestrictedOnPartitionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorKeyRestrictedOnPartitionTest.java
@@ -25,6 +25,7 @@ import java.util.stream.IntStream;
 
 import org.junit.After;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import org.apache.cassandra.config.CassandraRelevantProperties;
@@ -95,6 +96,11 @@ public class VectorKeyRestrictedOnPartitionTest extends VectorKeyRestrictedTeste
         partitionRestrictedWidePartitionTest(word2vec.dimension(), 0, 1000);
     }
 
+    // We do not test BQ because it is no longer implemented as of https://github.com/datastax/cassandra/pull/1580.
+    // Technically, the test was covering the case where we have large vectors, but it was taking a significant
+    // amount of time, so until we re-implement BQ, we can ignore this test. See for details
+    // https://github.com/riptano/cndb/issues/15985.
+    @Ignore
     @Test
     public void partitionRestrictedWidePartitionBqCompressedTest()
     {

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorLocalTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorLocalTest.java
@@ -131,6 +131,7 @@ public class VectorLocalTest extends VectorTester.VersionedWithChecksums
     // amount of time, so until we re-implement BQ, we can ignore this test. See for details
     // https://github.com/riptano/cndb/issues/15985.
     @Ignore
+    @Test
     public void randomizedBqCompressedTest()
     {
         randomizedTest(2048);


### PR DESCRIPTION
Ignore `partitionRestrictedWidePartitionBqCompressedTest` until we re-introduce binary quantization in https://github.com/riptano/cndb/issues/15985.

This test was meant to test binary quantization, it takes a lot of time and it's occasionally flaky due to recall.

Binary quantization is removed as of
https://github.com/datastax/cassandra/pull/1580. The similar `VectorLocalTest.randomizedBqCompressedTest` was marked as ignored by https://github.com/riptano/cndb/issues/15469.
