### PR TITLE
CNDB-18108 Add system property to disable UDFs and skip SecurityManager installation (#2452)

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -393,6 +393,12 @@ public enum CassandraRelevantProperties
     DISABLE_STCS_IN_L0("cassandra.disable_stcs_in_l0"),
     DISABLE_TCACTIVE_OPENSSL("cassandra.disable_tcactive_openssl"),
     DISABLE_UNUSED_CONNECTION_MONITORING("cassandra.messagingService.disableUnusedConnectionMonitoring"),
+    /**
+     * Disables user-defined functions (UDFs). When set to true, UDF creation and execution are blocked.
+     * This property can be used to forcibly disable UDFs for security reasons, or when running on JDK
+     * versions where SecurityManager-based sandboxing may not be reliable or available.
+     */
+    DISABLE_USER_DEFINED_FUNCTIONS("cassandra.disable_user_defined_functions", "false"),
     /** property for the rate of the scheduled task that monitors disk usage */
     DISK_USAGE_MONITOR_INTERVAL_MS("cassandra.disk_usage.monitor_interval_ms", convertToString(TimeUnit.SECONDS.toMillis(30))),
     /** property for the interval on which the repeated client warnings and diagnostic events about disk usage are ignored */

--- a/src/java/org/apache/cassandra/cql3/functions/UDFunction.java
+++ b/src/java/org/apache/cassandra/cql3/functions/UDFunction.java
@@ -41,6 +41,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.concurrent.ImmediateExecutor;
+import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.config.Config;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.ColumnIdentifier;
@@ -488,6 +489,10 @@ public abstract class UDFunction extends UserFunction implements ScalarFunction
 
     public static void assertUdfsEnabled(String language)
     {
+        if (CassandraRelevantProperties.DISABLE_USER_DEFINED_FUNCTIONS.getBoolean())
+            throw new InvalidRequestException("User-defined functions are disabled. " +
+                                              "The system property cassandra.disable_user_defined_functions is set to true.");
+
         if (!DatabaseDescriptor.enableUserDefinedFunctions())
             throw new InvalidRequestException("User-defined functions are disabled in cassandra.yaml - set user_defined_functions_enabled=true to enable");
         if (!"java".equalsIgnoreCase(language))

--- a/src/java/org/apache/cassandra/security/ThreadAwareSecurityManager.java
+++ b/src/java/org/apache/cassandra/security/ThreadAwareSecurityManager.java
@@ -33,9 +33,13 @@ import java.util.Enumeration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import io.netty.util.concurrent.FastThreadLocal;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.utils.logging.LoggingSupportFactory;
+
+import static org.apache.cassandra.config.CassandraRelevantProperties.DISABLE_USER_DEFINED_FUNCTIONS;
 
 /**
  * Custom {@link SecurityManager} and {@link Policy} implementation that only performs access checks
@@ -86,6 +90,16 @@ public final class ThreadAwareSecurityManager extends SecurityManager
         if (installed)
             return;
 
+        // Skip SecurityManager installation if UDFs are disabled via system property.
+        // The SecurityManager is only used for sandboxing UDFs, so it's not needed when UDFs are disabled.
+        if (DISABLE_USER_DEFINED_FUNCTIONS.getBoolean())
+        {
+            logger.info("Skipping ThreadAwareSecurityManager installation because UDFs are disabled via system property {}",
+                        DISABLE_USER_DEFINED_FUNCTIONS.getKey());
+            installed = true; // Mark as installed to prevent re-entry
+            return;
+        }
+
         // this line is needed - we need to make sure AccessControlException is loaded before we install this SM
         // otherwise we may get into stackoverflow when javax.security is not allowed package, and ACE is tried to be
         // loaded when it is going to be thrown from SM (class loader triggers SM to verify javax.security,
@@ -96,6 +110,16 @@ public final class ThreadAwareSecurityManager extends SecurityManager
         System.setSecurityManager(new ThreadAwareSecurityManager());
         LoggingSupportFactory.getLoggingSupport().onStartup();
         installed = true;
+    }
+
+    /**
+     * Reset the installed flag for testing purposes only.
+     * This allows tests to verify the install() method behavior.
+     */
+    @VisibleForTesting
+    public static void resetInstalledFlagForTests()
+    {
+        installed = false;
     }
 
     static

--- a/test/unit/org/apache/cassandra/cql3/functions/UDFunctionDisableTest.java
+++ b/test/unit/org/apache/cassandra/cql3/functions/UDFunctionDisableTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.cql3.functions;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.exceptions.InvalidRequestException;
+
+import static org.apache.cassandra.config.CassandraRelevantProperties.DISABLE_USER_DEFINED_FUNCTIONS;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for the cassandra.disable_user_defined_functions system property.
+ */
+public class UDFunctionDisableTest extends CQLTester
+{
+    private String originalValue;
+
+    @Before
+    public void setUp()
+    {
+        // Save original value
+        originalValue = DISABLE_USER_DEFINED_FUNCTIONS.getString();
+    }
+
+    @After
+    public void tearDown()
+    {
+        // Restore original value
+        if (originalValue != null)
+            DISABLE_USER_DEFINED_FUNCTIONS.setString(originalValue);
+        else
+            DISABLE_USER_DEFINED_FUNCTIONS.reset();
+    }
+
+    @Test
+    public void testUDFDisabledViaSystemProperty()
+    {
+        // Disable UDFs
+        DISABLE_USER_DEFINED_FUNCTIONS.setBoolean(true);
+
+        try
+        {
+            UDFunction.assertUdfsEnabled("java");
+            fail("Expected InvalidRequestException when UDFs are disabled via system property");
+        }
+        catch (InvalidRequestException e)
+        {
+            assertTrue("Error message should mention system property",
+                       e.getMessage().contains(DISABLE_USER_DEFINED_FUNCTIONS.getKey()));
+            assertTrue("Error message should indicate property is set to true",
+                       e.getMessage().contains("set to true"));
+        }
+    }
+
+    @Test
+    public void testUDFDisabledPropertyExplicitlyFalse()
+    {
+        // Explicitly set to false (should not block if other conditions are met)
+        DISABLE_USER_DEFINED_FUNCTIONS.setBoolean(false);
+
+        // Note: It may still throw if enable_user_defined_functions is false in config,
+        // but we're only testing the system property check here
+        try
+        {
+            UDFunction.assertUdfsEnabled("java");
+        }
+        catch (InvalidRequestException e)
+        {
+            assertFalse("Error should not be about system property when set to false", e.getMessage().contains(DISABLE_USER_DEFINED_FUNCTIONS.getKey()));
+        }
+    }
+
+    @Test
+    public void testUDFDisabledPropertyNotSet()
+    {
+        DISABLE_USER_DEFINED_FUNCTIONS.reset();
+
+        try
+        {
+            UDFunction.assertUdfsEnabled("java");
+        }
+        catch (InvalidRequestException e)
+        {
+            assertFalse("Error should not be about system property when not set", e.getMessage().contains(DISABLE_USER_DEFINED_FUNCTIONS.getKey()));
+        }
+    }
+
+    @Test
+    public void testUDFDisabledPropertyCaseInsensitive()
+    {
+        String[] trueValues = { "true", "TRUE", "True", "TrUe" };
+
+        for (String value : trueValues)
+        {
+            DISABLE_USER_DEFINED_FUNCTIONS.setString(value);
+
+            try
+            {
+                UDFunction.assertUdfsEnabled("java");
+                fail("Expected InvalidRequestException for value: " + value);
+            }
+            catch (InvalidRequestException e)
+            {
+                assertTrue("Error message should mention system property for value: " + value,
+                           e.getMessage().contains(DISABLE_USER_DEFINED_FUNCTIONS.getKey()));
+            }
+        }
+    }
+
+    @Test
+    public void testUDFDisabledPropertyInvalidValues()
+    {
+        String[] falseValues = { "false", "FALSE", "yes", "no", "0", "1", "invalid", "" };
+
+        for (String value : falseValues)
+        {
+            DISABLE_USER_DEFINED_FUNCTIONS.setString(value);
+
+            try
+            {
+                UDFunction.assertUdfsEnabled("java");
+            }
+            catch (InvalidRequestException e)
+            {
+                assertFalse("Error should not be about system property for value: " + value, e.getMessage().contains(DISABLE_USER_DEFINED_FUNCTIONS.getKey()));
+            }
+        }
+    }
+
+    @Test
+    public void testSecurityManagerNotInstalledWhenUDFsDisabled()
+    {
+        // Save current SecurityManager state
+        SecurityManager originalSecurityManager = System.getSecurityManager();
+
+        try
+        {
+            // Clear any existing SecurityManager
+            System.setSecurityManager(null);
+
+            // Enable UDF disable flag
+            DISABLE_USER_DEFINED_FUNCTIONS.setBoolean(true);
+
+            // Reset the installed flag for testing
+            org.apache.cassandra.security.ThreadAwareSecurityManager.resetInstalledFlagForTests();
+
+            // Attempt to install SecurityManager - should be skipped
+            org.apache.cassandra.security.ThreadAwareSecurityManager.install();
+
+            // Verify SecurityManager was NOT installed
+            assertNull("SecurityManager should not be installed when UDFs are disabled",
+                       System.getSecurityManager());
+        }
+        finally
+        {
+            // Reset the installed flag again to cleanup
+            org.apache.cassandra.security.ThreadAwareSecurityManager.resetInstalledFlagForTests();
+            // Restore original SecurityManager
+            System.setSecurityManager(originalSecurityManager);
+        }
+    }
+}


### PR DESCRIPTION
Introduces the `-Dcassandra.disable_user_defined_functions` system property:

* When set to `true`, UDF creation and execution are blocked, and ThreadAwareSecurityManager installation is skipped
* Takes precedence over the YAML `enable_user_defined_functions` setting
* Defaults to `false` to maintain backward compatibility
* SecurityManager installation is skipped because it is only used for sandboxing UDFs
