### PR TITLE
CNDB-18216: Fix logging of paged queries exposing user data (#2495)

### DIFF
--- a/src/java/org/apache/cassandra/db/AbstractReadQuery.java
+++ b/src/java/org/apache/cassandra/db/AbstractReadQuery.java
@@ -61,6 +61,7 @@ abstract class AbstractReadQuery extends MonitorableImpl implements ReadQuery
     }
 
     // Monitorable interface
+    @Override
     public String name()
     {
         return toCQLString(Redaction.REDACT);
@@ -135,7 +136,7 @@ abstract class AbstractReadQuery extends MonitorableImpl implements ReadQuery
         appendCQLWhereClause(builder, redaction);
 
         if (limits() != DataLimits.NONE)
-            builder.append(' ').append(limits());
+            builder.append(' ').append(limits().toCQLString());
 
         // ALLOW FILTERING might not be strictly necessary
         builder.append(" ALLOW FILTERING");
@@ -148,6 +149,12 @@ abstract class AbstractReadQuery extends MonitorableImpl implements ReadQuery
              .append(SelectOptions.EXCLUDED_INDEXES, excluded)
              .append(SelectOptions.ANN_OPTIONS, rowFilter().annOptions().toCQLString());
         });
+
+        // The limits used by the subsequent queries of paging don't have a clear direct translation into CQL.
+        // However, they change the meaning of the query, and it can be useful to identify them in logs.
+        // That's why here we append a fragment of invalid CQL syntanx, at the end of the query.
+        if (limits.isPagingContinuation())
+            builder.append(" [paging continuation]");
 
         return builder.toString();
     }

--- a/src/java/org/apache/cassandra/db/filter/DataLimits.java
+++ b/src/java/org/apache/cassandra/db/filter/DataLimits.java
@@ -236,6 +236,17 @@ public abstract class DataLimits
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Whether this is for the continuation of a paged query, that is, whether it comes from
+     * {@link #forPaging(PageSize, ByteBuffer, int)} or {@link #forGroupByInternalPaging}.
+     *
+     * @return whether this is for the continuation of a paged query
+     */
+    public boolean isPagingContinuation()
+    {
+        return false;
+    }
+
     public abstract boolean hasEnoughLiveData(CachedPartition cached,
                                               long nowInSec,
                                               boolean countPartitionsWithOnlyStaticData,
@@ -336,6 +347,8 @@ public abstract class DataLimits
      * Estimate the number of results that a full scan of the provided cfs would yield.
      */
     public abstract float estimateTotalResults(ColumnFamilyStore cfs);
+
+    public abstract String toCQLString();
 
     public static abstract class Counter extends StoppingTransformation<BaseRowIterator<?>>
     {
@@ -707,6 +720,12 @@ public abstract class DataLimits
         @Override
         public String toString()
         {
+            return toCQLString();
+        }
+
+        @Override
+        public String toCQLString()
+        {
             List<String> limits = new ArrayList<>(3);
 
             if (bytesLimit != NO_LIMIT)
@@ -748,6 +767,12 @@ public abstract class DataLimits
         public DataLimits forPaging(PageSize pageSize, ByteBuffer lastReturnedKey, int lastReturnedKeyRemaining)
         {
             throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isPagingContinuation()
+        {
+            return true;
         }
 
         @Override
@@ -1339,6 +1364,12 @@ public abstract class DataLimits
         public DataLimits forGroupByInternalPaging(GroupingState state)
         {
             throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isPagingContinuation()
+        {
+            return true;
         }
 
         @Override

--- a/test/distributed/org/apache/cassandra/distributed/test/SlowQueryLoggerTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/SlowQueryLoggerTest.java
@@ -17,6 +17,7 @@
 package org.apache.cassandra.distributed.test;
 
 import java.nio.ByteBuffer;
+import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
@@ -46,6 +47,8 @@ import org.assertj.core.api.AbstractIterableAssert;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.ListAssert;
 
+import static java.util.regex.Pattern.quote;
+
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static org.apache.cassandra.distributed.api.ConsistencyLevel.ALL;
 import static org.apache.cassandra.utils.MonotonicClock.Global.approxTime;
@@ -68,7 +71,11 @@ public class SlowQueryLoggerTest extends TestBaseImpl
 
         cluster = init(Cluster.build(2)
                               .withInstanceInitializer(SlowQueryLoggerTest.BBHelper::install)
-                              .withConfig(config -> config.set("slow_query_log_timeout_in_ms", SLOW_QUERY_LOG_TIMEOUT_MS))
+                              .withConfig(config -> {
+                                  config.set("slow_query_log_timeout_in_ms", SLOW_QUERY_LOG_TIMEOUT_MS);
+                                  config.set("read_request_timeout_in_ms", 60000L);
+                                  config.set("range_request_timeout_in_ms", 60000L);
+                              })
                               .start());
         coordinator = cluster.coordinator(1);
         node = cluster.get(2);
@@ -108,14 +115,24 @@ public class SlowQueryLoggerTest extends TestBaseImpl
 
         // verify that slow queries are logged with redacted values
         long mark = node.logs().mark();
-        Object[][] rows = coordinator.execute(format("SELECT * FROM %s.%s WHERE k = 'secret_k' AND c = 'secret_c' AND v = 'secret_v' ALLOW FILTERING"), ALL);
+        String query = format("SELECT * FROM %s.%s WHERE k = 'secret_k' AND c = 'secret_c' AND v = 'secret_v' ALLOW FILTERING");
+        Object[][] rows = coordinator.execute(query, ALL);
         Assertions.assertThat(rows).hasNumberOfRows(1);
         assertLogsContain(mark, node, "operations were slow", format("<SELECT \\* FROM %s\\.%s WHERE k = \\? AND c = \\? AND v = \\? ALLOW FILTERING>"));
         assertLogsDoNotContain(mark, node, "secret_k", "secret_c", "secret_v");
 
+        // verify again with paging
+        mark = node.logs().mark();
+        Iterator<Object[]> pagedRows = coordinator.executeWithPaging(query, ALL, 1);
+        while (pagedRows.hasNext())
+            pagedRows.next();
+        assertLogsContain(mark, node, "operations were slow", quote(format("<SELECT * FROM %s.%s WHERE k = ? AND c = ? AND v = ? LIMIT 1 ALLOW FILTERING>")));
+        assertLogsContain(mark, node, "operations were slow", quote(format("<SELECT * FROM %s.%s WHERE k = ? AND v = ? LIMIT 1 ALLOW FILTERING [paging continuation]>")));
+        assertLogsDoNotContain(mark, node, "secret_k", "secret_c", "secret_v");
+
         // verify that large values include size hints
         mark = node.logs().mark();
-        String query = format("SELECT * FROM %s.%s WHERE b = ? ALLOW FILTERING");
+        query = format("SELECT * FROM %s.%s WHERE b = ? ALLOW FILTERING");
         coordinator.execute(query, ALL, ByteBuffer.allocate(100 + 1));
         coordinator.execute(query, ALL, ByteBuffer.allocate(1024 + 1));
         coordinator.execute(query, ALL, ByteBuffer.allocate(10 * 1024 + 1));
@@ -183,6 +200,19 @@ public class SlowQueryLoggerTest extends TestBaseImpl
                           "  Fetched/returned/tombstones:",
                           "    partitions: 10/3/0",
                           "    rows: 100/25/0");
+
+        // paged query
+        mark = node.logs().mark();
+        Iterator<Object[]> pagedRows = coordinator.executeWithPaging(format("SELECT * FROM %s.%s"), ALL, 5);
+        int readRows = 0;
+        while (pagedRows.hasNext())
+        {
+            pagedRows.next();
+            readRows++;
+        }
+        Assertions.assertThat(readRows).isEqualTo(numRows);
+        assertLogsContain(mark, node, quote(format("<SELECT * FROM %s.%s LIMIT 5 ALLOW FILTERING>")));
+        assertLogsContain(mark, node, quote(format("<SELECT * FROM %s.%s WHERE token(k) >= token(?) LIMIT 5 ALLOW FILTERING [paging continuation]>")));
 
         // test multiple slow runs of different queries with the same redacted form, it should log the slowest one
         mark = node.logs().mark();

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/SlowSAIQueryLoggerTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/SlowSAIQueryLoggerTest.java
@@ -15,6 +15,7 @@
  */
 package org.apache.cassandra.distributed.test.sai;
 
+import java.util.Iterator;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -44,6 +45,7 @@ import org.apache.cassandra.index.sai.plan.QueryController;
 import org.apache.cassandra.index.sai.plan.QueryMonitorableExecutionInfo;
 import org.awaitility.Awaitility;
 
+import static java.util.regex.Pattern.quote;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static org.apache.cassandra.distributed.test.SlowQueryLoggerTest.assertLogsContain;
 import static org.apache.cassandra.distributed.test.SlowQueryLoggerTest.assertLogsDoNotContain;
@@ -402,6 +404,19 @@ public class SlowSAIQueryLoggerTest extends TestBaseImpl
             assertLogsContain(mark, node,
                               "partitionTombstonesFetched: 1",
                               "rowTombstonesFetched: 2");
+
+            // test with paged queries
+            mark = node.logs().mark();
+            String query =  withKeyspace("SELECT * FROM %s.t WHERE n >= 0");
+            Iterator<Object[]> pagedRows = coordinator.executeWithPaging(query, ConsistencyLevel.ONE, 1);
+            while (pagedRows.hasNext())
+                pagedRows.next();
+            assertLogsContain(mark, node,
+                              quote(withKeyspace("<SELECT * FROM %s.t WHERE n >= ? LIMIT 1 ALLOW FILTERING>")),
+                              "NumericIndexScan");
+            assertLogsContain(mark, node,
+                              quote(withKeyspace("<SELECT * FROM %s.t WHERE token(k) >= token(?) AND n >= ? LIMIT 1 ALLOW FILTERING [paging continuation]>")),
+                              "NumericIndexScan");
         }
     }
 

--- a/test/unit/org/apache/cassandra/service/reads/range/RangeCommandsTest.java
+++ b/test/unit/org/apache/cassandra/service/reads/range/RangeCommandsTest.java
@@ -292,6 +292,12 @@ public class RangeCommandsTest extends CQLTester
         {
             return wrapped.withBytesLimit(bytesLimit);
         }
+
+        @Override
+        public String toCQLString()
+        {
+            return wrapped.toCQLString();
+        }
     }
 
     public static final class MockedIndex extends StubIndex


### PR DESCRIPTION
The slow query logger won't print unredacted partition keys on paged queries.

Also, it would be possible to identify these queries by the addition of the [paging continuation] suffix to the CQL query.

