### PR TITLE
CNDB-18296: Upgrading jackson dependencies to 2.21.4

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -597,9 +597,9 @@
           <dependency groupId="org.slf4j" artifactId="jcl-over-slf4j" version="2.0.9" />
           <dependency groupId="ch.qos.logback" artifactId="logback-core" version="1.5.25"/>
           <dependency groupId="ch.qos.logback" artifactId="logback-classic" version="1.5.25"/>
-          <dependency groupId="com.fasterxml.jackson.core" artifactId="jackson-core" version="2.18.6"/>
-          <dependency groupId="com.fasterxml.jackson.core" artifactId="jackson-databind" version="2.18.6"/>
-          <dependency groupId="com.fasterxml.jackson.core" artifactId="jackson-annotations" version="2.18.6"/>
+          <dependency groupId="com.fasterxml.jackson.core" artifactId="jackson-core" version="2.21.4"/>
+          <dependency groupId="com.fasterxml.jackson.core" artifactId="jackson-databind" version="2.21.4"/>
+          <dependency groupId="com.fasterxml.jackson.core" artifactId="jackson-annotations" version="2.21.4"/>
           <dependency groupId="org.msgpack" artifactId="jackson-dataformat-msgpack" version="0.9.11"/>
 
           <dependency groupId="com.googlecode.json-simple" artifactId="json-simple" version="1.1"/>

--- a/build.xml
+++ b/build.xml
@@ -599,7 +599,7 @@
           <dependency groupId="ch.qos.logback" artifactId="logback-classic" version="1.5.25"/>
           <dependency groupId="com.fasterxml.jackson.core" artifactId="jackson-core" version="2.21.4"/>
           <dependency groupId="com.fasterxml.jackson.core" artifactId="jackson-databind" version="2.21.4"/>
-          <dependency groupId="com.fasterxml.jackson.core" artifactId="jackson-annotations" version="2.21.4"/>
+          <dependency groupId="com.fasterxml.jackson.core" artifactId="jackson-annotations" version="2.21"/>
           <dependency groupId="org.msgpack" artifactId="jackson-dataformat-msgpack" version="0.9.11"/>
 
           <dependency groupId="com.googlecode.json-simple" artifactId="json-simple" version="1.1"/>


### PR DESCRIPTION
addresses [CVE-2026-54512](https://www.cve.org/CVERecord?id=CVE-2026-54512) for Cassandra dependencies.

Fixes [CNDB-18296](https://github.com/riptano/cndb/issues/18296)
