### PR TITLE
CNDB-17983: Redact expressions and orderers in SAI query plan (#2448)

### DIFF
--- a/src/java/org/apache/cassandra/cql3/CqlBuilder.java
+++ b/src/java/org/apache/cassandra/cql3/CqlBuilder.java
@@ -29,6 +29,7 @@ import com.google.common.annotations.VisibleForTesting;
 import org.apache.cassandra.cql3.functions.FunctionName;
 import org.apache.cassandra.db.filter.RowFilter;
 import org.apache.cassandra.db.marshal.AbstractType;
+import org.apache.cassandra.db.marshal.Redaction;
 
 /**
  * Utility class to facilitate the creation of the CQL representation of {@code SchemaElements}.
@@ -271,12 +272,8 @@ public final class CqlBuilder
 
     /**
      * Builds a `WITH option1 = ... AND option2 = ... AND option3 = ... clause
-<<<<<<< HEAD
-     * @param builder a receiver to receive a builder allowing to add each option
-=======
      *
      * @param builder a consumer to receive a builder for the options to append
->>>>>>> 4714c43331 (CNDB-13129: Add index hints)
      */
     public CqlBuilder appendOptions(Consumer<OptionsBuilder> builder)
     {
@@ -289,12 +286,12 @@ public final class CqlBuilder
      *
      * @param filter the row filter to append
      * @param hasKeyRestrictions whether the query has key restrictions that have already been appended
-     * @param redact whether to redact the column values in the row filter
+     * @param redaction whether to redact the column values in the row filter
      * @return this CQL builder after appending the row filter
      */
-    public CqlBuilder append(RowFilter filter, boolean hasKeyRestrictions, boolean redact)
+    public CqlBuilder append(RowFilter filter, boolean hasKeyRestrictions, Redaction redaction)
     {
-        return filter.isEmpty() ? this : appendRestrictions(filter.toCQLString(redact), hasKeyRestrictions);
+        return filter.isEmpty() ? this : appendRestrictions(filter.toCQLString(redaction), hasKeyRestrictions);
     }
 
     /**

--- a/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
@@ -111,6 +111,7 @@ import org.apache.cassandra.db.guardrails.Guardrails;
 import org.apache.cassandra.db.marshal.CompositeType;
 import org.apache.cassandra.db.marshal.FloatType;
 import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.db.partitions.PartitionIterator;
 import org.apache.cassandra.db.rows.Row;
 import org.apache.cassandra.db.rows.RowIterator;
@@ -2158,7 +2159,7 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
         ColumnFilter columnFilter = selection.newSelectors(options).getColumnFilter();
         StringBuilder sb = new StringBuilder();
 
-        sb.append("SELECT ").append(queriedColumns().toCQLString(false));
+        sb.append("SELECT ").append(queriedColumns().toCQLString(Redaction.NONE));
         sb.append(" FROM ").append(table.keyspace).append('.').append(table.name);
         if (restrictions.isKeyRange() || restrictions.usesSecondaryIndexing())
         {
@@ -2188,7 +2189,7 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
                         sb.append(" AND ");
                 }
                 if (!dataRange.isUnrestricted(table))
-                    sb.append(dataRange.toCQLString(table, rowFilter, false));
+                    sb.append(dataRange.toCQLString(table, rowFilter, Redaction.NONE));
             }
         }
         else
@@ -2212,7 +2213,7 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
             {
                 sb.append(" = ");
                 if (compoundPk) sb.append('(');
-                DataRange.appendKeyString(sb, table.partitionKeyType, Iterables.getOnlyElement(keys), false);
+                DataRange.appendKeyString(sb, table.partitionKeyType, Iterables.getOnlyElement(keys), Redaction.NONE);
                 if (compoundPk) sb.append(')');
             }
             else
@@ -2225,7 +2226,7 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
                         sb.append(", ");
 
                     if (compoundPk) sb.append('(');
-                    DataRange.appendKeyString(sb, table.partitionKeyType, key, false);
+                    DataRange.appendKeyString(sb, table.partitionKeyType, key, Redaction.NONE);
                     if (compoundPk) sb.append(')');
                     first = false;
                 }
@@ -2237,7 +2238,7 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
             if (!rowFilter.isEmpty())
                 sb.append(" AND ").append(rowFilter);
 
-            String filterString = filter.toCQLString(table, rowFilter, false);
+            String filterString = filter.toCQLString(table, rowFilter, Redaction.NONE);
             if (!filterString.isEmpty())
                 sb.append(" AND ").append(filterString);
         }

--- a/src/java/org/apache/cassandra/db/AbstractReadQuery.java
+++ b/src/java/org/apache/cassandra/db/AbstractReadQuery.java
@@ -19,8 +19,6 @@ package org.apache.cassandra.db;
 
 import java.util.Set;
 
-import com.google.common.annotations.VisibleForTesting;
-
 import org.apache.cassandra.cql3.ColumnIdentifier;
 import org.apache.cassandra.cql3.CqlBuilder;
 import org.apache.cassandra.cql3.statements.SelectOptions;
@@ -28,6 +26,7 @@ import org.apache.cassandra.db.filter.ColumnFilter;
 import org.apache.cassandra.db.filter.DataLimits;
 import org.apache.cassandra.db.filter.IndexHints;
 import org.apache.cassandra.db.filter.RowFilter;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.db.monitoring.MonitorableImpl;
 import org.apache.cassandra.db.partitions.PartitionIterator;
 import org.apache.cassandra.db.partitions.UnfilteredPartitionIterators;
@@ -64,7 +63,7 @@ abstract class AbstractReadQuery extends MonitorableImpl implements ReadQuery
     // Monitorable interface
     public String name()
     {
-        return toRedactedCQLString();
+        return toCQLString(Redaction.REDACT);
     }
 
     @Override
@@ -98,27 +97,6 @@ abstract class AbstractReadQuery extends MonitorableImpl implements ReadQuery
     }
 
     /**
-     * Recreates the CQL string corresponding to this query, representing any specific values with '?',
-     * to prevent leaking sensitive data.
-     * @see #toCQLString(boolean)
-     */
-    public String toRedactedCQLString()
-    {
-        return toCQLString(true);
-    }
-
-    /**
-     * Recreates the CQL string corresponding to this query, printing specific values without any redaction.
-     * This might leak sensitive data if the query string ends up in logs or any other unprotected place, so this only
-     * should be used for debugging purposes or to present the query string to the same end user that created the query.
-     * @see #toCQLString(boolean)
-     */
-    public String toUnredactedCQLString()
-    {
-        return toCQLString(false);
-    }
-
-    /**
      * Recreates the CQL string corresponding to this query.
      * </p>
      * If the {@code redact} parameter is set to {@code true}, the query string will be redacted, replacing any specific
@@ -133,18 +111,28 @@ abstract class AbstractReadQuery extends MonitorableImpl implements ReadQuery
      * we query them all). So this shouldn't be relied upon too strongly, but this should be good enough for
      * debugging purposes which is what this is for.
      *
-     * @param redact whether to redact the queried column values.
+     * @param redaction whether to redact the queried column values.
      */
-    @VisibleForTesting
-    protected String toCQLString(boolean redact)
+
+    public String toUnredactedCQLString()
+    {
+        return toCQLString(Redaction.NONE);
+    }
+
+    public String toRedactedCQLString()
+    {
+        return toCQLString(Redaction.REDACT);
+    }
+
+    public String toCQLString(Redaction redaction)
     {
         CqlBuilder builder = new CqlBuilder();
-        builder.append("SELECT ").append(columnFilter().toCQLString(redact));
+        builder.append("SELECT ").append(columnFilter().toCQLString(redaction));
         builder.append(" FROM ").append(ColumnIdentifier.maybeQuote(metadata().keyspace))
                .append('.')
                .append(ColumnIdentifier.maybeQuote(metadata().name));
 
-        appendCQLWhereClause(builder, redact);
+        appendCQLWhereClause(builder, redaction);
 
         if (limits() != DataLimits.NONE)
             builder.append(' ').append(limits());
@@ -164,5 +152,5 @@ abstract class AbstractReadQuery extends MonitorableImpl implements ReadQuery
         return builder.toString();
     }
 
-    protected abstract void appendCQLWhereClause(CqlBuilder builder, boolean redact);
+    protected abstract void appendCQLWhereClause(CqlBuilder builder, Redaction redaction);
 }

--- a/src/java/org/apache/cassandra/db/Clustering.java
+++ b/src/java/org/apache/cassandra/db/Clustering.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import org.apache.cassandra.cache.IMeasurableMemory;
 import org.apache.cassandra.db.marshal.ByteArrayAccessor;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.db.marshal.AbstractType;
@@ -79,13 +80,14 @@ public interface Clustering<V> extends ClusteringPrefix<V>, IMeasurableMemory
         return sb.toString();
     }
 
-    default String toCQLString(TableMetadata metadata, boolean redact)
+    default String toCQLString(TableMetadata metadata, Redaction redaction)
     {
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < size(); i++)
         {
             ColumnMetadata c = metadata.clusteringColumns().get(i);
-            sb.append(i == 0 ? "" : ", ").append(c.type.toCQLString(bufferAt(i), redact));
+            ByteBuffer value = bufferAt(i);
+            sb.append(i == 0 ? "" : ", ").append(c.type.toCQLString(value, redaction));
         }
         return sb.toString();
     }

--- a/src/java/org/apache/cassandra/db/DataRange.java
+++ b/src/java/org/apache/cassandra/db/DataRange.java
@@ -19,6 +19,7 @@ package org.apache.cassandra.db;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.db.filter.*;
@@ -301,10 +302,10 @@ public class DataRange
         return String.format("range=%s pfilter=%s", keyRange.getString(metadata.partitionKeyType), clusteringIndexFilter.toString(metadata));
     }
 
-    public String toCQLString(TableMetadata metadata, RowFilter rowFilter, boolean redact)
+    public String toCQLString(TableMetadata metadata, RowFilter rowFilter, Redaction redaction)
     {
         if (isUnrestricted(metadata))
-            return rowFilter.toCQLString(redact);
+            return rowFilter.toCQLString(redaction);
 
         if (isSinglePartition())
         {
@@ -313,20 +314,20 @@ public class DataRange
              * key are the same. If that is the case, we want to print the query as an equality on the partition key
              * rather than a token range, as if it was a partition query, for better readability.
              */
-            return ((DecoratedKey) startKey()).toCQLString(metadata, redact);
+            return ((DecoratedKey) startKey()).toCQLString(metadata, redaction);
         }
         else
         {
             StringBuilder builder = new StringBuilder();
             if (!startKey().isMinimum())
             {
-                appendCQLClause(startKey(), builder, metadata, true, keyRange.isStartInclusive(), redact);
+                appendCQLClause(startKey(), builder, metadata, true, keyRange.isStartInclusive(), redaction);
             }
             if (!stopKey().isMinimum())
             {
                 if (builder.length() > 0)
                     builder.append(" AND ");
-                appendCQLClause(stopKey(), builder, metadata, false, keyRange.isEndInclusive(), redact);
+                appendCQLClause(stopKey(), builder, metadata, false, keyRange.isEndInclusive(), redaction);
             }
             return builder.toString();
         }
@@ -337,7 +338,7 @@ public class DataRange
                                  TableMetadata metadata,
                                  boolean isStart,
                                  boolean isInclusive,
-                                 boolean redact)
+                                 Redaction redaction)
     {
         builder.append("token(");
         builder.append(ColumnMetadata.toCQLString(metadata.partitionKeyColumns()));
@@ -346,14 +347,14 @@ public class DataRange
         {
             builder.append(getOperator(isStart, isInclusive)).append(" ");
             builder.append("token(");
-            appendKeyString(builder, metadata.partitionKeyType, ((DecoratedKey)pos).getKey(), redact);
-            builder.append(")");
+            appendKeyString(builder, metadata.partitionKeyType, ((DecoratedKey)pos).getKey(), redaction);
+            builder.append(')');
         }
         else
         {
             Token.KeyBound keyBound = (Token.KeyBound) pos;
             builder.append(getOperator(isStart, isStart == keyBound.isMinimumBound)).append(' ');
-            builder.append(redact ? "?" : keyBound.getToken());
+            builder.append(redaction == Redaction.REDACT ? "?" : keyBound.getToken());
         }
     }
 
@@ -366,18 +367,18 @@ public class DataRange
 
     // TODO: this is reused in SinglePartitionReadCommand but this should not really be here. Ideally
     // we need a more "native" handling of composite partition keys.
-    public static void appendKeyString(StringBuilder builder, AbstractType<?> type, ByteBuffer key, boolean redact)
+    public static void appendKeyString(StringBuilder builder, AbstractType<?> type, ByteBuffer key, Redaction redaction)
     {
         if (type instanceof CompositeType)
         {
             CompositeType ct = (CompositeType)type;
             ByteBuffer[] values = ct.split(key);
             for (int i = 0; i < ct.subTypes().size(); i++)
-                builder.append(i == 0 ? "" : ", ").append(ct.subTypes().get(i).toCQLString(values[i], redact));
+                builder.append(i == 0 ? "" : ", ").append(ct.subTypes().get(i).toCQLString(values[i], redaction));
         }
         else
         {
-            builder.append(type.toCQLString(key, redact));
+            builder.append(type.toCQLString(key, redaction));
         }
     }
 

--- a/src/java/org/apache/cassandra/db/DecoratedKey.java
+++ b/src/java/org/apache/cassandra/db/DecoratedKey.java
@@ -24,6 +24,7 @@ import java.util.StringJoiner;
 import java.util.function.BiFunction;
 
 import org.apache.cassandra.db.marshal.CompositeType;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.dht.IPartitioner;
 import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.dht.Token.KeyBound;
@@ -164,29 +165,29 @@ public abstract class DecoratedKey implements PartitionPosition, FilterKey
     /**
      * Returns a CQL representation of this key.
      *
-     * @param metadata the metadata of the table that this key belogs to
-     * @param redact whether to redact the key value, as in "k1 = ? AND k2 = ?".
+     * @param metadata the table metadata
+     * @param redaction whether to redact the key value, as in "k1 = ? AND k2 = ?".
      * @return a CQL representation of this key
      */
-    public String toCQLString(TableMetadata metadata, boolean redact)
+    public String toCQLString(TableMetadata metadata, Redaction redaction)
     {
         List<ColumnMetadata> columns = metadata.partitionKeyColumns();
 
         if (columns.size() == 1)
-            return toCQLString(columns.get(0), getKey(), redact);
+            return toCQLString(columns.get(0), getKey(), redaction);
 
         ByteBuffer[] values = ((CompositeType) metadata.partitionKeyType).split(getKey());
         StringJoiner joiner = new StringJoiner(" AND ");
 
         for (int i = 0; i < columns.size(); i++)
-            joiner.add(toCQLString(columns.get(i), values[i], redact));
+            joiner.add(toCQLString(columns.get(i), values[i], redaction));
 
         return joiner.toString();
     }
 
-    private static String toCQLString(ColumnMetadata metadata, ByteBuffer key, boolean redact)
+    private static String toCQLString(ColumnMetadata metadata, ByteBuffer key, Redaction redaction)
     {
-        return String.format("%s = %s", metadata.name.toCQLString(), metadata.type.toCQLString(key, redact));
+        return String.format("%s = %s", metadata.name.toCQLString(), metadata.type.toCQLString(key, redaction));
     }
 
     public Token getToken()

--- a/src/java/org/apache/cassandra/db/MultiPartitionReadQuery.java
+++ b/src/java/org/apache/cassandra/db/MultiPartitionReadQuery.java
@@ -19,6 +19,7 @@ package org.apache.cassandra.db;
 import java.util.List;
 
 import org.apache.cassandra.cql3.CqlBuilder;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.schema.TableMetadata;
 
 /**
@@ -28,18 +29,18 @@ public interface MultiPartitionReadQuery extends ReadQuery
 {
     List<DataRange> ranges();
 
-    default void appendCQLWhereClause(CqlBuilder builder, boolean redact)
+    default void appendCQLWhereClause(CqlBuilder builder, Redaction redaction)
     {
         // Append the data ranges.
         TableMetadata metadata = metadata();
-        boolean hasRanges = appendRanges(builder, redact);
+        boolean hasRanges = appendRanges(builder, redaction);
 
         // Append the clustering index filter and the row filter.
-        String filter = ranges().get(0).clusteringIndexFilter.toCQLString(metadata, rowFilter(), redact);
+        String filter = ranges().get(0).clusteringIndexFilter.toCQLString(metadata, rowFilter(), redaction);
         builder.appendRestrictions(filter, hasRanges);
     }
 
-    private boolean appendRanges(CqlBuilder builder, boolean redact)
+    private boolean appendRanges(CqlBuilder builder, Redaction redaction)
     {
         List<DataRange> ranges = ranges();
         if (ranges.size() == 1)
@@ -48,7 +49,7 @@ public interface MultiPartitionReadQuery extends ReadQuery
             if (range.isUnrestricted(metadata()))
                 return false;
 
-            String rangeString = range.toCQLString(metadata(), rowFilter(), redact);
+            String rangeString = range.toCQLString(metadata(), rowFilter(), redaction);
             if (!rangeString.isEmpty())
             {
                 builder.append(" WHERE ").append(rangeString);
@@ -62,7 +63,7 @@ public interface MultiPartitionReadQuery extends ReadQuery
             {
                 if (i > 0)
                     builder.append(" OR ");
-                builder.append(ranges.get(i).toCQLString(metadata(), rowFilter(), redact));
+                builder.append(ranges.get(i).toCQLString(metadata(), rowFilter(), redaction));
             }
             builder.append(')');
             return true;

--- a/src/java/org/apache/cassandra/db/MultiRangeReadCommand.java
+++ b/src/java/org/apache/cassandra/db/MultiRangeReadCommand.java
@@ -32,6 +32,7 @@ import org.apache.cassandra.db.filter.ClusteringIndexFilter;
 import org.apache.cassandra.db.filter.ColumnFilter;
 import org.apache.cassandra.db.filter.DataLimits;
 import org.apache.cassandra.db.filter.RowFilter;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.db.partitions.PartitionIterator;
 import org.apache.cassandra.db.partitions.UnfilteredPartitionIterator;
 import org.apache.cassandra.db.partitions.UnfilteredPartitionIterators;
@@ -374,9 +375,9 @@ public class MultiRangeReadCommand extends ReadCommand implements MultiPartition
     }
 
     @Override
-    public void appendCQLWhereClause(CqlBuilder builder, boolean redact)
+    public void appendCQLWhereClause(CqlBuilder builder, Redaction redaction)
     {
-        MultiPartitionReadQuery.super.appendCQLWhereClause(builder, redact);
+        MultiPartitionReadQuery.super.appendCQLWhereClause(builder, redaction);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/PartitionRangeReadCommand.java
+++ b/src/java/org/apache/cassandra/db/PartitionRangeReadCommand.java
@@ -24,6 +24,7 @@ import java.util.concurrent.TimeUnit;
 import com.google.common.annotations.VisibleForTesting;
 
 import org.apache.cassandra.cql3.CqlBuilder;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.db.memtable.Memtable;
 import org.apache.cassandra.net.Verb;
 import org.apache.cassandra.schema.TableMetadata;
@@ -479,9 +480,9 @@ public class PartitionRangeReadCommand extends ReadCommand implements PartitionR
     }
 
     @Override
-    public void appendCQLWhereClause(CqlBuilder builder, boolean redact)
+    public void appendCQLWhereClause(CqlBuilder builder, Redaction redaction)
     {
-        PartitionRangeReadQuery.super.appendCQLWhereClause(builder, redact);
+        PartitionRangeReadQuery.super.appendCQLWhereClause(builder, redaction);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/PartitionRangeReadQuery.java
+++ b/src/java/org/apache/cassandra/db/PartitionRangeReadQuery.java
@@ -99,10 +99,4 @@ public interface PartitionRangeReadQuery extends MultiPartitionReadQuery
         return dataRange().selectsAllPartition() && !rowFilter().hasExpressionOnClusteringOrRegularColumns();
     }
 
-    default void appendCQLWhereClause(StringBuilder sb, boolean redact)
-    {
-        String filterString = dataRange().toCQLString(metadata(), rowFilter(), redact);
-        if (!filterString.isEmpty())
-            sb.append(" WHERE ").append(filterString);
-    }
 }

--- a/src/java/org/apache/cassandra/db/ReadCommand.java
+++ b/src/java/org/apache/cassandra/db/ReadCommand.java
@@ -60,6 +60,7 @@ import org.apache.cassandra.db.filter.DataLimits;
 import org.apache.cassandra.db.filter.LocalReadSizeTooLargeException;
 import org.apache.cassandra.db.filter.RowFilter;
 import org.apache.cassandra.db.filter.TombstoneOverwhelmingException;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.db.partitions.PartitionIterator;
 import org.apache.cassandra.db.partitions.PurgeFunction;
 import org.apache.cassandra.db.partitions.UnfilteredPartitionIterator;
@@ -709,7 +710,7 @@ public abstract class ReadCommand extends AbstractReadQuery
                 Threshold guardrail = shouldRespectTombstoneThresholds()
                                                 ? Guardrails.scannedTombstones
                                                 : Threshold.NEVER_TRIGGERED;
-                return guardrail.newCounter(ReadCommand.this::toRedactedCQLString, false, null);
+                return guardrail.newCounter(() -> ReadCommand.this.toCQLString(Redaction.REDACT), false, null);
             }
 
             private MetricRecording()
@@ -773,7 +774,7 @@ public abstract class ReadCommand extends AbstractReadQuery
                 {
                     metric.tombstoneFailures.inc();
                     throw new TombstoneOverwhelmingException(tombstones.get(),
-                                                             ReadCommand.this.toRedactedCQLString(),
+                                                             ReadCommand.this.toCQLString(Redaction.REDACT),
                                                              ReadCommand.this.metadata(),
                                                              currentKey,
                                                              clustering);
@@ -873,7 +874,7 @@ public abstract class ReadCommand extends AbstractReadQuery
                 if (failBytes != -1 && this.sizeInBytes >= failBytes)
                 {
                     String msg = String.format("Query %s attempted to read %d bytes but max allowed is %s; query aborted  (see local_read_size_fail_threshold)",
-                                               ReadCommand.this.toRedactedCQLString(), this.sizeInBytes, failThreshold);
+                                               ReadCommand.this.toCQLString(Redaction.REDACT), this.sizeInBytes, failThreshold);
                     Tracing.trace(msg);
                     MessageParams.remove(ParamType.LOCAL_READ_SIZE_WARN);
                     MessageParams.add(ParamType.LOCAL_READ_SIZE_FAIL, this.sizeInBytes);

--- a/src/java/org/apache/cassandra/db/ReadExecutionController.java
+++ b/src/java/org/apache/cassandra/db/ReadExecutionController.java
@@ -25,6 +25,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Snapshot;
 import org.apache.cassandra.db.filter.DataLimits;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.index.Index;
 import org.apache.cassandra.metrics.DecayingEstimatedHistogramReservoir;
 import org.apache.cassandra.schema.TableMetadata;
@@ -266,7 +267,7 @@ public class ReadExecutionController implements AutoCloseable
 
     private void addSample()
     {
-        String cql = command.toRedactedCQLString();
+        String cql = command.toCQLString(Redaction.REDACT);
         int timeMicros = (int) Math.min(TimeUnit.NANOSECONDS.toMicros(clock.now() - createdAtNanos), Integer.MAX_VALUE);
         ColumnFamilyStore cfs = ColumnFamilyStore.getIfExists(baseMetadata.id);
         if (cfs != null)

--- a/src/java/org/apache/cassandra/db/SinglePartitionReadCommand.java
+++ b/src/java/org/apache/cassandra/db/SinglePartitionReadCommand.java
@@ -46,6 +46,7 @@ import org.apache.cassandra.db.filter.DataLimits;
 import org.apache.cassandra.db.filter.RowFilter;
 import org.apache.cassandra.db.lifecycle.SSTableSet;
 import org.apache.cassandra.db.lifecycle.View;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.db.memtable.Memtable;
 import org.apache.cassandra.db.partitions.CachedBTreePartition;
 import org.apache.cassandra.db.partitions.CachedPartition;
@@ -1267,9 +1268,9 @@ public class SinglePartitionReadCommand extends ReadCommand implements SinglePar
     }
 
     @Override
-    public void appendCQLWhereClause(CqlBuilder builder, boolean redact)
+    public void appendCQLWhereClause(CqlBuilder builder, Redaction redaction)
     {
-        SinglePartitionReadQuery.super.appendCQLWhereClause(builder, redact);
+        SinglePartitionReadQuery.super.appendCQLWhereClause(builder, redaction);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/SinglePartitionReadQuery.java
+++ b/src/java/org/apache/cassandra/db/SinglePartitionReadQuery.java
@@ -31,6 +31,7 @@ import org.apache.cassandra.db.filter.ClusteringIndexFilter;
 import org.apache.cassandra.db.filter.ColumnFilter;
 import org.apache.cassandra.db.filter.DataLimits;
 import org.apache.cassandra.db.filter.RowFilter;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.db.partitions.PartitionIterator;
 import org.apache.cassandra.db.partitions.UnfilteredPartitionIterator;
 import org.apache.cassandra.db.partitions.UnfilteredPartitionIterators;
@@ -155,16 +156,16 @@ public interface SinglePartitionReadQuery extends ReadQuery
         return rowFilter().clusteringKeyRestrictionsAreSatisfiedBy(clustering);
     }
 
-    default void appendCQLWhereClause(CqlBuilder builder, boolean redact)
+    default void appendCQLWhereClause(CqlBuilder builder, Redaction redaction)
     {
         builder.append(" WHERE ");
 
         // Append the partition key restrictions.
         TableMetadata metadata = metadata();
-        builder.append(partitionKey().toCQLString(metadata, redact));
+        builder.append(partitionKey().toCQLString(metadata, redaction));
 
         // Append the clustering index filter and the row filter.
-        String filter = clusteringIndexFilter().toCQLString(metadata(), rowFilter(), redact);
+        String filter = clusteringIndexFilter().toCQLString(metadata(), rowFilter(), redaction);
         builder.appendRestrictions(filter, true);
     }
 

--- a/src/java/org/apache/cassandra/db/Slices.java
+++ b/src/java/org/apache/cassandra/db/Slices.java
@@ -28,6 +28,7 @@ import com.google.common.collect.Iterators;
 import org.apache.cassandra.cql3.CqlBuilder;
 import org.apache.cassandra.cql3.Operator;
 import org.apache.cassandra.db.filter.RowFilter;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.db.marshal.AbstractType;
@@ -155,10 +156,10 @@ public abstract class Slices implements Iterable<Slice>
      *
      * @param metadata the table metadata
      * @param rowFilter a row filter
-     * @param redact whether to redact the slice column values
+     * @param redaction whether to redact the slice column values
      * @return a CQL string representing this slice and the specified {@link RowFilter}
      */
-    public abstract String toCQLString(TableMetadata metadata, RowFilter rowFilter, boolean redact);
+    public abstract String toCQLString(TableMetadata metadata, RowFilter rowFilter, Redaction redaction);
 
     /**
      * Checks if this <code>Slices</code> is empty.
@@ -550,7 +551,7 @@ public abstract class Slices implements Iterable<Slice>
         }
 
         @Override
-        public String toCQLString(TableMetadata metadata, RowFilter rowFilter, boolean redact)
+        public String toCQLString(TableMetadata metadata, RowFilter rowFilter, Redaction redaction)
         {
             CqlBuilder sb = new CqlBuilder();
 
@@ -602,7 +603,7 @@ public abstract class Slices implements Iterable<Slice>
 
                     if (values.size() == 1)
                     {
-                        sb.append(" = ").append(column.type.toCQLString(first.startValue, redact));
+                        sb.append(" = ").append(column.type.toCQLString(first.startValue, redaction));
                         rowFilter = rowFilter.without(column, Operator.EQ, first.startValue);
                     }
                     else
@@ -611,7 +612,7 @@ public abstract class Slices implements Iterable<Slice>
                         int j = 0;
                         for (ByteBuffer value : values)
                         {
-                            sb.append(j++ == 0 ? "" : ", ").append(column.type.toCQLString(value, redact));
+                            sb.append(j++ == 0 ? "" : ", ").append(column.type.toCQLString(value, redaction));
                             rowFilter = rowFilter.without(column, Operator.EQ, value);
                         }
                         sb.append(")");
@@ -635,7 +636,7 @@ public abstract class Slices implements Iterable<Slice>
                         else
                             operator = first.startInclusive ? Operator.GTE : Operator.GT;
                         sb.append(' ').append(operator).append(' ')
-                          .append(column.type.toCQLString(first.startValue, redact));
+                          .append(column.type.toCQLString(first.startValue, redaction));
                         rowFilter = rowFilter.without(column, operator, first.startValue);
                     }
                     if (first.endValue != null)
@@ -649,7 +650,7 @@ public abstract class Slices implements Iterable<Slice>
                         else
                             operator = first.endInclusive ? Operator.LTE : Operator.LT;
                         sb.append(' ').append(operator).append(' ')
-                          .append(column.type.toCQLString(first.endValue, redact));
+                          .append(column.type.toCQLString(first.endValue, redaction));
                         rowFilter = rowFilter.without(column, operator, first.endValue);
                     }
                 }
@@ -663,7 +664,7 @@ public abstract class Slices implements Iterable<Slice>
             }
 
             // Append the row filter.
-            sb.append(rowFilter, true, redact);
+            sb.append(rowFilter, true, redaction);
 
             return sb.toString();
         }
@@ -787,9 +788,9 @@ public abstract class Slices implements Iterable<Slice>
         }
 
         @Override
-        public String toCQLString(TableMetadata metadata, RowFilter rowFilter, boolean redact)
+        public String toCQLString(TableMetadata metadata, RowFilter rowFilter, Redaction redaction)
         {
-            return rowFilter.toCQLString(redact);
+            return rowFilter.toCQLString(redaction);
         }
     }
 
@@ -864,7 +865,7 @@ public abstract class Slices implements Iterable<Slice>
         }
 
         @Override
-        public String toCQLString(TableMetadata metadata, RowFilter rowFilter, boolean redact)
+        public String toCQLString(TableMetadata metadata, RowFilter rowFilter, Redaction redaction)
         {
             return "";
         }

--- a/src/java/org/apache/cassandra/db/filter/ClusteringIndexFilter.java
+++ b/src/java/org/apache/cassandra/db/filter/ClusteringIndexFilter.java
@@ -20,6 +20,7 @@ package org.apache.cassandra.db.filter;
 import java.io.IOException;
 
 import org.apache.cassandra.db.*;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.db.partitions.CachedPartition;
 import org.apache.cassandra.db.partitions.Partition;
 import org.apache.cassandra.db.rows.*;
@@ -159,10 +160,10 @@ public interface ClusteringIndexFilter
      *
      * @param metadata the table metadata
      * @param rowFilter a row filter
-     * @param redact whether to redact the clustering column value
+     * @param redaction whether to redact the clustering column value
      * @return a CQL string representing this clustering index filter and the specified {@link RowFilter}
      */
-    String toCQLString(TableMetadata metadata, RowFilter rowFilter, boolean redact);
+    String toCQLString(TableMetadata metadata, RowFilter rowFilter, Redaction redaction);
 
     public interface Serializer
     {

--- a/src/java/org/apache/cassandra/db/filter/ClusteringIndexNamesFilter.java
+++ b/src/java/org/apache/cassandra/db/filter/ClusteringIndexNamesFilter.java
@@ -22,6 +22,7 @@ import java.util.*;
 
 import org.apache.cassandra.cql3.CqlBuilder;
 import org.apache.cassandra.db.*;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.db.partitions.*;
 import org.apache.cassandra.db.rows.*;
 import org.apache.cassandra.db.transform.Transformation;
@@ -163,10 +164,10 @@ public class ClusteringIndexNamesFilter extends AbstractClusteringIndexFilter
     }
 
     @Override
-    public String toCQLString(TableMetadata metadata, RowFilter rowFilter, boolean redact)
+    public String toCQLString(TableMetadata metadata, RowFilter rowFilter, Redaction redaction)
     {
         if (metadata.clusteringColumns().isEmpty() || clusterings.isEmpty())
-            return rowFilter.toCQLString(redact);
+            return rowFilter.toCQLString(redaction);
 
         boolean isSingleColumn = metadata.clusteringColumns().size() == 1;
         boolean isSingleClustering = clusterings.size() == 1;
@@ -183,7 +184,7 @@ public class ClusteringIndexNamesFilter extends AbstractClusteringIndexFilter
         {
             builder.append(i++ == 0 ? "" : ", ")
                    .append(isSingleColumn ? "" : '(')
-                   .append(clustering.toCQLString(metadata, redact))
+                   .append(clustering.toCQLString(metadata, redaction))
                    .append(isSingleColumn ? "" : ')');
 
             maxClusteringSize = Math.max(maxClusteringSize, clustering.size());
@@ -198,7 +199,7 @@ public class ClusteringIndexNamesFilter extends AbstractClusteringIndexFilter
         for (i = 0; i < clusterings.first().size(); i++)
             rowFilter = rowFilter.withoutFirstLevelExpression(metadata.clusteringColumns().get(i));
 
-        builder.append(rowFilter, true, redact);
+        builder.append(rowFilter, true, redaction);
         appendOrderByToCQLString(metadata, builder);
         return builder.toString();
     }

--- a/src/java/org/apache/cassandra/db/filter/ClusteringIndexSliceFilter.java
+++ b/src/java/org/apache/cassandra/db/filter/ClusteringIndexSliceFilter.java
@@ -20,6 +20,8 @@ package org.apache.cassandra.db.filter;
 import java.io.IOException;
 
 import org.apache.cassandra.cql3.CqlBuilder;
+import org.apache.cassandra.db.marshal.Redaction;
+import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.db.*;
 import org.apache.cassandra.db.partitions.CachedPartition;
 import org.apache.cassandra.db.partitions.Partition;
@@ -27,7 +29,6 @@ import org.apache.cassandra.db.rows.*;
 import org.apache.cassandra.db.transform.Transformation;
 import org.apache.cassandra.io.util.DataInputPlus;
 import org.apache.cassandra.io.util.DataOutputPlus;
-import org.apache.cassandra.schema.TableMetadata;
 
 /**
  * A filter over a single partition.
@@ -135,14 +136,12 @@ public class ClusteringIndexSliceFilter extends AbstractClusteringIndexFilter
     }
 
     @Override
-    public String toCQLString(TableMetadata metadata, RowFilter rowFilter, boolean redact)
+    public String toCQLString(TableMetadata metadata, RowFilter rowFilter, Redaction redaction)
     {
-        CqlBuilder sb = new CqlBuilder();
-
-        sb.append(slices.toCQLString(metadata, rowFilter, redact));
-        appendOrderByToCQLString(metadata, sb);
-
-        return sb.toString();
+        CqlBuilder builder = new CqlBuilder();
+        builder.append(slices.toCQLString(metadata, rowFilter, redaction));
+        appendOrderByToCQLString(metadata, builder);
+        return builder.toString();
     }
 
     public Kind kind()

--- a/src/java/org/apache/cassandra/db/filter/ColumnFilter.java
+++ b/src/java/org/apache/cassandra/db/filter/ColumnFilter.java
@@ -28,6 +28,7 @@ import com.google.common.collect.TreeMultimap;
 
 import org.apache.cassandra.cql3.ColumnIdentifier;
 import org.apache.cassandra.db.*;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.db.rows.CellPath;
 import org.apache.cassandra.io.util.DataInputPlus;
 import org.apache.cassandra.io.util.DataOutputPlus;
@@ -298,10 +299,10 @@ public abstract class ColumnFilter
     /**
      * Returns the CQL string corresponding to this {@code ColumnFilter}.
      *
-     * @param redact whether to redact the queried column names, in case they contain sensitive data.
+     * @param redaction whether to redact the queried column names, in case they contain sensitive data.
      * @return the CQL string corresponding to this {@code ColumnFilter}.
      */
-    public abstract String toCQLString(boolean redact);
+    public abstract String toCQLString(Redaction redaction);
 
     /**
      * Returns the sub-selections or {@code null} if there are none.
@@ -615,7 +616,7 @@ public abstract class ColumnFilter
         }
 
         @Override
-        public String toCQLString(boolean redact)
+        public String toCQLString(Redaction redaction)
         {
             return "*";
         }
@@ -817,21 +818,21 @@ public abstract class ColumnFilter
             {
                 prefix = queried.statics.isEmpty()
                        ? "<all regulars>/"
-                       : String.format("<all regulars>+%s/", toString(queried.statics.selectOrderIterator(), false, false));
+                       : String.format("<all regulars>+%s/", toString(queried.statics.selectOrderIterator(), false, Redaction.NONE));
             }
 
-            return prefix + toString(queried.selectOrderIterator(), false, false);
+            return prefix + toString(queried.selectOrderIterator(), false, Redaction.NONE);
         }
 
         @Override
-        public String toCQLString(boolean redact)
+        public String toCQLString(Redaction redaction)
         {
-            return queried.isEmpty() ? "*" : toString(queried.selectOrderIterator(), true, redact);
+            return queried.isEmpty() ? "*" : toString(queried.selectOrderIterator(), true, redaction);
         }
 
-        private String toString(Iterator<ColumnMetadata> columns, boolean cql, boolean redact)
+        private String toString(Iterator<ColumnMetadata> columns, boolean cql, Redaction redaction)
         {
-            assert cql || !redact : "Cannot redact non-CQL representation";
+            assert cql || redaction == Redaction.NONE : "Cannot redact non-CQL representation";
 
             StringJoiner joiner = cql ? new StringJoiner(", ") : new StringJoiner(", ", "[", "]");
 
@@ -847,7 +848,7 @@ public abstract class ColumnFilter
                 if (s.isEmpty())
                     joiner.add(columnName);
                 else
-                    s.forEach(subSel -> joiner.add(String.format("%s%s", columnName, subSel.toString(cql, redact))));
+                    s.forEach(subSel -> joiner.add(String.format("%s%s", columnName, subSel.toString(cql, redaction))));
             }
             return joiner.toString();
         }

--- a/src/java/org/apache/cassandra/db/filter/ColumnSubselection.java
+++ b/src/java/org/apache/cassandra/db/filter/ColumnSubselection.java
@@ -24,6 +24,7 @@ import java.util.Comparator;
 import org.apache.cassandra.db.TypeSizes;
 import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.db.marshal.CollectionType;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.db.marshal.UTF8Type;
 import org.apache.cassandra.db.rows.CellPath;
 import org.apache.cassandra.exceptions.UnknownColumnException;
@@ -91,17 +92,17 @@ public abstract class ColumnSubselection implements Comparable<ColumnSubselectio
     @Override
     public String toString()
     {
-        return toString(false, false);
+        return toString(false, Redaction.NONE);
     }
 
     /**
      * Returns a string representation of this subselection.
      *
      * @param cql if true, the string representation will be in CQL format
-     * @param redact if true, the string representation will redact sensitive data
+     * @param redaction if true, the string representation will redact sensitive data
      * @return a string representation of this subselection
      */
-    protected abstract String toString(boolean cql, boolean redact);
+    protected abstract String toString(boolean cql, Redaction redaction);
 
     private static class Slice extends ColumnSubselection
     {
@@ -137,13 +138,13 @@ public abstract class ColumnSubselection implements Comparable<ColumnSubselectio
         }
 
         @Override
-        protected String toString(boolean cql, boolean redact)
+        protected String toString(boolean cql, Redaction redaction)
         {
             // This asserts we're dealing with a collection since that's the only thing it's used for so far.
             AbstractType<?> type = ((CollectionType<?>)column().type).nameComparator();
             return String.format("[%s:%s]",
-                                 from == CellPath.BOTTOM ? "" : (cql ? type.toCQLString(from.get(0), redact) : type.getString(from.get(0))),
-                                 to == CellPath.TOP ? "" : (cql ? type.toCQLString(to.get(0), redact) : type.getString(to.get(0))));
+                                 from == CellPath.BOTTOM ? "" : (cql ? type.toCQLString(from.get(0), redaction) : type.getString(from.get(0))),
+                                 to == CellPath.TOP ? "" : (cql ? type.toCQLString(to.get(0), redaction) : type.getString(to.get(0))));
         }
     }
 
@@ -173,11 +174,11 @@ public abstract class ColumnSubselection implements Comparable<ColumnSubselectio
         }
 
         @Override
-        protected String toString(boolean cql, boolean redact)
+        protected String toString(boolean cql, Redaction redaction)
         {
             // This asserts we're dealing with a collection since that's the only thing it's used for so far.
             AbstractType<?> type = ((CollectionType<?>)column().type).nameComparator();
-            return String.format("[%s]", cql ? type.toCQLString(element.get(0), redact) : type.getString(element.get(0)));
+            return String.format("[%s]", cql ? type.toCQLString(element.get(0), redaction) : type.getString(element.get(0)));
         }
     }
 

--- a/src/java/org/apache/cassandra/db/filter/RowFilter.java
+++ b/src/java/org/apache/cassandra/db/filter/RowFilter.java
@@ -60,6 +60,7 @@ import org.apache.cassandra.db.marshal.FloatType;
 import org.apache.cassandra.db.marshal.ListType;
 import org.apache.cassandra.db.marshal.LongType;
 import org.apache.cassandra.db.marshal.MapType;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.db.marshal.UTF8Type;
 import org.apache.cassandra.db.marshal.VectorType;
 import org.apache.cassandra.db.partitions.PartitionIterator;
@@ -468,9 +469,9 @@ public class RowFilter
      *
      * @return a CQL representation of this row filter
      */
-    public String toCQLString(boolean redact)
+    public String toCQLString(Redaction redaction)
     {
-        return root.toCQLString(redact);
+        return root.toCQLString(redaction);
     }
 
     public String toString(boolean cql)
@@ -882,10 +883,10 @@ public class RowFilter
 
         public String toString(boolean cql)
         {
-            return toCQLString(false);
+            return toCQLString(Redaction.NONE);
         }
 
-        public String toCQLString(boolean redact)
+        public String toCQLString(Redaction redaction)
         {
             StringBuilder sb = new StringBuilder();
             for (Expression expression : expressions)
@@ -894,14 +895,14 @@ public class RowFilter
                     continue;
                 if (sb.length() > 0)
                     sb.append(isDisjunction ? " OR " : " AND ");
-                sb.append(expression.toCQLString(redact));
+                sb.append(expression.toCQLString(redaction));
             }
             for (FilterElement child : children)
             {
                 if (sb.length() > 0)
                     sb.append(isDisjunction ? " OR " : " AND ");
                 sb.append('(');
-                sb.append(child.toCQLString(redact));
+                sb.append(child.toCQLString(redaction));
                 sb.append(')');
             }
             for (Expression expression : expressions)
@@ -910,7 +911,7 @@ public class RowFilter
                     continue;
                 if (sb.length() > 0)
                     sb.append(' ');
-                sb.append(expression.toCQLString(redact));
+                sb.append(expression.toCQLString(redaction));
             }
             return sb.toString();
         }
@@ -1197,7 +1198,7 @@ public class RowFilter
         @Override
         public String toString()
         {
-            return toCQLString(false);
+            return toCQLString(Redaction.NONE);
         }
 
         /**
@@ -1205,9 +1206,14 @@ public class RowFilter
          *
          * @return a CQL representation of this expression
          */
-        public String toCQLString(boolean redact)
+        public String toCQLString(Redaction redaction)
         {
             return "";
+        }
+
+        public String toCQLString(boolean redact)
+        {
+            return toCQLString(redact ? Redaction.REDACT : Redaction.NONE);
         }
 
         public static class Serializer
@@ -1515,7 +1521,7 @@ public class RowFilter
         }
 
         @Override
-        public String toCQLString(boolean redact)
+        public String toCQLString(Redaction redaction)
         {
             AbstractType<?> type = column.type;
             switch (operator)
@@ -1540,25 +1546,24 @@ public class RowFilter
                     // These don't have a value, so we return here to prevent an error calling type.getString(value)
                     return String.format("ORDER BY %s %s", column.name.toCQLString(), operator);
                 case ANN:
-                    return String.format("ORDER BY %s ANN OF %s", column.name.toCQLString(), truncateValue(type.toCQLString(value, redact)));
+                    return String.format("ORDER BY %s ANN OF %s", column.name.toCQLString(), truncateValue(type.toCQLString(value, redaction)));
                 case LIKE_PREFIX:
-                    return likeToCQLString("'%s%%'", type, redact);
+                    return likeToCQLString("'%s%%'", type, redaction);
                 case LIKE_SUFFIX:
-                    return likeToCQLString("'%%%s'", type, redact);
+                    return likeToCQLString("'%%%s'", type, redaction);
                 case LIKE_CONTAINS:
-                    return likeToCQLString("'%%%s%%'", type, redact);
+                    return likeToCQLString("'%%%s%%'", type, redaction);
                 case LIKE_MATCHES:
-                    return likeToCQLString("'%s'", type, redact);
+                    return likeToCQLString("'%s'", type, redaction);
                 default:
                     break;
             }
-
-            return String.format("%s %s %s", column.name.toCQLString(), operator, truncateValue(type.toCQLString(value, redact)));
+            return String.format("%s %s %s", column.name.toCQLString(), operator, truncateValue(type.toCQLString(value, redaction)));
         }
 
-        private String likeToCQLString(String pattern, AbstractType<?> type, boolean redact)
+        private String likeToCQLString(String pattern, AbstractType<?> type, Redaction redaction)
         {
-            if (redact)
+            if (redaction == Redaction.REDACT)
                 return String.format("%s LIKE ?", column.name.toCQLString());
 
             String stringValue = String.format(pattern, type.getString(value));
@@ -1680,12 +1685,14 @@ public class RowFilter
         }
 
         @Override
-        public String toCQLString(boolean redact)
+        public String toCQLString(Redaction redaction)
         {
             MapType<?, ?> mt = (MapType<?, ?>) column.type;
-            AbstractType<?> nt = mt.nameComparator();
-            AbstractType<?> vt = mt.valueComparator();
-            return String.format("%s[%s] %s %s", column.name.toCQLString(), nt.toCQLString(key, redact), operator, vt.toCQLString(value, redact));
+            return String.format("%s[%s] %s %s",
+                                 column.name.toCQLString(),
+                                 mt.nameComparator().toCQLString(key, redaction),
+                                 operator,
+                                 mt.valueComparator().toCQLString(value, redaction));
         }
 
         @Override
@@ -1852,13 +1859,13 @@ public class RowFilter
         }
 
         @Override
-        public String toCQLString(boolean redact)
+        public String toCQLString(Redaction redaction)
         {
             return String.format("GEO_DISTANCE(%s, %s) %s %s",
                                  column.name.toCQLString(),
-                                 column.type.toCQLString(value, redact),
+                                 column.type.toCQLString(value, redaction),
                                  distanceOperator,
-                                 FloatType.instance.toCQLString(distance, redact));
+                                 FloatType.instance.toCQLString(distance, redaction));
         }
 
         @Override
@@ -1932,7 +1939,7 @@ public class RowFilter
         }
 
         @Override
-        public String toCQLString(boolean redact)
+        public String toCQLString(Redaction redaction)
         {
             return String.format("expr(%s, %s)",
                                  ColumnIdentifier.maybeQuote(targetIndex.name),
@@ -1976,6 +1983,12 @@ public class RowFilter
     public static abstract class UserExpression extends Expression
     {
         private static final DeserializerRegistry deserializers = new DeserializerRegistry();
+
+        @Override
+        public String toCQLString(Redaction redaction)
+        {
+            return toCQLString(redaction == Redaction.REDACT);
+        }
         private static final class DeserializerRegistry
         {
             private final AtomicInteger counter = new AtomicInteger(0);

--- a/src/java/org/apache/cassandra/db/marshal/AbstractType.java
+++ b/src/java/org/apache/cassandra/db/marshal/AbstractType.java
@@ -208,11 +208,11 @@ public abstract class AbstractType<T> implements Comparator<ByteBuffer>, Assignm
      * Returns a CQL literal representing the specified binary value, or "?" if redaction is requested.
      *
      * @param bytes the value to convert to a CQL literal
-     * @param redact whether to mask the value with '?' (for redaction purposes)
+     * @param redaction whether to mask the value with '?' (for redaction purposes)
      */
-    public String toCQLString(ByteBuffer bytes, boolean redact)
+    public String toCQLString(ByteBuffer bytes, Redaction redaction)
     {
-        if (redact)
+        if (redaction == Redaction.REDACT)
             return RedactionUtil.redact(bytes, isValueLengthFixed());
 
         if (bytes == null)
@@ -238,10 +238,23 @@ public abstract class AbstractType<T> implements Comparator<ByteBuffer>, Assignm
         return getString(bytes, ByteBufferAccessor.instance);
     }
 
+    public final String getString(ByteBuffer bytes, Redaction redaction)
+    {
+        if (redaction == Redaction.REDACT)
+            return RedactionUtil.redact(bytes, isValueLengthFixed());
+
+        return getString(bytes, ByteBufferAccessor.instance);
+    }
+
     public final String getString(ByteBuffer bytes, boolean truncate)
     {
         String s = getString(bytes);
         return truncate ? truncateString(s) : s;
+    }
+
+    public String toCQLString(ByteBuffer bytes, boolean redact)
+    {
+        return toCQLString(bytes, redact ? Redaction.REDACT : Redaction.NONE);
     }
 
     /**

--- a/src/java/org/apache/cassandra/db/marshal/Redaction.java
+++ b/src/java/org/apache/cassandra/db/marshal/Redaction.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.marshal;
+
+/**
+ * Named boolan to express whether sensitive data should be presented in clear or redacted.
+ * This is generally applied to column values, or things containing column values.
+ * </p>
+ * Column values should be redacted when printed in logs.
+ * They shouldn't be redacted when used in user-facing error messages or query tracing.
+ */
+public enum Redaction
+{
+    NONE, REDACT
+}

--- a/src/java/org/apache/cassandra/db/rows/AbstractRow.java
+++ b/src/java/org/apache/cassandra/db/rows/AbstractRow.java
@@ -23,6 +23,7 @@ import java.util.stream.StreamSupport;
 
 import com.google.common.collect.Iterables;
 
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.db.marshal.ValueAccessor;
 import org.apache.cassandra.db.Clustering;
 import org.apache.cassandra.db.Digest;
@@ -143,7 +144,7 @@ public abstract class AbstractRow implements Row
         if (includeClusterKeys)
             sb.append(clustering().toString(metadata));
         else
-            sb.append(clustering().toCQLString(metadata, false));
+            sb.append(clustering().toCQLString(metadata, Redaction.NONE));
         sb.append(" | ");
         boolean isFirst = true;
         for (ColumnData cd : this)

--- a/src/java/org/apache/cassandra/index/sai/plan/Expression.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Expression.java
@@ -39,6 +39,7 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.cql3.Operator;
 import org.apache.cassandra.db.marshal.AbstractType;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.db.marshal.CompositeType;
 import org.apache.cassandra.db.marshal.FloatType;
 import org.apache.cassandra.index.sai.IndexContext;
@@ -532,16 +533,22 @@ public class Expression
         return boundedAnnEuclideanDistanceThreshold;
     }
 
+    @Override
     public String toString()
+    {
+        return toString(false);
+    }
+
+    public String toString(boolean redact)
     {
         return String.format("Expression{name: %s, op: %s, lower: (%s, %s), upper: (%s, %s), exclusions: %s}",
                              context.getColumnName(),
                              operation,
-                             lower == null ? "null" : validator.getString(lower.value.raw),
+                             lower == null ? "null" : validator.getString(lower.value.raw, redact ? Redaction.REDACT : Redaction.NONE),
                              lower != null && lower.inclusive,
-                             upper == null ? "null" : validator.getString(upper.value.raw),
+                             upper == null ? "null" : validator.getString(upper.value.raw, redact ? Redaction.REDACT : Redaction.NONE),
                              upper != null && upper.inclusive,
-                             Iterators.toString(Iterators.transform(exclusions.iterator(), validator::getString)));
+                             Iterators.toString(Iterators.transform(exclusions.iterator(), x -> validator.getString(x, redact ? Redaction.REDACT : Redaction.NONE))));
     }
 
     public String getIndexName()

--- a/src/java/org/apache/cassandra/index/sai/plan/Orderer.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Orderer.java
@@ -35,6 +35,8 @@ import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
 import org.apache.cassandra.cql3.Operator;
 import org.apache.cassandra.db.filter.ANNOptions;
 import org.apache.cassandra.db.filter.RowFilter;
+import org.apache.cassandra.db.marshal.Redaction;
+import org.apache.cassandra.db.marshal.RedactionUtil;
 import org.apache.cassandra.index.SecondaryIndexManager;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.StorageAttachedIndex;
@@ -171,13 +173,25 @@ public class Orderer
     @Override
     public String toString()
     {
+        return toString(Redaction.NONE);
+    }
+
+    public String toString(Redaction redaction)
+    {
         String direction = isAscending() ? "ASC" : "DESC";
         String annOptionsString = annOptions != null ? annOptions.toCQLString() : "";
         if (isANN())
-            return context.getColumnName() + " ANN OF " + Arrays.toString(getRawVectorTerm()) + ' ' + direction + annOptionsString;
+            return context.getColumnName() + " ANN OF " + getVectorTermAsString(redaction) + ' ' + direction + annOptionsString;
         if (isBM25())
-            return context.getColumnName() + " BM25 OF " + TypeUtil.getString(term, context.getValidator()) + ' ' + direction;
+            return context.getColumnName() + " BM25 OF " + context.getValidator().toCQLString(term, redaction) + ' ' + direction;
         return context.getColumnName() + ' ' + direction;
+    }
+
+    public String getVectorTermAsString(Redaction redaction)
+    {
+        return redaction == Redaction.REDACT
+               ? RedactionUtil.redact(0)
+               : Arrays.toString(getRawVectorTerm());
     }
 
     public VectorFloat<?> getVectorTerm()

--- a/src/java/org/apache/cassandra/index/sai/plan/Plan.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Plan.java
@@ -36,6 +36,7 @@ import org.slf4j.LoggerFactory;
 import org.apache.cassandra.cache.ChunkCache;
 import org.apache.cassandra.db.filter.IndexHints;
 import org.apache.cassandra.db.filter.RowFilter;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.index.sai.iterators.KeyRangeIntersectionIterator;
@@ -286,60 +287,47 @@ abstract public class Plan
      */
     protected abstract double estimateSelectivity();
 
-    public final String toUnredactedStringRecursive()
-    {
-        return toStringRecursive(false, null);
-    }
-
     /**
-     * Formats the whole plan as a pretty tree, redacting the queried column values.
-     */
-    public final String toRedactedStringRecursive()
-    {
-        return toRedactedStringRecursive(null);
-    }
-
-    /**
-     * Formats the whole plan as a pretty tree, redacting the queried column values, with indentation.
+     * Formats the whole plan as a pretty tree.
      *
-     * @param indent a string used for indentation
+     * @param redaction whether to redact the queried column values.
      */
-    public final String toRedactedStringRecursive(String indent)
+    public String toStringRecursive(Redaction redaction)
     {
-        return toStringRecursive(true, indent);
+        return toStringRecursive(redaction, null);
     }
 
     /**
      * Formats the whole plan as a pretty tree, with indentation
      *
-     * @param redact whether to redact the queried column values.
+     * @param redaction whether to redact the queried column values.
      * @param indent a string used for indentation
      */
-    private String toStringRecursive(boolean redact, String indent)
+    public String toStringRecursive(Redaction redaction, String indent)
     {
-        TreeFormatter<Plan> formatter = new TreeFormatter<>(plan -> plan.toString(redact), Plan::subplans, indent);
+        TreeFormatter<Plan> formatter = new TreeFormatter<>(plan -> plan.toString(redaction), Plan::subplans, indent);
         return formatter.format(this);
     }
 
     /**
      * Returns the string representation of this node only, without redacting the queried column values.
-     * @see #toString(boolean)
+     * @see #toString(Redaction)
      */
     @Override
     public final String toString()
     {
-        return toString(false);
+        return toString(Redaction.NONE);
     }
 
     /**
      * Returns the string representation of this node only
      *
-     * @param redact whether to redact the queried column values.
+     * @param redaction whether to redact the queried column values.
      */
-    public final String toString(boolean redact)
+    public final String toString(Redaction redaction)
     {
-        String title = title(redact);
-        String description = description();
+        String title = title(redaction);
+        String description = description(redaction);
         return (title.isEmpty())
                ? String.format("%s (%s)\n%s", getClass().getSimpleName(), cost(), description).stripTrailing()
                : String.format("%s %s (%s)\n%s", getClass().getSimpleName(), title, cost(), description).stripTrailing();
@@ -350,7 +338,7 @@ abstract public class Plan
      * The information is included in the output of {@link #toString()} and {@link #toRedactedStringRecursive()}.
      * It is up to subclasses to implement it.
      */
-    protected String title(boolean redact)
+    protected String title(Redaction redaction)
     {
         return "";
     }
@@ -360,7 +348,7 @@ abstract public class Plan
      * The information is included in the output of {@link #toString()} and {@link #toRedactedStringRecursive()}.
      * It is up to subclasses to implement it.
      */
-    protected String description()
+    protected String description(Redaction redaction)
     {
         return "";
     }
@@ -395,7 +383,7 @@ abstract public class Plan
     protected Plan optimize()
     {
         if (logger.isTraceEnabled())
-            logger.trace("Optimizing plan:\n{}", toRedactedStringRecursive());
+            logger.trace("Optimizing plan:\n{}", toStringRecursive(Redaction.REDACT));
 
         Plan bestPlanSoFar = this;
         List<Leaf> leaves = nodesOfType(Leaf.class);
@@ -410,14 +398,14 @@ abstract public class Plan
 
             Plan candidate = bestPlanSoFar.removeRestriction(leaf.id);
             if (logger.isTraceEnabled())
-                logger.trace("Candidate query plan:\n{}", candidate.toRedactedStringRecursive());
+                logger.trace("Candidate query plan:\n{}", candidate.toStringRecursive(Redaction.REDACT));
 
             if (candidate.fullCost() <= bestPlanSoFar.fullCost())
                 bestPlanSoFar = candidate;
         }
 
         if (logger.isTraceEnabled())
-            logger.trace("Optimized plan:\n{}", bestPlanSoFar.toRedactedStringRecursive());
+            logger.trace("Optimized plan:\n{}", bestPlanSoFar.toStringRecursive(Redaction.REDACT));
         return bestPlanSoFar;
     }
 
@@ -920,26 +908,26 @@ abstract public class Plan
         }
 
         @Override
-        protected final String title(boolean redact)
+        protected final String title(Redaction redaction)
         {
             return String.format("of %s (sel: %.9f, step: %.1f)",
                                  getIndexName(), selectivity(), access.meanDistance());
         }
 
         @Override
-        protected String description()
+        protected String description(Redaction redaction)
         {
             StringBuilder sb = new StringBuilder();
             if (predicate != null)
             {
                 sb.append("predicate: ");
-                sb.append(predicate);
+                sb.append(predicate.toString(redaction == Redaction.REDACT));
                 sb.append('\n');
             }
             if (ordering != null)
             {
                 sb.append("ordering: ");
-                sb.append(ordering);
+                sb.append(ordering.toString(redaction));
                 sb.append('\n');
             }
             return sb.toString();
@@ -1529,9 +1517,9 @@ abstract public class Plan
         }
 
         @Override
-        protected String description()
+        protected String description(Redaction redaction)
         {
-            return ordering.toString();
+            return ordering.toString(redaction);
         }
     }
 
@@ -1619,9 +1607,9 @@ abstract public class Plan
         }
 
         @Override
-        protected String description()
+        protected String description(Redaction redaction)
         {
-            return ordering.toString();
+            return ordering.toString(redaction);
         }
     }
 
@@ -1662,6 +1650,12 @@ abstract public class Plan
         protected void visitIndexes(Consumer<IndexContext> consumer)
         {
             consumer.accept(ordering.context);
+        }
+
+        @Override
+        protected String description(Redaction redaction)
+        {
+            return ordering.toString(redaction);
         }
     }
 
@@ -1851,9 +1845,9 @@ abstract public class Plan
         }
 
         @Override
-        protected String title(boolean redact)
+        protected String title(Redaction redaction)
         {
-            return String.format("%s (sel: %.9f)", filter.toCQLString(redact), selectivity() / source.get().selectivity());
+            return String.format("%s (sel: %.9f)", filter.toCQLString(redaction), selectivity() / source.get().selectivity());
         }
     }
 
@@ -1919,7 +1913,7 @@ abstract public class Plan
         }
 
         @Override
-        protected String title(boolean redact)
+        protected String title(Redaction redaction)
         {
             return "" + limit;
         }

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -40,6 +40,7 @@ import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import org.apache.cassandra.db.Clustering;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.index.FeatureNeedsIndexRebuildException;
 import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.index.sai.metrics.TableQueryMetrics;
@@ -417,11 +418,11 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
         updateIndexMetricsQueriesCount(plan);
 
         if (logger.isTraceEnabled())
-            logger.trace("Query execution plan:\n" + plan.toRedactedStringRecursive());
+            logger.trace("Query execution plan:\n" + plan.toStringRecursive(Redaction.REDACT));
 
         if (Tracing.isTracing())
         {
-            Tracing.trace("Query execution plan:\n" + plan.toUnredactedStringRecursive());
+            Tracing.trace("Query execution plan:\n" + plan.toStringRecursive(Redaction.NONE));
             List<Plan.IndexScan> origIndexScans = keysIterationPlan.nodesOfType(Plan.IndexScan.class);
             List<Plan.IndexScan> selectedIndexScans = plan.nodesOfType(Plan.IndexScan.class);
             Tracing.trace("Selecting {} {} of {} out of {} indexes",

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryMonitorableExecutionInfo.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryMonitorableExecutionInfo.java
@@ -19,6 +19,7 @@ package org.apache.cassandra.index.sai.plan;
 import java.util.function.Supplier;
 
 import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.db.monitoring.Monitorable;
 import org.apache.cassandra.index.sai.QueryContext;
 
@@ -93,7 +94,7 @@ public class QueryMonitorableExecutionInfo implements Monitorable.ExecutionInfo
 
     private static String toLogString(Plan plan)
     {
-        String s = plan.toRedactedStringRecursive(DOUBLE_INDENT);
+        String s = plan.toStringRecursive(Redaction.REDACT, DOUBLE_INDENT);
         return s.endsWith("\n") ? s.substring(0, s.length() - 1) : s;
     }
 

--- a/src/java/org/apache/cassandra/service/context/DefaultOperationContext.java
+++ b/src/java/org/apache/cassandra/service/context/DefaultOperationContext.java
@@ -21,6 +21,7 @@ package org.apache.cassandra.service.context;
 import java.util.function.Supplier;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.ReadCommand;
+import org.apache.cassandra.db.marshal.Redaction;
 
 /**
  * Default implementation of {@link OperationContext}.
@@ -58,7 +59,7 @@ public class DefaultOperationContext implements OperationContext
         @Override
         public OperationContext forRead(ReadCommand command, ColumnFamilyStore cfs)
         {
-            return new DefaultOperationContext(command::toUnredactedCQLString);
+            return new DefaultOperationContext(() -> command.toCQLString(Redaction.NONE));
         }
     }
 }

--- a/src/java/org/apache/cassandra/service/reads/ReplicaFilteringProtection.java
+++ b/src/java/org/apache/cassandra/service/reads/ReplicaFilteringProtection.java
@@ -46,6 +46,7 @@ import org.apache.cassandra.db.filter.ClusteringIndexFilter;
 import org.apache.cassandra.db.filter.ClusteringIndexNamesFilter;
 import org.apache.cassandra.db.filter.DataLimits;
 import org.apache.cassandra.db.filter.RowFilter;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.db.partitions.PartitionIterator;
 import org.apache.cassandra.db.partitions.UnfilteredPartitionIterator;
 import org.apache.cassandra.db.partitions.UnfilteredPartitionIterators;
@@ -305,19 +306,19 @@ public class ReplicaFilteringProtection<E extends Endpoints<E>>
             // of cached rows we have had during the query.
             if (!hitFailureThreshold && maxRowsCached > cachedRowsWarnThreshold)
             {
-                String unredactedMessage = cachedRowsWarnMessage(false);
-                String redactedMessage = cachedRowsWarnMessage(true);
+                String unredactedMessage = cachedRowsWarnMessage(Redaction.NONE);
+                String redactedMessage = cachedRowsWarnMessage(Redaction.REDACT);
                 ClientWarn.instance.warn(unredactedMessage);
                 oneMinuteLogger.warn(redactedMessage);
                 Tracing.trace(unredactedMessage);
             }
         }
 
-        private String cachedRowsWarnMessage(boolean redact)
+        private String cachedRowsWarnMessage(Redaction redaction)
         {
             return String.format(CACHED_ROWS_WARN_MESSAGE,
                                  maxRowsCached,
-                                 redact ? command.toRedactedCQLString() : command.toUnredactedCQLString(),
+                                 command.toCQLString(redaction),
                                  cachedRowsWarnThreshold);
         }
 
@@ -357,8 +358,8 @@ public class ReplicaFilteringProtection<E extends Endpoints<E>>
         if (currentRowsCached == cachedRowsFailThreshold + 1)
         {
             hitFailureThreshold = true;
-            String unredactedMessage = cachedRowsFailMessage(false);
-            String redactedMessage = cachedRowsFailMessage(true);
+            String unredactedMessage = cachedRowsFailMessage(Redaction.NONE);
+            String redactedMessage = cachedRowsFailMessage(Redaction.REDACT);
 
             logger.error(redactedMessage);
             Tracing.trace(unredactedMessage);
@@ -366,11 +367,11 @@ public class ReplicaFilteringProtection<E extends Endpoints<E>>
         }
     }
 
-    private String cachedRowsFailMessage(boolean redact)
+    private String cachedRowsFailMessage(Redaction redaction)
     {
         return String.format(CACHED_ROWS_FAIL_MESSAGE,
                              currentRowsCached,
-                             redact ? command.toRedactedCQLString() : command.toUnredactedCQLString(),
+                             command.toCQLString(redaction),
                              cachedRowsFailThreshold);
     }
 

--- a/src/java/org/apache/cassandra/service/reads/repair/ReadRepairEvent.java
+++ b/src/java/org/apache/cassandra/service/reads/repair/ReadRepairEvent.java
@@ -32,6 +32,7 @@ import com.google.common.annotations.VisibleForTesting;
 
 import org.apache.cassandra.db.ConsistencyLevel;
 import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.diag.DiagnosticEvent;
 import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.service.reads.DigestResolver;
@@ -65,7 +66,7 @@ final class ReadRepairEvent extends DiagnosticEvent
     {
         this.keyspace = readRepair.cfs.keyspace;
         this.tableName = readRepair.cfs.getTableName();
-        this.cqlCommand = readRepair.command.toRedactedCQLString();
+        this.cqlCommand = readRepair.command.toCQLString(Redaction.REDACT);
         this.consistency = readRepair.replicaPlan().consistencyLevel();
         this.speculativeRetry = readRepair.cfs.metadata().params.speculativeRetry.kind();
         this.destinations = destinations;

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/SlowSAIQueryLoggerTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/SlowSAIQueryLoggerTest.java
@@ -18,6 +18,7 @@ package org.apache.cassandra.distributed.test.sai;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Pattern;
 
 import com.google.common.util.concurrent.Uninterruptibles;
 import org.junit.Test;
@@ -110,7 +111,8 @@ public class SlowSAIQueryLoggerTest extends TestBaseImpl
                               "triePostingsDecodes: 0",
                               "annGraphSearchLatencyNanos: 0",
                               "SAI slow query plan:",
-                              "NumericIndexScan");
+                              "NumericIndexScan",
+                              Pattern.quote("predicate: Expression{name: n, op: RANGE, lower: (?, false), upper: (null, false), exclusions: []}"));
 
             // test aggregated numeric query
             mark = node.logs().mark();
@@ -136,7 +138,8 @@ public class SlowSAIQueryLoggerTest extends TestBaseImpl
                               "triePostingsDecodes: 0",
                               "annGraphSearchLatencyNanos: 0",
                               "SAI slowest query plan:",
-                              "NumericIndexScan");
+                              "NumericIndexScan",
+                              Pattern.quote("predicate: Expression{name: n, op: RANGE, lower: (?, false), upper: (null, false), exclusions: []}"));
 
             // test single text query
             mark = node.logs().mark();
@@ -162,7 +165,8 @@ public class SlowSAIQueryLoggerTest extends TestBaseImpl
                               "triePostingsDecodes: 2",
                               "annGraphSearchLatencyNanos: 0",
                               "SAI slow query plan:",
-                              "LiteralIndexScan");
+                              "LiteralIndexScan",
+                              Pattern.quote("predicate: Expression{name: s, op: EQ, lower: (?, true), upper: (?, true), exclusions: []}"));
 
             // test aggregated text query
             mark = node.logs().mark();
@@ -188,7 +192,8 @@ public class SlowSAIQueryLoggerTest extends TestBaseImpl
                               "triePostingsDecodes: 2",
                               "annGraphSearchLatencyNanos: 0",
                               "SAI slowest query plan:",
-                              "LiteralIndexScan");
+                              "LiteralIndexScan",
+                              Pattern.quote("predicate: Expression{name: s, op: EQ, lower: (?, true), upper: (?, true), exclusions: []}"));
 
             // test single ANN query
             mark = node.logs().mark();
@@ -214,7 +219,8 @@ public class SlowSAIQueryLoggerTest extends TestBaseImpl
                               "triePostingsDecodes: 0",
                               "annGraphSearchLatencyNanos: [1-9][0-9]*", // unknown, but greater than zero
                               "SAI slow query plan:",
-                              "AnnIndexScan");
+                              "AnnIndexScan",
+                              Pattern.quote("v ANN OF ? DESC"));
 
             // test aggregated ANN query
             mark = node.logs().mark();
@@ -240,7 +246,8 @@ public class SlowSAIQueryLoggerTest extends TestBaseImpl
                               "triePostingsDecodes: 0",
                               "annGraphSearchLatencyNanos: [1-9][0-9]*", // unknown, but greater than zero
                               "SAI slowest query plan:",
-                              "AnnIndexScan");
+                              "AnnIndexScan",
+                              Pattern.quote("v ANN OF ? DESC"));
 
             // test single hybrid query
             mark = node.logs().mark();
@@ -266,7 +273,8 @@ public class SlowSAIQueryLoggerTest extends TestBaseImpl
                               "triePostingsDecodes: 0",
                               "annGraphSearchLatencyNanos: 0",
                               "SAI slow query plan:",
-                              "LiteralIndexScan");
+                              "LiteralIndexScan",
+                              Pattern.quote("ordering: s ASC"));
 
             // test aggregated hybrid query
             mark = node.logs().mark();
@@ -292,34 +300,36 @@ public class SlowSAIQueryLoggerTest extends TestBaseImpl
                               "triePostingsDecodes: 0",
                               "annGraphSearchLatencyNanos: 0",
                               "SAI slowest query plan:",
-                              "LiteralIndexScan");
+                              "LiteralIndexScan",
+                              Pattern.quote("ordering: s ASC"));
 
             // Disable query optimizer to prevent skipping hybrid query logic and hit orderByResults to verify metrics update
             node.runOnInstance(() -> QueryController.QUERY_OPT_LEVEL = 0);
             mark = node.logs().mark();
             coordinator.execute(hybridQuery, ConsistencyLevel.ONE);
             assertLogsContain(mark, node,
-                    "SAI slow query metrics:",
-                    "sstablesHit: 2",
-                    "segmentsHit: 2",
-                    "keysFetched: 3",
-                    "partitionsFetched: 3",
-                    "partitionsReturned: 2",
-                    "partitionTombstonesFetched: 0",
-                    "rowsFetched: 3",
-                    "rowsReturned: 3",
-                    "rowTombstonesFetched: 0",
-                    "trieSegmentsHit: 0",
-                    "bkdPostingListsHit: 1",
-                    "bkdSegmentsHit: 1",
-                    "bkdPostingsSkips: 0",
-                    "bkdPostingsDecodes: 4",
-                    "triePostingsSkips: 0",
-                    "triePostingsDecodes: 0",
-                    "annGraphSearchLatencyNanos: 0",
-                    "SAI slow query plan:",
-                    "KeysSort",
-                    "NumericIndexScan");
+                              "SAI slow query metrics:",
+                              "sstablesHit: 2",
+                              "segmentsHit: 2",
+                              "keysFetched: 3",
+                              "partitionsFetched: 3",
+                              "partitionsReturned: 2",
+                              "partitionTombstonesFetched: 0",
+                              "rowsFetched: 3",
+                              "rowsReturned: 3",
+                              "rowTombstonesFetched: 0",
+                              "trieSegmentsHit: 0",
+                              "triePostingsSkips: 0",
+                              "triePostingsDecodes: 0",
+                              "bkdSegmentsHit: 1",
+                              "bkdPostingListsHit: 1",
+                              "bkdPostingsSkips: 0",
+                              "bkdPostingsDecodes: 4",
+                              "annGraphSearchLatencyNanos: 0",
+                              "SAI slow query plan:",
+                              "KeysSort",
+                              "NumericIndexScan",
+                              Pattern.quote("predicate: Expression{name: n, op: RANGE, lower: (?, false), upper: (null, false), exclusions: []}"));
 
             node.runOnInstance(() -> QueryController.QUERY_OPT_LEVEL = CassandraRelevantProperties.SAI_QUERY_OPT_LEVEL.getInt());
 

--- a/test/unit/org/apache/cassandra/Util.java
+++ b/test/unit/org/apache/cassandra/Util.java
@@ -94,6 +94,7 @@ import org.apache.cassandra.db.lifecycle.LifecycleTransaction;
 import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.db.marshal.AsciiType;
 import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.db.marshal.UTF8Type;
 import org.apache.cassandra.db.marshal.UserType;
 import org.apache.cassandra.db.partitions.FilteredPartition;
@@ -431,7 +432,7 @@ public class Util
             {
                 try (UnfilteredRowIterator partition = iterator.next())
                 {
-                    throw new AssertionError("Expected no results for query " + command.toUnredactedCQLString() + " but got key " + command.metadata().partitionKeyType.getString(partition.partitionKey().getKey()));
+                    throw new AssertionError("Expected no results for query " + command.toCQLString(Redaction.NONE) + " but got key " + command.metadata().partitionKeyType.getString(partition.partitionKey().getKey()));
                 }
             }
         }
@@ -446,7 +447,7 @@ public class Util
             {
                 try (RowIterator partition = iterator.next())
                 {
-                    throw new AssertionError("Expected no results for query " + command.toUnredactedCQLString() + " but got key " + command.metadata().partitionKeyType.getString(partition.partitionKey().getKey()));
+                    throw new AssertionError("Expected no results for query " + command.toCQLString(Redaction.NONE) + " but got key " + command.metadata().partitionKeyType.getString(partition.partitionKey().getKey()));
                 }
             }
         }

--- a/test/unit/org/apache/cassandra/db/ReadCommandCQLTester.java
+++ b/test/unit/org/apache/cassandra/db/ReadCommandCQLTester.java
@@ -19,6 +19,7 @@ import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 
 import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.assertj.core.api.Assertions;
 
 public abstract class ReadCommandCQLTester<T extends ReadCommand> extends CQLTester
@@ -39,11 +40,11 @@ public abstract class ReadCommandCQLTester<T extends ReadCommand> extends CQLTes
     {
         T command = parseCommand(query);
 
-        String actualUnredactedCQL = command.toUnredactedCQLString();
+        String actualUnredactedCQL = command.toCQLString(Redaction.NONE);
         Assertions.assertThat(actualUnredactedCQL)
                   .isEqualTo(formatQuery(expectedUnredactedCQL));
 
-        String actualRedactedCQL = command.toRedactedCQLString();
+        String actualRedactedCQL = command.toCQLString(Redaction.REDACT);
         Assertions.assertThat(actualRedactedCQL)
                   .isEqualTo(formatQuery(expectedRedactedCQL));
 

--- a/test/unit/org/apache/cassandra/db/SinglePartitionSliceCommandTest.java
+++ b/test/unit/org/apache/cassandra/db/SinglePartitionSliceCommandTest.java
@@ -39,6 +39,8 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.cassandra.SchemaLoader;
+import org.apache.cassandra.db.marshal.Redaction;
+import org.apache.cassandra.db.rows.*;
 import org.apache.cassandra.Util;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.ColumnIdentifier;
@@ -488,7 +490,7 @@ public class SinglePartitionSliceCommandTest
                                                             DataLimits.NONE,
                                                             key,
                                                             sliceFilter);
-        String ret = cmd.toRedactedCQLString();
+        String ret = cmd.toCQLString(Redaction.REDACT);
         Assert.assertNotNull(ret);
         assertFalse(ret.isEmpty());
     }

--- a/test/unit/org/apache/cassandra/db/filter/ANNOptionsTest.java
+++ b/test/unit/org/apache/cassandra/db/filter/ANNOptionsTest.java
@@ -35,6 +35,7 @@ import org.apache.cassandra.cql3.statements.schema.IndexTarget;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.ReadCommand;
 import org.apache.cassandra.db.TypeSizes;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.exceptions.SyntaxException;
 import org.apache.cassandra.index.Index;
@@ -190,22 +191,22 @@ public class ANNOptionsTest extends CQLTester
         // without ANN options
         String formattedQuery = formatQuery("SELECT * FROM %%s ORDER BY v ANN OF [1, 1]");
         ReadCommand command = parseReadCommand(formattedQuery);
-        Assertions.assertThat(command.toRedactedCQLString()).doesNotContain("WITH ann_options");
+        Assertions.assertThat(command.toCQLString(Redaction.NONE)).doesNotContain("WITH ann_options");
 
         // with rerank_k option
         formattedQuery = formatQuery("SELECT * FROM %%s ORDER BY v ANN OF [1, 1] LIMIT 1 WITH ann_options = {'rerank_k': 2}");
         command = parseReadCommand(formattedQuery);
-        Assertions.assertThat(command.toRedactedCQLString()).contains("WITH ann_options = {'rerank_k': 2}");
+        Assertions.assertThat(command.toCQLString(Redaction.NONE)).contains("WITH ann_options = {'rerank_k': 2}");
 
         // with use_pruning option
         formattedQuery = formatQuery("SELECT * FROM %%s ORDER BY v ANN OF [1, 1] WITH ann_options = {'use_pruning': true}");
         command = parseReadCommand(formattedQuery);
-        Assertions.assertThat(command.toRedactedCQLString()).contains("WITH ann_options = {'use_pruning': true}");
+        Assertions.assertThat(command.toCQLString(Redaction.NONE)).contains("WITH ann_options = {'use_pruning': true}");
 
         // with both options
         formattedQuery = formatQuery("SELECT * FROM %%s ORDER BY v ANN OF [1, 1] LIMIT 1 WITH ann_options = {'rerank_k': 2, 'use_pruning': false}");
         command = parseReadCommand(formattedQuery);
-        Assertions.assertThat(command.toRedactedCQLString()).contains("WITH ann_options = {'rerank_k': 2, 'use_pruning': false}");
+        Assertions.assertThat(command.toCQLString(Redaction.NONE)).contains("WITH ann_options = {'rerank_k': 2, 'use_pruning': false}");
     }
 
     /**

--- a/test/unit/org/apache/cassandra/db/filter/ColumnFilterTest.java
+++ b/test/unit/org/apache/cassandra/db/filter/ColumnFilterTest.java
@@ -32,6 +32,7 @@ import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.ColumnIdentifier;
 import org.apache.cassandra.db.RegularAndStaticColumns;
 import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.db.marshal.SetType;
 import org.apache.cassandra.db.rows.CellPath;
 import org.apache.cassandra.dht.Murmur3Partitioner;
@@ -102,8 +103,8 @@ public class ColumnFilterTest
         Consumer<ColumnFilter> check = filter -> {
             testRoundTrips(filter);
             assertEquals("*/*", filter.toString());
-            assertEquals("*", filter.toCQLString(false));
-            assertEquals("*", filter.toCQLString(true));
+            assertEquals("*", filter.toCQLString(Redaction.NONE));
+            assertEquals("*", filter.toCQLString(Redaction.REDACT));
             assertFetchedQueried(true, true, filter, v1, v2, s1, s2);
             assertCellFetchedQueried(true, true, filter, v2, path0, path1, path2, path3, path4);
             assertCellFetchedQueried(true, true, filter, s2, path0, path1, path2, path3, path4);
@@ -122,8 +123,8 @@ public class ColumnFilterTest
         Consumer<ColumnFilter> check = filter -> {
             testRoundTrips(filter);
             assertEquals("[]", filter.toString());
-            assertEquals("*", filter.toCQLString(true));
-            assertEquals("*", filter.toCQLString(false));
+            assertEquals("*", filter.toCQLString(Redaction.REDACT));
+            assertEquals("*", filter.toCQLString(Redaction.NONE));
             assertFetchedQueried(false, false, filter, v1, v2, s1, s2);
             assertCellFetchedQueried(false, false, filter, v2, path0, path1, path2, path3, path4);
             assertCellFetchedQueried(false, false, filter, s2, path0, path1, path2, path3, path4);
@@ -139,8 +140,8 @@ public class ColumnFilterTest
         Consumer<ColumnFilter> check = filter -> {
             testRoundTrips(filter);
             assertEquals("[v1]", filter.toString());
-            assertEquals("v1", filter.toCQLString(true));
-            assertEquals("v1", filter.toCQLString(false));
+            assertEquals("v1", filter.toCQLString(Redaction.REDACT));
+            assertEquals("v1", filter.toCQLString(Redaction.NONE));
             assertFetchedQueried(true, true, filter, v1);
             assertFetchedQueried(false, false, filter, v2, s1, s2);
             assertCellFetchedQueried(false, false, filter, v2, path0, path1, path2, path3, path4);
@@ -157,8 +158,8 @@ public class ColumnFilterTest
         Consumer<ColumnFilter> check = filter -> {
             testRoundTrips(filter);
             assertEquals("[Escaped Name]", filter.toString());
-            assertEquals("\"Escaped Name\"", filter.toCQLString(false));
-            assertEquals("\"Escaped Name\"", filter.toCQLString(true));
+            assertEquals("\"Escaped Name\"", filter.toCQLString(Redaction.NONE));
+            assertEquals("\"Escaped Name\"", filter.toCQLString(Redaction.REDACT));
             assertFetchedQueried(true, true, filter, escaped);
             assertFetchedQueried(false, false, filter, v2, s1, s2);
             assertCellFetchedQueried(false, false, filter, v2, path0, path1, path2, path3, path4);
@@ -175,8 +176,8 @@ public class ColumnFilterTest
         Consumer<ColumnFilter> check = filter -> {
             testRoundTrips(filter);
             assertEquals("[v2]", filter.toString());
-            assertEquals("v2", filter.toCQLString(false));
-            assertEquals("v2", filter.toCQLString(true));
+            assertEquals("v2", filter.toCQLString(Redaction.NONE));
+            assertEquals("v2", filter.toCQLString(Redaction.REDACT));
             assertFetchedQueried(true, true, filter, v2);
             assertFetchedQueried(false, false, filter, v1, s1, s2);
             assertCellFetchedQueried(true, true, filter, v2, path0, path1, path2, path3, path4);
@@ -193,8 +194,8 @@ public class ColumnFilterTest
         Consumer<ColumnFilter> check = filter -> {
             testRoundTrips(filter);
             assertEquals("[s1]", filter.toString());
-            assertEquals("s1", filter.toCQLString(false));
-            assertEquals("s1", filter.toCQLString(true));
+            assertEquals("s1", filter.toCQLString(Redaction.NONE));
+            assertEquals("s1", filter.toCQLString(Redaction.REDACT));
             assertFetchedQueried(true, true, filter, s1);
             assertFetchedQueried(false, false, filter, v1, v2, s2);
             assertCellFetchedQueried(false, false, filter, v2, path0, path1, path2, path3, path4);
@@ -211,8 +212,8 @@ public class ColumnFilterTest
         Consumer<ColumnFilter> check = filter -> {
             testRoundTrips(filter);
             assertEquals("[s2]", filter.toString());
-            assertEquals("s2", filter.toCQLString(false));
-            assertEquals("s2", filter.toCQLString(true));
+            assertEquals("s2", filter.toCQLString(Redaction.NONE));
+            assertEquals("s2", filter.toCQLString(Redaction.REDACT));
             assertFetchedQueried(true, true, filter, s2);
             assertFetchedQueried(false, false, filter, v1, v2, s1);
             assertCellFetchedQueried(false, false, filter, v2, path0, path1, path2, path3, path4);
@@ -229,8 +230,8 @@ public class ColumnFilterTest
         Consumer<ColumnFilter> check = filter -> {
             testRoundTrips(filter);
             assertEquals("[s1, s2, v1, v2]", filter.toString());
-            assertEquals("s1, s2, v1, v2", filter.toCQLString(false));
-            assertEquals("s1, s2, v1, v2", filter.toCQLString(true));
+            assertEquals("s1, s2, v1, v2", filter.toCQLString(Redaction.NONE));
+            assertEquals("s1, s2, v1, v2", filter.toCQLString(Redaction.REDACT));
             assertFetchedQueried(true, true, filter, v1, v2, s1, s2);
             assertCellFetchedQueried(true, true, filter, v2, path0, path1, path2, path3, path4);
             assertCellFetchedQueried(true, true, filter, s2, path0, path1, path2, path3, path4);
@@ -246,8 +247,8 @@ public class ColumnFilterTest
         ColumnFilter filter = ColumnFilter.selectionBuilder().select(v2, path1).select(v2, path3).build();
         testRoundTrips(filter);
         assertEquals("[v2[1], v2[3]]", filter.toString());
-        assertEquals("v2[1], v2[3]", filter.toCQLString(false));
-        assertEquals("v2[?], v2[?]", filter.toCQLString(true));
+        assertEquals("v2[1], v2[3]", filter.toCQLString(Redaction.NONE));
+        assertEquals("v2[?], v2[?]", filter.toCQLString(Redaction.REDACT));
         assertFetchedQueried(true, true, filter, v2);
         assertFetchedQueried(false, false, filter, v1, s1, s2);
         assertCellFetchedQueried(true, true, filter, v2, path1, path3);
@@ -261,8 +262,8 @@ public class ColumnFilterTest
         ColumnFilter filter = ColumnFilter.selectionBuilder().select(s2, path1).select(s2, path3).build();
         testRoundTrips(filter);
         assertEquals("[s2[1], s2[3]]", filter.toString());
-        assertEquals("s2[1], s2[3]", filter.toCQLString(false));
-        assertEquals("s2[?], s2[?]", filter.toCQLString(true));
+        assertEquals("s2[1], s2[3]", filter.toCQLString(Redaction.NONE));
+        assertEquals("s2[?], s2[?]", filter.toCQLString(Redaction.REDACT));
         assertFetchedQueried(true, true, filter, s2);
         assertFetchedQueried(false, false, filter, v1, v2, s1);
         assertCellFetchedQueried(false, false, filter, v2, path0, path1, path2, path3, path4);
@@ -276,8 +277,8 @@ public class ColumnFilterTest
         ColumnFilter filter = ColumnFilter.selectionBuilder().slice(v2, path1, path3).build();
         testRoundTrips(filter);
         assertEquals("[v2[1:3]]", filter.toString());
-        assertEquals("v2[1:3]", filter.toCQLString(false));
-        assertEquals("v2[?:?]", filter.toCQLString(true));
+        assertEquals("v2[1:3]", filter.toCQLString(Redaction.NONE));
+        assertEquals("v2[?:?]", filter.toCQLString(Redaction.REDACT));
         assertFetchedQueried(true, true, filter, v2);
         assertFetchedQueried(false, false, filter, v1, s1, s2);
         assertCellFetchedQueried(true, true, filter, v2, path1, path2, path3);
@@ -291,8 +292,8 @@ public class ColumnFilterTest
         ColumnFilter filter = ColumnFilter.selectionBuilder().slice(s2, path1, path3).build();
         testRoundTrips(filter);
         assertEquals("[s2[1:3]]", filter.toString());
-        assertEquals("s2[1:3]", filter.toCQLString(false));
-        assertEquals("s2[?:?]", filter.toCQLString(true));
+        assertEquals("s2[1:3]", filter.toCQLString(Redaction.NONE));
+        assertEquals("s2[?:?]", filter.toCQLString(Redaction.REDACT));
         assertFetchedQueried(true, true, filter, s2);
         assertFetchedQueried(false, false, filter, v1, v2, s1);
         assertCellFetchedQueried(false, false, filter, v2, path0, path1, path2, path3, path4);
@@ -313,8 +314,8 @@ public class ColumnFilterTest
                                           .build();
         testRoundTrips(filter);
         assertEquals("[s1, s2[0], s2[2:4], v1, v2[0:2], v2[4]]", filter.toString());
-        assertEquals("s1, s2[0], s2[2:4], v1, v2[0:2], v2[4]", filter.toCQLString(false));
-        assertEquals("s1, s2[?], s2[?:?], v1, v2[?:?], v2[?]", filter.toCQLString(true));
+        assertEquals("s1, s2[0], s2[2:4], v1, v2[0:2], v2[4]", filter.toCQLString(Redaction.NONE));
+        assertEquals("s1, s2[?], s2[?:?], v1, v2[?:?], v2[?]", filter.toCQLString(Redaction.REDACT));
         assertFetchedQueried(true, true, filter, v1, v2, s1, s2);
         assertCellFetchedQueried(true, true, filter, v2, path0, path1, path2, path4);
         assertCellFetchedQueried(false, false, filter, v2, path3);
@@ -342,10 +343,10 @@ public class ColumnFilterTest
             testRoundTrips(filter);
             assertFetchedQueried(true, true, filter, v1);
             if (returnStaticContentOnPartitionWithNoRows)
-            {
+        {
                 assertEquals("*/[v1]", filter.toString());
-                assertEquals("v1", filter.toCQLString(false));
-                assertEquals("v1", filter.toCQLString(true));
+                assertEquals("v1", filter.toCQLString(Redaction.NONE));
+                assertEquals("v1", filter.toCQLString(Redaction.REDACT));
                 assertFetchedQueried(true, false, filter, s1, s2, v2);
                 assertCellFetchedQueried(true, false, filter, v2, path0, path1, path2, path3, path4);
                 assertCellFetchedQueried(true, false, filter, s2, path0, path1, path2, path3, path4);
@@ -353,8 +354,8 @@ public class ColumnFilterTest
             else
             {
                 assertEquals("<all regulars>/[v1]", filter.toString());
-                assertEquals("v1", filter.toCQLString(false));
-                assertEquals("v1", filter.toCQLString(true));
+                assertEquals("v1", filter.toCQLString(Redaction.NONE));
+                assertEquals("v1", filter.toCQLString(Redaction.REDACT));
                 assertFetchedQueried(true, false, filter, v2);
                 assertFetchedQueried(false, false, filter, s1, s2);
                 assertCellFetchedQueried(true, false, filter, v2, path0, path1, path2, path3, path4);
@@ -384,10 +385,10 @@ public class ColumnFilterTest
             testRoundTrips(filter);
             assertFetchedQueried(true, true, filter, s1);
             if (returnStaticContentOnPartitionWithNoRows)
-            {
+        {
                 assertEquals("*/[s1]", filter.toString());
-                assertEquals("s1", filter.toCQLString(false));
-                assertEquals("s1", filter.toCQLString(true));
+                assertEquals("s1", filter.toCQLString(Redaction.NONE));
+                assertEquals("s1", filter.toCQLString(Redaction.REDACT));
                 assertFetchedQueried(true, false, filter, v1, v2, s2);
                 assertCellFetchedQueried(true, false, filter, v2, path0, path1, path2, path3, path4);
                 assertCellFetchedQueried(false, false, filter, s2, path0, path1, path2, path3, path4);
@@ -395,8 +396,8 @@ public class ColumnFilterTest
             else
             {
                 assertEquals("<all regulars>+[s1]/[s1]", filter.toString());
-                assertEquals("s1", filter.toCQLString(false));
-                assertEquals("s1", filter.toCQLString(true));
+                assertEquals("s1", filter.toCQLString(Redaction.NONE));
+                assertEquals("s1", filter.toCQLString(Redaction.REDACT));
                 assertFetchedQueried(true, false, filter, v1, v2);
                 assertFetchedQueried(false, false, filter, s2);
                 assertCellFetchedQueried(true, false, filter, v2, path0, path1, path2, path3, path4);
@@ -428,10 +429,10 @@ public class ColumnFilterTest
         testRoundTrips(filter);
         assertFetchedQueried(true, true, filter, v2);
         if (returnStaticContentOnPartitionWithNoRows)
-            {
+        {
             assertEquals("*/[v2[1]]", filter.toString());
-            assertEquals("v2[1]", filter.toCQLString(false));
-            assertEquals("v2[?]", filter.toCQLString(true));
+            assertEquals("v2[1]", filter.toCQLString(Redaction.NONE));
+            assertEquals("v2[?]", filter.toCQLString(Redaction.REDACT));
             assertFetchedQueried(true, false, filter, s1, s2, v1);
             assertCellFetchedQueried(true, true, filter, v2, path1);
             assertCellFetchedQueried(true, false, filter, v2, path0, path2, path3, path4);
@@ -440,8 +441,8 @@ public class ColumnFilterTest
         else
         {
             assertEquals("<all regulars>/[v2[1]]", filter.toString());
-            assertEquals("v2[1]", filter.toCQLString(false));
-            assertEquals("v2[?]", filter.toCQLString(true));
+            assertEquals("v2[1]", filter.toCQLString(Redaction.NONE));
+            assertEquals("v2[?]", filter.toCQLString(Redaction.REDACT));
             assertFetchedQueried(true, false, filter, v1);
             assertFetchedQueried(false, false, filter, s1, s2);
             assertCellFetchedQueried(true, true, filter, v2, path1);
@@ -472,8 +473,8 @@ public class ColumnFilterTest
         if (returnStaticContentOnPartitionWithNoRows)
         {
             assertEquals("*/[s2[1]]", filter.toString());
-            assertEquals("s2[1]", filter.toCQLString(false));
-            assertEquals("s2[?]", filter.toCQLString(true));
+            assertEquals("s2[1]", filter.toCQLString(Redaction.NONE));
+            assertEquals("s2[?]", filter.toCQLString(Redaction.REDACT));
             assertFetchedQueried(true, false, filter, v1, v2, s1);
             assertCellFetchedQueried(true, false, filter, v2, path0, path1, path2, path3, path4);
             assertCellFetchedQueried(true, true, filter, s2, path1);
@@ -482,8 +483,8 @@ public class ColumnFilterTest
         else
         {
             assertEquals("<all regulars>+[s2[1]]/[s2[1]]", filter.toString());
-            assertEquals("s2[1]", filter.toCQLString(false));
-            assertEquals("s2[?]", filter.toCQLString(true));
+            assertEquals("s2[1]", filter.toCQLString(Redaction.NONE));
+            assertEquals("s2[?]", filter.toCQLString(Redaction.REDACT));
             assertFetchedQueried(true, false, filter, v1, v2);
             assertFetchedQueried(false, false, filter, s1);
             assertCellFetchedQueried(false, false, filter, v2, path0, path1, path2, path3, path4);

--- a/test/unit/org/apache/cassandra/db/filter/IndexHintsTest.java
+++ b/test/unit/org/apache/cassandra/db/filter/IndexHintsTest.java
@@ -27,6 +27,7 @@ import org.apache.cassandra.cql3.QualifiedName;
 import org.apache.cassandra.cql3.restrictions.SingleColumnRestriction;
 import org.apache.cassandra.cql3.statements.PropertyDefinitions;
 import org.apache.cassandra.cql3.statements.SelectOptions;
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.index.sai.analyzer.AnalyzerEqOperatorSupport;
 
 import org.junit.BeforeClass;
@@ -357,7 +358,7 @@ public class IndexHintsTest extends CQLTester
         // without index hints
         String formattedQuery = formatQuery("SELECT * FROM %%s WHERE a = 0");
         ReadCommand command = parseReadCommand(formattedQuery);
-        Assertions.assertThat(command.toRedactedCQLString())
+        Assertions.assertThat(command.toCQLString(Redaction.REDACT))
                   .doesNotContain("included_indexes")
                   .doesNotContain("excluded_indexes");
 
@@ -365,7 +366,7 @@ public class IndexHintsTest extends CQLTester
         formattedQuery = formatQuery("SELECT * FROM %%s WHERE a = 0 AND b = 0 " +
                                      "WITH included_indexes={} AND excluded_indexes={}");
         command = parseReadCommand(formattedQuery);
-        Assertions.assertThat(command.toRedactedCQLString())
+        Assertions.assertThat(command.toCQLString(Redaction.REDACT))
                   .doesNotContain("included_indexes")
                   .doesNotContain("excluded_indexes");
 
@@ -373,7 +374,7 @@ public class IndexHintsTest extends CQLTester
         formattedQuery = formatQuery("SELECT * FROM %%s WHERE a = 0 AND b = 0 " +
                                      "WITH included_indexes={idx1,idx2}");
         command = parseReadCommand(formattedQuery);
-        Assertions.assertThat(command.toRedactedCQLString())
+        Assertions.assertThat(command.toCQLString(Redaction.REDACT))
                   .contains(" WITH included_indexes = {idx1, idx2}")
                   .doesNotContain("excluded_indexes");
 
@@ -381,7 +382,7 @@ public class IndexHintsTest extends CQLTester
         formattedQuery = formatQuery("SELECT * FROM %%s WHERE a = 0 AND b = 0 ALLOW FILTERING " +
                                      "WITH excluded_indexes={idx1,idx2}");
         command = parseReadCommand(formattedQuery);
-        Assertions.assertThat(command.toRedactedCQLString())
+        Assertions.assertThat(command.toCQLString(Redaction.REDACT))
                   .contains(" WITH excluded_indexes = {idx1, idx2}")
                   .doesNotContain("included_indexes");
 
@@ -389,14 +390,14 @@ public class IndexHintsTest extends CQLTester
         formattedQuery = formatQuery("SELECT * FROM %%s WHERE a = 0 AND b = 0 ALLOW FILTERING " +
                                      "WITH included_indexes={idx1} AND excluded_indexes={idx2}");
         command = parseReadCommand(formattedQuery);
-        Assertions.assertThat(command.toRedactedCQLString())
+        Assertions.assertThat(command.toCQLString(Redaction.REDACT))
                   .contains(" WITH included_indexes = {idx1} AND excluded_indexes = {idx2}");
 
         // with a single-partition read command
         formattedQuery = formatQuery("SELECT * FROM %%s WHERE k=1 AND a = 0 AND b = 0 ALLOW FILTERING " +
                                      "WITH included_indexes={idx1} AND excluded_indexes={idx2}");
         command = parseReadCommand(formattedQuery);
-        Assertions.assertThat(command.toRedactedCQLString())
+        Assertions.assertThat(command.toCQLString(Redaction.REDACT))
                   .contains(" WITH included_indexes = {idx1} AND excluded_indexes = {idx2}");
     }
 

--- a/test/unit/org/apache/cassandra/index/sai/cql/QueryTracingTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/QueryTracingTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.cql;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.index.sai.SAITester;
+import org.apache.cassandra.service.ClientState;
+import org.apache.cassandra.tracing.Tracing;
+import org.apache.cassandra.tracing.TracingTestImpl;
+import org.assertj.core.api.Assertions;
+
+import static org.apache.cassandra.config.CassandraRelevantProperties.CUSTOM_TRACING_CLASS;
+
+public class QueryTracingTest extends SAITester
+{
+    private static TracingTestImpl tracing;
+
+    @BeforeClass
+    public static void setUpClass()
+    {
+        CUSTOM_TRACING_CLASS.setString("org.apache.cassandra.tracing.TracingTestImpl");
+        SAITester.setUpClass();
+        Tracing.instance.newSession(ClientState.forInternalCalls(), Tracing.TraceType.QUERY);
+        tracing = (TracingTestImpl) Tracing.instance;
+    }
+
+    @AfterClass
+    public static void tearDownClass()
+    {
+        tracing.stopSession();
+        SAITester.tearDownClass();
+    }
+
+    @Test
+    public void testTracing()
+    {
+        createTable("CREATE TABLE %s(k int PRIMARY KEY, n int, t text, at text, v vector<float,2>)");
+        execute("INSERT INTO %s(k, n, t, at, v) VALUES (0, 0, 'hello', 'good bye', [1, 2])");
+        createIndex("CREATE CUSTOM INDEX ON %s(n) USING 'org.apache.cassandra.index.sai.StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX ON %s(t) USING 'org.apache.cassandra.index.sai.StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX ON %s(at) USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' WITH OPTIONS = { 'index_analyzer': 'standard' }");
+        createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'org.apache.cassandra.index.sai.StorageAttachedIndex'");
+
+        // queries on numeric index
+        assertTraceHasPlan("SELECT * FROM %s WHERE n = 0",
+                           "Filter n = 0",
+                           "NumericIndexScan",
+                           "predicate: Expression{name: n, op: EQ, lower: (0, true), upper: (0, true), exclusions: []}");
+        assertTraceHasPlan("SELECT * FROM %s WHERE n > 0",
+                           "Filter n > 0",
+                           "NumericIndexScan",
+                           "predicate: Expression{name: n, op: RANGE, lower: (0, false), upper: (null, false), exclusions: []}");
+        assertTraceHasPlan("SELECT * FROM %s WHERE n < 0",
+                           "Filter n < 0",
+                           "NumericIndexScan",
+                           "predicate: Expression{name: n, op: RANGE, lower: (null, false), upper: (0, false), exclusions: []}");
+        assertTraceHasPlan("SELECT * FROM %s WHERE n >= 0",
+                           "Filter n >= 0",
+                           "NumericIndexScan",
+                           "predicate: Expression{name: n, op: RANGE, lower: (0, true), upper: (null, false), exclusions: []}");
+        assertTraceHasPlan("SELECT * FROM %s WHERE n <= 0",
+                           "Filter n <= 0",
+                           "NumericIndexScan",
+                           "predicate: Expression{name: n, op: RANGE, lower: (null, false), upper: (0, true), exclusions: []}");
+        assertTraceHasPlan("SELECT * FROM %s ORDER BY n LIMIT 10",
+                           "NumericIndexScan",
+                           "ordering: n ASC");
+
+        // queries on literal index
+        assertTraceHasPlan("SELECT * FROM %s WHERE t = 'hello'",
+                           "Filter t = 'hello'",
+                           "LiteralIndexScan",
+                           "predicate: Expression{name: t, op: EQ, lower: (hello, true), upper: (hello, true), exclusions: []}");
+        assertTraceHasPlan("SELECT * FROM %s ORDER BY t LIMIT 10",
+                           "LiteralIndexScan",
+                           "ordering: t ASC");
+
+        // queries on analyzed index
+        assertTraceHasPlan("SELECT * FROM %s WHERE at : 'good'",
+                           "Filter at : 'good'",
+                           "LiteralIndexScan",
+                           "predicate: Expression{name: at, op: MATCH, lower: (good, true), upper: (good, true), exclusions: []}");
+        assertTraceHasPlan("SELECT * FROM %s ORDER BY at BM25 OF 'good' LIMIT 10",
+                           "Bm25IndexScan",
+                           "at BM25 OF 'good' DESC");
+
+        // queries on vector index
+        assertTraceHasPlan("SELECT * FROM %s ORDER BY v ANN OF [1.2, 3.4] LIMIT 10",
+                           "AnnIndexScan",
+                           "v ANN OF [1.2, 3.4] DESC");
+    }
+
+    private void assertTraceHasPlan(String query, String... expected)
+    {
+        TracingTestImpl tracing = (TracingTestImpl) Tracing.instance;
+        tracing.getTraces().clear();
+
+        execute(query);
+
+        for (String trace : tracing.getTraces())
+        {
+            if (!trace.startsWith("Query execution plan"))
+                continue;
+
+            for (String s : expected)
+            {
+                Assertions.assertThat(trace).as("Trace should contain {} but found: {}", expected, trace).contains(s);
+            }
+            return;
+        }
+        Assert.fail("Query plan not found in traces");
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/plan/ExpressionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/plan/ExpressionTest.java
@@ -22,10 +22,13 @@ import java.nio.ByteBuffer;
 
 import org.junit.Test;
 
+import org.apache.cassandra.cql3.Operator;
 import org.apache.cassandra.db.marshal.UTF8Type;
+import org.apache.cassandra.index.sai.SAITester;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ExpressionTest
 {
@@ -50,5 +53,56 @@ public class ExpressionTest
         Expression.Bound b2 = new Expression.Bound(buf2, UTF8Type.instance, true);
         assertNotEquals(b1, b2);
         assertNotEquals(b1.hashCode(), b2.hashCode());
+    }
+
+    @Test
+    public void toStringRedactionTest()
+    {
+        // test a few operators, just enough to see different variants to the string representations
+        Expression expression = makeExpression(Operator.EQ);
+        assertThat(expression.toString(true))
+                .isEqualTo("Expression{name: col, op: EQ, lower: (?, true), upper: (?, true), exclusions: []}");
+        assertThat(expression.toString(false))
+                .isEqualTo("Expression{name: col, op: EQ, lower: (sensitive, true), upper: (sensitive, true), exclusions: []}");
+
+        expression = makeExpression(Operator.GT);
+        assertThat(expression.toString(true))
+                .isEqualTo("Expression{name: col, op: RANGE, lower: (?, false), upper: (null, false), exclusions: []}");
+        assertThat(expression.toString(false))
+                .isEqualTo("Expression{name: col, op: RANGE, lower: (sensitive, false), upper: (null, false), exclusions: []}");
+
+        expression = makeExpression(Operator.GTE);
+        assertThat(expression.toString(true))
+                .isEqualTo("Expression{name: col, op: RANGE, lower: (?, true), upper: (null, false), exclusions: []}");
+        assertThat(expression.toString(false))
+                .isEqualTo("Expression{name: col, op: RANGE, lower: (sensitive, true), upper: (null, false), exclusions: []}");
+
+        expression = makeExpression(Operator.LT);
+        assertThat(expression.toString(true))
+                .isEqualTo("Expression{name: col, op: RANGE, lower: (null, false), upper: (?, false), exclusions: []}");
+        assertThat(expression.toString(false))
+                .isEqualTo("Expression{name: col, op: RANGE, lower: (null, false), upper: (sensitive, false), exclusions: []}");
+
+        expression = makeExpression(Operator.LTE);
+        assertThat(expression.toString(true))
+                .isEqualTo("Expression{name: col, op: RANGE, lower: (null, false), upper: (?, true), exclusions: []}");
+        assertThat(expression.toString(false))
+                .isEqualTo("Expression{name: col, op: RANGE, lower: (null, false), upper: (sensitive, true), exclusions: []}");
+
+        // test exclusions, which also need redaction
+        expression = new Expression(SAITester.createIndexContext("col", UTF8Type.instance));
+        expression.add(Operator.GT, UTF8Type.instance.decompose("sensitive_1"));
+        expression.add(Operator.NEQ, UTF8Type.instance.decompose("sensitive_2"));
+        assertThat(expression.toString(true))
+                .isEqualTo("Expression{name: col, op: RANGE, lower: (?, false), upper: (null, false), exclusions: [?]}");
+        assertThat(expression.toString(false))
+                .isEqualTo("Expression{name: col, op: RANGE, lower: (sensitive_1, false), upper: (null, false), exclusions: [sensitive_2]}");
+    }
+
+    private static Expression makeExpression(Operator op)
+    {
+        Expression expression = new Expression(SAITester.createIndexContext("col", UTF8Type.instance));
+        expression.add(op, UTF8Type.instance.decompose("sensitive"));
+        return expression;
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/plan/OrdererTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/plan/OrdererTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.plan;
+
+import org.junit.Test;
+
+import org.apache.cassandra.cql3.Operator;
+import org.apache.cassandra.db.filter.ANNOptions;
+import org.apache.cassandra.db.marshal.FloatType;
+import org.apache.cassandra.db.marshal.Redaction;
+import org.apache.cassandra.db.marshal.UTF8Type;
+import org.apache.cassandra.db.marshal.VectorType;
+import org.apache.cassandra.index.sai.IndexContext;
+import org.apache.cassandra.index.sai.SAITester;
+import org.apache.cassandra.index.sai.cql.VectorTester;
+import org.assertj.core.api.Assertions;
+
+public class OrdererTest extends VectorTester
+{
+    @Test
+    public void toStringRedactionTest()
+    {
+        // ANN
+        VectorType<Float> vectorType = VectorType.getInstance(FloatType.instance, 2);
+        IndexContext context = SAITester.createIndexContext("col", vectorType);
+        Orderer orderer = new Orderer(context, Operator.ANN, vectorType.decompose(vector(1f, 2f)), ANNOptions.NONE);
+        assertToString(orderer, "col ANN OF ? DESC", "col ANN OF [1.0, 2.0] DESC");
+
+        // BM25
+        IndexContext textContext = SAITester.createIndexContext("col", UTF8Type.instance);
+        orderer = new Orderer(textContext, Operator.BM25, UTF8Type.instance.decompose("sensitive"), ANNOptions.NONE);
+        assertToString(orderer, "col BM25 OF ? DESC", "col BM25 OF 'sensitive' DESC");
+
+        // Generic ORDER BY
+        orderer = new Orderer(textContext, Operator.ORDER_BY_ASC, null, ANNOptions.NONE);
+        assertToString(orderer, "col ASC", "col ASC");
+        orderer = new Orderer(textContext, Operator.ORDER_BY_DESC, null, ANNOptions.NONE);
+        assertToString(orderer, "col DESC", "col DESC");
+    }
+
+    private static void assertToString(Orderer orderer, String expectedRedacted, String expectedUnredacted)
+    {
+        Assertions.assertThat(orderer.toString(Redaction.REDACT))
+                  .isEqualTo(expectedRedacted);
+        Assertions.assertThat(orderer.toString(Redaction.NONE))
+                  .isEqualTo(expectedUnredacted);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/plan/PlanTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/plan/PlanTest.java
@@ -36,7 +36,7 @@ import org.junit.Test;
 import org.apache.cassandra.cql3.Operator;
 import org.apache.cassandra.db.filter.IndexHints;
 import org.apache.cassandra.db.filter.RowFilter;
-
+import org.apache.cassandra.db.marshal.Redaction;
 import org.apache.cassandra.index.sai.disk.vector.VectorMemtableIndex;
 import org.apache.cassandra.index.sai.iterators.KeyRangeIterator;
 import org.apache.cassandra.index.sai.iterators.LongIterator;
@@ -68,14 +68,15 @@ public class PlanTest
     {
         Orderer orderer = Mockito.mock(Orderer.class);
         Mockito.when(orderer.isANN()).thenReturn(true);
-        Mockito.when(orderer.toString()).thenReturn("ORDER BY v ANN OF [...]");
+        Mockito.when(orderer.toString(Redaction.REDACT)).thenReturn("ORDER BY v ANN OF ?");
+        Mockito.when(orderer.toString(Redaction.NONE)).thenReturn("ORDER BY v ANN OF X");
         return orderer;
     }
 
-    private static final RowFilter.Expression pred1 = filerPred("pred1", Operator.LT);
-    private static final RowFilter.Expression pred2 = filerPred("pred2", Operator.LT);
-    private static final RowFilter.Expression pred3 = filerPred("pred3", Operator.LT);
-    private static final RowFilter.Expression pred4 = filerPred("pred4", Operator.LT);
+    private static final RowFilter.Expression pred1 = filterPred("pred1", Operator.LT);
+    private static final RowFilter.Expression pred2 = filterPred("pred2", Operator.LT);
+    private static final RowFilter.Expression pred3 = filterPred("pred3", Operator.LT);
+    private static final RowFilter.Expression pred4 = filterPred("pred4", Operator.LT);
 
     private static final Expression saiPred1 = saiPred("pred1", Expression.Op.RANGE, false);
     private static final  Expression saiPred2 = saiPred("pred2", Expression.Op.RANGE, false);
@@ -100,18 +101,19 @@ public class PlanTest
     private static Expression saiPred(String column, Expression.Op operation, boolean isLiteral)
     {
         Expression pred = Mockito.mock(Expression.class);
-        Mockito.when(pred.toString()).thenReturn(operation.toString() + '(' + column + ')');
+        Mockito.when(pred.toString(false)).thenReturn(operation.toString() + '(' + column + ", X)");
+        Mockito.when(pred.toString(true)).thenReturn(operation.toString() + '(' + column + ", ?)");
         Mockito.when(pred.getIndexName()).thenReturn(column + "_idx");
         Mockito.when(pred.getOp()).thenReturn(operation);
         Mockito.when(pred.isLiteral()).thenReturn(isLiteral);
         return pred;
     }
 
-    private static RowFilter.Expression filerPred(String column, Operator operation)
+    private static RowFilter.Expression filterPred(String column, Operator operation)
     {
         RowFilter.Expression pred = Mockito.mock(RowFilter.Expression.class);
-        Mockito.when(pred.toCQLString(false)).thenReturn(column + ' ' + operation + " X");
-        Mockito.when(pred.toCQLString(true)).thenReturn(column + ' ' + operation + " ?");
+        Mockito.when(pred.toCQLString(Redaction.NONE)).thenReturn(column + ' ' + operation + " X");
+        Mockito.when(pred.toCQLString(Redaction.REDACT)).thenReturn(column + ' ' + operation + " ?");
         Mockito.when(pred.operator()).thenReturn(operation);
         return pred;
     }
@@ -573,18 +575,18 @@ public class PlanTest
                               " └─ Filter pred1 < %s AND pred2 < %<s AND pred4 < %<s (sel: 1.000000000) (rows: 3.0, cost/row: 3895.8, cost: 44171.3..55858.7)\n" +
                               "     └─ Fetch (rows: 3.0, cost/row: 3895.8, cost: 44171.3..55858.7)\n" +
                               "         └─ KeysSort (keys: 3.0, cost/key: 3792.4, cost: 44171.3..55548.4)\n" +
-                              "            ORDER BY v ANN OF [...]\n" +
+                              "            ORDER BY v ANN OF %<s\n" +
                               "             └─ Union (keys: 1999.0, cost/key: 14.8, cost: 13500.0..43001.3)\n" +
                               "                 ├─ Intersection (keys: 1000.0, cost/key: 29.4, cost: 9000.0..38401.3)\n" +
                               "                 │   ├─ NumericIndexScan of pred2_idx (sel: 0.002000000, step: 1.0) (keys: 2000.0, cost/key: 0.1, cost: 4500.0..4700.0)\n" +
-                              "                 │   │  predicate: RANGE(pred2)\n" +
+                              "                 │   │  predicate: RANGE(pred2, %<s)\n" +
                               "                 │   └─ NumericIndexScan of pred1_idx (sel: 0.500000000, step: 250.0) (keys: 2000.0, cost/key: 14.6, cost: 4500.0..33701.3)\n" +
-                              "                 │      predicate: RANGE(pred1)\n" +
+                              "                 │      predicate: RANGE(pred1, %<s)\n" +
                               "                 └─ LiteralIndexScan of pred4_idx (sel: 0.001000000, step: 1.0) (keys: 1000.0, cost/key: 0.1, cost: 4500.0..4600.0)\n" +
-                              "                    predicate: RANGE(pred4)\n";
+                              "                    predicate: RANGE(pred4, %<s)\n";
 
-        assertEquals(String.format(expectedPlan, 'X'), limit.toUnredactedStringRecursive());
-        assertEquals(String.format(expectedPlan, '?'), limit.toRedactedStringRecursive());
+        assertEquals(String.format(expectedPlan, 'X'), limit.toStringRecursive(Redaction.NONE));
+        assertEquals(String.format(expectedPlan, '?'), limit.toStringRecursive(Redaction.REDACT));
     }
 
     @Test
@@ -876,7 +878,7 @@ public class PlanTest
 
         Plan optimizedPlan = origPlan.optimize();
         List<Plan.IndexScan> resultIndexScans = optimizedPlan.nodesOfType(Plan.IndexScan.class);
-        assertTrue("original:\n" + origPlan.toRedactedStringRecursive() + "optimized:\n" + optimizedPlan.toRedactedStringRecursive(),
+        assertTrue("original:\n" + origPlan.toStringRecursive(Redaction.REDACT) + "optimized:\n" + optimizedPlan.toStringRecursive(Redaction.REDACT),
                      expectedIndexScanCount.contains(resultIndexScans.size()));
     }
 
@@ -994,7 +996,7 @@ public class PlanTest
             Plan.KeysIteration indexScan = factory.indexScan(saiPred(column, operation, operation == Expression.Op.EQ),
                                                                     (long) (selectivities.get(i) * metrics.rows));
             indexScans.add(indexScan);
-            rowFilterBuilder.add(filerPred(column, operation == Expression.Op.RANGE ? Operator.LT : Operator.EQ));
+            rowFilterBuilder.add(filterPred(column, operation == Expression.Op.RANGE ? Operator.LT : Operator.EQ));
         }
 
         Plan.KeysIteration intersection = factory.intersection(indexScans);
@@ -1005,7 +1007,7 @@ public class PlanTest
 
         Plan optimizedPlan = origPlan.optimize();
         List<Plan.IndexScan> resultIndexScans = optimizedPlan.nodesOfType(Plan.IndexScan.class);
-        assertTrue("original:\n" + origPlan.toRedactedStringRecursive() + "optimized:\n" + optimizedPlan.toRedactedStringRecursive(),
+        assertTrue("original:\n" + origPlan.toStringRecursive(Redaction.REDACT) + "optimized:\n" + optimizedPlan.toStringRecursive(Redaction.REDACT),
                      expectedIndexScanCount.contains(resultIndexScans.size()));
     }
 


### PR DESCRIPTION
Adds the missing redaction of plan expressions and orderers.

Also, refactor toCQLString methods to use a Redaction.[NONE|REDACT] enum.
