### PR TITLE
CNDB-18275: Port CNDB-18238: Update JVector to fix a regression in recall. The pruning option is now ignored and no matter what a user sets pruning will be always pointing to FALSE (#2479) (#2485)

### DIFF
--- a/.build/parent-pom-template.xml
+++ b/.build/parent-pom-template.xml
@@ -1259,7 +1259,7 @@
       <dependency>
         <groupId>io.github.jbellis</groupId>
         <artifactId>jvector</artifactId>
-        <version>4.0.0-rc.8</version>
+        <version>4.0.0-rc.8-hf1</version>
       </dependency>
       <dependency>
         <groupId>com.carrotsearch.randomizedtesting</groupId>

--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -921,7 +921,7 @@ public enum CassandraRelevantProperties
 
     /** Controls the maximum top-k limit for vector search */
     SAI_VECTOR_SEARCH_MAX_TOP_K("cassandra.sai.vector_search.max_top_k", "1000"),
-    SAI_VECTOR_USE_PRUNING_DEFAULT("cassandra.sai.jvector.use_pruning_default", "1000"),
+    SAI_VECTOR_USE_PRUNING_DEFAULT("cassandra.sai.jvector.use_pruning_default", "false"),
 
     /** The class to use for selecting the current version of the SAI on-disk index format on a per-keyspace basis. */
     SAI_VERSION_SELECTOR_CLASS("cassandra.sai.version.selector.class", ""),

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorSiftSmallTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorSiftSmallTest.java
@@ -72,8 +72,8 @@ public class VectorSiftSmallTest extends VectorTester.Versioned
         // Run a few queries with increasing rerank_k to validate that recall increases
         ensureIncreasingRerankKIncreasesRecall(queryVectors, groundTruth);
 
-        // Run queries with and without pruning to validate recall improves
-        ensureDisablingPruningIncreasesRecall(queryVectors, groundTruth);
+        // Test that use_pruning option works (even though JVector ignores it)
+        testUsePruningOptionCompatibility(queryVectors, groundTruth);
 
         flush();
         var diskRecall = testRecall(100, queryVectors, groundTruth);
@@ -114,19 +114,30 @@ public class VectorSiftSmallTest extends VectorTester.Versioned
                    strictlyIncreasedCount > 3);
     }
 
-    private void ensureDisablingPruningIncreasesRecall(List<float[]> queryVectors, List<List<Integer>> groundTruth)
+    /**
+     * Tests that the use_pruning option is accepted and works without errors.
+     * <p>
+     * IMPORTANT: As of JVector PR #682, pruning is deprecated and always disabled.
+     * JVector's usePruning() method now always sets pruneSearch = false regardless of input.
+     * This test verifies API compatibility - the option is accepted but has no effect on recall
+     * since JVector ignores it for top-K queries.
+     */
+    private void testUsePruningOptionCompatibility(List<float[]> queryVectors, List<List<Integer>> groundTruth)
     {
         int limit = 10;
-        // Test with pruning enabled
-        double recallWithPruning = testRecall(limit, queryVectors, groundTruth, null, true);
+        
+        // Test with pruning "enabled" (actually disabled by JVector)
+        double recallWithPruningTrue = testRecall(limit, queryVectors, groundTruth, null, true);
 
-        // Test with pruning disabled
-        double recallWithoutPruning = testRecall(limit, queryVectors, groundTruth, null, false);
+        // Test with pruning explicitly disabled
+        double recallWithPruningFalse = testRecall(limit, queryVectors, groundTruth, null, false);
 
-        // Recall should be at least as good when pruning is disabled
-        assertTrue("Recall without pruning (" + recallWithoutPruning +
-                  ") should be at least as good as recall with pruning (" + recallWithPruning + ')',
-                  recallWithoutPruning >= recallWithPruning);
+        // Since JVector always disables pruning, recall should be identical
+        // (allowing for minor floating point differences)
+        assertTrue("Recall with use_pruning=true (" + recallWithPruningTrue +
+                  ") should equal recall with use_pruning=false (" + recallWithPruningFalse +
+                  ") since JVector always disables pruning for top-K queries",
+                  Math.abs(recallWithPruningTrue - recallWithPruningFalse) < 0.001);
     }
 
     // Note: test only fails when scores are sent from replica to coordinator.


### PR DESCRIPTION
...
4.0.0-rc.8 has a regression in recall when we run queries with pruning set to true. This is the default behavior in our vector queries - we use pruning.
...
This hotfix changes the defaults of pruning being set to False. JVector testing shows that no pruning produces similar latencies but better recall, so this was the simplest way to fix recall in a hotfix release in JVector.

The pruning option is ignored and no matter what a user sets pruning will be always pointing to FALSE.

NOTE: It is a known issue that currently `VectorCompactionTest` and `VectorSiftSmallTest` are timing out in CI so I reran them locally and they still pass.

...
