### PR TITLE
CNDB-18210: upgrade logback to 1.5.35

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -595,8 +595,8 @@
           <dependency groupId="org.slf4j" artifactId="slf4j-api" version="2.0.9"/>
           <dependency groupId="org.slf4j" artifactId="log4j-over-slf4j" version="2.0.9"/>
           <dependency groupId="org.slf4j" artifactId="jcl-over-slf4j" version="2.0.9" />
-          <dependency groupId="ch.qos.logback" artifactId="logback-core" version="1.5.25"/>
-          <dependency groupId="ch.qos.logback" artifactId="logback-classic" version="1.5.25"/>
+          <dependency groupId="ch.qos.logback" artifactId="logback-core" version="1.5.35"/>
+          <dependency groupId="ch.qos.logback" artifactId="logback-classic" version="1.5.35"/>
           <dependency groupId="com.fasterxml.jackson.core" artifactId="jackson-core" version="2.21.4"/>
           <dependency groupId="com.fasterxml.jackson.core" artifactId="jackson-databind" version="2.21.4"/>
           <dependency groupId="com.fasterxml.jackson.core" artifactId="jackson-annotations" version="2.21"/>


### PR DESCRIPTION
### What is the issue
Need to upgrade logback to resolve https://github.com/advisories/GHSA-p47f-322f-whfh, https://github.com/advisories/GHSA-jhq6-gfmj-v8fx

### What does this PR fix and why was it fixed
Upgrades logback to 1.5.35
