### PR TITLE
CNDB-18216: Fix logging of paged queries exposing user data

### DIFF
--- a/src/java/org/apache/cassandra/db/AbstractReadQuery.java
+++ b/src/java/org/apache/cassandra/db/AbstractReadQuery.java
@@ -61,6 +61,7 @@ abstract class AbstractReadQuery extends MonitorableImpl implements ReadQuery
     }
 
     // Monitorable interface
+    @Override
     public String name()
     {
         return toCQLString(Redaction.REDACT);
@@ -124,7 +125,7 @@ abstract class AbstractReadQuery extends MonitorableImpl implements ReadQuery
         appendCQLWhereClause(builder, redaction);
 
         if (limits() != DataLimits.NONE)
-            builder.append(' ').append(limits());
+            builder.append(' ').append(limits().toCQLString());
 
         // ALLOW FILTERING might not be strictly necessary
         builder.append(" ALLOW FILTERING");
@@ -137,6 +138,12 @@ abstract class AbstractReadQuery extends MonitorableImpl implements ReadQuery
              .append(SelectOptions.EXCLUDED_INDEXES, excluded)
              .append(SelectOptions.ANN_OPTIONS, rowFilter().annOptions().toCQLString());
         });
+
+        // The limits used by the subsequent queries of paging don't have a clear direct translation into CQL.
+        // However, they change the meaning of the query, and it can be useful to identify them in logs.
+        // That's why here we append a fragment of invalid CQL syntanx, at the end of the query.
+        if (limits.isPagingContinuation())
+            builder.append(" [paging continuation]");
 
         return builder.toString();
     }

--- a/src/java/org/apache/cassandra/db/filter/DataLimits.java
+++ b/src/java/org/apache/cassandra/db/filter/DataLimits.java
@@ -233,6 +233,17 @@ public abstract class DataLimits
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Whether this is for the continuation of a paged query, that is, whether it comes from
+     * {@link #forPaging(PageSize, ByteBuffer, int)} or {@link #forGroupByInternalPaging}.
+     *
+     * @return whether this is for the continuation of a paged query
+     */
+    public boolean isPagingContinuation()
+    {
+        return false;
+    }
+
     public abstract boolean hasEnoughLiveData(CachedPartition cached,
                                               int nowInSec,
                                               boolean countPartitionsWithOnlyStaticData,
@@ -333,6 +344,8 @@ public abstract class DataLimits
      * Estimate the number of results that a full scan of the provided cfs would yield.
      */
     public abstract float estimateTotalResults(ColumnFamilyStore cfs);
+
+    public abstract String toCQLString();
 
     public static abstract class Counter extends StoppingTransformation<BaseRowIterator<?>>
     {
@@ -704,6 +717,12 @@ public abstract class DataLimits
         @Override
         public String toString()
         {
+            return toCQLString();
+        }
+
+        @Override
+        public String toCQLString()
+        {
             List<String> limits = new ArrayList<>(3);
 
             if (bytesLimit != NO_LIMIT)
@@ -745,6 +764,12 @@ public abstract class DataLimits
         public DataLimits forPaging(PageSize pageSize, ByteBuffer lastReturnedKey, int lastReturnedKeyRemaining)
         {
             throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isPagingContinuation()
+        {
+            return true;
         }
 
         @Override
@@ -1336,6 +1361,12 @@ public abstract class DataLimits
         public DataLimits forGroupByInternalPaging(GroupingState state)
         {
             throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isPagingContinuation()
+        {
+            return true;
         }
 
         @Override

--- a/test/distributed/org/apache/cassandra/distributed/test/SlowQueryLoggerTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/SlowQueryLoggerTest.java
@@ -17,6 +17,7 @@
 package org.apache.cassandra.distributed.test;
 
 import java.nio.ByteBuffer;
+import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
@@ -46,6 +47,8 @@ import org.assertj.core.api.AbstractIterableAssert;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.ListAssert;
 
+import static java.util.regex.Pattern.quote;
+
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static org.apache.cassandra.distributed.api.ConsistencyLevel.ALL;
 import static org.apache.cassandra.utils.MonotonicClock.approxTime;
@@ -68,7 +71,11 @@ public class SlowQueryLoggerTest extends TestBaseImpl
 
         cluster = init(Cluster.build(2)
                               .withInstanceInitializer(SlowQueryLoggerTest.BBHelper::install)
-                              .withConfig(config -> config.set("slow_query_log_timeout_in_ms", SLOW_QUERY_LOG_TIMEOUT_MS))
+                              .withConfig(config -> {
+                                  config.set("slow_query_log_timeout_in_ms", SLOW_QUERY_LOG_TIMEOUT_MS);
+                                  config.set("read_request_timeout_in_ms", 60000L);
+                                  config.set("range_request_timeout_in_ms", 60000L);
+                              })
                               .start());
         coordinator = cluster.coordinator(1);
         node = cluster.get(2);
@@ -108,14 +115,24 @@ public class SlowQueryLoggerTest extends TestBaseImpl
 
         // verify that slow queries are logged with redacted values
         long mark = node.logs().mark();
-        Object[][] rows = coordinator.execute(format("SELECT * FROM %s.%s WHERE k = 'secret_k' AND c = 'secret_c' AND v = 'secret_v' ALLOW FILTERING"), ALL);
+        String query = format("SELECT * FROM %s.%s WHERE k = 'secret_k' AND c = 'secret_c' AND v = 'secret_v' ALLOW FILTERING");
+        Object[][] rows = coordinator.execute(query, ALL);
         Assertions.assertThat(rows).hasNumberOfRows(1);
         assertLogsContain(mark, node, "operations were slow", format("<SELECT \\* FROM %s\\.%s WHERE k = \\? AND c = \\? AND v = \\? ALLOW FILTERING>"));
         assertLogsDoNotContain(mark, node, "secret_k", "secret_c", "secret_v");
 
+        // verify again with paging
+        mark = node.logs().mark();
+        Iterator<Object[]> pagedRows = coordinator.executeWithPaging(query, ALL, 1);
+        while (pagedRows.hasNext())
+            pagedRows.next();
+        assertLogsContain(mark, node, "operations were slow", quote(format("<SELECT * FROM %s.%s WHERE k = ? AND c = ? AND v = ? LIMIT 1 ALLOW FILTERING>")));
+        assertLogsContain(mark, node, "operations were slow", quote(format("<SELECT * FROM %s.%s WHERE k = ? AND v = ? LIMIT 1 ALLOW FILTERING [paging continuation]>")));
+        assertLogsDoNotContain(mark, node, "secret_k", "secret_c", "secret_v");
+
         // verify that large values include size hints
         mark = node.logs().mark();
-        String query = format("SELECT * FROM %s.%s WHERE b = ? ALLOW FILTERING");
+        query = format("SELECT * FROM %s.%s WHERE b = ? ALLOW FILTERING");
         coordinator.execute(query, ALL, ByteBuffer.allocate(100 + 1));
         coordinator.execute(query, ALL, ByteBuffer.allocate(1024 + 1));
         coordinator.execute(query, ALL, ByteBuffer.allocate(10 * 1024 + 1));
@@ -183,6 +200,19 @@ public class SlowQueryLoggerTest extends TestBaseImpl
                           "  Fetched/returned/tombstones:",
                           "    partitions: 10/3/0",
                           "    rows: 100/25/0");
+
+        // paged query
+        mark = node.logs().mark();
+        Iterator<Object[]> pagedRows = coordinator.executeWithPaging(format("SELECT * FROM %s.%s"), ALL, 5);
+        int readRows = 0;
+        while (pagedRows.hasNext())
+        {
+            pagedRows.next();
+            readRows++;
+        }
+        Assertions.assertThat(readRows).isEqualTo(numRows);
+        assertLogsContain(mark, node, quote(format("<SELECT * FROM %s.%s LIMIT 5 ALLOW FILTERING>")));
+        assertLogsContain(mark, node, quote(format("<SELECT * FROM %s.%s WHERE token(k) >= token(?) LIMIT 5 ALLOW FILTERING [paging continuation]>")));
 
         // test multiple slow runs of different queries with the same redacted form, it should log the slowest one
         mark = node.logs().mark();

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/SlowSAIQueryLoggerTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/SlowSAIQueryLoggerTest.java
@@ -15,6 +15,7 @@
  */
 package org.apache.cassandra.distributed.test.sai;
 
+import java.util.Iterator;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -44,6 +45,7 @@ import org.apache.cassandra.index.sai.plan.QueryController;
 import org.apache.cassandra.index.sai.plan.QueryMonitorableExecutionInfo;
 import org.awaitility.Awaitility;
 
+import static java.util.regex.Pattern.quote;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static org.apache.cassandra.distributed.test.SlowQueryLoggerTest.assertLogsContain;
 import static org.apache.cassandra.distributed.test.SlowQueryLoggerTest.assertLogsDoNotContain;
@@ -400,6 +402,19 @@ public class SlowSAIQueryLoggerTest extends TestBaseImpl
             assertLogsContain(mark, node,
                               "partitionTombstonesFetched: 1",
                               "rowTombstonesFetched: 2");
+
+            // test with paged queries
+            mark = node.logs().mark();
+            String query =  withKeyspace("SELECT * FROM %s.t WHERE n >= 0");
+            Iterator<Object[]> pagedRows = coordinator.executeWithPaging(query, ConsistencyLevel.ONE, 1);
+            while (pagedRows.hasNext())
+                pagedRows.next();
+            assertLogsContain(mark, node,
+                              quote(withKeyspace("<SELECT * FROM %s.t WHERE n >= ? LIMIT 1 ALLOW FILTERING>")),
+                              "NumericIndexScan");
+            assertLogsContain(mark, node,
+                              quote(withKeyspace("<SELECT * FROM %s.t WHERE token(k) >= token(?) AND n >= ? LIMIT 1 ALLOW FILTERING [paging continuation]>")),
+                              "NumericIndexScan");
         }
     }
 

--- a/test/unit/org/apache/cassandra/service/reads/range/RangeCommandsTest.java
+++ b/test/unit/org/apache/cassandra/service/reads/range/RangeCommandsTest.java
@@ -38,7 +38,6 @@ import org.apache.cassandra.db.partitions.CachedPartition;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.index.StubIndex;
 import org.apache.cassandra.schema.IndexMetadata;
-import org.apache.cassandra.service.QueryInfoTracker;
 
 import static org.apache.cassandra.db.ConsistencyLevel.ONE;
 import static org.apache.cassandra.service.QueryInfoTracker.*;
@@ -287,6 +286,12 @@ public class RangeCommandsTest extends CQLTester
         public DataLimits withBytesLimit(int bytesLimit)
         {
             return wrapped.withBytesLimit(bytesLimit);
+        }
+
+        @Override
+        public String toCQLString()
+        {
+            return wrapped.toCQLString();
         }
     }
 


### PR DESCRIPTION
### What is the issue

The special `DataLimits` used by paged queries after the first page has been retrieved are not correctly printed as CQL in `AbstractReadQuery#toRedactedCQLString`. As a result, the limits are not correctly printed in slow query logs. For example:
```
<SELECT * FROM distributed_test_keyspace.t_0 WHERE token(k) >= token(?) CQLPagingLimits[super=LIMIT 3, lastReturnedKey=00000001, lastReturnedKeyRemaining=2147483645] ALLOW FILTERING>, time 203 msec - slow timeout 100 msec/cross-node
  Fetched/returned/tombstones:
    partitions: 1/1/0
    rows: 3/3/0
```
More importantly, the non-SQL representation of the limits exposes user data without any redaction.

### What does this PR fix and why was it fixed

Unfortunately there is no a direct, clear CQL translation of the type of data limits used by the commands generated after paging has retrieved the first page. That special data limit contains the last read partition key and the number of rows the remain to be read in that partition. 

This PR makes `toCQLString` simply print the original query, and adds `[paging continuation]` at the end of the query to make it easier to identify paging followup queries in the slow query logger. Since all followup queries will have the same string representation, they will be grouped together in the slow query log reports, which should make it easier to read.

For example, this is a log report for paging with fetch size 5:
```
2 operations were slow in the last 4514 msecs:
<SELECT * FROM k.t LIMIT 5 ALLOW FILTERING>, was slow 2 times: avg/min/max 204/204/205 msec - slow timeout 100 msec/cross-node
  Slowest fetched/returned/tombstones:
    partitions: 1/1/0
    rows: 5/5/0
<SELECT * FROM k.t WHERE token(k) >= token(?) LIMIT 5 ALLOW FILTERING [paging continuation]>, was slow 20 times: avg/min/max 204/199/207 msec - slow timeout 100 msec/cross-node
  Slowest fetched/returned/tombstones:
    partitions: 1/1/0
    rows: 5/5/0
```
The second query, which was slow 20 times, is caused by additional page requests.
