### PR TITLE
CNDB-18296: Upgrading jackson dependencies to 2.21.4 (#2489)

### DIFF
--- a/.build/parent-pom-template.xml
+++ b/.build/parent-pom-template.xml
@@ -426,12 +426,12 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
-        <version>2.21.2</version>
+        <version>2.21.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.21.2</version>
+        <version>2.21.4</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
@@ -446,7 +446,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-jsr310</artifactId>
-        <version>2.21.2</version>
+        <version>2.21.4</version>
       </dependency>
       <dependency>
         <groupId>org.msgpack</groupId>
@@ -456,7 +456,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>
         <artifactId>jackson-dataformat-yaml</artifactId>
-        <version>2.21.2</version>
+        <version>2.21.4</version>
         <scope>test</scope>
         <!-- CASSANDRA-20848 2.19.x would bring snakeyaml 2.4 which is for now incompatible with rest of the codebase -->
         <exclusions>


### PR DESCRIPTION
addresses
[CVE-2026-54512](https://www.cve.org/CVERecord?id=CVE-2026-54512) for Cassandra dependencies.

Fixes [CNDB-18296](https://github.com/riptano/cndb/issues/18296)
