### PR TITLE
CNDB-18364: Add INDEX_WRITE_BYTES sensor metric to CQL Response

### DIFF
--- a/src/java/org/apache/cassandra/cql3/statements/BatchStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/BatchStatement.java
@@ -448,16 +448,15 @@ public class BatchStatement implements CQLStatement
 
         ResultMessage<ResultMessage.Void> result = new ResultMessage.Void();
         RequestSensors sensors = RequestTracker.instance.get();
-        Map<TableId, TableMetadata> tableMetadataById = statements.stream()
-                                                                  .map(ModificationStatement::metadata)
-                                                                  .collect(Collectors.toMap(metadata -> metadata.id, Function.identity(), (existing, replacement) -> existing));
-        for (TableMetadata metadata : tableMetadataById.values())
-        {
-            Context context = Context.from(metadata);
-            SensorsCustomParams.addSensorToCQLResponse(result, options.wrapped.getProtocolVersion(), sensors, context, org.apache.cassandra.sensors.Type.WRITE_BYTES);
-            SensorsCustomParams.addSensorToCQLResponse(result, options.wrapped.getProtocolVersion(), sensors, context, org.apache.cassandra.sensors.Type.INDEX_WRITE_BYTES);
-        }
-
+        statements.stream()
+                  .map(ModificationStatement::metadata)
+                  .distinct()
+                  .forEach(metadata ->
+                           {
+                               Context context = Context.from(metadata);
+                               SensorsCustomParams.addSensorToCQLResponse(result, options.wrapped.getProtocolVersion(), sensors, context, org.apache.cassandra.sensors.Type.WRITE_BYTES);
+                               SensorsCustomParams.addSensorToCQLResponse(result, options.wrapped.getProtocolVersion(), sensors, context, org.apache.cassandra.sensors.Type.INDEX_WRITE_BYTES);
+                           });
         return result;
     }
 
@@ -512,13 +511,26 @@ public class BatchStatement implements CQLStatement
                                                    options.getNowInSeconds(state),
                                                    queryStartNanoTime))
         {
-            return new ResultMessage.Rows(ModificationStatement.buildCasResultSet(ksName,
-                                                                                  tableName,
-                                                                                  result,
-                                                                                  columnsWithConditions,
-                                                                                  true,
-                                                                                  state,
-                                                                                  options.forStatement(0)));
+            ResultMessage.Rows rows = new ResultMessage.Rows(ModificationStatement.buildCasResultSet(ksName,
+                                                                                                     tableName,
+                                                                                                     result,
+                                                                                                     columnsWithConditions,
+                                                                                                     true,
+                                                                                                     state,
+                                                                                                     options.forStatement(0)));
+            RequestSensors sensors = RequestTracker.instance.get();
+            statements.stream()
+                      .map(ModificationStatement::metadata)
+                      .distinct()
+                      .forEach(metadata ->
+                               {
+                                   Context context = Context.from(metadata);
+                                   SensorsCustomParams.addSensorToCQLResponse(rows, options.wrapped.getProtocolVersion(), sensors, context, org.apache.cassandra.sensors.Type.WRITE_BYTES);
+                                   SensorsCustomParams.addSensorToCQLResponse(rows, options.wrapped.getProtocolVersion(), sensors, context, org.apache.cassandra.sensors.Type.INDEX_WRITE_BYTES);
+                                   // Conditional batches always perform a Paxos read, so READ_BYTES is always tracked
+                                   SensorsCustomParams.addSensorToCQLResponse(rows, options.wrapped.getProtocolVersion(), sensors, context, org.apache.cassandra.sensors.Type.READ_BYTES);
+                               });
+            return rows;
         }
     }
 

--- a/src/java/org/apache/cassandra/cql3/statements/BatchStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/BatchStatement.java
@@ -455,6 +455,7 @@ public class BatchStatement implements CQLStatement
         {
             Context context = Context.from(metadata);
             SensorsCustomParams.addSensorToCQLResponse(result, options.wrapped.getProtocolVersion(), sensors, context, org.apache.cassandra.sensors.Type.WRITE_BYTES);
+            SensorsCustomParams.addSensorToCQLResponse(result, options.wrapped.getProtocolVersion(), sensors, context, org.apache.cassandra.sensors.Type.INDEX_WRITE_BYTES);
         }
 
         return result;

--- a/src/java/org/apache/cassandra/cql3/statements/BatchStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/BatchStatement.java
@@ -453,20 +453,20 @@ public class BatchStatement implements CQLStatement
         }
 
         RequestSensors sensors = RequestTracker.instance.get();
-        statements.stream()
-                  .map(ModificationStatement::metadata)
-                  .distinct()
-                  .forEach(metadata ->
-                           {
-                               Context context = Context.from(metadata);
-                               SensorsCustomParams.addSensorToCQLResponse(result, options.wrapped.getProtocolVersion(), sensors, context, org.apache.cassandra.sensors.Type.WRITE_BYTES);
-                               SensorsCustomParams.addSensorToCQLResponse(result, options.wrapped.getProtocolVersion(), sensors, context, org.apache.cassandra.sensors.Type.INDEX_WRITE_BYTES);
-                               if (hasConditions)
-                               {
-                                   // Conditional batches always perform a Paxos read, so READ_BYTES is always tracked
-                                   SensorsCustomParams.addSensorToCQLResponse(result, options.wrapped.getProtocolVersion(), sensors, context, org.apache.cassandra.sensors.Type.READ_BYTES);
-                               }
-                           });
+        Map<TableId, TableMetadata> tableMetadataById = statements.stream()
+                                                                  .map(ModificationStatement::metadata)
+                                                                  .collect(Collectors.toMap(metadata -> metadata.id, Function.identity(), (existing, replacement) -> existing));
+        for (TableMetadata metadata : tableMetadataById.values())
+        {
+            Context context = Context.from(metadata);
+            SensorsCustomParams.addSensorToCQLResponse(result, options.wrapped.getProtocolVersion(), sensors, context, org.apache.cassandra.sensors.Type.WRITE_BYTES);
+            SensorsCustomParams.addSensorToCQLResponse(result, options.wrapped.getProtocolVersion(), sensors, context, org.apache.cassandra.sensors.Type.INDEX_WRITE_BYTES);
+            if (hasConditions)
+            {
+                // Conditional batches always perform a Paxos read, so READ_BYTES is always tracked
+                SensorsCustomParams.addSensorToCQLResponse(result, options.wrapped.getProtocolVersion(), sensors, context, org.apache.cassandra.sensors.Type.READ_BYTES);
+            }
+        }
         return result;
     }
 

--- a/src/java/org/apache/cassandra/cql3/statements/BatchStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/BatchStatement.java
@@ -437,16 +437,21 @@ public class BatchStatement implements CQLStatement
         if (options.getSerialConsistency(queryState) == null)
             throw new InvalidRequestException("Invalid empty serial consistency level");
 
+        ResultMessage<?> result;
         if (hasConditions)
-            return executeWithConditions(options, queryState, queryStartNanoTime);
-
-        if (updatesVirtualTables)
-            executeInternalWithoutCondition(queryState, options, queryStartNanoTime);
+        {
+            result = executeWithConditions(options, queryState, queryStartNanoTime);
+        }
         else
-            executeWithoutConditions(getMutations(queryState, options, false, timestamp, nowInSeconds, queryStartNanoTime),
-                                     queryState, cl, queryStartNanoTime);
+        {
+            if (updatesVirtualTables)
+                executeInternalWithoutCondition(queryState, options, queryStartNanoTime);
+            else
+                executeWithoutConditions(getMutations(queryState, options, false, timestamp, nowInSeconds, queryStartNanoTime),
+                                         queryState, cl, queryStartNanoTime);
+            result = new ResultMessage.Void();
+        }
 
-        ResultMessage<ResultMessage.Void> result = new ResultMessage.Void();
         RequestSensors sensors = RequestTracker.instance.get();
         statements.stream()
                   .map(ModificationStatement::metadata)
@@ -456,6 +461,11 @@ public class BatchStatement implements CQLStatement
                                Context context = Context.from(metadata);
                                SensorsCustomParams.addSensorToCQLResponse(result, options.wrapped.getProtocolVersion(), sensors, context, org.apache.cassandra.sensors.Type.WRITE_BYTES);
                                SensorsCustomParams.addSensorToCQLResponse(result, options.wrapped.getProtocolVersion(), sensors, context, org.apache.cassandra.sensors.Type.INDEX_WRITE_BYTES);
+                               if (hasConditions)
+                               {
+                                   // Conditional batches always perform a Paxos read, so READ_BYTES is always tracked
+                                   SensorsCustomParams.addSensorToCQLResponse(result, options.wrapped.getProtocolVersion(), sensors, context, org.apache.cassandra.sensors.Type.READ_BYTES);
+                               }
                            });
         return result;
     }
@@ -511,26 +521,13 @@ public class BatchStatement implements CQLStatement
                                                    options.getNowInSeconds(state),
                                                    queryStartNanoTime))
         {
-            ResultMessage.Rows rows = new ResultMessage.Rows(ModificationStatement.buildCasResultSet(ksName,
-                                                                                                     tableName,
-                                                                                                     result,
-                                                                                                     columnsWithConditions,
-                                                                                                     true,
-                                                                                                     state,
-                                                                                                     options.forStatement(0)));
-            RequestSensors sensors = RequestTracker.instance.get();
-            statements.stream()
-                      .map(ModificationStatement::metadata)
-                      .distinct()
-                      .forEach(metadata ->
-                               {
-                                   Context context = Context.from(metadata);
-                                   SensorsCustomParams.addSensorToCQLResponse(rows, options.wrapped.getProtocolVersion(), sensors, context, org.apache.cassandra.sensors.Type.WRITE_BYTES);
-                                   SensorsCustomParams.addSensorToCQLResponse(rows, options.wrapped.getProtocolVersion(), sensors, context, org.apache.cassandra.sensors.Type.INDEX_WRITE_BYTES);
-                                   // Conditional batches always perform a Paxos read, so READ_BYTES is always tracked
-                                   SensorsCustomParams.addSensorToCQLResponse(rows, options.wrapped.getProtocolVersion(), sensors, context, org.apache.cassandra.sensors.Type.READ_BYTES);
-                               });
-            return rows;
+            return new ResultMessage.Rows(ModificationStatement.buildCasResultSet(ksName,
+                                                                                  tableName,
+                                                                                  result,
+                                                                                  columnsWithConditions,
+                                                                                  true,
+                                                                                  state,
+                                                                                  options.forStatement(0)));
         }
     }
 

--- a/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
@@ -448,10 +448,15 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
                                        int userOffset,
                                        long queryStartNanoTime) throws RequestValidationException, RequestExecutionException
     {
+        ResultMessage.Rows msg;
         try (PartitionIterator data = query.execute(options.getConsistency(), queryState, queryStartNanoTime))
         {
-            return processResults(data, options, selectors, nowInSec, userLimit, userOffset);
+            msg = processResults(data, options, selectors, nowInSec, userLimit, userOffset);
         }
+        RequestSensors sensors = RequestTracker.instance.get();
+        Context context = Context.from(this.table);
+        SensorsCustomParams.addSensorToCQLResponse(msg, options.getProtocolVersion(), sensors, context, Type.READ_BYTES);
+        return msg;
     }
 
     @Override

--- a/src/java/org/apache/cassandra/cql3/statements/UpdateStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/UpdateStatement.java
@@ -129,6 +129,7 @@ public class UpdateStatement extends ModificationStatement
         RequestSensors sensors = RequestTracker.instance.get();
         Context context = Context.from(this.metadata());
         SensorsCustomParams.addSensorToCQLResponse(result, options.getProtocolVersion(), sensors, context, Type.WRITE_BYTES);
+        SensorsCustomParams.addSensorToCQLResponse(result, options.getProtocolVersion(), sensors, context, Type.INDEX_WRITE_BYTES);
         // CAS updates incorporate read sensors
         SensorsCustomParams.addSensorToCQLResponse(result, options.getProtocolVersion(), sensors, context, Type.READ_BYTES);
 

--- a/src/java/org/apache/cassandra/db/SystemKeyspace.java
+++ b/src/java/org/apache/cassandra/db/SystemKeyspace.java
@@ -672,15 +672,21 @@ public final class SystemKeyspace
     }
 
     /**
-     * Decorates a paxos comit consumer with methods to track bytes written to the Paxos system table under the context of the user table that initiated Paxos.
+     * Decorates a paxos commit consumer with methods to track bytes written to the Paxos system table under the
+     * context of the user table that initiated Paxos. Both {@link Type#WRITE_BYTES} and
+     * {@link Type#INDEX_WRITE_BYTES} are registered under {@link #PaxosContext} before the write runs and
+     * transferred to the user-table context afterward, so that any index writes on {@code system.paxos} are
+     * attributed to the user table consistently with base-table writes.
      */
     private static void trackPaxosBytes(Commit commit, Runnable paxosCommitConsumer)
     {
         // Track bytes written to the Paxos system table for the commit that initiated Paxos
         registerPaxosSensor(Type.WRITE_BYTES);
+        registerPaxosSensor(Type.INDEX_WRITE_BYTES);
         paxosCommitConsumer.run();
         // transfer bytes written to the Paxos system table to the user table for the commit that initiated Paxos
         transferPaxosSensorBytes(commit.update.metadata(), Type.WRITE_BYTES);
+        transferPaxosSensorBytes(commit.update.metadata(), Type.INDEX_WRITE_BYTES);
     }
 
     private static void registerPaxosSensor(Type type)

--- a/src/java/org/apache/cassandra/index/sai/memory/TrieMemtableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/TrieMemtableIndex.java
@@ -241,6 +241,10 @@ public class TrieMemtableIndex extends AbstractMemtableIndex
         if (oldRemaining == newRemaining && validator.compare(oldValue, newValue) == 0)
             return;
 
+        RequestSensors sensors = requestTracker.get();
+        if (sensors != null)
+            sensors.registerSensor(sensorContext, Type.INDEX_WRITE_BYTES);
+
         // The terms inserted into the index could still be the same in the case of certain analyzer configs.
         // We don't know yet though, and instead of eagerly determining it, we leave it to the index to handle it.
         rangeIndexes[boundaries.getShardForKey(key)].update(key,
@@ -250,10 +254,14 @@ public class TrieMemtableIndex extends AbstractMemtableIndex
                                                             allocatedBytes -> {
                                                                 memtable.markExtraOnHeapUsed(allocatedBytes, opGroup);
                                                                 estimatedOnHeapMemoryUsed.add(allocatedBytes);
+                                                                if (sensors != null)
+                                                                    sensors.incrementSensor(sensorContext, Type.INDEX_WRITE_BYTES, allocatedBytes);
                                                                 },
                                                             allocatedBytes -> {
                                                                 memtable.markExtraOffHeapUsed(allocatedBytes, opGroup);
                                                                 estimatedOffHeapMemoryUsed.add(allocatedBytes);
+                                                                if (sensors != null)
+                                                                    sensors.incrementSensor(sensorContext, Type.INDEX_WRITE_BYTES, allocatedBytes);
                                                             });
         writeCount.increment();
         onIndexUpdated();
@@ -262,6 +270,10 @@ public class TrieMemtableIndex extends AbstractMemtableIndex
     @Override
     public void update(DecoratedKey key, Clustering clustering, Iterator<ByteBuffer> oldValues, Iterator<ByteBuffer> newValues, Memtable memtable, OpOrder.Group opGroup)
     {
+        RequestSensors sensors = requestTracker.get();
+        if (sensors != null)
+            sensors.registerSensor(sensorContext, Type.INDEX_WRITE_BYTES);
+
         // We defer on comparing old and new values here. Instead, we rely on the index to do the comparison and then
         // have custom logic in the aggregator to ensure that we properly add/keep new values and remove old values
         // that are not present in the new values.
@@ -272,10 +284,14 @@ public class TrieMemtableIndex extends AbstractMemtableIndex
                                                             allocatedBytes -> {
                                                                 memtable.markExtraOnHeapUsed(allocatedBytes, opGroup);
                                                                 estimatedOnHeapMemoryUsed.add(allocatedBytes);
+                                                                if (sensors != null)
+                                                                    sensors.incrementSensor(sensorContext, Type.INDEX_WRITE_BYTES, allocatedBytes);
                                                             },
                                                             allocatedBytes -> {
                                                                 memtable.markExtraOffHeapUsed(allocatedBytes, opGroup);
                                                                 estimatedOffHeapMemoryUsed.add(allocatedBytes);
+                                                                if (sensors != null)
+                                                                    sensors.incrementSensor(sensorContext, Type.INDEX_WRITE_BYTES, allocatedBytes);
                                                             });
         writeCount.increment();
     }

--- a/src/java/org/apache/cassandra/net/ResponseVerbHandler.java
+++ b/src/java/org/apache/cassandra/net/ResponseVerbHandler.java
@@ -89,6 +89,7 @@ public class ResponseVerbHandler implements IVerbHandler
                 Context context = Context.from(pu.metadata());
                 if (pu.metadata().isIndex()) continue;
                 incrementSensor(sensors, context, Type.WRITE_BYTES, message);
+                incrementSensor(sensors, context, Type.INDEX_WRITE_BYTES, message);
             }
         }
         else if (callbackInfo.callback instanceof ReadCallback)

--- a/src/java/org/apache/cassandra/net/ResponseVerbHandler.java
+++ b/src/java/org/apache/cassandra/net/ResponseVerbHandler.java
@@ -98,14 +98,14 @@ public class ResponseVerbHandler implements IVerbHandler
             Context context = Context.from(readCallback.command());
             incrementSensor(sensors, context, Type.READ_BYTES, message);
         }
-        // Covers Paxos Prepare and Propose callbacks. Paxos Commit callback is a regular WriteCallbackInfo
+        // Covers Paxos Prepare and Propose callbacks. Paxos Commit callback is a regular WriteCallbackInfo.
+        // INDEX_WRITE_BYTES is not tracked here: prepare/propose only write to system.paxos, which has no indexes.
         else if (callbackInfo.callback instanceof AbstractPaxosCallback)
         {
             AbstractPaxosCallback<?> paxosCallback = (AbstractPaxosCallback<?>) callbackInfo.callback;
             Context context = Context.from(paxosCallback.getMetadata());
             incrementSensor(sensors, context, Type.READ_BYTES, message);
             incrementSensor(sensors, context, Type.WRITE_BYTES, message);
-            incrementSensor(sensors, context, Type.INDEX_WRITE_BYTES, message);
         }
     }
 

--- a/src/java/org/apache/cassandra/net/ResponseVerbHandler.java
+++ b/src/java/org/apache/cassandra/net/ResponseVerbHandler.java
@@ -105,6 +105,7 @@ public class ResponseVerbHandler implements IVerbHandler
             Context context = Context.from(paxosCallback.getMetadata());
             incrementSensor(sensors, context, Type.READ_BYTES, message);
             incrementSensor(sensors, context, Type.WRITE_BYTES, message);
+            incrementSensor(sensors, context, Type.INDEX_WRITE_BYTES, message);
         }
     }
 

--- a/src/java/org/apache/cassandra/service/StorageProxy.java
+++ b/src/java/org/apache/cassandra/service/StorageProxy.java
@@ -490,6 +490,7 @@ public class StorageProxy implements StorageProxyMBean
         Context context = Context.from(metadata);
         sensors.registerSensor(context, Type.WRITE_BYTES); // track user table + paxos table write bytes
         sensors.registerSensor(context, Type.READ_BYTES); // track user table + paxos table read bytes
+        sensors.registerSensor(context, Type.INDEX_WRITE_BYTES); // track secondary index write bytes on commit
         ExecutorLocals locals = ExecutorLocals.create(sensors);
         ExecutorLocals.set(locals);
         try

--- a/src/java/org/apache/cassandra/service/StorageProxy.java
+++ b/src/java/org/apache/cassandra/service/StorageProxy.java
@@ -122,6 +122,7 @@ import org.apache.cassandra.schema.SchemaConstants;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.sensors.Context;
 import org.apache.cassandra.sensors.RequestSensors;
+import org.apache.cassandra.sensors.RequestTracker;
 import org.apache.cassandra.sensors.SensorsFactory;
 import org.apache.cassandra.sensors.Type;
 import org.apache.cassandra.service.paxos.Commit;
@@ -209,10 +210,9 @@ public class StorageProxy implements StorageProxyMBean
 
             QueryInfoTracker.WriteTracker writeTracker = StorageProxy.queryTracker().onWrite(clientState, true, mutations, consistencyLevel);
 
-            // Request sensors are utilized to track usages from replicas serving atomic batch request
-            RequestSensors sensors = SensorsFactory.instance.createRequestSensors(mutations.stream().map(IMutation::getKeyspaceName).toArray(String[]::new));
-            ExecutorLocals locals = ExecutorLocals.create(sensors);
-            ExecutorLocals.set(locals);
+            // Sensors are installed on the thread-local by the static mutateAtomically() before entering this mutator.
+            // Read them back here so they can be passed explicitly to wrapBatchResponseHandlers().
+            RequestSensors sensors = RequestTracker.instance.get();
 
             if (mutations.stream().anyMatch(mutation -> Keyspace.open(mutation.getKeyspaceName()).getReplicationStrategy().hasTransientReplicas()))
                 throw new AssertionError("Logged batches are unsupported with transient replication");
@@ -1390,6 +1390,15 @@ public class StorageProxy implements StorageProxyMBean
                                         ClientState clientState)
     throws UnavailableException, OverloadedException, WriteTimeoutException
     {
+        // Request sensors are utilized to track usages from replicas serving atomic batch request.
+        // Must be installed on the thread-local before calling mutator.mutateAtomically() so that
+        // AbstractWriteResponseHandler captures a non-null sensors object, and ResponseVerbHandler
+        // can accumulate replica sensor values back into it.
+        // This mirrors the same pattern used in mutate() and cas() for consistency across all
+        // coordinator write paths.
+        RequestSensors sensors = SensorsFactory.instance.createRequestSensors(mutations.stream().map(IMutation::getKeyspaceName).toArray(String[]::new));
+        ExecutorLocals.set(ExecutorLocals.create(sensors));
+
         mutator.mutateAtomically(mutations, consistencyLevel, requireQuorumForRemove, queryStartNanoTime, metrics, clientState);
     }
 

--- a/src/java/org/apache/cassandra/service/StorageProxy.java
+++ b/src/java/org/apache/cassandra/service/StorageProxy.java
@@ -98,7 +98,6 @@ import org.apache.cassandra.gms.IFailureDetector;
 import org.apache.cassandra.hints.Hint;
 import org.apache.cassandra.hints.HintsService;
 import org.apache.cassandra.locator.AbstractReplicationStrategy;
-import org.apache.cassandra.locator.DynamicEndpointSnitch;
 import org.apache.cassandra.locator.EndpointsForToken;
 import org.apache.cassandra.locator.IEndpointSnitch;
 import org.apache.cassandra.locator.InetAddressAndPort;
@@ -321,6 +320,7 @@ public class StorageProxy implements StorageProxyMBean
                 {
                     if (pu.metadata().isIndex()) continue;
                     sensors.registerSensor(Context.from(pu.metadata()), Type.WRITE_BYTES);
+                    sensors.registerSensor(Context.from(pu.metadata()), Type.INDEX_WRITE_BYTES);
                 }
                 StorageProxy.WriteResponseHandlerWrapper wrapper = StorageProxy.wrapBatchResponseHandler(mutation,
                                                                                                          consistencyLevel,
@@ -1102,6 +1102,7 @@ public class StorageProxy implements StorageProxyMBean
                 {
                     if (pu.metadata().isIndex()) continue;
                     sensors.registerSensor(Context.from(pu.metadata()), Type.WRITE_BYTES);
+                    sensors.registerSensor(Context.from(pu.metadata()), Type.INDEX_WRITE_BYTES);
                 }
 
                 if (mutation instanceof CounterMutation)

--- a/src/java/org/apache/cassandra/service/StorageProxy.java
+++ b/src/java/org/apache/cassandra/service/StorageProxy.java
@@ -210,10 +210,6 @@ public class StorageProxy implements StorageProxyMBean
 
             QueryInfoTracker.WriteTracker writeTracker = StorageProxy.queryTracker().onWrite(clientState, true, mutations, consistencyLevel);
 
-            // Sensors are installed on the thread-local by the static mutateAtomically() before entering this mutator.
-            // Read them back here so they can be passed explicitly to wrapBatchResponseHandlers().
-            RequestSensors sensors = RequestTracker.instance.get();
-
             if (mutations.stream().anyMatch(mutation -> Keyspace.open(mutation.getKeyspaceName()).getReplicationStrategy().hasTransientReplicas()))
                 throw new AssertionError("Logged batches are unsupported with transient replication");
 
@@ -240,7 +236,7 @@ public class StorageProxy implements StorageProxyMBean
 
                 BatchlogResponseHandler.BatchlogCleanup cleanup = new BatchlogResponseHandler.BatchlogCleanup(mutations.size(), () -> clearBatchlog(keyspace, replicaPlan, batchUUID));
 
-                List<StorageProxy.WriteResponseHandlerWrapper> wrappers = wrapBatchResponseHandlers(mutations, consistencyLevel, batchConsistencyLevel, cleanup, queryStartNanoTime, sensors);
+                List<StorageProxy.WriteResponseHandlerWrapper> wrappers = wrapBatchResponseHandlers(mutations, consistencyLevel, batchConsistencyLevel, cleanup, queryStartNanoTime);
 
                 // persist batchlog before writing batched mutations
                 persistBatchlog(mutations, queryStartNanoTime, replicaPlan, batchUUID);
@@ -307,21 +303,13 @@ public class StorageProxy implements StorageProxyMBean
                                                                               ConsistencyLevel consistencyLevel,
                                                                               ConsistencyLevel batchConsistencyLevel,
                                                                               BatchlogResponseHandler.BatchlogCleanup cleanup,
-                                                                              long queryStartNanoTime,
-                                                                              RequestSensors sensors)
+                                                                              long queryStartNanoTime)
         {
             List<StorageProxy.WriteResponseHandlerWrapper> wrappers = new ArrayList<>(mutations.size());
 
             // add a handler for each mutation - includes checking availability, but doesn't initiate any writes, yet
             for (Mutation mutation : mutations)
             {
-                // register the sensors for the mutation before the actual write is performed
-                for (PartitionUpdate pu: mutation.getPartitionUpdates())
-                {
-                    if (pu.metadata().isIndex()) continue;
-                    sensors.registerSensor(Context.from(pu.metadata()), Type.WRITE_BYTES);
-                    sensors.registerSensor(Context.from(pu.metadata()), Type.INDEX_WRITE_BYTES);
-                }
                 StorageProxy.WriteResponseHandlerWrapper wrapper = StorageProxy.wrapBatchResponseHandler(mutation,
                                                                                                          consistencyLevel,
                                                                                                          batchConsistencyLevel,
@@ -1398,6 +1386,19 @@ public class StorageProxy implements StorageProxyMBean
         // coordinator write paths.
         RequestSensors sensors = SensorsFactory.instance.createRequestSensors(mutations.stream().map(IMutation::getKeyspaceName).toArray(String[]::new));
         ExecutorLocals.set(ExecutorLocals.create(sensors));
+
+        // Register sensors for each mutation partition before the mutator constructs WriteResponseHandlers.
+        // AbstractWriteResponseHandler captures the sensors reference at construction time, so both
+        // sensor creation (above) and registration (here) must precede any call to getWriteResponseHandler().
+        for (Mutation mutation : mutations)
+        {
+            for (PartitionUpdate pu : mutation.getPartitionUpdates())
+            {
+                if (pu.metadata().isIndex()) continue;
+                sensors.registerSensor(Context.from(pu.metadata()), Type.WRITE_BYTES);
+                sensors.registerSensor(Context.from(pu.metadata()), Type.INDEX_WRITE_BYTES);
+            }
+        }
 
         mutator.mutateAtomically(mutations, consistencyLevel, requireQuorumForRemove, queryStartNanoTime, metrics, clientState);
     }

--- a/src/java/org/apache/cassandra/service/StorageProxy.java
+++ b/src/java/org/apache/cassandra/service/StorageProxy.java
@@ -473,11 +473,34 @@ public class StorageProxy implements StorageProxyMBean
                                                                                 key,
                                                                                 consistencyForPaxos,
                                                                                 consistencyForCommit);
-        // Request sensors are utilized to track usages from replicas serving a cas request
+        // All three sensor types are registered against the user-table context here on the coordinator.
+        // This same context is reused for system.paxos I/O via the following two-step mechanism:
+        //
+        // 1. Re-attribution inside SystemKeyspace (replica-local):
+        //    Every system.paxos read (loadPaxosState) and write (savePaxosPromise / savePaxosProposal /
+        //    savePaxosCommit) temporarily registers a sensor under PaxosContext (system.paxos metadata),
+        //    measures the actual bytes, then calls transferPaxosSensorBytes() which copies that value into
+        //    Context.from(userTableMetadata) on the same RequestSensors — re-keying the measurement from
+        //    system.paxos to the user table before the reply is sent.
+        //    Concretely: Prepare reads+writes system.paxos (loadPaxosState + savePaxosPromise),
+        //    Propose reads+writes system.paxos (loadPaxosState + savePaxosProposal), and
+        //    Commit writes system.paxos (savePaxosCommit) and, when the condition was met, also applies
+        //    the user-table mutation — all of these bytes end up under the user-table context after transfer.
+        //
+        // 2. Merging replica values back into the coordinator sensor (ResponseVerbHandler):
+        //    Each verb handler (PrepareVerbHandler, ProposeVerbHandler, CommitVerbHandler) on the replica
+        //    encodes the accumulated sensor values into the internode response as custom parameters
+        //    (SensorsCustomParams.addSensorsToInternodeResponse). The coordinator's ResponseVerbHandler
+        //    detects AbstractPaxosCallback instances and calls incrementSensor() on this RequestSensors
+        //    object with the user-table context, accumulating all replica contributions here.
+        //
+        // The Commit object carries the user-table TableMetadata (set in Commit.newPrepare via
+        // Schema.instance.validateTable above), so message.payload.update.metadata() on every verb handler
+        // is the user-table metadata, not system.paxos — guaranteeing consistent context across all replicas.
         RequestSensors sensors = SensorsFactory.instance.createRequestSensors(keyspaceName);
         Context context = Context.from(metadata);
-        sensors.registerSensor(context, Type.WRITE_BYTES); // track user table + paxos table write bytes
-        sensors.registerSensor(context, Type.READ_BYTES); // track user table + paxos table read bytes
+        sensors.registerSensor(context, Type.WRITE_BYTES); // tracks user table + system.paxos write bytes (see comment above)
+        sensors.registerSensor(context, Type.READ_BYTES);  // tracks user table + system.paxos read bytes (see comment above)
         sensors.registerSensor(context, Type.INDEX_WRITE_BYTES); // track secondary index write bytes on commit
         ExecutorLocals locals = ExecutorLocals.create(sensors);
         ExecutorLocals.set(locals);

--- a/src/java/org/apache/cassandra/service/paxos/CommitVerbHandler.java
+++ b/src/java/org/apache/cassandra/service/paxos/CommitVerbHandler.java
@@ -43,6 +43,7 @@ public class CommitVerbHandler implements IVerbHandler<Commit>
         RequestSensors sensors = SensorsFactory.instance.createRequestSensors(message.payload.update.metadata().keyspace);
         Context context = Context.from(message.payload.update.metadata());
         sensors.registerSensor(context, Type.WRITE_BYTES);
+        sensors.registerSensor(context, Type.INDEX_WRITE_BYTES);
         sensors.registerSensor(context, Type.INTERNODE_BYTES);
         sensors.incrementSensor(context, Type.INTERNODE_BYTES, message.payloadSize(MessagingService.current_version));
         ExecutorLocals locals = ExecutorLocals.create(sensors);

--- a/src/java/org/apache/cassandra/service/paxos/PrepareVerbHandler.java
+++ b/src/java/org/apache/cassandra/service/paxos/PrepareVerbHandler.java
@@ -47,6 +47,7 @@ public class PrepareVerbHandler implements IVerbHandler<Commit>
         // Prepare phase incorporates a read to check the cas condition, so a read sensor is registered in addition to the write sensor
         sensors.registerSensor(context, Type.READ_BYTES);
         sensors.registerSensor(context, Type.WRITE_BYTES);
+        sensors.registerSensor(context, Type.INDEX_WRITE_BYTES);
         sensors.registerSensor(context, Type.INTERNODE_BYTES);
         sensors.incrementSensor(context, Type.INTERNODE_BYTES, message.payloadSize(MessagingService.current_version));
         ExecutorLocals locals = ExecutorLocals.create(sensors);

--- a/src/java/org/apache/cassandra/service/paxos/PrepareVerbHandler.java
+++ b/src/java/org/apache/cassandra/service/paxos/PrepareVerbHandler.java
@@ -44,10 +44,10 @@ public class PrepareVerbHandler implements IVerbHandler<Commit>
         RequestSensors sensors = SensorsFactory.instance.createRequestSensors(message.payload.update.metadata().keyspace);
         Context context = Context.from(message.payload.update.metadata());
 
-        // Prepare phase incorporates a read to check the cas condition, so a read sensor is registered in addition to the write sensor
+        // Prepare phase incorporates a read to check the cas condition, so a read sensor is registered in addition to the write sensor.
+        // INDEX_WRITE_BYTES is not registered here because prepare only writes to system.paxos, which has no indexes.
         sensors.registerSensor(context, Type.READ_BYTES);
         sensors.registerSensor(context, Type.WRITE_BYTES);
-        sensors.registerSensor(context, Type.INDEX_WRITE_BYTES);
         sensors.registerSensor(context, Type.INTERNODE_BYTES);
         sensors.incrementSensor(context, Type.INTERNODE_BYTES, message.payloadSize(MessagingService.current_version));
         ExecutorLocals locals = ExecutorLocals.create(sensors);

--- a/src/java/org/apache/cassandra/service/paxos/ProposeVerbHandler.java
+++ b/src/java/org/apache/cassandra/service/paxos/ProposeVerbHandler.java
@@ -47,6 +47,7 @@ public class ProposeVerbHandler implements IVerbHandler<Commit>
         // Propose phase consults the Paxos table for more recent promises, so a read sensor is registered in addition to the write sensor
         sensors.registerSensor(context, Type.READ_BYTES);
         sensors.registerSensor(context, Type.WRITE_BYTES);
+        sensors.registerSensor(context, Type.INDEX_WRITE_BYTES);
         sensors.registerSensor(context, Type.INTERNODE_BYTES);
         sensors.incrementSensor(context, Type.INTERNODE_BYTES, message.payloadSize(MessagingService.current_version));
         ExecutorLocals locals = ExecutorLocals.create(sensors);

--- a/src/java/org/apache/cassandra/service/paxos/ProposeVerbHandler.java
+++ b/src/java/org/apache/cassandra/service/paxos/ProposeVerbHandler.java
@@ -44,10 +44,10 @@ public class ProposeVerbHandler implements IVerbHandler<Commit>
         RequestSensors sensors = SensorsFactory.instance.createRequestSensors(message.payload.update.metadata().keyspace);
         Context context = Context.from(message.payload.update.metadata());
 
-        // Propose phase consults the Paxos table for more recent promises, so a read sensor is registered in addition to the write sensor
+        // Propose phase consults the Paxos table for more recent promises, so a read sensor is registered in addition to the write sensor.
+        // INDEX_WRITE_BYTES is not registered here because propose only writes to system.paxos, which has no indexes.
         sensors.registerSensor(context, Type.READ_BYTES);
         sensors.registerSensor(context, Type.WRITE_BYTES);
-        sensors.registerSensor(context, Type.INDEX_WRITE_BYTES);
         sensors.registerSensor(context, Type.INTERNODE_BYTES);
         sensors.incrementSensor(context, Type.INTERNODE_BYTES, message.payloadSize(MessagingService.current_version));
         ExecutorLocals locals = ExecutorLocals.create(sensors);

--- a/test/distributed/org/apache/cassandra/distributed/test/sensors/SensorsTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sensors/SensorsTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.cassandra.distributed.test.sensors;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -25,6 +26,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -53,11 +56,26 @@ import org.assertj.core.api.Assertions;
 @RunWith(Parameterized.class)
 public class SensorsTest extends TestBaseImpl
 {
-    private static final String EXPECTED_WRITE_BYTES_HEADER = "WRITE_BYTES_REQUEST." + KEYSPACE + ".tbl";
-    private static final String EXPECTED_READ_BYTES_HEADER = "READ_BYTES_REQUEST." + KEYSPACE + ".tbl";
-    private static final String EXPECTED_INDEX_WRITE_BYTES_HEADER = "INDEX_WRITE_BYTES_REQUEST." + KEYSPACE + ".tbl";
-    private static final String EXPECTED_COL_WRITE_BYTES_HEADER = "WRITE_BYTES_REQUEST." + KEYSPACE + ".tbl_col";
-    private static final String EXPECTED_COL_INDEX_WRITE_BYTES_HEADER = "INDEX_WRITE_BYTES_REQUEST." + KEYSPACE + ".tbl_col";
+    // Table names — shared by setupCluster(), truncateTables(), and data()
+    private static final String TBL = "tbl";
+    private static final String TBL_COUNTER = "tbl_counter";
+    private static final String TBL_2I = "tbl_2i";
+    private static final String TBL_SAI = "tbl_sai_idx";
+    private static final String TBL_COL = "tbl_col";
+
+    // Sensor header constants per table
+    private static final String WRITE_TBL = "WRITE_BYTES_REQUEST." + KEYSPACE + "." + TBL;
+    private static final String READ_TBL = "READ_BYTES_REQUEST." + KEYSPACE + "." + TBL;
+    private static final String WRITE_COUNTER = "WRITE_BYTES_REQUEST." + KEYSPACE + "." + TBL_COUNTER;
+    private static final String WRITE_2I = "WRITE_BYTES_REQUEST." + KEYSPACE + "." + TBL_2I;
+    private static final String READ_2I = "READ_BYTES_REQUEST." + KEYSPACE + "." + TBL_2I;
+    private static final String INDEX_WRITE_2I = "INDEX_WRITE_BYTES_REQUEST." + KEYSPACE + "." + TBL_2I;
+    private static final String WRITE_SAI = "WRITE_BYTES_REQUEST." + KEYSPACE + "." + TBL_SAI;
+    private static final String READ_SAI = "READ_BYTES_REQUEST." + KEYSPACE + "." + TBL_SAI;
+    private static final String INDEX_WRITE_SAI = "INDEX_WRITE_BYTES_REQUEST." + KEYSPACE + "." + TBL_SAI;
+    private static final String WRITE_COL = "WRITE_BYTES_REQUEST." + KEYSPACE + "." + TBL_COL;
+    private static final String INDEX_WRITE_COL = "INDEX_WRITE_BYTES_REQUEST." + KEYSPACE + "." + TBL_COL;
+
     /**
      * Using a combination of 2 nodes with ALL consistency level to ensure internode communication code paths are exercised in the test
      */
@@ -65,112 +83,214 @@ public class SensorsTest extends TestBaseImpl
     private static final ConsistencyLevel CONSISTENCY_LEVEL = ConsistencyLevel.ALL;
 
     /**
-     * Schema to be used for the test
+     * Single shared cluster for all parameterized scenarios — avoids the metaspace exhaustion that results from
+     * spinning up a new in-process dtest cluster (with its own isolated classloader) for every scenario.
+     * All tables are created once in {@link #setupCluster()}; each scenario truncates them in {@link #truncateTables()}.
+     */
+    private static Cluster cluster;
+
+    /**
+     * Table name for the scenario — kept for test name readability in parameterized output only.
      */
     @Parameterized.Parameter(0)
     public String schema;
+
     /**
      * Queries to be executed to prepare the table, for example insert some data before read to populate read sensors.
-     * Will be run before the {@link #testQuery}
+     * Will be run before the {@link #testQuery}.
      */
     @Parameterized.Parameter(1)
     public String[] prepQueries;
 
     /**
-     * Query to be executed to test the sensors, will be run after the {@link #prepQueries}
+     * Query to be executed to test the sensors, will be run after the {@link #prepQueries}.
      */
     @Parameterized.Parameter(2)
     public String testQuery;
 
     /**
-     * Expected headers in the custom payload for the test queries
+     * Expected headers in the custom payload for the test queries.
      */
     @Parameterized.Parameter(3)
     public String[] expectedHeaders;
 
     @BeforeClass
-    public static void setup()
+    public static void setupCluster() throws IOException
     {
         CassandraRelevantProperties.SENSORS_FACTORY.setString(ActiveSensorsFactory.class.getName());
+
+        cluster = init(Cluster.build(NODES_COUNT).start());
+
+        // Create all table variants upfront so the cluster is reused across every parameterized scenario.
+        // Each scenario truncates the relevant tables in @Before rather than recreating the cluster.
+        cluster.schemaChange(withKeyspace("CREATE TABLE %s." + TBL + " (pk int PRIMARY KEY, v1 text)"));
+        cluster.schemaChange(withKeyspace("CREATE TABLE %s." + TBL_COUNTER + " (pk int PRIMARY KEY, total counter)"));
+        cluster.schemaChange(withKeyspace("CREATE TABLE %s." + TBL_2I + " (pk int PRIMARY KEY, v1 text)"));
+        cluster.schemaChange(withKeyspace("CREATE INDEX ON %s." + TBL_2I + " (v1)"));
+        cluster.schemaChange(withKeyspace("CREATE TABLE %s." + TBL_SAI + " (pk int PRIMARY KEY, v1 text)"));
+        cluster.schemaChange(withKeyspace("CREATE CUSTOM INDEX ON %s." + TBL_SAI + " (v1) USING '" + StorageAttachedIndex.class.getName() + "'"));
+        cluster.schemaChange(withKeyspace("CREATE TABLE %s." + TBL_COL + " (pk int PRIMARY KEY, tags set<text>)"));
+        cluster.schemaChange(withKeyspace("CREATE CUSTOM INDEX ON %s." + TBL_COL + " (tags) USING '" + StorageAttachedIndex.class.getName() + "'"));
+    }
+
+    @AfterClass
+    public static void teardownCluster()
+    {
+        if (cluster != null)
+            cluster.close();
+    }
+
+    @Before
+    public void truncateTables()
+    {
+        cluster.schemaChange(withKeyspace("TRUNCATE %s." + TBL));
+        cluster.schemaChange(withKeyspace("TRUNCATE %s." + TBL_COUNTER));
+        cluster.schemaChange(withKeyspace("TRUNCATE %s." + TBL_2I));
+        cluster.schemaChange(withKeyspace("TRUNCATE %s." + TBL_SAI));
+        cluster.schemaChange(withKeyspace("TRUNCATE %s." + TBL_COL));
     }
 
     @Parameterized.Parameters(name = "schema={0}, prepQueries={1}, testQuery={2}, expectedHeaders={3}")
     public static Collection<Object[]> data()
     {
-        String tableSchema = withKeyspace("CREATE TABLE %s.tbl (pk int PRIMARY KEY, v1 text)");
-        String counterTableSchema = withKeyspace("CREATE TABLE %s.tbl (pk int PRIMARY KEY, total counter)");
-        // Exercise both legacy 2i and SAI so that both index write paths are covered
-        String createLegacyIndex = withKeyspace("CREATE INDEX ON %s.tbl (v1)");
-        String createSAIIndex = withKeyspace("CREATE CUSTOM INDEX ON %s.tbl (v1) USING '" + StorageAttachedIndex.class.getName() + "'");
+        List<Object[]> result = new ArrayList<>();
+        result.addAll(baselineScenarios());
+        result.addAll(secondaryIndexScenarios());
+        result.addAll(saiScalarScenarios());
+        result.addAll(saiCollectionScenarios());
+        return result;
+    }
 
-        // Table with a non-frozen set column: exercises the TrieMemtableIndex.update(Iterator<ByteBuffer>, Iterator<ByteBuffer>)
-        // overload (the collection update path), which is distinct from the scalar update(ByteBuffer, ByteBuffer) overload
-        String collectionTableSchema = withKeyspace("CREATE TABLE %s.tbl_col (pk int PRIMARY KEY, tags set<text>)");
-        String createCollectionSAIIndex = withKeyspace("CREATE CUSTOM INDEX ON %s.tbl_col (tags) USING '" + StorageAttachedIndex.class.getName() + "'");
-        String collectionWrite = withKeyspace("INSERT INTO %s.tbl_col(pk, tags) VALUES (1, {'a', 'b'})");
-        // Overwrites the existing set value for pk=1, triggering the updateRow → update(Iterator, Iterator) path
-        String collectionUpdate = withKeyspace("INSERT INTO %s.tbl_col(pk, tags) VALUES (1, {'c', 'd'})");
-
-        String write = withKeyspace("INSERT INTO %s.tbl(pk, v1) VALUES (1, 'read me')");
-        String counter = withKeyspace("UPDATE %s.tbl SET total = total + 1 WHERE pk = 1");
-        String read = withKeyspace("SELECT * FROM %s.tbl WHERE pk=1");
-        String cas = withKeyspace("UPDATE %s.tbl SET v1 = 'cas update' WHERE pk = 1 IF v1 = 'read me'");
-        // CAS insert: IF NOT EXISTS on a new row exercises the insertRow index path via Paxos commit
-        String casInsert = withKeyspace("INSERT INTO %s.tbl(pk, v1) VALUES (5, 'cas insert') IF NOT EXISTS");
+    /**
+     * Baseline scenarios: non-indexed writes, reads and CAS on {@value TBL} and {@value TBL_COUNTER}.
+     */
+    private static List<Object[]> baselineScenarios()
+    {
+        String[] noPrep = new String[0];
+        String write = withKeyspace("INSERT INTO %s." + TBL + "(pk, v1) VALUES (1, 'read me')");
+        String counter = withKeyspace("UPDATE %s." + TBL_COUNTER + " SET total = total + 1 WHERE pk = 1");
+        String read = withKeyspace("SELECT * FROM %s." + TBL + " WHERE pk=1");
+        String range = withKeyspace("SELECT * FROM %s." + TBL);
+        String cas = withKeyspace("UPDATE %s." + TBL + " SET v1 = 'cas update' WHERE pk = 1 IF v1 = 'read me'");
         String loggedBatch = String.format("BEGIN BATCH\n" +
-                                           "INSERT INTO %s.tbl(pk, v1) VALUES (2, 'read me 2');\n" +
-                                           "INSERT INTO %s.tbl(pk, v1) VALUES (3, 'read me 3');\n" +
+                                           "INSERT INTO %s." + TBL + "(pk, v1) VALUES (2, 'read me 2');\n" +
+                                           "INSERT INTO %s." + TBL + "(pk, v1) VALUES (3, 'read me 3');\n" +
                                            "APPLY BATCH;", KEYSPACE, KEYSPACE);
         String unloggedBatch = String.format("BEGIN UNLOGGED BATCH\n" +
-                                             "INSERT INTO %s.tbl(pk, v1) VALUES (4, 'read me 2');\n" +
-                                             "INSERT INTO %s.tbl(pk, v1) VALUES (4, 'read me 3');\n" +
+                                             "INSERT INTO %s." + TBL + "(pk, v1) VALUES (4, 'read me 2');\n" +
+                                             "INSERT INTO %s." + TBL + "(pk, v1) VALUES (4, 'read me 3');\n" +
                                              "APPLY BATCH;", KEYSPACE, KEYSPACE);
-        // Batch variants that overwrite already-existing rows (pk=2,3 / pk=4) to exercise the updateRow index path
-        String loggedBatchUpdate = String.format("BEGIN BATCH\n" +
-                                                 "INSERT INTO %s.tbl(pk, v1) VALUES (2, 'updated 2');\n" +
-                                                 "INSERT INTO %s.tbl(pk, v1) VALUES (3, 'updated 3');\n" +
-                                                 "APPLY BATCH;", KEYSPACE, KEYSPACE);
-        String unloggedBatchUpdate = String.format("BEGIN UNLOGGED BATCH\n" +
-                                                   "INSERT INTO %s.tbl(pk, v1) VALUES (4, 'updated 2');\n" +
-                                                   "INSERT INTO %s.tbl(pk, v1) VALUES (4, 'updated 3');\n" +
-                                                   "APPLY BATCH;", KEYSPACE, KEYSPACE);
-        String range = withKeyspace("SELECT * FROM %s.tbl");
 
         List<Object[]> result = new ArrayList<>();
+        result.add(new Object[]{ TBL, noPrep, write, new String[]{ WRITE_TBL } });
+        result.add(new Object[]{ TBL_COUNTER, noPrep, counter, new String[]{ WRITE_COUNTER } });
+        result.add(new Object[]{ TBL, new String[]{ write }, read, new String[]{ READ_TBL } });
+        result.add(new Object[]{ TBL, noPrep, cas, new String[]{ WRITE_TBL, READ_TBL } });
+        result.add(new Object[]{ TBL, noPrep, loggedBatch, new String[]{ WRITE_TBL } });
+        result.add(new Object[]{ TBL, noPrep, unloggedBatch, new String[]{ WRITE_TBL } });
+        result.add(new Object[]{ TBL, new String[]{ write }, range, new String[]{ READ_TBL } });
+        return result;
+    }
+
+    /**
+     * Secondary index (2i) scenarios on {@value TBL_2I}: inserts (insertRow path), updates (updateRow path),
+     * and CAS (insert via IF NOT EXISTS / update via IF condition).
+     */
+    private static List<Object[]> secondaryIndexScenarios()
+    {
         String[] noPrep = new String[0];
+        String write = withKeyspace("INSERT INTO %s." + TBL_2I + "(pk, v1) VALUES (1, '2i read me')");
+        String writeUpdate = withKeyspace("INSERT INTO %s." + TBL_2I + "(pk, v1) VALUES (1, '2i updated')");
+        String cas = withKeyspace("UPDATE %s." + TBL_2I + " SET v1 = '2i cas update' WHERE pk = 1 IF v1 = '2i read me'");
+        String casInsert = withKeyspace("INSERT INTO %s." + TBL_2I + "(pk, v1) VALUES (5, '2i cas insert') IF NOT EXISTS");
+        String loggedBatch = String.format("BEGIN BATCH\n" +
+                                           "INSERT INTO %s." + TBL_2I + "(pk, v1) VALUES (2, '2i read me 2');\n" +
+                                           "INSERT INTO %s." + TBL_2I + "(pk, v1) VALUES (3, '2i read me 3');\n" +
+                                           "APPLY BATCH;", KEYSPACE, KEYSPACE);
+        String unloggedBatch = String.format("BEGIN UNLOGGED BATCH\n" +
+                                             "INSERT INTO %s." + TBL_2I + "(pk, v1) VALUES (4, '2i read me 2');\n" +
+                                             "INSERT INTO %s." + TBL_2I + "(pk, v1) VALUES (4, '2i read me 3');\n" +
+                                             "APPLY BATCH;", KEYSPACE, KEYSPACE);
+        String loggedBatchUpdate = String.format("BEGIN BATCH\n" +
+                                                 "INSERT INTO %s." + TBL_2I + "(pk, v1) VALUES (2, '2i updated 2');\n" +
+                                                 "INSERT INTO %s." + TBL_2I + "(pk, v1) VALUES (3, '2i updated 3');\n" +
+                                                 "APPLY BATCH;", KEYSPACE, KEYSPACE);
+        String unloggedBatchUpdate = String.format("BEGIN UNLOGGED BATCH\n" +
+                                                   "INSERT INTO %s." + TBL_2I + "(pk, v1) VALUES (4, '2i updated 2');\n" +
+                                                   "INSERT INTO %s." + TBL_2I + "(pk, v1) VALUES (4, '2i updated 3');\n" +
+                                                   "APPLY BATCH;", KEYSPACE, KEYSPACE);
 
-        // baseline: non-indexed writes, reads and CAS
-        result.add(new Object[]{ tableSchema, noPrep, write, new String[]{ EXPECTED_WRITE_BYTES_HEADER } });
-        result.add(new Object[]{ counterTableSchema, noPrep, counter, new String[]{ EXPECTED_WRITE_BYTES_HEADER } });
-        result.add(new Object[]{ tableSchema, new String[]{ write }, read, new String[]{ EXPECTED_READ_BYTES_HEADER } });
-        result.add(new Object[]{ tableSchema, noPrep, cas, new String[]{ EXPECTED_WRITE_BYTES_HEADER, EXPECTED_READ_BYTES_HEADER } });
-        result.add(new Object[]{ tableSchema, noPrep, loggedBatch, new String[]{ EXPECTED_WRITE_BYTES_HEADER } });
-        result.add(new Object[]{ tableSchema, noPrep, unloggedBatch, new String[]{ EXPECTED_WRITE_BYTES_HEADER } });
-        result.add(new Object[]{ tableSchema, new String[]{ write }, range, new String[]{ EXPECTED_READ_BYTES_HEADER } });
+        List<Object[]> result = new ArrayList<>();
+        // inserts: insertRow path
+        result.add(new Object[]{ TBL_2I, noPrep, write, new String[]{ WRITE_2I, INDEX_WRITE_2I } });
+        result.add(new Object[]{ TBL_2I, noPrep, loggedBatch, new String[]{ WRITE_2I, INDEX_WRITE_2I } });
+        result.add(new Object[]{ TBL_2I, noPrep, unloggedBatch, new String[]{ WRITE_2I, INDEX_WRITE_2I } });
+        // updates: updateRow path (row pre-exists, new value differs to ensure index allocation)
+        result.add(new Object[]{ TBL_2I, new String[]{ write }, writeUpdate, new String[]{ WRITE_2I, INDEX_WRITE_2I } });
+        result.add(new Object[]{ TBL_2I, new String[]{ loggedBatch }, loggedBatchUpdate, new String[]{ WRITE_2I, INDEX_WRITE_2I } });
+        result.add(new Object[]{ TBL_2I, new String[]{ unloggedBatch }, unloggedBatchUpdate, new String[]{ WRITE_2I, INDEX_WRITE_2I } });
+        // CAS: IF NOT EXISTS (insertRow path) and IF condition (updateRow path)
+        result.add(new Object[]{ TBL_2I, noPrep, casInsert, new String[]{ WRITE_2I, READ_2I, INDEX_WRITE_2I } });
+        result.add(new Object[]{ TBL_2I, new String[]{ write }, cas, new String[]{ WRITE_2I, READ_2I, INDEX_WRITE_2I } });
+        return result;
+    }
 
-        // legacy index: inserts (insertRow path), updates (updateRow path), and CAS (insert via IF NOT EXISTS / update via IF condition)
-        result.add(new Object[]{ tableSchema, new String[]{ createLegacyIndex }, write, new String[]{ EXPECTED_WRITE_BYTES_HEADER, EXPECTED_INDEX_WRITE_BYTES_HEADER } });
-        result.add(new Object[]{ tableSchema, new String[]{ createLegacyIndex }, loggedBatch, new String[]{ EXPECTED_WRITE_BYTES_HEADER, EXPECTED_INDEX_WRITE_BYTES_HEADER } });
-        result.add(new Object[]{ tableSchema, new String[]{ createLegacyIndex }, unloggedBatch, new String[]{ EXPECTED_WRITE_BYTES_HEADER, EXPECTED_INDEX_WRITE_BYTES_HEADER } });
-        result.add(new Object[]{ tableSchema, new String[]{ createLegacyIndex, write }, write, new String[]{ EXPECTED_WRITE_BYTES_HEADER, EXPECTED_INDEX_WRITE_BYTES_HEADER } });
-        result.add(new Object[]{ tableSchema, new String[]{ createLegacyIndex, loggedBatch }, loggedBatchUpdate, new String[]{ EXPECTED_WRITE_BYTES_HEADER, EXPECTED_INDEX_WRITE_BYTES_HEADER } });
-        result.add(new Object[]{ tableSchema, new String[]{ createLegacyIndex, unloggedBatch }, unloggedBatchUpdate, new String[]{ EXPECTED_WRITE_BYTES_HEADER, EXPECTED_INDEX_WRITE_BYTES_HEADER } });
-        result.add(new Object[]{ tableSchema, new String[]{ createLegacyIndex }, casInsert, new String[]{ EXPECTED_WRITE_BYTES_HEADER, EXPECTED_READ_BYTES_HEADER, EXPECTED_INDEX_WRITE_BYTES_HEADER } });
-        result.add(new Object[]{ tableSchema, new String[]{ createLegacyIndex, write }, cas, new String[]{ EXPECTED_WRITE_BYTES_HEADER, EXPECTED_READ_BYTES_HEADER, EXPECTED_INDEX_WRITE_BYTES_HEADER } });
+    /**
+     * SAI scenarios on a scalar column ({@value TBL_SAI}): inserts (insertRow path), updates (updateRow path),
+     * and CAS (insert via IF NOT EXISTS / update via IF condition).
+     * The update path exercises {@code TrieMemtableIndex.update(ByteBuffer, ByteBuffer)}.
+     */
+    private static List<Object[]> saiScalarScenarios()
+    {
+        String[] noPrep = new String[0];
+        String write = withKeyspace("INSERT INTO %s." + TBL_SAI + "(pk, v1) VALUES (1, 'sai read me')");
+        String writeUpdate = withKeyspace("INSERT INTO %s." + TBL_SAI + "(pk, v1) VALUES (1, 'sai updated')");
+        String cas = withKeyspace("UPDATE %s." + TBL_SAI + " SET v1 = 'sai cas update' WHERE pk = 1 IF v1 = 'sai read me'");
+        String casInsert = withKeyspace("INSERT INTO %s." + TBL_SAI + "(pk, v1) VALUES (5, 'sai cas insert') IF NOT EXISTS");
+        String loggedBatch = String.format("BEGIN BATCH\n" +
+                                           "INSERT INTO %s." + TBL_SAI + "(pk, v1) VALUES (2, 'sai read me 2');\n" +
+                                           "INSERT INTO %s." + TBL_SAI + "(pk, v1) VALUES (3, 'sai read me 3');\n" +
+                                           "APPLY BATCH;", KEYSPACE, KEYSPACE);
+        String unloggedBatch = String.format("BEGIN UNLOGGED BATCH\n" +
+                                             "INSERT INTO %s." + TBL_SAI + "(pk, v1) VALUES (4, 'sai read me 2');\n" +
+                                             "INSERT INTO %s." + TBL_SAI + "(pk, v1) VALUES (4, 'sai read me 3');\n" +
+                                             "APPLY BATCH;", KEYSPACE, KEYSPACE);
+        String loggedBatchUpdate = String.format("BEGIN BATCH\n" +
+                                                 "INSERT INTO %s." + TBL_SAI + "(pk, v1) VALUES (2, 'sai updated 2');\n" +
+                                                 "INSERT INTO %s." + TBL_SAI + "(pk, v1) VALUES (3, 'sai updated 3');\n" +
+                                                 "APPLY BATCH;", KEYSPACE, KEYSPACE);
+        String unloggedBatchUpdate = String.format("BEGIN UNLOGGED BATCH\n" +
+                                                   "INSERT INTO %s." + TBL_SAI + "(pk, v1) VALUES (4, 'sai updated 2');\n" +
+                                                   "INSERT INTO %s." + TBL_SAI + "(pk, v1) VALUES (4, 'sai updated 3');\n" +
+                                                   "APPLY BATCH;", KEYSPACE, KEYSPACE);
 
-        // SAI on a scalar column: inserts (insertRow path), updates (updateRow path), and CAS (insert via IF NOT EXISTS / update via IF condition)
-        result.add(new Object[]{ tableSchema, new String[]{ createSAIIndex }, write, new String[]{ EXPECTED_WRITE_BYTES_HEADER, EXPECTED_INDEX_WRITE_BYTES_HEADER } });
-        result.add(new Object[]{ tableSchema, new String[]{ createSAIIndex }, loggedBatch, new String[]{ EXPECTED_WRITE_BYTES_HEADER, EXPECTED_INDEX_WRITE_BYTES_HEADER } });
-        result.add(new Object[]{ tableSchema, new String[]{ createSAIIndex }, unloggedBatch, new String[]{ EXPECTED_WRITE_BYTES_HEADER, EXPECTED_INDEX_WRITE_BYTES_HEADER } });
-        result.add(new Object[]{ tableSchema, new String[]{ createSAIIndex, write }, write, new String[]{ EXPECTED_WRITE_BYTES_HEADER, EXPECTED_INDEX_WRITE_BYTES_HEADER } });
-        result.add(new Object[]{ tableSchema, new String[]{ createSAIIndex, loggedBatch }, loggedBatchUpdate, new String[]{ EXPECTED_WRITE_BYTES_HEADER, EXPECTED_INDEX_WRITE_BYTES_HEADER } });
-        result.add(new Object[]{ tableSchema, new String[]{ createSAIIndex, unloggedBatch }, unloggedBatchUpdate, new String[]{ EXPECTED_WRITE_BYTES_HEADER, EXPECTED_INDEX_WRITE_BYTES_HEADER } });
-        result.add(new Object[]{ tableSchema, new String[]{ createSAIIndex }, casInsert, new String[]{ EXPECTED_WRITE_BYTES_HEADER, EXPECTED_READ_BYTES_HEADER, EXPECTED_INDEX_WRITE_BYTES_HEADER } });
-        result.add(new Object[]{ tableSchema, new String[]{ createSAIIndex, write }, cas, new String[]{ EXPECTED_WRITE_BYTES_HEADER, EXPECTED_READ_BYTES_HEADER, EXPECTED_INDEX_WRITE_BYTES_HEADER } });
+        List<Object[]> result = new ArrayList<>();
+        // inserts: insertRow path
+        result.add(new Object[]{ TBL_SAI, noPrep, write, new String[]{ WRITE_SAI, INDEX_WRITE_SAI } });
+        result.add(new Object[]{ TBL_SAI, noPrep, loggedBatch, new String[]{ WRITE_SAI, INDEX_WRITE_SAI } });
+        result.add(new Object[]{ TBL_SAI, noPrep, unloggedBatch, new String[]{ WRITE_SAI, INDEX_WRITE_SAI } });
+        // updates: updateRow path (row pre-exists, new value differs to ensure index allocation)
+        result.add(new Object[]{ TBL_SAI, new String[]{ write }, writeUpdate, new String[]{ WRITE_SAI, INDEX_WRITE_SAI } });
+        result.add(new Object[]{ TBL_SAI, new String[]{ loggedBatch }, loggedBatchUpdate, new String[]{ WRITE_SAI, INDEX_WRITE_SAI } });
+        result.add(new Object[]{ TBL_SAI, new String[]{ unloggedBatch }, unloggedBatchUpdate, new String[]{ WRITE_SAI, INDEX_WRITE_SAI } });
+        // CAS: IF NOT EXISTS (insertRow path) and IF condition (updateRow path)
+        result.add(new Object[]{ TBL_SAI, noPrep, casInsert, new String[]{ WRITE_SAI, READ_SAI, INDEX_WRITE_SAI } });
+        result.add(new Object[]{ TBL_SAI, new String[]{ write }, cas, new String[]{ WRITE_SAI, READ_SAI, INDEX_WRITE_SAI } });
+        return result;
+    }
 
-        // SAI on a non-frozen collection column: inserts and updates (exercises the TrieMemtableIndex.update(Iterator, Iterator) overload)
-        result.add(new Object[]{ collectionTableSchema, new String[]{ createCollectionSAIIndex }, collectionWrite, new String[]{ EXPECTED_COL_WRITE_BYTES_HEADER, EXPECTED_COL_INDEX_WRITE_BYTES_HEADER } });
-        result.add(new Object[]{ collectionTableSchema, new String[]{ createCollectionSAIIndex, collectionWrite }, collectionUpdate, new String[]{ EXPECTED_COL_WRITE_BYTES_HEADER, EXPECTED_COL_INDEX_WRITE_BYTES_HEADER } });
+    /**
+     * SAI scenarios on a non-frozen collection column ({@value TBL_COL}): inserts and updates.
+     * The update path exercises {@code TrieMemtableIndex.update(Iterator, Iterator)}.
+     */
+    private static List<Object[]> saiCollectionScenarios()
+    {
+        String collectionWrite = withKeyspace("INSERT INTO %s." + TBL_COL + "(pk, tags) VALUES (1, {'a', 'b'})");
+        String collectionUpdate = withKeyspace("INSERT INTO %s." + TBL_COL + "(pk, tags) VALUES (1, {'c', 'd'})");
+
+        List<Object[]> result = new ArrayList<>();
+        result.add(new Object[]{ TBL_COL, new String[0], collectionWrite, new String[]{ WRITE_COL, INDEX_WRITE_COL } });
+        result.add(new Object[]{ TBL_COL, new String[]{ collectionWrite }, collectionUpdate, new String[]{ WRITE_COL, INDEX_WRITE_COL } });
         return result;
     }
 
@@ -200,26 +320,25 @@ public class SensorsTest extends TestBaseImpl
     }
 
     /**
-     * Execute the test with the given {@code propagateViaNativeProtocol} flag and return the custom payload
+     * Execute the test with the given {@code propagateViaNativeProtocol} flag and return the custom payload.
      */
     private Map<String, ByteBuffer> executeTest(boolean propagateViaNativeProtocol) throws Throwable
     {
-        CassandraRelevantProperties.SENSORS_VIA_NATIVE_PROTOCOL.setBoolean(propagateViaNativeProtocol);
         AtomicReference<Map<String, ByteBuffer>> customPayload = new AtomicReference<>();
-        try (Cluster cluster = init(Cluster.build(NODES_COUNT).start()))
-        {
-            cluster.schemaChange(schema);
-            for (String prepQuery : this.prepQueries)
-                cluster.coordinator(1).execute(prepQuery, ConsistencyLevel.ALL);
-            // work around serializability of @Parameterized.Parameter by providing a locally scoped variable
-            String query = this.testQuery;
-            // Any methods used inside the runOnInstance() block should be static, otherwise java.io.NotSerializableException will be thrown
-            cluster.get(1).acceptsOnInstance(
-                   (IIsolatedExecutor.SerializableConsumer<AtomicReference<Map<String, ByteBuffer>>>)
-                   (reference) -> reference.set(executeWithResult(query).getCustomPayload()))
-                   .accept(customPayload);
-        }
-
+        for (String prepQuery : this.prepQueries)
+            cluster.coordinator(1).execute(prepQuery, ConsistencyLevel.ALL);
+        // work around serializability of @Parameterized.Parameter by providing a locally scoped variable
+        String query = this.testQuery;
+        // The cluster is shared across scenarios, so SENSORS_VIA_NATIVE_PROTOCOL must be set inside the node's
+        // classloader via runOnInstance rather than on the outer test JVM — the node won't see outer JVM property changes.
+        // Any methods used inside the runOnInstance() block should be static, otherwise java.io.NotSerializableException will be thrown
+        cluster.get(1).acceptsOnInstance(
+               (IIsolatedExecutor.SerializableConsumer<AtomicReference<Map<String, ByteBuffer>>>)
+               (reference) -> {
+                   CassandraRelevantProperties.SENSORS_VIA_NATIVE_PROTOCOL.setBoolean(propagateViaNativeProtocol);
+                   reference.set(executeWithResult(query).getCustomPayload());
+               })
+               .accept(customPayload);
         return customPayload.get();
     }
 

--- a/test/distributed/org/apache/cassandra/distributed/test/sensors/SensorsTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sensors/SensorsTest.java
@@ -39,6 +39,7 @@ import org.apache.cassandra.distributed.Cluster;
 import org.apache.cassandra.distributed.api.ConsistencyLevel;
 import org.apache.cassandra.distributed.api.IIsolatedExecutor;
 import org.apache.cassandra.distributed.test.TestBaseImpl;
+import org.apache.cassandra.index.sai.StorageAttachedIndex;
 import org.apache.cassandra.sensors.ActiveSensorsFactory;
 import org.apache.cassandra.transport.ProtocolVersion;
 import org.apache.cassandra.transport.messages.ResultMessage;
@@ -55,6 +56,8 @@ public class SensorsTest extends TestBaseImpl
     private static final String EXPECTED_WRITE_BYTES_HEADER = "WRITE_BYTES_REQUEST." + KEYSPACE + ".tbl";
     private static final String EXPECTED_READ_BYTES_HEADER = "READ_BYTES_REQUEST." + KEYSPACE + ".tbl";
     private static final String EXPECTED_INDEX_WRITE_BYTES_HEADER = "INDEX_WRITE_BYTES_REQUEST." + KEYSPACE + ".tbl";
+    private static final String EXPECTED_COL_WRITE_BYTES_HEADER = "WRITE_BYTES_REQUEST." + KEYSPACE + ".tbl_col";
+    private static final String EXPECTED_COL_INDEX_WRITE_BYTES_HEADER = "INDEX_WRITE_BYTES_REQUEST." + KEYSPACE + ".tbl_col";
     /**
      * Using a combination of 2 nodes with ALL consistency level to ensure internode communication code paths are exercised in the test
      */
@@ -96,12 +99,24 @@ public class SensorsTest extends TestBaseImpl
     {
         String tableSchema = withKeyspace("CREATE TABLE %s.tbl (pk int PRIMARY KEY, v1 text)");
         String counterTableSchema = withKeyspace("CREATE TABLE %s.tbl (pk int PRIMARY KEY, total counter)");
-        String createIndex = withKeyspace("CREATE INDEX ON %s.tbl (v1)");
+        // Exercise both legacy 2i and SAI so that both index write paths are covered
+        String createLegacyIndex = withKeyspace("CREATE INDEX ON %s.tbl (v1)");
+        String createSAIIndex = withKeyspace("CREATE CUSTOM INDEX ON %s.tbl (v1) USING '" + StorageAttachedIndex.class.getName() + "'");
+
+        // Table with a non-frozen set column: exercises the TrieMemtableIndex.update(Iterator<ByteBuffer>, Iterator<ByteBuffer>)
+        // overload (the collection update path), which is distinct from the scalar update(ByteBuffer, ByteBuffer) overload
+        String collectionTableSchema = withKeyspace("CREATE TABLE %s.tbl_col (pk int PRIMARY KEY, tags set<text>)");
+        String createCollectionSAIIndex = withKeyspace("CREATE CUSTOM INDEX ON %s.tbl_col (tags) USING '" + StorageAttachedIndex.class.getName() + "'");
+        String collectionWrite = withKeyspace("INSERT INTO %s.tbl_col(pk, tags) VALUES (1, {'a', 'b'})");
+        // Overwrites the existing set value for pk=1, triggering the updateRow → update(Iterator, Iterator) path
+        String collectionUpdate = withKeyspace("INSERT INTO %s.tbl_col(pk, tags) VALUES (1, {'c', 'd'})");
 
         String write = withKeyspace("INSERT INTO %s.tbl(pk, v1) VALUES (1, 'read me')");
         String counter = withKeyspace("UPDATE %s.tbl SET total = total + 1 WHERE pk = 1");
         String read = withKeyspace("SELECT * FROM %s.tbl WHERE pk=1");
         String cas = withKeyspace("UPDATE %s.tbl SET v1 = 'cas update' WHERE pk = 1 IF v1 = 'read me'");
+        // CAS insert: IF NOT EXISTS on a new row exercises the insertRow index path via Paxos commit
+        String casInsert = withKeyspace("INSERT INTO %s.tbl(pk, v1) VALUES (5, 'cas insert') IF NOT EXISTS");
         String loggedBatch = String.format("BEGIN BATCH\n" +
                                            "INSERT INTO %s.tbl(pk, v1) VALUES (2, 'read me 2');\n" +
                                            "INSERT INTO %s.tbl(pk, v1) VALUES (3, 'read me 3');\n" +
@@ -110,24 +125,52 @@ public class SensorsTest extends TestBaseImpl
                                              "INSERT INTO %s.tbl(pk, v1) VALUES (4, 'read me 2');\n" +
                                              "INSERT INTO %s.tbl(pk, v1) VALUES (4, 'read me 3');\n" +
                                              "APPLY BATCH;", KEYSPACE, KEYSPACE);
+        // Batch variants that overwrite already-existing rows (pk=2,3 / pk=4) to exercise the updateRow index path
+        String loggedBatchUpdate = String.format("BEGIN BATCH\n" +
+                                                 "INSERT INTO %s.tbl(pk, v1) VALUES (2, 'updated 2');\n" +
+                                                 "INSERT INTO %s.tbl(pk, v1) VALUES (3, 'updated 3');\n" +
+                                                 "APPLY BATCH;", KEYSPACE, KEYSPACE);
+        String unloggedBatchUpdate = String.format("BEGIN UNLOGGED BATCH\n" +
+                                                   "INSERT INTO %s.tbl(pk, v1) VALUES (4, 'updated 2');\n" +
+                                                   "INSERT INTO %s.tbl(pk, v1) VALUES (4, 'updated 3');\n" +
+                                                   "APPLY BATCH;", KEYSPACE, KEYSPACE);
         String range = withKeyspace("SELECT * FROM %s.tbl");
 
         List<Object[]> result = new ArrayList<>();
         String[] noPrep = new String[0];
+
+        // baseline: non-indexed writes, reads and CAS
         result.add(new Object[]{ tableSchema, noPrep, write, new String[]{ EXPECTED_WRITE_BYTES_HEADER } });
         result.add(new Object[]{ counterTableSchema, noPrep, counter, new String[]{ EXPECTED_WRITE_BYTES_HEADER } });
         result.add(new Object[]{ tableSchema, new String[]{ write }, read, new String[]{ EXPECTED_READ_BYTES_HEADER } });
-        // CAS requests incorporate read (and write) bytes from the paxos (and user) tables
         result.add(new Object[]{ tableSchema, noPrep, cas, new String[]{ EXPECTED_WRITE_BYTES_HEADER, EXPECTED_READ_BYTES_HEADER } });
         result.add(new Object[]{ tableSchema, noPrep, loggedBatch, new String[]{ EXPECTED_WRITE_BYTES_HEADER } });
         result.add(new Object[]{ tableSchema, noPrep, unloggedBatch, new String[]{ EXPECTED_WRITE_BYTES_HEADER } });
         result.add(new Object[]{ tableSchema, new String[]{ write }, range, new String[]{ EXPECTED_READ_BYTES_HEADER } });
-        // writes to an indexed table must propagate both WRITE_BYTES and INDEX_WRITE_BYTES
-        result.add(new Object[]{ tableSchema, new String[]{ createIndex }, write, new String[]{ EXPECTED_WRITE_BYTES_HEADER, EXPECTED_INDEX_WRITE_BYTES_HEADER } });
-        result.add(new Object[]{ tableSchema, new String[]{ createIndex }, loggedBatch, new String[]{ EXPECTED_WRITE_BYTES_HEADER, EXPECTED_INDEX_WRITE_BYTES_HEADER } });
-        result.add(new Object[]{ tableSchema, new String[]{ createIndex }, unloggedBatch, new String[]{ EXPECTED_WRITE_BYTES_HEADER, EXPECTED_INDEX_WRITE_BYTES_HEADER } });
-        // CAS writes to an indexed table must propagate WRITE_BYTES, READ_BYTES and INDEX_WRITE_BYTES
-        result.add(new Object[]{ tableSchema, new String[]{ createIndex, write }, cas, new String[]{ EXPECTED_WRITE_BYTES_HEADER, EXPECTED_READ_BYTES_HEADER, EXPECTED_INDEX_WRITE_BYTES_HEADER } });
+
+        // legacy index: inserts (insertRow path), updates (updateRow path), and CAS (insert via IF NOT EXISTS / update via IF condition)
+        result.add(new Object[]{ tableSchema, new String[]{ createLegacyIndex }, write, new String[]{ EXPECTED_WRITE_BYTES_HEADER, EXPECTED_INDEX_WRITE_BYTES_HEADER } });
+        result.add(new Object[]{ tableSchema, new String[]{ createLegacyIndex }, loggedBatch, new String[]{ EXPECTED_WRITE_BYTES_HEADER, EXPECTED_INDEX_WRITE_BYTES_HEADER } });
+        result.add(new Object[]{ tableSchema, new String[]{ createLegacyIndex }, unloggedBatch, new String[]{ EXPECTED_WRITE_BYTES_HEADER, EXPECTED_INDEX_WRITE_BYTES_HEADER } });
+        result.add(new Object[]{ tableSchema, new String[]{ createLegacyIndex, write }, write, new String[]{ EXPECTED_WRITE_BYTES_HEADER, EXPECTED_INDEX_WRITE_BYTES_HEADER } });
+        result.add(new Object[]{ tableSchema, new String[]{ createLegacyIndex, loggedBatch }, loggedBatchUpdate, new String[]{ EXPECTED_WRITE_BYTES_HEADER, EXPECTED_INDEX_WRITE_BYTES_HEADER } });
+        result.add(new Object[]{ tableSchema, new String[]{ createLegacyIndex, unloggedBatch }, unloggedBatchUpdate, new String[]{ EXPECTED_WRITE_BYTES_HEADER, EXPECTED_INDEX_WRITE_BYTES_HEADER } });
+        result.add(new Object[]{ tableSchema, new String[]{ createLegacyIndex }, casInsert, new String[]{ EXPECTED_WRITE_BYTES_HEADER, EXPECTED_READ_BYTES_HEADER, EXPECTED_INDEX_WRITE_BYTES_HEADER } });
+        result.add(new Object[]{ tableSchema, new String[]{ createLegacyIndex, write }, cas, new String[]{ EXPECTED_WRITE_BYTES_HEADER, EXPECTED_READ_BYTES_HEADER, EXPECTED_INDEX_WRITE_BYTES_HEADER } });
+
+        // SAI on a scalar column: inserts (insertRow path), updates (updateRow path), and CAS (insert via IF NOT EXISTS / update via IF condition)
+        result.add(new Object[]{ tableSchema, new String[]{ createSAIIndex }, write, new String[]{ EXPECTED_WRITE_BYTES_HEADER, EXPECTED_INDEX_WRITE_BYTES_HEADER } });
+        result.add(new Object[]{ tableSchema, new String[]{ createSAIIndex }, loggedBatch, new String[]{ EXPECTED_WRITE_BYTES_HEADER, EXPECTED_INDEX_WRITE_BYTES_HEADER } });
+        result.add(new Object[]{ tableSchema, new String[]{ createSAIIndex }, unloggedBatch, new String[]{ EXPECTED_WRITE_BYTES_HEADER, EXPECTED_INDEX_WRITE_BYTES_HEADER } });
+        result.add(new Object[]{ tableSchema, new String[]{ createSAIIndex, write }, write, new String[]{ EXPECTED_WRITE_BYTES_HEADER, EXPECTED_INDEX_WRITE_BYTES_HEADER } });
+        result.add(new Object[]{ tableSchema, new String[]{ createSAIIndex, loggedBatch }, loggedBatchUpdate, new String[]{ EXPECTED_WRITE_BYTES_HEADER, EXPECTED_INDEX_WRITE_BYTES_HEADER } });
+        result.add(new Object[]{ tableSchema, new String[]{ createSAIIndex, unloggedBatch }, unloggedBatchUpdate, new String[]{ EXPECTED_WRITE_BYTES_HEADER, EXPECTED_INDEX_WRITE_BYTES_HEADER } });
+        result.add(new Object[]{ tableSchema, new String[]{ createSAIIndex }, casInsert, new String[]{ EXPECTED_WRITE_BYTES_HEADER, EXPECTED_READ_BYTES_HEADER, EXPECTED_INDEX_WRITE_BYTES_HEADER } });
+        result.add(new Object[]{ tableSchema, new String[]{ createSAIIndex, write }, cas, new String[]{ EXPECTED_WRITE_BYTES_HEADER, EXPECTED_READ_BYTES_HEADER, EXPECTED_INDEX_WRITE_BYTES_HEADER } });
+
+        // SAI on a non-frozen collection column: inserts and updates (exercises the TrieMemtableIndex.update(Iterator, Iterator) overload)
+        result.add(new Object[]{ collectionTableSchema, new String[]{ createCollectionSAIIndex }, collectionWrite, new String[]{ EXPECTED_COL_WRITE_BYTES_HEADER, EXPECTED_COL_INDEX_WRITE_BYTES_HEADER } });
+        result.add(new Object[]{ collectionTableSchema, new String[]{ createCollectionSAIIndex, collectionWrite }, collectionUpdate, new String[]{ EXPECTED_COL_WRITE_BYTES_HEADER, EXPECTED_COL_INDEX_WRITE_BYTES_HEADER } });
         return result;
     }
 

--- a/test/distributed/org/apache/cassandra/distributed/test/sensors/SensorsTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sensors/SensorsTest.java
@@ -54,6 +54,7 @@ public class SensorsTest extends TestBaseImpl
 {
     private static final String EXPECTED_WRITE_BYTES_HEADER = "WRITE_BYTES_REQUEST." + KEYSPACE + ".tbl";
     private static final String EXPECTED_READ_BYTES_HEADER = "READ_BYTES_REQUEST." + KEYSPACE + ".tbl";
+    private static final String EXPECTED_INDEX_WRITE_BYTES_HEADER = "INDEX_WRITE_BYTES_REQUEST." + KEYSPACE + ".tbl";
     /**
      * Using a combination of 2 nodes with ALL consistency level to ensure internode communication code paths are exercised in the test
      */
@@ -95,6 +96,7 @@ public class SensorsTest extends TestBaseImpl
     {
         String tableSchema = withKeyspace("CREATE TABLE %s.tbl (pk int PRIMARY KEY, v1 text)");
         String counterTableSchema = withKeyspace("CREATE TABLE %s.tbl (pk int PRIMARY KEY, total counter)");
+        String createIndex = withKeyspace("CREATE INDEX ON %s.tbl (v1)");
 
         String write = withKeyspace("INSERT INTO %s.tbl(pk, v1) VALUES (1, 'read me')");
         String counter = withKeyspace("UPDATE %s.tbl SET total = total + 1 WHERE pk = 1");
@@ -120,6 +122,8 @@ public class SensorsTest extends TestBaseImpl
         result.add(new Object[]{ tableSchema, noPrep, loggedBatch, new String[]{ EXPECTED_WRITE_BYTES_HEADER } });
         result.add(new Object[]{ tableSchema, noPrep, unloggedBatch, new String[]{ EXPECTED_WRITE_BYTES_HEADER } });
         result.add(new Object[]{ tableSchema, new String[]{ write }, range, new String[]{ EXPECTED_READ_BYTES_HEADER } });
+        // writes to an indexed table must propagate both WRITE_BYTES and INDEX_WRITE_BYTES
+        result.add(new Object[]{ tableSchema, new String[]{ createIndex }, write, new String[]{ EXPECTED_WRITE_BYTES_HEADER, EXPECTED_INDEX_WRITE_BYTES_HEADER } });
         return result;
     }
 

--- a/test/distributed/org/apache/cassandra/distributed/test/sensors/SensorsTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sensors/SensorsTest.java
@@ -158,6 +158,7 @@ public class SensorsTest extends TestBaseImpl
         result.addAll(secondaryIndexScenarios());
         result.addAll(saiScalarScenarios());
         result.addAll(saiCollectionScenarios());
+        result.addAll(conditionalBatchScenarios());
         return result;
     }
 
@@ -194,7 +195,8 @@ public class SensorsTest extends TestBaseImpl
 
     /**
      * Secondary index (2i) scenarios on {@value TBL_2I}: inserts (insertRow path), updates (updateRow path),
-     * and CAS (insert via IF NOT EXISTS / update via IF condition).
+     * CAS (insert via IF NOT EXISTS / update via IF condition), and multi-table batches mixing
+     * {@value TBL_2I} and {@value TBL_SAI} (exercises the per-table sensor loop for two distinct tables).
      */
     private static List<Object[]> secondaryIndexScenarios()
     {
@@ -203,6 +205,7 @@ public class SensorsTest extends TestBaseImpl
         String writeUpdate = withKeyspace("INSERT INTO %s." + TBL_2I + "(pk, v1) VALUES (1, '2i updated')");
         String cas = withKeyspace("UPDATE %s." + TBL_2I + " SET v1 = '2i cas update' WHERE pk = 1 IF v1 = '2i read me'");
         String casInsert = withKeyspace("INSERT INTO %s." + TBL_2I + "(pk, v1) VALUES (5, '2i cas insert') IF NOT EXISTS");
+        // single-table batches (same table, multiple rows)
         String loggedBatch = String.format("BEGIN BATCH\n" +
                                            "INSERT INTO %s." + TBL_2I + "(pk, v1) VALUES (2, '2i read me 2');\n" +
                                            "INSERT INTO %s." + TBL_2I + "(pk, v1) VALUES (3, '2i read me 3');\n" +
@@ -219,6 +222,19 @@ public class SensorsTest extends TestBaseImpl
                                                    "INSERT INTO %s." + TBL_2I + "(pk, v1) VALUES (4, '2i updated 2');\n" +
                                                    "INSERT INTO %s." + TBL_2I + "(pk, v1) VALUES (4, '2i updated 3');\n" +
                                                    "APPLY BATCH;", KEYSPACE, KEYSPACE);
+        // multi-table batches: tbl_2i + tbl_sai in the same batch — sensors must appear for both tables
+        String multiTableLoggedBatch = String.format("BEGIN BATCH\n" +
+                                                     "INSERT INTO %s." + TBL_2I + "(pk, v1) VALUES (20, 'mt 2i a');\n" +
+                                                     "INSERT INTO %s." + TBL_2I + "(pk, v1) VALUES (21, 'mt 2i b');\n" +
+                                                     "INSERT INTO %s." + TBL_SAI + "(pk, v1) VALUES (20, 'mt sai a');\n" +
+                                                     "INSERT INTO %s." + TBL_SAI + "(pk, v1) VALUES (21, 'mt sai b');\n" +
+                                                     "APPLY BATCH;", KEYSPACE, KEYSPACE, KEYSPACE, KEYSPACE);
+        String multiTableUnloggedBatch = String.format("BEGIN UNLOGGED BATCH\n" +
+                                                       "INSERT INTO %s." + TBL_2I + "(pk, v1) VALUES (22, 'mt 2i a');\n" +
+                                                       "INSERT INTO %s." + TBL_2I + "(pk, v1) VALUES (23, 'mt 2i b');\n" +
+                                                       "INSERT INTO %s." + TBL_SAI + "(pk, v1) VALUES (22, 'mt sai a');\n" +
+                                                       "INSERT INTO %s." + TBL_SAI + "(pk, v1) VALUES (23, 'mt sai b');\n" +
+                                                       "APPLY BATCH;", KEYSPACE, KEYSPACE, KEYSPACE, KEYSPACE);
 
         List<Object[]> result = new ArrayList<>();
         // inserts: insertRow path
@@ -232,6 +248,9 @@ public class SensorsTest extends TestBaseImpl
         // CAS: IF NOT EXISTS (insertRow path) and IF condition (updateRow path)
         result.add(new Object[]{ TBL_2I, noPrep, casInsert, new String[]{ WRITE_2I, READ_2I, INDEX_WRITE_2I } });
         result.add(new Object[]{ TBL_2I, new String[]{ write }, cas, new String[]{ WRITE_2I, READ_2I, INDEX_WRITE_2I } });
+        // multi-table: sensors from both tbl_2i and tbl_sai must be present in the response
+        result.add(new Object[]{ TBL_2I + "+" + TBL_SAI, noPrep, multiTableLoggedBatch, new String[]{ WRITE_2I, INDEX_WRITE_2I, WRITE_SAI, INDEX_WRITE_SAI } });
+        result.add(new Object[]{ TBL_2I + "+" + TBL_SAI, noPrep, multiTableUnloggedBatch, new String[]{ WRITE_2I, INDEX_WRITE_2I, WRITE_SAI, INDEX_WRITE_SAI } });
         return result;
     }
 
@@ -294,6 +313,65 @@ public class SensorsTest extends TestBaseImpl
         return result;
     }
 
+    /**
+     * Conditional batch scenarios: BEGIN BATCH statements with IF conditions, routed through
+     * {@code BatchStatement.executeWithConditions}. These exercise the {@code ResultMessage.Rows}
+     * return path, which must also carry INDEX_WRITE_BYTES sensors.
+     *
+     * Cassandra requires all statements in a conditional batch to target the same partition key and table.
+     * Multi-statement scenarios below use multiple statements on the same partition to exercise the
+     * repeated-same-TableMetadata path through {@code .distinct()} in the sensor loop.
+     */
+    private static List<Object[]> conditionalBatchScenarios()
+    {
+        String[] noPrep = new String[0];
+
+        // 2i: single conditional statement — IF NOT EXISTS (insert path)
+        String prep2i = withKeyspace("INSERT INTO %s." + TBL_2I + "(pk, v1) VALUES (1, '2i read me')");
+        String conditionalBatch2iInsert = String.format("BEGIN BATCH\n" +
+                                                        "INSERT INTO %s." + TBL_2I + "(pk, v1) VALUES (10, '2i cond batch insert') IF NOT EXISTS;\n" +
+                                                        "APPLY BATCH;", KEYSPACE);
+        // 2i: single conditional statement — IF condition (update path)
+        String conditionalBatch2iUpdate = String.format("BEGIN BATCH\n" +
+                                                        "UPDATE %s." + TBL_2I + " SET v1 = '2i cond batch update' WHERE pk = 1 IF v1 = '2i read me';\n" +
+                                                        "APPLY BATCH;", KEYSPACE);
+        // 2i: multiple statements on the same partition — conditional insert + unconditional insert on pk=10,
+        // exercises the duplicate-TableMetadata path (same metadata object appears twice in statements list)
+        String conditionalBatch2iMultiStmt = String.format("BEGIN BATCH\n" +
+                                                           "INSERT INTO %s." + TBL_2I + "(pk, v1) VALUES (10, '2i multi a') IF NOT EXISTS;\n" +
+                                                           "INSERT INTO %s." + TBL_2I + "(pk, v1) VALUES (10, '2i multi b');\n" +
+                                                           "APPLY BATCH;", KEYSPACE, KEYSPACE);
+
+        // SAI: single conditional statement — IF NOT EXISTS (insert path)
+        String prepSai = withKeyspace("INSERT INTO %s." + TBL_SAI + "(pk, v1) VALUES (1, 'sai read me')");
+        String conditionalBatchSaiInsert = String.format("BEGIN BATCH\n" +
+                                                         "INSERT INTO %s." + TBL_SAI + "(pk, v1) VALUES (10, 'sai cond batch insert') IF NOT EXISTS;\n" +
+                                                         "APPLY BATCH;", KEYSPACE);
+        // SAI: single conditional statement — IF condition (update path)
+        String conditionalBatchSaiUpdate = String.format("BEGIN BATCH\n" +
+                                                         "UPDATE %s." + TBL_SAI + " SET v1 = 'sai cond batch update' WHERE pk = 1 IF v1 = 'sai read me';\n" +
+                                                         "APPLY BATCH;", KEYSPACE);
+        // SAI: multiple statements on the same partition — conditional insert + unconditional insert on pk=10,
+        // exercises the duplicate-TableMetadata path (same metadata object appears twice in statements list)
+        String conditionalBatchSaiMultiStmt = String.format("BEGIN BATCH\n" +
+                                                            "INSERT INTO %s." + TBL_SAI + "(pk, v1) VALUES (10, 'sai multi a') IF NOT EXISTS;\n" +
+                                                            "INSERT INTO %s." + TBL_SAI + "(pk, v1) VALUES (10, 'sai multi b');\n" +
+                                                            "APPLY BATCH;", KEYSPACE, KEYSPACE);
+
+        List<Object[]> result = new ArrayList<>();
+        // 2i conditional batch: IF NOT EXISTS (insert path) and IF condition (update path)
+        result.add(new Object[]{ TBL_2I, noPrep, conditionalBatch2iInsert, new String[]{ WRITE_2I, READ_2I, INDEX_WRITE_2I } });
+        result.add(new Object[]{ TBL_2I, new String[]{ prep2i }, conditionalBatch2iUpdate, new String[]{ WRITE_2I, READ_2I, INDEX_WRITE_2I } });
+        // 2i conditional batch: multiple statements on same partition (duplicate TableMetadata in statements list)
+        result.add(new Object[]{ TBL_2I, noPrep, conditionalBatch2iMultiStmt, new String[]{ WRITE_2I, READ_2I, INDEX_WRITE_2I } });
+        // SAI conditional batch: IF NOT EXISTS (insert path) and IF condition (update path)
+        result.add(new Object[]{ TBL_SAI, noPrep, conditionalBatchSaiInsert, new String[]{ WRITE_SAI, READ_SAI, INDEX_WRITE_SAI } });
+        result.add(new Object[]{ TBL_SAI, new String[]{ prepSai }, conditionalBatchSaiUpdate, new String[]{ WRITE_SAI, READ_SAI, INDEX_WRITE_SAI } });
+        // SAI conditional batch: multiple statements on same partition (duplicate TableMetadata in statements list)
+        result.add(new Object[]{ TBL_SAI, noPrep, conditionalBatchSaiMultiStmt, new String[]{ WRITE_SAI, READ_SAI, INDEX_WRITE_SAI } });
+        return result;
+    }
+
     @Test
     public void testSensorsInCQLResponseEnabled() throws Throwable
     {
@@ -344,7 +422,7 @@ public class SensorsTest extends TestBaseImpl
 
     private double getBytesForHeader(Map<String, ByteBuffer> customPayload, String expectedHeader)
     {
-        Assertions.assertThat(customPayload).containsKey(expectedHeader);
+        Assertions.assertThat(customPayload).describedAs("Expected header %s not found in custom payload", expectedHeader).containsKey(expectedHeader);
         return ByteBufferUtil.toDouble(customPayload.get(expectedHeader));
     }
 

--- a/test/distributed/org/apache/cassandra/distributed/test/sensors/SensorsTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sensors/SensorsTest.java
@@ -126,6 +126,8 @@ public class SensorsTest extends TestBaseImpl
         result.add(new Object[]{ tableSchema, new String[]{ createIndex }, write, new String[]{ EXPECTED_WRITE_BYTES_HEADER, EXPECTED_INDEX_WRITE_BYTES_HEADER } });
         result.add(new Object[]{ tableSchema, new String[]{ createIndex }, loggedBatch, new String[]{ EXPECTED_WRITE_BYTES_HEADER, EXPECTED_INDEX_WRITE_BYTES_HEADER } });
         result.add(new Object[]{ tableSchema, new String[]{ createIndex }, unloggedBatch, new String[]{ EXPECTED_WRITE_BYTES_HEADER, EXPECTED_INDEX_WRITE_BYTES_HEADER } });
+        // CAS writes to an indexed table must propagate WRITE_BYTES, READ_BYTES and INDEX_WRITE_BYTES
+        result.add(new Object[]{ tableSchema, new String[]{ createIndex, write }, cas, new String[]{ EXPECTED_WRITE_BYTES_HEADER, EXPECTED_READ_BYTES_HEADER, EXPECTED_INDEX_WRITE_BYTES_HEADER } });
         return result;
     }
 

--- a/test/distributed/org/apache/cassandra/distributed/test/sensors/SensorsTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sensors/SensorsTest.java
@@ -124,6 +124,8 @@ public class SensorsTest extends TestBaseImpl
         result.add(new Object[]{ tableSchema, new String[]{ write }, range, new String[]{ EXPECTED_READ_BYTES_HEADER } });
         // writes to an indexed table must propagate both WRITE_BYTES and INDEX_WRITE_BYTES
         result.add(new Object[]{ tableSchema, new String[]{ createIndex }, write, new String[]{ EXPECTED_WRITE_BYTES_HEADER, EXPECTED_INDEX_WRITE_BYTES_HEADER } });
+        result.add(new Object[]{ tableSchema, new String[]{ createIndex }, loggedBatch, new String[]{ EXPECTED_WRITE_BYTES_HEADER, EXPECTED_INDEX_WRITE_BYTES_HEADER } });
+        result.add(new Object[]{ tableSchema, new String[]{ createIndex }, unloggedBatch, new String[]{ EXPECTED_WRITE_BYTES_HEADER, EXPECTED_INDEX_WRITE_BYTES_HEADER } });
         return result;
     }
 

--- a/test/distributed/org/apache/cassandra/distributed/test/sensors/SensorsTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sensors/SensorsTest.java
@@ -162,11 +162,11 @@ public class SensorsTest extends TestBaseImpl
     @Before
     public void truncateTables()
     {
-        cluster.schemaChange(withKeyspace("TRUNCATE %s." + TBL));
-        cluster.schemaChange(withKeyspace("TRUNCATE %s." + TBL_COUNTER));
-        cluster.schemaChange(withKeyspace("TRUNCATE %s." + TBL_2I));
-        cluster.schemaChange(withKeyspace("TRUNCATE %s." + TBL_SAI));
-        cluster.schemaChange(withKeyspace("TRUNCATE %s." + TBL_COL));
+        cluster.coordinator(1).execute(withKeyspace("TRUNCATE %s." + TBL), ConsistencyLevel.ALL);
+        cluster.coordinator(1).execute(withKeyspace("TRUNCATE %s." + TBL_COUNTER), ConsistencyLevel.ALL);
+        cluster.coordinator(1).execute(withKeyspace("TRUNCATE %s." + TBL_2I), ConsistencyLevel.ALL);
+        cluster.coordinator(1).execute(withKeyspace("TRUNCATE %s." + TBL_SAI), ConsistencyLevel.ALL);
+        cluster.coordinator(1).execute(withKeyspace("TRUNCATE %s." + TBL_COL), ConsistencyLevel.ALL);
     }
 
     @Parameterized.Parameters(name = "{0}")

--- a/test/distributed/org/apache/cassandra/distributed/test/sensors/SensorsTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sensors/SensorsTest.java
@@ -22,8 +22,11 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.AfterClass;
@@ -43,10 +46,18 @@ import org.apache.cassandra.distributed.api.ConsistencyLevel;
 import org.apache.cassandra.distributed.api.IIsolatedExecutor;
 import org.apache.cassandra.distributed.test.TestBaseImpl;
 import org.apache.cassandra.index.sai.StorageAttachedIndex;
+import org.apache.cassandra.cql3.QueryProcessor;
+import org.apache.cassandra.cql3.UntypedResultSet;
+import org.apache.cassandra.schema.SchemaConstants;
 import org.apache.cassandra.sensors.ActiveSensorsFactory;
+import org.apache.cassandra.service.ClientState;
 import org.apache.cassandra.transport.ProtocolVersion;
 import org.apache.cassandra.transport.messages.ResultMessage;
+import org.apache.cassandra.tracing.TraceKeyspace;
+import org.apache.cassandra.tracing.TraceStateImpl;
+import org.apache.cassandra.tracing.Tracing;
 import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.UUIDGen;
 import org.assertj.core.api.Assertions;
 
 /**
@@ -444,5 +455,109 @@ public class SensorsTest extends TestBaseImpl
                                                           ProtocolVersion.CURRENT,
                                                           prepared.keyspace);
         return prepared.statement.execute(QueryProcessor.internalQueryState(), initialOptions, nanoTime);
+    }
+
+    /**
+     * Verifies that enabling tracing on a CQL INSERT does not inflate the user table's {@code WRITE_BYTES_REQUEST}
+     * sensor in the response custom payload.
+     *
+     * <p>Trace writes are submitted to {@code Stage.TRACING} with an isolated {@link org.apache.cassandra.sensors.RequestSensors}
+     * instance. The {@code StorageProxy.mutate()} call on that thread creates its own {@code system_traces} sensor set
+     * and never touches the user table's sensor set on the coordinator thread. Therefore the sensor payload for a traced
+     * INSERT must be byte-for-byte identical to that of an untraced INSERT against the same table.
+     */
+    @Test
+    public void testTraceWriteDoesNotInflateSensors() throws Throwable
+    {
+        cluster.schemaChange(withKeyspace("CREATE TABLE IF NOT EXISTS %s.tbl_trace_isolation (pk int PRIMARY KEY, v1 text)"));
+
+        String insert = withKeyspace("INSERT INTO %s.tbl_trace_isolation (pk, v1) VALUES (1, 'hello')");
+        String expectedHeader = "WRITE_BYTES_REQUEST." + KEYSPACE + ".tbl_trace_isolation";
+
+        // Untraced INSERT — baseline WRITE_BYTES for the user table.
+        AtomicReference<Map<String, ByteBuffer>> refNoTrace = new AtomicReference<>();
+        cluster.get(1).acceptsOnInstance(
+               (IIsolatedExecutor.SerializableConsumer<AtomicReference<Map<String, ByteBuffer>>>)
+               (reference) -> {
+                   CassandraRelevantProperties.SENSORS_VIA_NATIVE_PROTOCOL.setBoolean(true);
+                   reference.set(executeWithResult(insert).getCustomPayload());
+               })
+               .accept(refNoTrace);
+        Map<String, ByteBuffer> payloadNoTrace = refNoTrace.get();
+        Assertions.assertThat(payloadNoTrace)
+                  .describedAs("Untraced INSERT must carry sensor payload")
+                  .isNotNull()
+                  .containsKey(expectedHeader);
+        double writeBytesNoTrace = ByteBufferUtil.toDouble(payloadNoTrace.get(expectedHeader));
+        Assertions.assertThat(writeBytesNoTrace)
+                  .describedAs("Untraced INSERT WRITE_BYTES must be > 0")
+                  .isGreaterThan(0D);
+
+        // Traced INSERT — Tracing.instance.newSession() is called inside the node's classloader so the
+        // TRACING thread-local is set correctly on the node side. The trace writes to system_traces must
+        // not appear in the user table's sensor payload.
+        // Use Object[] to carry both the custom payload map and the session UUID out of the node's
+        // isolated classloader in a single acceptsOnInstance call. Two-element array: [0] = payload
+        // map, [1] = session UUID. AtomicReference set inside the lambda only updates the node-side
+        // copy, so we use the consumer argument itself to ferry data back to the outer JVM.
+        Object[] tracedResult = new Object[2];
+        cluster.get(1).acceptsOnInstance(
+               (IIsolatedExecutor.SerializableConsumer<Object[]>)
+               (result) -> {
+                   CassandraRelevantProperties.SENSORS_VIA_NATIVE_PROTOCOL.setBoolean(true);
+                   // Ensure stopSession() waits for all Stage.TRACING futures so that
+                   // system_traces.sessions is durable before we query it after the call.
+                   int prevTimeout = TraceStateImpl.WAIT_FOR_PENDING_EVENTS_TIMEOUT_SECS;
+                   TraceStateImpl.WAIT_FOR_PENDING_EVENTS_TIMEOUT_SECS = 60;
+                   UUID sessionId = UUIDGen.getTimeUUID();
+                   result[1] = sessionId;
+                   Tracing.instance.newSession(ClientState.forInternalCalls(), sessionId, Collections.emptyMap());
+                   // begin() writes the system_traces.sessions row — mirrors what QueryMessage does
+                   // before executing the CQL statement in the native protocol handler.
+                   Tracing.instance.begin("Execute CQL3 query", null, Collections.emptyMap());
+                   try
+                   {
+                       result[0] = executeWithResult(insert).getCustomPayload();
+                   }
+                   finally
+                   {
+                       // stopSession() calls waitForPendingEvents(), which (with the timeout set above)
+                       // blocks until all Stage.TRACING futures complete — guaranteeing the sessions
+                       // row is written before we query system_traces below.
+                       Tracing.instance.stopSession();
+                       TraceStateImpl.WAIT_FOR_PENDING_EVENTS_TIMEOUT_SECS = prevTimeout;
+                   }
+               })
+               .accept(tracedResult);
+        @SuppressWarnings("unchecked")
+        Map<String, ByteBuffer> payloadTraced = (Map<String, ByteBuffer>) tracedResult[0];
+        UUID sessionId = (UUID) tracedResult[1];
+        Assertions.assertThat(payloadTraced)
+                  .describedAs("Traced INSERT must carry sensor payload")
+                  .isNotNull()
+                  .containsKey(expectedHeader);
+        double writeBytesTraced = ByteBufferUtil.toDouble(payloadTraced.get(expectedHeader));
+
+        // Verify tracing was genuinely active: system_traces.sessions must contain a row for
+        // our session_id, written by TraceStateImpl when the query started.
+        AtomicBoolean traceSessionExists = new AtomicBoolean(false);
+        cluster.get(1).acceptsOnInstance(
+               (IIsolatedExecutor.SerializableConsumer<AtomicBoolean>)
+               (flag) -> {
+                   UntypedResultSet rows = QueryProcessor.executeInternal(
+                           "SELECT session_id FROM " + SchemaConstants.TRACE_KEYSPACE_NAME + '.' + TraceKeyspace.SESSIONS + " WHERE session_id = ?",
+                           sessionId);
+                   flag.set(rows != null && !rows.isEmpty());
+               })
+               .accept(traceSessionExists);
+        Assertions.assertThat(traceSessionExists.get())
+                  .describedAs("system_traces.sessions must contain a row for session %s — confirms tracing was active", sessionId)
+                  .isTrue();
+
+        // Trace writes go to system_traces on a separate TRACING thread with an isolated sensor set.
+        // The user table's WRITE_BYTES must be unchanged — not inflated by trace writes.
+        Assertions.assertThat(writeBytesTraced)
+                  .describedAs("Enabling tracing must not inflate WRITE_BYTES for the user table")
+                  .isEqualTo(writeBytesNoTrace);
     }
 }

--- a/test/distributed/org/apache/cassandra/distributed/test/sensors/SensorsTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sensors/SensorsTest.java
@@ -202,15 +202,15 @@ public class SensorsTest extends TestBaseImpl
                                              "APPLY BATCH;", KEYSPACE, KEYSPACE);
 
         List<Object[]> result = new ArrayList<>();
-        result.add(new Object[]{ "tbl: insert",                      noPrep,                write,       new String[]{ WRITE_TBL },           true  });
-        result.add(new Object[]{ "tbl_counter: counter update",      noPrep,                counter,     new String[]{ WRITE_COUNTER },        true  });
-        result.add(new Object[]{ "tbl: point read (paging)",         new String[]{ write }, read,        new String[]{ READ_TBL },             true  });
-        result.add(new Object[]{ "tbl: point read (no paging)",      new String[]{ write }, read,        new String[]{ READ_TBL },             false });
-        result.add(new Object[]{ "tbl: CAS update",                  noPrep,                cas,         new String[]{ WRITE_TBL, READ_TBL },  true  });
-        result.add(new Object[]{ "tbl: logged batch insert",         noPrep,                loggedBatch, new String[]{ WRITE_TBL },            true  });
-        result.add(new Object[]{ "tbl: unlogged batch insert",       noPrep,                unloggedBatch, new String[]{ WRITE_TBL },          true  });
-        result.add(new Object[]{ "tbl: range read (paging)",         new String[]{ write }, range,       new String[]{ READ_TBL },             true  });
-        result.add(new Object[]{ "tbl: range read (no paging)",      new String[]{ write }, range,       new String[]{ READ_TBL },             false });
+        result.add(new Object[]{ "tbl: insert", noPrep, write, new String[]{ WRITE_TBL }, true });
+        result.add(new Object[]{ "tbl_counter: counter update", noPrep, counter, new String[]{ WRITE_COUNTER }, true });
+        result.add(new Object[]{ "tbl: point read (paging)", new String[]{ write }, read, new String[]{ READ_TBL }, true });
+        result.add(new Object[]{ "tbl: point read (no paging)", new String[]{ write }, read, new String[]{ READ_TBL }, false });
+        result.add(new Object[]{ "tbl: CAS update", noPrep, cas, new String[]{ WRITE_TBL, READ_TBL }, true });
+        result.add(new Object[]{ "tbl: logged batch insert", noPrep, loggedBatch, new String[]{ WRITE_TBL }, true });
+        result.add(new Object[]{ "tbl: unlogged batch insert", noPrep, unloggedBatch, new String[]{ WRITE_TBL }, true });
+        result.add(new Object[]{ "tbl: range read (paging)", new String[]{ write }, range, new String[]{ READ_TBL }, true });
+        result.add(new Object[]{ "tbl: range read (no paging)", new String[]{ write }, range, new String[]{ READ_TBL }, false });
         return result;
     }
 
@@ -258,16 +258,16 @@ public class SensorsTest extends TestBaseImpl
                                                        "APPLY BATCH;", KEYSPACE, KEYSPACE, KEYSPACE, KEYSPACE);
 
         List<Object[]> result = new ArrayList<>();
-        result.add(new Object[]{ "2i: insert (insertRow path)",               noPrep,                       write,                  new String[]{ WRITE_2I, INDEX_WRITE_2I },                       true  });
-        result.add(new Object[]{ "2i: logged batch insert",                   noPrep,                       loggedBatch,            new String[]{ WRITE_2I, INDEX_WRITE_2I },                       true  });
-        result.add(new Object[]{ "2i: unlogged batch insert",                 noPrep,                       unloggedBatch,          new String[]{ WRITE_2I, INDEX_WRITE_2I },                       true  });
-        result.add(new Object[]{ "2i: update (updateRow path)",               new String[]{ write },        writeUpdate,            new String[]{ WRITE_2I, INDEX_WRITE_2I },                       true  });
-        result.add(new Object[]{ "2i: logged batch update",                   new String[]{ loggedBatch },  loggedBatchUpdate,      new String[]{ WRITE_2I, INDEX_WRITE_2I },                       true  });
-        result.add(new Object[]{ "2i: unlogged batch update",                 new String[]{ unloggedBatch },unloggedBatchUpdate,    new String[]{ WRITE_2I, INDEX_WRITE_2I },                       true  });
-        result.add(new Object[]{ "2i: CAS IF NOT EXISTS (insertRow path)",    noPrep,                       casInsert,              new String[]{ WRITE_2I, READ_2I, INDEX_WRITE_2I },              true  });
-        result.add(new Object[]{ "2i: CAS IF condition (updateRow path)",     new String[]{ write },        cas,                    new String[]{ WRITE_2I, READ_2I, INDEX_WRITE_2I },              true  });
-        result.add(new Object[]{ "2i+sai: multi-table logged batch",          noPrep,                       multiTableLoggedBatch,  new String[]{ WRITE_2I, INDEX_WRITE_2I, WRITE_SAI, INDEX_WRITE_SAI }, true  });
-        result.add(new Object[]{ "2i+sai: multi-table unlogged batch",        noPrep,                       multiTableUnloggedBatch,new String[]{ WRITE_2I, INDEX_WRITE_2I, WRITE_SAI, INDEX_WRITE_SAI }, true  });
+        result.add(new Object[]{ "2i: insert (insertRow path)", noPrep, write, new String[]{ WRITE_2I, INDEX_WRITE_2I }, true });
+        result.add(new Object[]{ "2i: logged batch insert", noPrep, loggedBatch, new String[]{ WRITE_2I, INDEX_WRITE_2I }, true });
+        result.add(new Object[]{ "2i: unlogged batch insert", noPrep, unloggedBatch, new String[]{ WRITE_2I, INDEX_WRITE_2I }, true });
+        result.add(new Object[]{ "2i: update (updateRow path)", new String[]{ write }, writeUpdate, new String[]{ WRITE_2I, INDEX_WRITE_2I }, true });
+        result.add(new Object[]{ "2i: logged batch update", new String[]{ loggedBatch }, loggedBatchUpdate, new String[]{ WRITE_2I, INDEX_WRITE_2I }, true });
+        result.add(new Object[]{ "2i: unlogged batch update", new String[]{ unloggedBatch }, unloggedBatchUpdate, new String[]{ WRITE_2I, INDEX_WRITE_2I }, true });
+        result.add(new Object[]{ "2i: CAS IF NOT EXISTS (insertRow path)", noPrep, casInsert, new String[]{ WRITE_2I, READ_2I, INDEX_WRITE_2I }, true });
+        result.add(new Object[]{ "2i: CAS IF condition (updateRow path)", new String[]{ write }, cas, new String[]{ WRITE_2I, READ_2I, INDEX_WRITE_2I }, true });
+        result.add(new Object[]{ "2i+sai: multi-table logged batch", noPrep, multiTableLoggedBatch, new String[]{ WRITE_2I, INDEX_WRITE_2I, WRITE_SAI, INDEX_WRITE_SAI }, true });
+        result.add(new Object[]{ "2i+sai: multi-table unlogged batch", noPrep, multiTableUnloggedBatch, new String[]{ WRITE_2I, INDEX_WRITE_2I, WRITE_SAI, INDEX_WRITE_SAI }, true });
         return result;
     }
 
@@ -301,14 +301,14 @@ public class SensorsTest extends TestBaseImpl
                                                    "APPLY BATCH;", KEYSPACE, KEYSPACE);
 
         List<Object[]> result = new ArrayList<>();
-        result.add(new Object[]{ "sai: insert (insertRow path)",              noPrep,                       write,             new String[]{ WRITE_SAI, INDEX_WRITE_SAI },       true  });
-        result.add(new Object[]{ "sai: logged batch insert",                  noPrep,                       loggedBatch,       new String[]{ WRITE_SAI, INDEX_WRITE_SAI },       true  });
-        result.add(new Object[]{ "sai: unlogged batch insert",                noPrep,                       unloggedBatch,     new String[]{ WRITE_SAI, INDEX_WRITE_SAI },       true  });
-        result.add(new Object[]{ "sai: update (updateRow path)",              new String[]{ write },        writeUpdate,       new String[]{ WRITE_SAI, INDEX_WRITE_SAI },       true  });
-        result.add(new Object[]{ "sai: logged batch update",                  new String[]{ loggedBatch },  loggedBatchUpdate, new String[]{ WRITE_SAI, INDEX_WRITE_SAI },       true  });
-        result.add(new Object[]{ "sai: unlogged batch update",                new String[]{ unloggedBatch },unloggedBatchUpdate,new String[]{ WRITE_SAI, INDEX_WRITE_SAI },      true  });
-        result.add(new Object[]{ "sai: CAS IF NOT EXISTS (insertRow path)",   noPrep,                       casInsert,         new String[]{ WRITE_SAI, READ_SAI, INDEX_WRITE_SAI }, true  });
-        result.add(new Object[]{ "sai: CAS IF condition (updateRow path)",    new String[]{ write },        cas,               new String[]{ WRITE_SAI, READ_SAI, INDEX_WRITE_SAI }, true  });
+        result.add(new Object[]{ "sai: insert (insertRow path)", noPrep, write, new String[]{ WRITE_SAI, INDEX_WRITE_SAI }, true });
+        result.add(new Object[]{ "sai: logged batch insert", noPrep, loggedBatch, new String[]{ WRITE_SAI, INDEX_WRITE_SAI }, true });
+        result.add(new Object[]{ "sai: unlogged batch insert", noPrep, unloggedBatch, new String[]{ WRITE_SAI, INDEX_WRITE_SAI }, true });
+        result.add(new Object[]{ "sai: update (updateRow path)", new String[]{ write }, writeUpdate, new String[]{ WRITE_SAI, INDEX_WRITE_SAI }, true });
+        result.add(new Object[]{ "sai: logged batch update", new String[]{ loggedBatch }, loggedBatchUpdate, new String[]{ WRITE_SAI, INDEX_WRITE_SAI }, true });
+        result.add(new Object[]{ "sai: unlogged batch update", new String[]{ unloggedBatch }, unloggedBatchUpdate, new String[]{ WRITE_SAI, INDEX_WRITE_SAI }, true });
+        result.add(new Object[]{ "sai: CAS IF NOT EXISTS (insertRow path)", noPrep, casInsert, new String[]{ WRITE_SAI, READ_SAI, INDEX_WRITE_SAI }, true });
+        result.add(new Object[]{ "sai: CAS IF condition (updateRow path)", new String[]{ write }, cas, new String[]{ WRITE_SAI, READ_SAI, INDEX_WRITE_SAI }, true });
         return result;
     }
 
@@ -373,12 +373,12 @@ public class SensorsTest extends TestBaseImpl
                                                             "APPLY BATCH;", KEYSPACE, KEYSPACE);
 
         List<Object[]> result = new ArrayList<>();
-        result.add(new Object[]{ "2i cond batch: IF NOT EXISTS (insertRow)",    noPrep,                conditionalBatch2iInsert,   new String[]{ WRITE_2I, READ_2I, INDEX_WRITE_2I },    true  });
-        result.add(new Object[]{ "2i cond batch: IF condition (updateRow)",     new String[]{ prep2i },conditionalBatch2iUpdate,   new String[]{ WRITE_2I, READ_2I, INDEX_WRITE_2I },    true  });
-        result.add(new Object[]{ "2i cond batch: multi-stmt same partition",    noPrep,                conditionalBatch2iMultiStmt,new String[]{ WRITE_2I, READ_2I, INDEX_WRITE_2I },    true  });
-        result.add(new Object[]{ "sai cond batch: IF NOT EXISTS (insertRow)",   noPrep,                conditionalBatchSaiInsert,  new String[]{ WRITE_SAI, READ_SAI, INDEX_WRITE_SAI }, true  });
-        result.add(new Object[]{ "sai cond batch: IF condition (updateRow)",    new String[]{ prepSai },conditionalBatchSaiUpdate,  new String[]{ WRITE_SAI, READ_SAI, INDEX_WRITE_SAI }, true  });
-        result.add(new Object[]{ "sai cond batch: multi-stmt same partition",   noPrep,                conditionalBatchSaiMultiStmt,new String[]{ WRITE_SAI, READ_SAI, INDEX_WRITE_SAI },true  });
+        result.add(new Object[]{ "2i cond batch: IF NOT EXISTS (insertRow)", noPrep, conditionalBatch2iInsert, new String[]{ WRITE_2I, READ_2I, INDEX_WRITE_2I }, true });
+        result.add(new Object[]{ "2i cond batch: IF condition (updateRow)", new String[]{ prep2i }, conditionalBatch2iUpdate, new String[]{ WRITE_2I, READ_2I, INDEX_WRITE_2I }, true });
+        result.add(new Object[]{ "2i cond batch: multi-stmt same partition", noPrep, conditionalBatch2iMultiStmt, new String[]{ WRITE_2I, READ_2I, INDEX_WRITE_2I }, true });
+        result.add(new Object[]{ "sai cond batch: IF NOT EXISTS (insertRow)", noPrep, conditionalBatchSaiInsert, new String[]{ WRITE_SAI, READ_SAI, INDEX_WRITE_SAI }, true });
+        result.add(new Object[]{ "sai cond batch: IF condition (updateRow)", new String[]{ prepSai }, conditionalBatchSaiUpdate, new String[]{ WRITE_SAI, READ_SAI, INDEX_WRITE_SAI }, true });
+        result.add(new Object[]{ "sai cond batch: multi-stmt same partition", noPrep, conditionalBatchSaiMultiStmt, new String[]{ WRITE_SAI, READ_SAI, INDEX_WRITE_SAI }, true });
         return result;
     }
 

--- a/test/distributed/org/apache/cassandra/distributed/test/sensors/SensorsTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sensors/SensorsTest.java
@@ -46,7 +46,6 @@ import org.apache.cassandra.distributed.api.ConsistencyLevel;
 import org.apache.cassandra.distributed.api.IIsolatedExecutor;
 import org.apache.cassandra.distributed.test.TestBaseImpl;
 import org.apache.cassandra.index.sai.StorageAttachedIndex;
-import org.apache.cassandra.cql3.QueryProcessor;
 import org.apache.cassandra.cql3.UntypedResultSet;
 import org.apache.cassandra.schema.SchemaConstants;
 import org.apache.cassandra.sensors.ActiveSensorsFactory;
@@ -101,10 +100,10 @@ public class SensorsTest extends TestBaseImpl
     private static Cluster cluster;
 
     /**
-     * Table name for the scenario — kept for test name readability in parameterized output only.
+     * Human-readable scenario name used as the JUnit test display name.
      */
     @Parameterized.Parameter(0)
-    public String schema;
+    public String scenarioName;
 
     /**
      * Queries to be executed to prepare the table, for example insert some data before read to populate read sensors.
@@ -124,6 +123,15 @@ public class SensorsTest extends TestBaseImpl
      */
     @Parameterized.Parameter(3)
     public String[] expectedHeaders;
+
+    /**
+     * When {@code true}, the query is executed with a page size, which always takes the paging
+     * path ({@code execute(Pager,...)}). When {@code false}, no page size is supplied
+     * ({@link PageSize#NONE}), causing {@code canSkipPaging} to return {@code true} and routing
+     * execution through the distributed non-paging path ({@code execute(ReadQuery,...)}).
+     */
+    @Parameterized.Parameter(4)
+    public boolean paging;
 
     @BeforeClass
     public static void setupCluster() throws IOException
@@ -161,7 +169,7 @@ public class SensorsTest extends TestBaseImpl
         cluster.schemaChange(withKeyspace("TRUNCATE %s." + TBL_COL));
     }
 
-    @Parameterized.Parameters(name = "schema={0}, prepQueries={1}, testQuery={2}, expectedHeaders={3}")
+    @Parameterized.Parameters(name = "{0}")
     public static Collection<Object[]> data()
     {
         List<Object[]> result = new ArrayList<>();
@@ -194,13 +202,15 @@ public class SensorsTest extends TestBaseImpl
                                              "APPLY BATCH;", KEYSPACE, KEYSPACE);
 
         List<Object[]> result = new ArrayList<>();
-        result.add(new Object[]{ TBL, noPrep, write, new String[]{ WRITE_TBL } });
-        result.add(new Object[]{ TBL_COUNTER, noPrep, counter, new String[]{ WRITE_COUNTER } });
-        result.add(new Object[]{ TBL, new String[]{ write }, read, new String[]{ READ_TBL } });
-        result.add(new Object[]{ TBL, noPrep, cas, new String[]{ WRITE_TBL, READ_TBL } });
-        result.add(new Object[]{ TBL, noPrep, loggedBatch, new String[]{ WRITE_TBL } });
-        result.add(new Object[]{ TBL, noPrep, unloggedBatch, new String[]{ WRITE_TBL } });
-        result.add(new Object[]{ TBL, new String[]{ write }, range, new String[]{ READ_TBL } });
+        result.add(new Object[]{ "tbl: insert",                      noPrep,                write,       new String[]{ WRITE_TBL },           true  });
+        result.add(new Object[]{ "tbl_counter: counter update",      noPrep,                counter,     new String[]{ WRITE_COUNTER },        true  });
+        result.add(new Object[]{ "tbl: point read (paging)",         new String[]{ write }, read,        new String[]{ READ_TBL },             true  });
+        result.add(new Object[]{ "tbl: point read (no paging)",      new String[]{ write }, read,        new String[]{ READ_TBL },             false });
+        result.add(new Object[]{ "tbl: CAS update",                  noPrep,                cas,         new String[]{ WRITE_TBL, READ_TBL },  true  });
+        result.add(new Object[]{ "tbl: logged batch insert",         noPrep,                loggedBatch, new String[]{ WRITE_TBL },            true  });
+        result.add(new Object[]{ "tbl: unlogged batch insert",       noPrep,                unloggedBatch, new String[]{ WRITE_TBL },          true  });
+        result.add(new Object[]{ "tbl: range read (paging)",         new String[]{ write }, range,       new String[]{ READ_TBL },             true  });
+        result.add(new Object[]{ "tbl: range read (no paging)",      new String[]{ write }, range,       new String[]{ READ_TBL },             false });
         return result;
     }
 
@@ -248,20 +258,16 @@ public class SensorsTest extends TestBaseImpl
                                                        "APPLY BATCH;", KEYSPACE, KEYSPACE, KEYSPACE, KEYSPACE);
 
         List<Object[]> result = new ArrayList<>();
-        // inserts: insertRow path
-        result.add(new Object[]{ TBL_2I, noPrep, write, new String[]{ WRITE_2I, INDEX_WRITE_2I } });
-        result.add(new Object[]{ TBL_2I, noPrep, loggedBatch, new String[]{ WRITE_2I, INDEX_WRITE_2I } });
-        result.add(new Object[]{ TBL_2I, noPrep, unloggedBatch, new String[]{ WRITE_2I, INDEX_WRITE_2I } });
-        // updates: updateRow path (row pre-exists, new value differs to ensure index allocation)
-        result.add(new Object[]{ TBL_2I, new String[]{ write }, writeUpdate, new String[]{ WRITE_2I, INDEX_WRITE_2I } });
-        result.add(new Object[]{ TBL_2I, new String[]{ loggedBatch }, loggedBatchUpdate, new String[]{ WRITE_2I, INDEX_WRITE_2I } });
-        result.add(new Object[]{ TBL_2I, new String[]{ unloggedBatch }, unloggedBatchUpdate, new String[]{ WRITE_2I, INDEX_WRITE_2I } });
-        // CAS: IF NOT EXISTS (insertRow path) and IF condition (updateRow path)
-        result.add(new Object[]{ TBL_2I, noPrep, casInsert, new String[]{ WRITE_2I, READ_2I, INDEX_WRITE_2I } });
-        result.add(new Object[]{ TBL_2I, new String[]{ write }, cas, new String[]{ WRITE_2I, READ_2I, INDEX_WRITE_2I } });
-        // multi-table: sensors from both tbl_2i and tbl_sai must be present in the response
-        result.add(new Object[]{ TBL_2I + "+" + TBL_SAI, noPrep, multiTableLoggedBatch, new String[]{ WRITE_2I, INDEX_WRITE_2I, WRITE_SAI, INDEX_WRITE_SAI } });
-        result.add(new Object[]{ TBL_2I + "+" + TBL_SAI, noPrep, multiTableUnloggedBatch, new String[]{ WRITE_2I, INDEX_WRITE_2I, WRITE_SAI, INDEX_WRITE_SAI } });
+        result.add(new Object[]{ "2i: insert (insertRow path)",               noPrep,                       write,                  new String[]{ WRITE_2I, INDEX_WRITE_2I },                       true  });
+        result.add(new Object[]{ "2i: logged batch insert",                   noPrep,                       loggedBatch,            new String[]{ WRITE_2I, INDEX_WRITE_2I },                       true  });
+        result.add(new Object[]{ "2i: unlogged batch insert",                 noPrep,                       unloggedBatch,          new String[]{ WRITE_2I, INDEX_WRITE_2I },                       true  });
+        result.add(new Object[]{ "2i: update (updateRow path)",               new String[]{ write },        writeUpdate,            new String[]{ WRITE_2I, INDEX_WRITE_2I },                       true  });
+        result.add(new Object[]{ "2i: logged batch update",                   new String[]{ loggedBatch },  loggedBatchUpdate,      new String[]{ WRITE_2I, INDEX_WRITE_2I },                       true  });
+        result.add(new Object[]{ "2i: unlogged batch update",                 new String[]{ unloggedBatch },unloggedBatchUpdate,    new String[]{ WRITE_2I, INDEX_WRITE_2I },                       true  });
+        result.add(new Object[]{ "2i: CAS IF NOT EXISTS (insertRow path)",    noPrep,                       casInsert,              new String[]{ WRITE_2I, READ_2I, INDEX_WRITE_2I },              true  });
+        result.add(new Object[]{ "2i: CAS IF condition (updateRow path)",     new String[]{ write },        cas,                    new String[]{ WRITE_2I, READ_2I, INDEX_WRITE_2I },              true  });
+        result.add(new Object[]{ "2i+sai: multi-table logged batch",          noPrep,                       multiTableLoggedBatch,  new String[]{ WRITE_2I, INDEX_WRITE_2I, WRITE_SAI, INDEX_WRITE_SAI }, true  });
+        result.add(new Object[]{ "2i+sai: multi-table unlogged batch",        noPrep,                       multiTableUnloggedBatch,new String[]{ WRITE_2I, INDEX_WRITE_2I, WRITE_SAI, INDEX_WRITE_SAI }, true  });
         return result;
     }
 
@@ -295,17 +301,14 @@ public class SensorsTest extends TestBaseImpl
                                                    "APPLY BATCH;", KEYSPACE, KEYSPACE);
 
         List<Object[]> result = new ArrayList<>();
-        // inserts: insertRow path
-        result.add(new Object[]{ TBL_SAI, noPrep, write, new String[]{ WRITE_SAI, INDEX_WRITE_SAI } });
-        result.add(new Object[]{ TBL_SAI, noPrep, loggedBatch, new String[]{ WRITE_SAI, INDEX_WRITE_SAI } });
-        result.add(new Object[]{ TBL_SAI, noPrep, unloggedBatch, new String[]{ WRITE_SAI, INDEX_WRITE_SAI } });
-        // updates: updateRow path (row pre-exists, new value differs to ensure index allocation)
-        result.add(new Object[]{ TBL_SAI, new String[]{ write }, writeUpdate, new String[]{ WRITE_SAI, INDEX_WRITE_SAI } });
-        result.add(new Object[]{ TBL_SAI, new String[]{ loggedBatch }, loggedBatchUpdate, new String[]{ WRITE_SAI, INDEX_WRITE_SAI } });
-        result.add(new Object[]{ TBL_SAI, new String[]{ unloggedBatch }, unloggedBatchUpdate, new String[]{ WRITE_SAI, INDEX_WRITE_SAI } });
-        // CAS: IF NOT EXISTS (insertRow path) and IF condition (updateRow path)
-        result.add(new Object[]{ TBL_SAI, noPrep, casInsert, new String[]{ WRITE_SAI, READ_SAI, INDEX_WRITE_SAI } });
-        result.add(new Object[]{ TBL_SAI, new String[]{ write }, cas, new String[]{ WRITE_SAI, READ_SAI, INDEX_WRITE_SAI } });
+        result.add(new Object[]{ "sai: insert (insertRow path)",              noPrep,                       write,             new String[]{ WRITE_SAI, INDEX_WRITE_SAI },       true  });
+        result.add(new Object[]{ "sai: logged batch insert",                  noPrep,                       loggedBatch,       new String[]{ WRITE_SAI, INDEX_WRITE_SAI },       true  });
+        result.add(new Object[]{ "sai: unlogged batch insert",                noPrep,                       unloggedBatch,     new String[]{ WRITE_SAI, INDEX_WRITE_SAI },       true  });
+        result.add(new Object[]{ "sai: update (updateRow path)",              new String[]{ write },        writeUpdate,       new String[]{ WRITE_SAI, INDEX_WRITE_SAI },       true  });
+        result.add(new Object[]{ "sai: logged batch update",                  new String[]{ loggedBatch },  loggedBatchUpdate, new String[]{ WRITE_SAI, INDEX_WRITE_SAI },       true  });
+        result.add(new Object[]{ "sai: unlogged batch update",                new String[]{ unloggedBatch },unloggedBatchUpdate,new String[]{ WRITE_SAI, INDEX_WRITE_SAI },      true  });
+        result.add(new Object[]{ "sai: CAS IF NOT EXISTS (insertRow path)",   noPrep,                       casInsert,         new String[]{ WRITE_SAI, READ_SAI, INDEX_WRITE_SAI }, true  });
+        result.add(new Object[]{ "sai: CAS IF condition (updateRow path)",    new String[]{ write },        cas,               new String[]{ WRITE_SAI, READ_SAI, INDEX_WRITE_SAI }, true  });
         return result;
     }
 
@@ -319,8 +322,8 @@ public class SensorsTest extends TestBaseImpl
         String collectionUpdate = withKeyspace("INSERT INTO %s." + TBL_COL + "(pk, tags) VALUES (1, {'c', 'd'})");
 
         List<Object[]> result = new ArrayList<>();
-        result.add(new Object[]{ TBL_COL, new String[0], collectionWrite, new String[]{ WRITE_COL, INDEX_WRITE_COL } });
-        result.add(new Object[]{ TBL_COL, new String[]{ collectionWrite }, collectionUpdate, new String[]{ WRITE_COL, INDEX_WRITE_COL } });
+        result.add(new Object[]{ "sai collection: insert",  new String[0],                   collectionWrite,  new String[]{ WRITE_COL, INDEX_WRITE_COL }, true  });
+        result.add(new Object[]{ "sai collection: update",  new String[]{ collectionWrite },  collectionUpdate, new String[]{ WRITE_COL, INDEX_WRITE_COL }, true  });
         return result;
     }
 
@@ -370,16 +373,12 @@ public class SensorsTest extends TestBaseImpl
                                                             "APPLY BATCH;", KEYSPACE, KEYSPACE);
 
         List<Object[]> result = new ArrayList<>();
-        // 2i conditional batch: IF NOT EXISTS (insert path) and IF condition (update path)
-        result.add(new Object[]{ TBL_2I, noPrep, conditionalBatch2iInsert, new String[]{ WRITE_2I, READ_2I, INDEX_WRITE_2I } });
-        result.add(new Object[]{ TBL_2I, new String[]{ prep2i }, conditionalBatch2iUpdate, new String[]{ WRITE_2I, READ_2I, INDEX_WRITE_2I } });
-        // 2i conditional batch: multiple statements on same partition (duplicate TableMetadata in statements list)
-        result.add(new Object[]{ TBL_2I, noPrep, conditionalBatch2iMultiStmt, new String[]{ WRITE_2I, READ_2I, INDEX_WRITE_2I } });
-        // SAI conditional batch: IF NOT EXISTS (insert path) and IF condition (update path)
-        result.add(new Object[]{ TBL_SAI, noPrep, conditionalBatchSaiInsert, new String[]{ WRITE_SAI, READ_SAI, INDEX_WRITE_SAI } });
-        result.add(new Object[]{ TBL_SAI, new String[]{ prepSai }, conditionalBatchSaiUpdate, new String[]{ WRITE_SAI, READ_SAI, INDEX_WRITE_SAI } });
-        // SAI conditional batch: multiple statements on same partition (duplicate TableMetadata in statements list)
-        result.add(new Object[]{ TBL_SAI, noPrep, conditionalBatchSaiMultiStmt, new String[]{ WRITE_SAI, READ_SAI, INDEX_WRITE_SAI } });
+        result.add(new Object[]{ "2i cond batch: IF NOT EXISTS (insertRow)",    noPrep,                conditionalBatch2iInsert,   new String[]{ WRITE_2I, READ_2I, INDEX_WRITE_2I },    true  });
+        result.add(new Object[]{ "2i cond batch: IF condition (updateRow)",     new String[]{ prep2i },conditionalBatch2iUpdate,   new String[]{ WRITE_2I, READ_2I, INDEX_WRITE_2I },    true  });
+        result.add(new Object[]{ "2i cond batch: multi-stmt same partition",    noPrep,                conditionalBatch2iMultiStmt,new String[]{ WRITE_2I, READ_2I, INDEX_WRITE_2I },    true  });
+        result.add(new Object[]{ "sai cond batch: IF NOT EXISTS (insertRow)",   noPrep,                conditionalBatchSaiInsert,  new String[]{ WRITE_SAI, READ_SAI, INDEX_WRITE_SAI }, true  });
+        result.add(new Object[]{ "sai cond batch: IF condition (updateRow)",    new String[]{ prepSai },conditionalBatchSaiUpdate,  new String[]{ WRITE_SAI, READ_SAI, INDEX_WRITE_SAI }, true  });
+        result.add(new Object[]{ "sai cond batch: multi-stmt same partition",   noPrep,                conditionalBatchSaiMultiStmt,new String[]{ WRITE_SAI, READ_SAI, INDEX_WRITE_SAI },true  });
         return result;
     }
 
@@ -410,6 +409,8 @@ public class SensorsTest extends TestBaseImpl
 
     /**
      * Execute the test with the given {@code propagateViaNativeProtocol} flag and return the custom payload.
+     * Routes through {@link #executeWithResultNoPaging} when {@link #paging} is {@code false},
+     * otherwise through {@link #executeWithResult}.
      */
     private Map<String, ByteBuffer> executeTest(boolean propagateViaNativeProtocol) throws Throwable
     {
@@ -418,6 +419,7 @@ public class SensorsTest extends TestBaseImpl
             cluster.coordinator(1).execute(prepQuery, ConsistencyLevel.ALL);
         // work around serializability of @Parameterized.Parameter by providing a locally scoped variable
         String query = this.testQuery;
+        boolean paging = this.paging;
         // The cluster is shared across scenarios, so SENSORS_VIA_NATIVE_PROTOCOL must be set inside the node's
         // classloader via runOnInstance rather than on the outer test JVM — the node won't see outer JVM property changes.
         // Any methods used inside the runOnInstance() block should be static, otherwise java.io.NotSerializableException will be thrown
@@ -425,7 +427,8 @@ public class SensorsTest extends TestBaseImpl
                (IIsolatedExecutor.SerializableConsumer<AtomicReference<Map<String, ByteBuffer>>>)
                (reference) -> {
                    CassandraRelevantProperties.SENSORS_VIA_NATIVE_PROTOCOL.setBoolean(propagateViaNativeProtocol);
-                   reference.set(executeWithResult(query).getCustomPayload());
+                   ResultMessage<?> result = paging ? executeWithResult(query) : executeWithResultNoPaging(query);
+                   reference.set(result.getCustomPayload());
                })
                .accept(customPayload);
         return customPayload.get();
@@ -437,24 +440,29 @@ public class SensorsTest extends TestBaseImpl
         return ByteBufferUtil.toDouble(customPayload.get(expectedHeader));
     }
 
-    /**
-     * TODO: update SimpleQueryResult in the dtest-api project to expose custom payload and use Coordinator##executeWithResult instead
-     */
+    /** TODO: update SimpleQueryResult in the dtest-api project to expose custom payload and use Coordinator##executeWithResult instead */
     private static ResultMessage<?> executeWithResult(String query)
+    {
+        return executeWithResult(query, PageSize.inRows(512));
+    }
+
+    /**
+     * Like {@link #executeWithResult(String)} but passes {@link PageSize#NONE} so that
+     * {@code canSkipPaging} returns {@code true} and the distributed non-paging path
+     * ({@code execute(ReadQuery,...)}) is taken instead of the paging path.
+     */
+    private static ResultMessage<?> executeWithResultNoPaging(String query)
+    {
+        return executeWithResult(query, PageSize.NONE);
+    }
+
+    private static ResultMessage<?> executeWithResult(String query, PageSize pageSize)
     {
         long nanoTime = System.nanoTime();
         QueryHandler.Prepared prepared = QueryProcessor.prepareInternal(query);
-        ConsistencyLevel consistencyLevel = ConsistencyLevel.valueOf(CONSISTENCY_LEVEL.name());
-        org.apache.cassandra.db.ConsistencyLevel cl = org.apache.cassandra.db.ConsistencyLevel.fromCode(consistencyLevel.ordinal());
-        QueryOptions initialOptions = QueryOptions.create(cl,
-                                                          null,
-                                                          false,
-                                                          PageSize.inRows(512),
-                                                          null,
-                                                          null,
-                                                          ProtocolVersion.CURRENT,
-                                                          prepared.keyspace);
-        return prepared.statement.execute(QueryProcessor.internalQueryState(), initialOptions, nanoTime);
+        org.apache.cassandra.db.ConsistencyLevel cl = org.apache.cassandra.db.ConsistencyLevel.fromCode(ConsistencyLevel.valueOf(CONSISTENCY_LEVEL.name()).ordinal());
+        QueryOptions options = QueryOptions.create(cl, null, false, pageSize, null, null, ProtocolVersion.CURRENT, prepared.keyspace);
+        return prepared.statement.execute(QueryProcessor.internalQueryState(), options, nanoTime);
     }
 
     /**

--- a/test/unit/org/apache/cassandra/sensors/ReplicaSensorsTrackingTest.java
+++ b/test/unit/org/apache/cassandra/sensors/ReplicaSensorsTrackingTest.java
@@ -340,18 +340,24 @@ public class ReplicaSensorsTrackingTest
         RequestSensors requestSensors = new ActiveRequestSensors();
         Context context = Context.from(cfs.metadata());
         requestSensors.registerSensor(context, Type.WRITE_BYTES);
+        requestSensors.registerSensor(context, Type.INDEX_WRITE_BYTES);
         Sensor actualWriteSensor = requestSensors.getSensor(context, Type.WRITE_BYTES).get();
+        Sensor actualIndexWriteSensor = requestSensors.getSensor(context, Type.INDEX_WRITE_BYTES).get();
         ExecutorLocals locals = ExecutorLocals.create(requestSensors);
         ExecutorLocals.set(locals);
 
         // init callback
         AbstractWriteResponseHandler<?> callback = createWriteResponseHandler(ConsistencyLevel.ALL, ConsistencyLevel.ALL);
 
-        // mimic a sensor to be used in replica response
+        // mimic sensors to be used in replica response
         Sensor mockingWriteSensor = new mockingSensor(context, Type.WRITE_BYTES);
         mockingWriteSensor.increment(13.0);
+        Sensor mockingIndexWriteSensor = new mockingSensor(context, Type.INDEX_WRITE_BYTES);
+        mockingIndexWriteSensor.increment(7.0);
 
-        assertReplicaSensorsTracked(writeRequest, callback, allowHints, Pair.create(actualWriteSensor, mockingWriteSensor));
+        assertReplicaSensorsTracked(writeRequest, callback, allowHints,
+                                    Pair.create(actualWriteSensor, mockingWriteSensor),
+                                    Pair.create(actualIndexWriteSensor, mockingIndexWriteSensor));
     }
 
     @SafeVarargs

--- a/test/unit/org/apache/cassandra/sensors/ReplicaSensorsTrackingTest.java
+++ b/test/unit/org/apache/cassandra/sensors/ReplicaSensorsTrackingTest.java
@@ -269,8 +269,10 @@ public class ReplicaSensorsTrackingTest
         Context context = Context.from(cfs.metadata());
         requestSensors.registerSensor(context, Type.WRITE_BYTES);
         requestSensors.registerSensor(context, Type.READ_BYTES);
+        requestSensors.registerSensor(context, Type.INDEX_WRITE_BYTES);
         Sensor actualWriteSensor = requestSensors.getSensor(context, Type.WRITE_BYTES).get();
         Sensor actualReadSensor = requestSensors.getSensor(context, Type.READ_BYTES).get();
+        Sensor actualIndexWriteSensor = requestSensors.getSensor(context, Type.INDEX_WRITE_BYTES).get();
         ExecutorLocals locals = ExecutorLocals.create(requestSensors);
         ExecutorLocals.set(locals);
 
@@ -282,10 +284,13 @@ public class ReplicaSensorsTrackingTest
         mockingPrepareWriteSensor.increment(13.0);
         Sensor mockingPrepareReadSensor = new mockingSensor(context, Type.READ_BYTES);
         mockingPrepareReadSensor.increment(14.0);
+        Sensor mockingPrepareIndexWriteSensor = new mockingSensor(context, Type.INDEX_WRITE_BYTES);
+        mockingPrepareIndexWriteSensor.increment(15.0);
         Pair<Sensor, Sensor> prepareWriterSensors = Pair.create(actualWriteSensor, mockingPrepareWriteSensor);
         Pair<Sensor, Sensor> prepareReadSensors = Pair.create(actualReadSensor, mockingPrepareReadSensor);
+        Pair<Sensor, Sensor> prepareIndexWriteSensors = Pair.create(actualIndexWriteSensor, mockingPrepareIndexWriteSensor);
 
-        assertReplicaSensorsTracked(prepare, callback, prepareWriterSensors, prepareReadSensors);
+        assertReplicaSensorsTracked(prepare, callback, prepareWriterSensors, prepareReadSensors, prepareIndexWriteSensors);
     }
 
     @Test
@@ -304,8 +309,10 @@ public class ReplicaSensorsTrackingTest
         Context context = Context.from(cfs.metadata());
         requestSensors.registerSensor(context, Type.WRITE_BYTES);
         requestSensors.registerSensor(context, Type.READ_BYTES);
+        requestSensors.registerSensor(context, Type.INDEX_WRITE_BYTES);
         Sensor actualWriteSensor = requestSensors.getSensor(context, Type.WRITE_BYTES).get();
         Sensor actualReadSensor = requestSensors.getSensor(context, Type.READ_BYTES).get();
+        Sensor actualIndexWriteSensor = requestSensors.getSensor(context, Type.INDEX_WRITE_BYTES).get();
         ExecutorLocals locals = ExecutorLocals.create(requestSensors);
         ExecutorLocals.set(locals);
 
@@ -316,10 +323,13 @@ public class ReplicaSensorsTrackingTest
         mockingProposeWriteSensor.increment(15.0);
         Sensor mockingProposeReadSensor = new mockingSensor(context, Type.READ_BYTES);
         mockingProposeReadSensor.increment(16.0);
+        Sensor mockingProposeIndexWriteSensor = new mockingSensor(context, Type.INDEX_WRITE_BYTES);
+        mockingProposeIndexWriteSensor.increment(17.0);
         Pair<Sensor, Sensor> proposeWriterSensors = Pair.create(actualWriteSensor, mockingProposeWriteSensor);
         Pair<Sensor, Sensor> proposeReadSensors = Pair.create(actualReadSensor, mockingProposeReadSensor);
+        Pair<Sensor, Sensor> proposeIndexWriteSensors = Pair.create(actualIndexWriteSensor, mockingProposeIndexWriteSensor);
 
-        assertReplicaSensorsTracked(propose, callback, proposeWriterSensors, proposeReadSensors);
+        assertReplicaSensorsTracked(propose, callback, proposeWriterSensors, proposeReadSensors, proposeIndexWriteSensors);
     }
 
     /**

--- a/test/unit/org/apache/cassandra/sensors/ReplicaSensorsTrackingTest.java
+++ b/test/unit/org/apache/cassandra/sensors/ReplicaSensorsTrackingTest.java
@@ -264,15 +264,14 @@ public class ReplicaSensorsTrackingTest
         Mutation mutation = new RowUpdateBuilder(cfs.metadata(), 0, "0").build();
         Message<Mutation> prepare = Message.builder(Verb.PAXOS_PREPARE_REQ, mutation).build();
 
-        // init request sensors, must happen before the callback is created
+        // init request sensors, must happen before the callback is created.
+        // INDEX_WRITE_BYTES is intentionally not registered: prepare only writes to system.paxos, which has no indexes.
         RequestSensors requestSensors = new ActiveRequestSensors();
         Context context = Context.from(cfs.metadata());
         requestSensors.registerSensor(context, Type.WRITE_BYTES);
         requestSensors.registerSensor(context, Type.READ_BYTES);
-        requestSensors.registerSensor(context, Type.INDEX_WRITE_BYTES);
         Sensor actualWriteSensor = requestSensors.getSensor(context, Type.WRITE_BYTES).get();
         Sensor actualReadSensor = requestSensors.getSensor(context, Type.READ_BYTES).get();
-        Sensor actualIndexWriteSensor = requestSensors.getSensor(context, Type.INDEX_WRITE_BYTES).get();
         ExecutorLocals locals = ExecutorLocals.create(requestSensors);
         ExecutorLocals.set(locals);
 
@@ -284,13 +283,10 @@ public class ReplicaSensorsTrackingTest
         mockingPrepareWriteSensor.increment(13.0);
         Sensor mockingPrepareReadSensor = new mockingSensor(context, Type.READ_BYTES);
         mockingPrepareReadSensor.increment(14.0);
-        Sensor mockingPrepareIndexWriteSensor = new mockingSensor(context, Type.INDEX_WRITE_BYTES);
-        mockingPrepareIndexWriteSensor.increment(15.0);
         Pair<Sensor, Sensor> prepareWriterSensors = Pair.create(actualWriteSensor, mockingPrepareWriteSensor);
         Pair<Sensor, Sensor> prepareReadSensors = Pair.create(actualReadSensor, mockingPrepareReadSensor);
-        Pair<Sensor, Sensor> prepareIndexWriteSensors = Pair.create(actualIndexWriteSensor, mockingPrepareIndexWriteSensor);
 
-        assertReplicaSensorsTracked(prepare, callback, prepareWriterSensors, prepareReadSensors, prepareIndexWriteSensors);
+        assertReplicaSensorsTracked(prepare, callback, prepareWriterSensors, prepareReadSensors);
     }
 
     @Test
@@ -304,15 +300,14 @@ public class ReplicaSensorsTrackingTest
         Mutation mutation = new RowUpdateBuilder(cfs.metadata(), 0, "0").build();
         Message<Mutation> propose = Message.builder(Verb.PAXOS_PROPOSE_REQ, mutation).build();
 
-        // init request sensors, must happen before the callback is created
+        // init request sensors, must happen before the callback is created.
+        // INDEX_WRITE_BYTES is intentionally not registered: propose only writes to system.paxos, which has no indexes.
         RequestSensors requestSensors = new ActiveRequestSensors();
         Context context = Context.from(cfs.metadata());
         requestSensors.registerSensor(context, Type.WRITE_BYTES);
         requestSensors.registerSensor(context, Type.READ_BYTES);
-        requestSensors.registerSensor(context, Type.INDEX_WRITE_BYTES);
         Sensor actualWriteSensor = requestSensors.getSensor(context, Type.WRITE_BYTES).get();
         Sensor actualReadSensor = requestSensors.getSensor(context, Type.READ_BYTES).get();
-        Sensor actualIndexWriteSensor = requestSensors.getSensor(context, Type.INDEX_WRITE_BYTES).get();
         ExecutorLocals locals = ExecutorLocals.create(requestSensors);
         ExecutorLocals.set(locals);
 
@@ -323,13 +318,10 @@ public class ReplicaSensorsTrackingTest
         mockingProposeWriteSensor.increment(15.0);
         Sensor mockingProposeReadSensor = new mockingSensor(context, Type.READ_BYTES);
         mockingProposeReadSensor.increment(16.0);
-        Sensor mockingProposeIndexWriteSensor = new mockingSensor(context, Type.INDEX_WRITE_BYTES);
-        mockingProposeIndexWriteSensor.increment(17.0);
         Pair<Sensor, Sensor> proposeWriterSensors = Pair.create(actualWriteSensor, mockingProposeWriteSensor);
         Pair<Sensor, Sensor> proposeReadSensors = Pair.create(actualReadSensor, mockingProposeReadSensor);
-        Pair<Sensor, Sensor> proposeIndexWriteSensors = Pair.create(actualIndexWriteSensor, mockingProposeIndexWriteSensor);
 
-        assertReplicaSensorsTracked(propose, callback, proposeWriterSensors, proposeReadSensors, proposeIndexWriteSensors);
+        assertReplicaSensorsTracked(propose, callback, proposeWriterSensors, proposeReadSensors);
     }
 
     /**

--- a/test/unit/org/apache/cassandra/sensors/SensorsIndexWriteTest.java
+++ b/test/unit/org/apache/cassandra/sensors/SensorsIndexWriteTest.java
@@ -134,12 +134,50 @@ public class SensorsIndexWriteTest
     }
 
     /**
-     * Tests that INDEX_WRITE_BYTES is tracked when a Paxos commit applies a mutation to a table with a secondary index.
+     * Tests that INDEX_WRITE_BYTES is tracked when a Paxos commit applies a mutation to a table with an SAI index.
      * Only the Commit phase is tested here because it is the only Paxos phase that writes to the base table and
-     * triggers secondary index updaters. The Prepare and Propose phases exclusively read and write the system.paxos
-     * table (via SystemKeyspace.loadPaxosState / savePaxosPromise / savePaxosProposal), which has no secondary indexes,
+     * triggers SAI index updaters. The Prepare and Propose phases exclusively read and write the system.paxos table
+     * (via SystemKeyspace.loadPaxosState / savePaxosPromise / savePaxosProposal), which has no SAI indexes,
      * and the SystemKeyspace.trackPaxosBytes transfer mechanism only transfers WRITE_BYTES and READ_BYTES — never
      * INDEX_WRITE_BYTES — so those phases will always produce a zero value for INDEX_WRITE_BYTES.
+     */
+    @Test
+    public void testPaxosCommitWithSAI()
+    {
+        ColumnFamilyStore saiStore = SensorsTestUtil.discardSSTables(KEYSPACE1, CF_STANDARD_SAI);
+        Context context = new Context(KEYSPACE1, CF_STANDARD_SAI, saiStore.metadata.id.toString());
+
+        PartitionUpdate update = new RowUpdateBuilder(saiStore.metadata(), 0, "0")
+                                 .add("val", "hi there")
+                                 .buildUpdate();
+        Commit commit = Commit.newProposal(UUIDGen.getTimeUUID(), update);
+        CommitVerbHandler.instance.doVerb(Message.builder(Verb.PAXOS_COMMIT_REQ, commit).build());
+
+        // INDEX_WRITE_BYTES must be tracked for a Paxos commit on a table with an SAI index
+        Sensor indexWriteSensor = SensorsTestUtil.getThreadLocalRequestSensor(context, Type.INDEX_WRITE_BYTES);
+        assertThat(indexWriteSensor).isNotNull();
+        assertThat(indexWriteSensor.getValue()).isGreaterThan(0);
+
+        // WRITE_BYTES must also be tracked
+        Sensor writeSensor = SensorsTestUtil.getThreadLocalRequestSensor(context, Type.WRITE_BYTES);
+        assertThat(writeSensor).isNotNull();
+        assertThat(writeSensor.getValue()).isGreaterThan(0);
+
+        // INDEX_WRITE_BYTES must be encoded in the response message custom params
+        Message lastMessage = capturedOutboundMessages.get(capturedOutboundMessages.size() - 1);
+        String indexWriteParam = SensorsCustomParams.paramForRequestSensor(indexWriteSensor).get();
+        assertThat(lastMessage.header.customParams()).containsKey(indexWriteParam);
+        double encodedValue = SensorsTestUtil.bytesToDouble(lastMessage.header.customParams().get(indexWriteParam));
+        assertThat(encodedValue).isEqualTo(indexWriteSensor.getValue());
+    }
+
+    /**
+     * Tests that INDEX_WRITE_BYTES is tracked when a Paxos commit applies a mutation to a table with a secondary
+     * (2i) index. Only the Commit phase is tested here because it is the only Paxos phase that writes to the base
+     * table and triggers secondary index updaters. The Prepare and Propose phases exclusively read and write the
+     * system.paxos table (via SystemKeyspace.loadPaxosState / savePaxosPromise / savePaxosProposal), which has no
+     * secondary indexes, and the SystemKeyspace.trackPaxosBytes transfer mechanism only transfers WRITE_BYTES and
+     * READ_BYTES — never INDEX_WRITE_BYTES — so those phases will always produce a zero value for INDEX_WRITE_BYTES.
      */
     @Test
     public void testPaxosCommitWithSecondaryIndex()

--- a/test/unit/org/apache/cassandra/sensors/SensorsIndexWriteTest.java
+++ b/test/unit/org/apache/cassandra/sensors/SensorsIndexWriteTest.java
@@ -39,6 +39,7 @@ import org.apache.cassandra.db.MutationVerbHandler;
 import org.apache.cassandra.db.RowUpdateBuilder;
 import org.apache.cassandra.db.compaction.CompactionManager;
 import org.apache.cassandra.db.marshal.AsciiType;
+import org.apache.cassandra.db.partitions.PartitionUpdate;
 import org.apache.cassandra.dht.Murmur3Partitioner;
 import org.apache.cassandra.index.sai.StorageAttachedIndex;
 import org.apache.cassandra.io.util.DataOutputBuffer;
@@ -48,7 +49,10 @@ import org.apache.cassandra.net.Verb;
 import org.apache.cassandra.schema.IndexMetadata;
 import org.apache.cassandra.schema.Indexes;
 import org.apache.cassandra.schema.KeyspaceParams;
+import org.apache.cassandra.service.paxos.Commit;
+import org.apache.cassandra.service.paxos.CommitVerbHandler;
 import org.apache.cassandra.utils.BloomFilter;
+import org.apache.cassandra.utils.UUIDGen;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -127,6 +131,44 @@ public class SensorsIndexWriteTest
         SensorsRegistry.instance.clear();
 
         BloomFilter.recreateOnFPChanceChange = false;
+    }
+
+    /**
+     * Tests that INDEX_WRITE_BYTES is tracked when a Paxos commit applies a mutation to a table with a secondary index.
+     * Only the Commit phase is tested here because it is the only Paxos phase that writes to the base table and
+     * triggers secondary index updaters. The Prepare and Propose phases exclusively read and write the system.paxos
+     * table (via SystemKeyspace.loadPaxosState / savePaxosPromise / savePaxosProposal), which has no secondary indexes,
+     * and the SystemKeyspace.trackPaxosBytes transfer mechanism only transfers WRITE_BYTES and READ_BYTES — never
+     * INDEX_WRITE_BYTES — so those phases will always produce a zero value for INDEX_WRITE_BYTES.
+     */
+    @Test
+    public void testPaxosCommitWithSecondaryIndex()
+    {
+        ColumnFamilyStore secondaryIndexStore = SensorsTestUtil.discardSSTables(KEYSPACE1, CF_STANDARD_SECONDARY_INDEX);
+        Context context = new Context(KEYSPACE1, CF_STANDARD_SECONDARY_INDEX, secondaryIndexStore.metadata.id.toString());
+
+        PartitionUpdate update = new RowUpdateBuilder(secondaryIndexStore.metadata(), 0, "0")
+                                 .add("val", "hi there")
+                                 .buildUpdate();
+        Commit commit = Commit.newProposal(UUIDGen.getTimeUUID(), update);
+        CommitVerbHandler.instance.doVerb(Message.builder(Verb.PAXOS_COMMIT_REQ, commit).build());
+
+        // INDEX_WRITE_BYTES must be tracked for a Paxos commit on a table with a secondary index
+        Sensor indexWriteSensor = SensorsTestUtil.getThreadLocalRequestSensor(context, Type.INDEX_WRITE_BYTES);
+        assertThat(indexWriteSensor).isNotNull();
+        assertThat(indexWriteSensor.getValue()).isGreaterThan(0);
+
+        // WRITE_BYTES must also be tracked
+        Sensor writeSensor = SensorsTestUtil.getThreadLocalRequestSensor(context, Type.WRITE_BYTES);
+        assertThat(writeSensor).isNotNull();
+        assertThat(writeSensor.getValue()).isGreaterThan(0);
+
+        // INDEX_WRITE_BYTES must be encoded in the response message custom params
+        Message lastMessage = capturedOutboundMessages.get(capturedOutboundMessages.size() - 1);
+        String indexWriteParam = SensorsCustomParams.paramForRequestSensor(indexWriteSensor).get();
+        assertThat(lastMessage.header.customParams()).containsKey(indexWriteParam);
+        double encodedValue = SensorsTestUtil.bytesToDouble(lastMessage.header.customParams().get(indexWriteParam));
+        assertThat(encodedValue).isEqualTo(indexWriteSensor.getValue());
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/sensors/SensorsIndexWriteTest.java
+++ b/test/unit/org/apache/cassandra/sensors/SensorsIndexWriteTest.java
@@ -163,6 +163,7 @@ public class SensorsIndexWriteTest
         assertThat(writeSensor.getValue()).isGreaterThan(0);
 
         // INDEX_WRITE_BYTES must be encoded in the response message custom params
+        assertThat(capturedOutboundMessages).isNotEmpty();
         Message lastMessage = capturedOutboundMessages.get(capturedOutboundMessages.size() - 1);
         String indexWriteParam = SensorsCustomParams.paramForRequestSensor(indexWriteSensor).get();
         assertThat(lastMessage.header.customParams()).containsKey(indexWriteParam);
@@ -201,6 +202,7 @@ public class SensorsIndexWriteTest
         assertThat(writeSensor.getValue()).isGreaterThan(0);
 
         // INDEX_WRITE_BYTES must be encoded in the response message custom params
+        assertThat(capturedOutboundMessages).isNotEmpty();
         Message lastMessage = capturedOutboundMessages.get(capturedOutboundMessages.size() - 1);
         String indexWriteParam = SensorsCustomParams.paramForRequestSensor(indexWriteSensor).get();
         assertThat(lastMessage.header.customParams()).containsKey(indexWriteParam);
@@ -308,6 +310,7 @@ public class SensorsIndexWriteTest
     private void assertResponseSensors(double requestValue, double registryValue, String requestParam, String globalParam)
     {
         // verify against the last message to enable testing of multiple mutations in a for loop
+        assertThat(capturedOutboundMessages).isNotEmpty();
         Message message = capturedOutboundMessages.get(capturedOutboundMessages.size() - 1);
         assertResponseSensors(message, requestValue, registryValue, requestParam, globalParam);
 

--- a/test/unit/org/apache/cassandra/sensors/SensorsIndexWriteTest.java
+++ b/test/unit/org/apache/cassandra/sensors/SensorsIndexWriteTest.java
@@ -138,8 +138,7 @@ public class SensorsIndexWriteTest
      * Only the Commit phase is tested here because it is the only Paxos phase that writes to the base table and
      * triggers SAI index updaters. The Prepare and Propose phases exclusively read and write the system.paxos table
      * (via SystemKeyspace.loadPaxosState / savePaxosPromise / savePaxosProposal), which has no SAI indexes,
-     * and the SystemKeyspace.trackPaxosBytes transfer mechanism only transfers WRITE_BYTES and READ_BYTES — never
-     * INDEX_WRITE_BYTES — so those phases will always produce a zero value for INDEX_WRITE_BYTES.
+     * so those phases will always produce a zero value for INDEX_WRITE_BYTES regardless of the transfer mechanism.
      */
     @Test
     public void testPaxosCommitWithSAI()
@@ -176,8 +175,8 @@ public class SensorsIndexWriteTest
      * (2i) index. Only the Commit phase is tested here because it is the only Paxos phase that writes to the base
      * table and triggers secondary index updaters. The Prepare and Propose phases exclusively read and write the
      * system.paxos table (via SystemKeyspace.loadPaxosState / savePaxosPromise / savePaxosProposal), which has no
-     * secondary indexes, and the SystemKeyspace.trackPaxosBytes transfer mechanism only transfers WRITE_BYTES and
-     * READ_BYTES — never INDEX_WRITE_BYTES — so those phases will always produce a zero value for INDEX_WRITE_BYTES.
+     * secondary indexes, so those phases will always produce a zero value for INDEX_WRITE_BYTES regardless of the
+     * transfer mechanism.
      */
     @Test
     public void testPaxosCommitWithSecondaryIndex()

--- a/test/unit/org/apache/cassandra/sensors/SensorsTraceWriteTest.java
+++ b/test/unit/org/apache/cassandra/sensors/SensorsTraceWriteTest.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.sensors;
+
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.SchemaLoader;
+import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.db.Mutation;
+import org.apache.cassandra.db.MutationVerbHandler;
+import org.apache.cassandra.db.RowUpdateBuilder;
+import org.apache.cassandra.net.Message;
+import org.apache.cassandra.net.Verb;
+import org.apache.cassandra.schema.Schema;
+import org.apache.cassandra.schema.SchemaConstants;
+import org.apache.cassandra.schema.SchemaTransformations;
+import org.apache.cassandra.schema.TableMetadata;
+import org.apache.cassandra.tracing.TraceKeyspace;
+import org.apache.cassandra.utils.UUIDGen;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that {@code WRITE_BYTES} is tracked when a {@code system_traces.events} mutation is
+ * applied on the replica side, exercising the same code path that runs after a coordinator sends
+ * a {@code MUTATION_REQ} for a trace write.
+ *
+ * <p>The complementary coordinator-level property — that trace writes do not inflate the user
+ * table's {@code WRITE_BYTES} reported to the client — is covered by
+ * {@code SensorsTest#testTraceWriteDoesNotInflateSensors()} in the distributed test suite.
+ */
+public class SensorsTraceWriteTest
+{
+    @BeforeClass
+    public static void setUpClass() throws Exception
+    {
+        CassandraRelevantProperties.SENSORS_FACTORY.setString(ActiveSensorsFactory.class.getName());
+        SchemaLoader.prepareServer();
+        // system_traces is a distributed system keyspace not loaded by SchemaLoader.prepareServer(),
+        // so register it explicitly so Keyspace.open(TRACE_KEYSPACE_NAME) works in the test.
+        Schema.instance.transform(SchemaTransformations.addKeyspace(TraceKeyspace.metadata(), true));
+    }
+
+    @After
+    public void afterTest()
+    {
+        RequestTracker.instance.set(null);
+        SensorsRegistry.instance.clear();
+    }
+
+    /**
+     * Verifies that {@code WRITE_BYTES} is incremented when a {@code system_traces.events} mutation
+     * is applied via {@link MutationVerbHandler} — the replica-side path that executes after a
+     * coordinator sends a {@code MUTATION_REQ} message.
+     */
+    @Test
+    public void testWriteBytesIncrementedForTraceMutation()
+    {
+        TableMetadata events = Keyspace.open(SchemaConstants.TRACE_KEYSPACE_NAME)
+                                       .getColumnFamilyStore("events")
+                                       .metadata();
+        Context context = new Context(SchemaConstants.TRACE_KEYSPACE_NAME, "events", events.id.toString());
+
+        SensorsRegistry.instance.onCreateKeyspace(Keyspace.open(SchemaConstants.TRACE_KEYSPACE_NAME).getMetadata());
+        SensorsRegistry.instance.onCreateTable(events);
+
+        Mutation mutation = new RowUpdateBuilder(events, 0, UUIDGen.getTimeUUID())
+                            .clustering(UUIDGen.getTimeUUID())
+                            .add("activity", "test trace event")
+                            .build();
+
+        // Drive the write on the current thread via MutationVerbHandler — same replica-side path
+        // that executes after a coordinator sends a MUTATION_REQ.
+        MutationVerbHandler.instance.doVerb(Message.builder(Verb.MUTATION_REQ, mutation).build());
+
+        RequestSensors sensors = RequestTracker.instance.get();
+        assertThat(sensors)
+                .as("RequestSensors must be set on the thread-local after MutationVerbHandler.doVerb()")
+                .isNotNull();
+        assertThat(sensors.getSensor(context, Type.WRITE_BYTES))
+                .as("WRITE_BYTES must be registered for system_traces.events")
+                .isPresent();
+        assertThat(sensors.getSensor(context, Type.WRITE_BYTES).get().getValue())
+                .as("WRITE_BYTES must be > 0 after the trace mutation is applied")
+                .isGreaterThan(0);
+    }
+}

--- a/test/unit/org/apache/cassandra/sensors/SensorsVirtualTableBatchTest.java
+++ b/test/unit/org/apache/cassandra/sensors/SensorsVirtualTableBatchTest.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.sensors;
+
+import java.nio.ByteBuffer;
+import java.util.Map;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.db.marshal.UTF8Type;
+import org.apache.cassandra.db.partitions.PartitionUpdate;
+import org.apache.cassandra.db.virtual.AbstractVirtualTable;
+import org.apache.cassandra.db.virtual.SimpleDataSet;
+import org.apache.cassandra.db.virtual.VirtualKeyspace;
+import org.apache.cassandra.db.virtual.VirtualKeyspaceRegistry;
+import org.apache.cassandra.schema.TableMetadata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies sensor behaviour for batches targeting virtual tables.
+ *
+ * <p>Only UNLOGGED batches are valid for virtual tables — LOGGED batches, conditional batches,
+ * and mixed batches (virtual + regular tables) are all rejected at validation time before
+ * execution begins.
+ *
+ * <p>Virtual table writes bypass the storage engine and replica round-trips entirely, so no
+ * {@link RequestSensors} are installed on the thread-local and the response carries no sensor
+ * custom-payload headers.
+ *
+ * <p>Tests use the native-protocol stack (not the internal query path) so that the full
+ * batch execution path is exercised, including the virtual-table branch that applies mutations
+ * directly without going through {@link org.apache.cassandra.service.StorageProxy}.
+ */
+public class SensorsVirtualTableBatchTest extends CQLTester
+{
+    // All lowercase so CQL unquoted identifiers (lowercased by QualifiedName) match the registry key.
+    private static final String KS_NAME = "sensors_virtual_table_batch_test_ks";
+    private static final String VT_NAME = "vt";
+
+    /** Minimal writable virtual table that accepts writes and discards them. */
+    private static class WritableVirtualTable extends AbstractVirtualTable
+    {
+        WritableVirtualTable(String keyspaceName, String tableName)
+        {
+            super(TableMetadata.builder(keyspaceName, tableName)
+                               .kind(TableMetadata.Kind.VIRTUAL)
+                               .addPartitionKeyColumn("key", UTF8Type.instance)
+                               .addRegularColumn("value", Int32Type.instance)
+                               .build());
+        }
+
+        @Override
+        public DataSet data()
+        {
+            return new SimpleDataSet(metadata());
+        }
+
+        @Override
+        public void apply(PartitionUpdate update)
+        {
+            // Accept writes but discard — we only care that the path is exercised.
+        }
+    }
+
+    @BeforeClass
+    public static void setUpClass()
+    {
+        // Enable active sensors so any accidental registration would be detectable.
+        CassandraRelevantProperties.SENSORS_FACTORY.setString(ActiveSensorsFactory.class.getName());
+
+        CQLTester.setUpClass();
+
+        // requireNetwork() must be called before registering the virtual keyspace:
+        // CQLTester.startServices() (called inside requireNetwork) also registers built-in virtual
+        // keyspaces, so our keyspace must be added after that call or it may be lost.
+        requireNetwork();
+
+        VirtualKeyspaceRegistry.instance.register(
+                new VirtualKeyspace(KS_NAME, ImmutableList.of(new WritableVirtualTable(KS_NAME, VT_NAME))));
+    }
+
+    @After
+    public void afterTest()
+    {
+        // Clear thread-local sensor state between tests.
+        RequestTracker.instance.set(null);
+    }
+
+    /**
+     * An UNLOGGED batch on a virtual table applies mutations directly without going through the
+     * storage engine or any replica round-trip. Because no storage activity occurs, no sensor
+     * values are produced and the response must carry no sensor custom-payload headers.
+     */
+    @Test
+    public void testUnloggedBatchOnVirtualTableProducesNoSensors() throws Throwable
+    {
+        com.datastax.driver.core.ResultSet rs =
+                executeNet("BEGIN UNLOGGED BATCH " +
+                           "UPDATE " + KS_NAME + '.' + VT_NAME + " SET value = 1 WHERE key = 'pk1';" +
+                           "UPDATE " + KS_NAME + '.' + VT_NAME + " SET value = 2 WHERE key = 'pk2';" +
+                           "APPLY BATCH");
+
+        // Virtual table writes produce no storage activity, so no sensor values are accumulated.
+        // The thread-local sensor reference is null (never initialised for this path).
+        assertThat(RequestTracker.instance.get())
+                .as("No RequestSensors should be initialised for a virtual table batch — no storage occurs")
+                .isNull();
+
+        // The response custom payload must also be empty: no storage means no sensor headers to report.
+        Map<String, ByteBuffer> payload = rs.getExecutionInfo().getIncomingPayload();
+        assertThat(payload)
+                .as("Response custom payload must contain no sensor headers for a virtual table batch")
+                .isNullOrEmpty();
+    }
+}

--- a/test/unit/org/apache/cassandra/sensors/SensorsVirtualTableBatchTest.java
+++ b/test/unit/org/apache/cassandra/sensors/SensorsVirtualTableBatchTest.java
@@ -20,6 +20,8 @@ package org.apache.cassandra.sensors;
 import java.nio.ByteBuffer;
 import java.util.Map;
 
+import org.apache.cassandra.utils.ByteBufferUtil;
+
 import com.google.common.collect.ImmutableList;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -38,7 +40,7 @@ import org.apache.cassandra.schema.TableMetadata;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Verifies sensor behaviour for batches targeting virtual tables.
+ * Verifies sensor behavior for batches targeting virtual tables.
  *
  * <p>Only UNLOGGED batches are valid for virtual tables — LOGGED batches, conditional batches,
  * and mixed batches (virtual + regular tables) are all rejected at validation time before
@@ -50,6 +52,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * <p>Tests use the native-protocol stack (not the internal query path) so that the full
  * batch execution path is exercised, including the virtual-table branch that applies mutations
  * directly without going through {@link org.apache.cassandra.service.StorageProxy}.
+ *
  */
 public class SensorsVirtualTableBatchTest extends CQLTester
 {
@@ -87,6 +90,8 @@ public class SensorsVirtualTableBatchTest extends CQLTester
     {
         // Enable active sensors so any accidental registration would be detectable.
         CassandraRelevantProperties.SENSORS_FACTORY.setString(ActiveSensorsFactory.class.getName());
+        // Required for sensor values to be written into the native-protocol response custom payload.
+        CassandraRelevantProperties.SENSORS_VIA_NATIVE_PROTOCOL.setBoolean(true);
 
         CQLTester.setUpClass();
 
@@ -104,11 +109,36 @@ public class SensorsVirtualTableBatchTest extends CQLTester
      * storage engine or any replica round-trip. Because {@link org.apache.cassandra.service.StorageProxy}
      * is never invoked, no {@link RequestSensors} is installed on the server thread and no sensor
      * headers appear in the response custom payload.
+     *
+     * <p>As a positive control, the same batch shape on a regular table is first verified to produce
+     * a non-zero {@code WRITE_BYTES_REQUEST} sensor header — confirming the sensor machinery and
+     * {@link CassandraRelevantProperties#SENSORS_VIA_NATIVE_PROTOCOL} flag are correctly wired up,
+     * so the absence of headers for the virtual table is a genuine result, not a misconfigured setup.
      */
     @Test
     public void testUnloggedBatchOnVirtualTableProducesNoSensors() throws Throwable
     {
-        com.datastax.driver.core.ResultSet rs =
+        // Positive control: a regular table batch must produce sensor headers.
+        // KEYSPACE is created by CQLTester.beforeTest(), so the CREATE TABLE is done inline here.
+        schemaChange("CREATE TABLE IF NOT EXISTS " + KEYSPACE + ".regular_tbl (key text PRIMARY KEY, value int)");
+        String expectedHeader = "WRITE_BYTES_REQUEST." + KEYSPACE + ".regular_tbl";
+
+        com.datastax.driver.core.ResultSet regularRs =
+                executeNet("BEGIN UNLOGGED BATCH " +
+                           "UPDATE " + KEYSPACE + ".regular_tbl SET value = 1 WHERE key = 'pk1';" +
+                           "UPDATE " + KEYSPACE + ".regular_tbl SET value = 2 WHERE key = 'pk2';" +
+                           "APPLY BATCH");
+        Map<String, ByteBuffer> regularPayload = regularRs.getExecutionInfo().getIncomingPayload();
+        assertThat(regularPayload)
+                .as("Regular table batch must produce sensor headers — confirms setup is correct")
+                .isNotNull()
+                .containsKey(expectedHeader);
+        assertThat(ByteBufferUtil.toDouble(regularPayload.get(expectedHeader)))
+                .as("WRITE_BYTES_REQUEST must be > 0 for a regular table batch")
+                .isGreaterThan(0.0);
+
+        // Virtual table batch must produce no sensor headers.
+        com.datastax.driver.core.ResultSet virtualRs =
                 executeNet("BEGIN UNLOGGED BATCH " +
                            "UPDATE " + KS_NAME + '.' + VT_NAME + " SET value = 1 WHERE key = 'pk1';" +
                            "UPDATE " + KS_NAME + '.' + VT_NAME + " SET value = 2 WHERE key = 'pk2';" +
@@ -116,8 +146,8 @@ public class SensorsVirtualTableBatchTest extends CQLTester
 
         // Virtual table writes bypass StorageProxy entirely, so no RequestSensors is installed
         // and no sensor headers are written into the response custom payload.
-        Map<String, ByteBuffer> payload = rs.getExecutionInfo().getIncomingPayload();
-        assertThat(payload)
+        Map<String, ByteBuffer> virtualPayload = virtualRs.getExecutionInfo().getIncomingPayload();
+        assertThat(virtualPayload)
                 .as("Response custom payload must contain no sensor headers for a virtual table batch")
                 .isNullOrEmpty();
     }

--- a/test/unit/org/apache/cassandra/sensors/SensorsVirtualTableBatchTest.java
+++ b/test/unit/org/apache/cassandra/sensors/SensorsVirtualTableBatchTest.java
@@ -21,7 +21,6 @@ import java.nio.ByteBuffer;
 import java.util.Map;
 
 import com.google.common.collect.ImmutableList;
-import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -46,8 +45,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * execution begins.
  *
  * <p>Virtual table writes bypass the storage engine and replica round-trips entirely, so no
- * {@link RequestSensors} are installed on the thread-local and the response carries no sensor
- * custom-payload headers.
+ * sensor custom-payload headers appear in the response.
  *
  * <p>Tests use the native-protocol stack (not the internal query path) so that the full
  * batch execution path is exercised, including the virtual-table branch that applies mutations
@@ -101,17 +99,11 @@ public class SensorsVirtualTableBatchTest extends CQLTester
                 new VirtualKeyspace(KS_NAME, ImmutableList.of(new WritableVirtualTable(KS_NAME, VT_NAME))));
     }
 
-    @After
-    public void afterTest()
-    {
-        // Clear thread-local sensor state between tests.
-        RequestTracker.instance.set(null);
-    }
-
     /**
      * An UNLOGGED batch on a virtual table applies mutations directly without going through the
-     * storage engine or any replica round-trip. Because no storage activity occurs, no sensor
-     * values are produced and the response must carry no sensor custom-payload headers.
+     * storage engine or any replica round-trip. Because {@link org.apache.cassandra.service.StorageProxy}
+     * is never invoked, no {@link RequestSensors} is installed on the server thread and no sensor
+     * headers appear in the response custom payload.
      */
     @Test
     public void testUnloggedBatchOnVirtualTableProducesNoSensors() throws Throwable
@@ -122,13 +114,8 @@ public class SensorsVirtualTableBatchTest extends CQLTester
                            "UPDATE " + KS_NAME + '.' + VT_NAME + " SET value = 2 WHERE key = 'pk2';" +
                            "APPLY BATCH");
 
-        // Virtual table writes produce no storage activity, so no sensor values are accumulated.
-        // The thread-local sensor reference is null (never initialised for this path).
-        assertThat(RequestTracker.instance.get())
-                .as("No RequestSensors should be initialised for a virtual table batch — no storage occurs")
-                .isNull();
-
-        // The response custom payload must also be empty: no storage means no sensor headers to report.
+        // Virtual table writes bypass StorageProxy entirely, so no RequestSensors is installed
+        // and no sensor headers are written into the response custom payload.
         Map<String, ByteBuffer> payload = rs.getExecutionInfo().getIncomingPayload();
         assertThat(payload)
                 .as("Response custom payload must contain no sensor headers for a virtual table batch")


### PR DESCRIPTION
### What is the issue

- Batch upserts with 'conditions' (CAS) were not working
  - `BatchStatment` was missing setting any sensor value back on the CQL response for batches with `conditions` (CAS) and missing `INDEX_WRITE_BYTES` for batches without `conditions`
- `INDEX_WRITE_BYTES` was not tracked for Update statements
  - `UpdateStatement` was missing setting `INDEX_WRITE_BYTES` in the CQL response 
- CAS upserts were missing `INDEX_WRITE_BYTES`
  -  `StorageProxy.cas()` was missing to register `INDEX_WRITE_BYTES`
- `StorageProxy`'s `DefaultMutator` was creating and registering sensors and this caused any custom Mutator to implement the same
- SAI Index 'update' paths were not tracking `INDEX_WRITE_BYTES`
  - `TrieMemtableIndex`'s `update` paths was not incrementing the INDEX_WRITE_BYTES sensor values

### What does this PR fix and why was it fixed

- `UpdateStatement` and `BatchStatement` now include `INDEX_WRITE_BYTES` in the CQL response custom payload alongside `WRITE_BYTES`
- `INDEX_WRITE_BYTES` is registered on the coordinator's RequestSensors in `StorageProxy.cas()`
- Moved the logic of creating and registering sensors from `DefaultMutator` to the `mutateAtomically` method of `StorageProxy` so any custom mutator doesn't have to do that again
- `INDEX_WRITE_BYTES` tracking is added in the **_update_** flow as well
- Added tests for inserts and updates with secondary index and SAI scenarios of logged batch, unlogged batch and CAS
- Refactored `SensorsTest.java` to re-use cluster for the parameterized tests
- The bytes written to the `system.paxos` table during a CAS operation are added to the base table write's `WRITE_BYTES`. `system.paxos` table doesn't have an index today, but in the future, if at all an index is introduced, for adding `INDEX_WRITE_BYTES` of ``system.paxos` to the `INDEX_WRITE_BYTES` of the base table, it is registered in `PrepareVerbHandler.java‎`, `ProposeVerbHandler.java` and `CommitVerbHandler` and transferred in `SystemKeyspace.trackPaxosBytes`
