### PR TITLE
CNDB-18356: include CAS latency metrics in allRequests metrics

### DIFF
--- a/src/java/org/apache/cassandra/metrics/ClientRequestsMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/ClientRequestsMetrics.java
@@ -87,6 +87,7 @@ public class ClientRequestsMetrics
         writeMetrics.release();
         casWriteMetrics.release();
         casReadMetrics.release();
+        allRequestsMetrics.release();
         readMetricsMap.values().forEach(ClientRequestMetrics::release);
         writeMetricsMap.values().forEach(ClientRequestMetrics::release);
     }

--- a/src/java/org/apache/cassandra/service/StorageProxy.java
+++ b/src/java/org/apache/cassandra/service/StorageProxy.java
@@ -669,6 +669,8 @@ public class StorageProxy implements StorageProxyMBean
             long latency = nanoTime() - requestTime.startedAtNanos();
             metrics.casWriteMetrics.executionTimeMetrics.addNano(latency);
             metrics.casWriteMetrics.serviceTimeMetrics.addNano(latency);
+            metrics.allRequestsMetrics.executionTimeMetrics.addNano(latency);
+            metrics.allRequestsMetrics.serviceTimeMetrics.addNano(latency);
             metrics.writeMetricsForLevel(consistencyForPaxos).executionTimeMetrics.addNano(latency);
             metrics.writeMetricsForLevel(consistencyForPaxos).serviceTimeMetrics.addNano(latency);
             Keyspace.openAndGetStore(metadata).metric.coordinatorCasWriteLatency.update(latency, NANOSECONDS);
@@ -2295,6 +2297,8 @@ public class StorageProxy implements StorageProxyMBean
             metrics.readMetrics.serviceTimeMetrics.addNano(serviceLatency);
             metrics.casReadMetrics.executionTimeMetrics.addNano(latency);
             metrics.casReadMetrics.serviceTimeMetrics.addNano(serviceLatency);
+            metrics.allRequestsMetrics.executionTimeMetrics.addNano(latency);
+            metrics.allRequestsMetrics.serviceTimeMetrics.addNano(serviceLatency);
             metrics.readMetricsForLevel(consistencyLevel).executionTimeMetrics.addNano(latency);
             metrics.readMetricsForLevel(consistencyLevel).serviceTimeMetrics.addNano(serviceLatency);
             ColumnFamilyStore cfs = Keyspace.open(metadata.keyspace).getColumnFamilyStore(metadata.name);

--- a/src/java/org/apache/cassandra/service/paxos/Paxos.java
+++ b/src/java/org/apache/cassandra/service/paxos/Paxos.java
@@ -826,6 +826,7 @@ public class Paxos
 
 
             metrics.casWriteMetrics.executionTimeMetrics.addNano(latency);
+            metrics.allRequestsMetrics.executionTimeMetrics.addNano(latency);
             metrics.writeMetricsForLevel(consistencyForConsensus).executionTimeMetrics.addNano(latency);
         }
     }
@@ -927,6 +928,7 @@ public class Paxos
             long latency = nanoTime() - start;
             metrics.readMetrics.executionTimeMetrics.addNano(latency);
             metrics.casReadMetrics.executionTimeMetrics.addNano(latency);
+            metrics.allRequestsMetrics.executionTimeMetrics.addNano(latency);
             metrics.readMetricsForLevel(consistencyForConsensus).executionTimeMetrics.addNano(latency);
             TableMetadata table = read.metadata();
             ColumnFamilyStore cfs = Keyspace.open(table.keyspace).getColumnFamilyStore(table.name);

--- a/test/unit/org/apache/cassandra/metrics/ClientRequestMetricsLatenciesTest.java
+++ b/test/unit/org/apache/cassandra/metrics/ClientRequestMetricsLatenciesTest.java
@@ -160,18 +160,21 @@ public class ClientRequestMetricsLatenciesTest
                                                   clientMetrics.readMetrics,
                                                   clientMetrics.readMetricsForLevel(QUORUM),
                                                   clientMetrics.casWriteMetrics,
+                                                  clientMetrics.allRequestsMetrics,
                                                   clientMetrics.writeMetricsForLevel(SERIAL));
             processQueryAndCheckMetricsWereBumped("UPDATE %1$s.%2$s SET v2=123 WHERE k=7 AND v1=7 IF v2=71;",
                                                   cl,
                                                   clientMetrics.readMetrics,
                                                   clientMetrics.readMetricsForLevel(QUORUM),
                                                   clientMetrics.casWriteMetrics,
+                                                  clientMetrics.allRequestsMetrics,
                                                   clientMetrics.writeMetricsForLevel(SERIAL));
             processQueryAndCheckMetricsWereBumped("UPDATE %1$s.%2$s SET v2=123 WHERE k=7 AND v1=7 IF v2=7;",
                                                   cl,
                                                   clientMetrics.readMetrics,
                                                   clientMetrics.readMetricsForLevel(QUORUM),
                                                   clientMetrics.casWriteMetrics,
+                                                  clientMetrics.allRequestsMetrics,
                                                   clientMetrics.writeMetricsForLevel(SERIAL));
         });
     }
@@ -182,11 +185,13 @@ public class ClientRequestMetricsLatenciesTest
         processQueryAndCheckMetricsWereBumped("SELECT * FROM %1$s.%2$s WHERE k=7 AND v1=7;",
                                               SERIAL,
                                               clientMetrics.casReadMetrics,
+                                              clientMetrics.allRequestsMetrics,
                                               clientMetrics.readMetrics,
                                               clientMetrics.readMetricsForLevel(SERIAL));
         processQueryAndCheckMetricsWereBumped("SELECT * FROM %1$s.%2$s WHERE k=7 AND v1=7;",
                                               LOCAL_SERIAL,
                                               clientMetrics.casReadMetrics,
+                                              clientMetrics.allRequestsMetrics,
                                               clientMetrics.readMetrics,
                                               clientMetrics.readMetricsForLevel(LOCAL_SERIAL));
     }
@@ -221,6 +226,7 @@ public class ClientRequestMetricsLatenciesTest
                                                       clientMetrics.readMetrics,
                                                       clientMetrics.readMetricsForLevel(QUORUM),
                                                       clientMetrics.casWriteMetrics,
+                                                      clientMetrics.allRequestsMetrics,
                                                       clientMetrics.writeMetricsForLevel(SERIAL),
                                                       clientMetrics.viewWriteMetrics);
                 processQueryAndCheckMetricsWereBumped("UPDATE %1$s.%2$s SET v2=123 WHERE k=7 AND v1=7 IF v2=7;",
@@ -228,6 +234,7 @@ public class ClientRequestMetricsLatenciesTest
                                                       clientMetrics.readMetrics,
                                                       clientMetrics.readMetricsForLevel(QUORUM),
                                                       clientMetrics.casWriteMetrics,
+                                                      clientMetrics.allRequestsMetrics,
                                                       clientMetrics.writeMetricsForLevel(SERIAL),
                                                       clientMetrics.viewWriteMetrics);
 
@@ -237,12 +244,14 @@ public class ClientRequestMetricsLatenciesTest
                                                       clientMetrics.readMetrics,
                                                       clientMetrics.readMetricsForLevel(QUORUM),
                                                       clientMetrics.casWriteMetrics,
+                                                      clientMetrics.allRequestsMetrics,
                                                       clientMetrics.writeMetricsForLevel(SERIAL));
                 processQueryAndCheckMetricsWereBumped("UPDATE %1$s.%2$s SET v2=123 WHERE k=7 AND v1=7 IF v2=7;",
                                                       cl,
                                                       clientMetrics.readMetrics,
                                                       clientMetrics.readMetricsForLevel(QUORUM),
                                                       clientMetrics.casWriteMetrics,
+                                                      clientMetrics.allRequestsMetrics,
                                                       clientMetrics.writeMetricsForLevel(SERIAL));
 
             });


### PR DESCRIPTION
### What is the issue
allRequest metrics are missing CAS latencies

### What does this PR fix and why was it fixed
includes CAS latency metrics in allRequests metrics
