### PR TITLE
CNDB-18110: Pluggable compression params selection     

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -23,10 +23,9 @@ import java.util.concurrent.TimeUnit;
 import org.apache.cassandra.concurrent.Stage;
 import org.apache.cassandra.db.memtable.TrieMemtable;
 import org.apache.cassandra.exceptions.ConfigurationException;
-import org.apache.cassandra.io.compress.AdaptiveCompressor;
-import org.apache.cassandra.io.compress.LZ4Compressor;
 import org.apache.cassandra.metrics.TableMetrics;
 import org.apache.cassandra.net.MessagingService;
+import org.apache.cassandra.schema.DefaultCompressionSelector;
 import org.apache.cassandra.sensors.SensorsFactory;
 import org.apache.cassandra.service.context.OperationContext;
 import org.apache.cassandra.service.reads.range.EndpointGroupingRangeCommandIterator;
@@ -772,10 +771,14 @@ public enum CassandraRelevantProperties
     DS_CURRENT_MESSAGING_VERSION("ds.current_messaging_version", Integer.toString(MessagingService.VERSION_DS_11)),
 
     /**
-     * Which compression algorithm to use for SSTable compression when not specified explicitly in the sstable options.
-     * Can be "fast", which selects {@link LZ4Compressor}, or "adaptive" which selects {@link AdaptiveCompressor}.
+     * Fully-qualified class name of a {@link org.apache.cassandra.schema.CompressionParams.Selector} implementation
+     * to use for selecting the default SSTable compression per keyspace.
+     * If not set, {@link org.apache.cassandra.schema.DefaultCompressionSelector} is used.
+     * <p>
+     * This property is read once at startup and cannot be changed dynamically, but the selector implementation
+     * can select the compressor dynamically.
      */
-    DEFAULT_SSTABLE_COMPRESSION("cassandra.default_sstable_compression", "fast"),
+    SSTABLE_COMPRESSION_SELECTOR_CLASS("cassandra.sstable.compression.selector.class", DefaultCompressionSelector.class.getName()),
 
     /**
      * Do not try to calculate optimal streaming candidates. This can take a lot of time in some configs specially

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -2135,19 +2135,12 @@ public class DatabaseDescriptor
 
     public static Config.FlushCompression getFlushCompression()
     {
-        return Objects.requireNonNullElseGet(conf.flush_compression, () -> shouldUseAdaptiveCompressionByDefault()
-                                                                           ? Config.FlushCompression.adaptive
-                                                                           : Config.FlushCompression.fast);
+        return Objects.requireNonNullElse(conf.flush_compression, Config.FlushCompression.fast);
     }
 
     public static void setFlushCompression(Config.FlushCompression compression)
     {
         conf.flush_compression = compression;
-    }
-
-    public static boolean shouldUseAdaptiveCompressionByDefault()
-    {
-        return CassandraRelevantProperties.DEFAULT_SSTABLE_COMPRESSION.getString().equals("adaptive");
     }
 
     /**

--- a/src/java/org/apache/cassandra/cql3/statements/schema/AlterTableStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/AlterTableStatement.java
@@ -433,7 +433,7 @@ public abstract class AlterTableStatement extends AlterSchemaStatement
 
         public KeyspaceMetadata apply(KeyspaceMetadata keyspace, TableMetadata table)
         {
-            attrs.validate();
+            attrs.validate(keyspaceName);
 
             TableParams params = attrs.asAlteredTableParams(table.params);
 

--- a/src/java/org/apache/cassandra/cql3/statements/schema/AlterViewStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/AlterViewStatement.java
@@ -66,7 +66,7 @@ public final class AlterViewStatement extends AlterSchemaStatement
         if (null == view)
             throw ire("Materialized view '%s.%s' doesn't exist", keyspaceName, viewName);
 
-        attrs.validate();
+        attrs.validate(keyspaceName);
 
         Guardrails.disallowedTableProperties.ensureAllowed(attrs.updatedProperties(), state);
         Guardrails.ignoredTableProperties.maybeIgnoreAndWarn(attrs.updatedProperties(), attrs::removeProperty, state);

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
@@ -211,8 +211,8 @@ public final class CreateTableStatement extends AlterSchemaStatement
 
     public TableMetadata.Builder builder(Types types)
     {
-        attrs.validate();
-        TableParams params = attrs.asNewTableParams();
+        attrs.validate(keyspaceName);
+        TableParams params = attrs.asNewTableParams(keyspaceName);
 
         // use a TreeMap to preserve ordering across JDK versions (see CASSANDRA-9492) - important for stable unit tests
         Map<ColumnIdentifier, CQL3Type> columns = new TreeMap<>(comparing(o -> o.bytes));

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateViewStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateViewStatement.java
@@ -310,7 +310,7 @@ public final class CreateViewStatement extends AlterSchemaStatement
          * Validate WITH params
          */
 
-        attrs.validate();
+        attrs.validate(keyspaceName);
 
         if (attrs.hasOption(TableParams.Option.DEFAULT_TIME_TO_LIVE)
             && attrs.getInt(TableParams.Option.DEFAULT_TIME_TO_LIVE.toString(), 0) != 0)
@@ -329,7 +329,7 @@ public final class CreateViewStatement extends AlterSchemaStatement
         if (attrs.hasProperty(TableAttributes.ID))
             builder.id(attrs.getId());
 
-        builder.params(attrs.asNewTableParams())
+        builder.params(attrs.asNewTableParams(keyspaceName))
                .kind(TableMetadata.Kind.VIEW);
 
         partitionKeyColumns.forEach(name -> builder.addPartitionKeyColumn(name, getType(table, name)));

--- a/src/java/org/apache/cassandra/cql3/statements/schema/TableAttributes.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/TableAttributes.java
@@ -74,10 +74,10 @@ public final class TableAttributes extends PropertyDefinitions
 
     private final Map<ColumnIdentifier, DroppedColumn.Raw> droppedColumnRecords = new HashMap<>();
 
-    public void validate()
+    public void validate(String keyspace)
     {
         validate(validKeywords, obsoleteKeywords);
-        build(TableParams.builder()).validate();
+        build(TableParams.builder(keyspace)).validate();
     }
 
     public void addDroppedColumnRecord(ColumnIdentifier name, CQL3Type.Raw type, boolean isStatic, long timestamp)
@@ -92,9 +92,9 @@ public final class TableAttributes extends PropertyDefinitions
         return droppedColumnRecords.values();
     }
 
-    TableParams asNewTableParams()
+    TableParams asNewTableParams(String keyspaceName)
     {
-        return build(TableParams.builder());
+        return build(TableParams.builder(keyspaceName));
     }
 
     TableParams asAlteredTableParams(TableParams previous)

--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -3138,7 +3138,7 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
     {
         try
         {
-            TableParams.builder().crcCheckChance(crcCheckChance).build().validate();
+            TableParams.builder(getKeyspaceName()).crcCheckChance(crcCheckChance).build().validate();
             for (ColumnFamilyStore cfs : concatWithIndexes())
             {
                 cfs.crcCheckChance.set(crcCheckChance);

--- a/src/java/org/apache/cassandra/io/sstable/format/SortedTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SortedTableWriter.java
@@ -45,7 +45,6 @@ import org.apache.cassandra.db.rows.Unfiltered;
 import org.apache.cassandra.guardrails.Guardrails;
 import org.apache.cassandra.io.FSWriteError;
 import org.apache.cassandra.io.compress.CompressedSequentialWriter;
-import org.apache.cassandra.io.compress.ICompressor;
 import org.apache.cassandra.io.sstable.Component;
 import org.apache.cassandra.io.sstable.Descriptor;
 import org.apache.cassandra.io.sstable.SSTable;
@@ -138,42 +137,21 @@ public abstract class SortedTableWriter extends SSTableWriter
     public static CompressionParams compressionFor(final OperationType opType, TableMetadataRef metadata)
     {
         CompressionParams compressionParams = metadata.getLocal().params.compression;
-        final ICompressor compressor = compressionParams.getSstableCompressor();
 
-        if (null != compressor && opType == OperationType.FLUSH)
+        if (compressionParams.getSstableCompressor() != null)
         {
-            // When we are flushing out of the memtable throughput of the compressor is critical as flushes,
-            // especially of large tables, can queue up and potentially block writes.
-            // This optimization allows us to fall back to a faster compressor if a particular
-            // compression algorithm indicates we should. See CASSANDRA-15379 for more details.
-            switch (DatabaseDescriptor.getFlushCompression())
+            if (opType == OperationType.FLUSH)
             {
-                // It is relatively easier to insert a Noop compressor than to disable compressed writing
-                // entirely as the "compression" member field is provided outside the scope of this class.
-                // It may make sense in the future to refactor the ownership of the compression flag so that
-                // We can bypass the CompressedSequentialWriter in this case entirely.
-                case none:
-                    compressionParams = CompressionParams.NOOP;
-                    break;
-                case fast:
-                    if (!compressor.recommendedUses().contains(ICompressor.Uses.FAST_COMPRESSION))
-                    {
-                        compressionParams = CompressionParams.FAST;
-                        break;
-                    }
-                    // else fall through
-                case adaptive:
-                    if (!compressor.recommendedUses().contains(ICompressor.Uses.FAST_COMPRESSION))
-                    {
-                        compressionParams = CompressionParams.FAST_ADAPTIVE;
-                        break;
-                    }
-                    // else fall through
-                case table:
-                default:
-                    compressionParams = Optional.ofNullable(compressionParams.forUse(ICompressor.Uses.FAST_COMPRESSION))
-                                                .orElse(compressionParams);
-                    break;
+                // When we are flushing out of the memtable throughput of the compressor is critical as flushes,
+                // especially of large tables, can queue up and potentially block writes.
+                // This optimization allows us to fall back to a faster compressor if a particular
+                // compression algorithm indicates we should. See CASSANDRA-15379 for more details.
+                compressionParams = compressionParams.forFlush(metadata.getLocal().keyspace);
+            }
+            else
+            {
+                // Allows to plugin custom per-keyspace resolution of compressionParams
+                compressionParams = compressionParams.forCompaction(metadata.getLocal().keyspace);
             }
         }
         return compressionParams;

--- a/src/java/org/apache/cassandra/schema/CompressionParams.java
+++ b/src/java/org/apache/cassandra/schema/CompressionParams.java
@@ -20,11 +20,9 @@ package org.apache.cassandra.schema;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Properties;
 import java.util.concurrent.ThreadLocalRandom;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -37,7 +35,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.cache.ChunkCache;
-import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.config.ParameterizedClass;
 import org.apache.cassandra.db.TypeSizes;
 import org.apache.cassandra.exceptions.ConfigurationException;
@@ -46,6 +44,7 @@ import org.apache.cassandra.io.compress.*;
 import org.apache.cassandra.io.util.DataInputPlus;
 import org.apache.cassandra.io.util.DataOutputPlus;
 import org.apache.cassandra.net.MessagingService;
+import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.PageAware;
 
 import static java.lang.String.format;
@@ -89,7 +88,104 @@ public final class CompressionParams
                                                                        DEFAULT_MIN_COMPRESS_RATIO,
                                                                        Collections.emptyMap());
 
-    public static final CompressionParams DEFAULT = DatabaseDescriptor.shouldUseAdaptiveCompressionByDefault() ? ADAPTIVE : FAST;
+    // This is volatile rather than final so that tests may use reflection to change it and safely publish across threads,
+    // but it should not be changed outside of tests.
+    @SuppressWarnings("FieldMayBeFinal")
+    private static volatile Selector SELECTOR = Selector.fromProperty();
+
+    /**
+     * Returns the default {@link CompressionParams} for tables and views in the given keyspace,
+     * as determined by the active {@link Selector}.
+     *
+     * @param keyspace the keyspace name, used by the selector to determine the appropriate default compression.
+     *                 May be {@code null} when no keyspace context is available (e.g. schema loading or
+     *                 {@link TableParams.Builder} default construction); selectors should treat {@code null}
+     *                 as a request for the global default.
+     * @return the default compression params for the given keyspace.
+     */
+    public static CompressionParams forNewTables(String keyspace)
+    {
+        return SELECTOR.newTableCompression(keyspace);
+    }
+
+    /**
+     * Returns the {@link CompressionParams} to use when flushing a memtable for the given keyspace, as determined
+     * by the active {@link Selector}.
+     *
+     * @param keyspace the keyspace whose memtable is being flushed.
+     * @return the compression params that should be used for the flush SSTable.
+     */
+    public CompressionParams forFlush(String keyspace)
+    {
+        return SELECTOR.flushCompression(keyspace, this);
+    }
+
+    /**
+     * Returns the {@link CompressionParams} to use when compacting SSTables for the given keyspace, as determined
+     * by the active {@link Selector}.
+     *
+     * @param keyspace the keyspace being compacted.
+     * @return the compression params that should be used for the compaction output SSTable.
+     */
+    public CompressionParams forCompaction(String keyspace)
+    {
+        return SELECTOR.compactionCompression(keyspace, this);
+    }
+
+    /**
+     * Interface for selecting the SSTable compression for newly created tables, for flushing, and for compacting
+     * tables in the given keyspace.
+     * <p>
+     * Implementations are loaded via the system property
+     * {@link CassandraRelevantProperties#SSTABLE_COMPRESSION_SELECTOR_CLASS}.
+     * If not set {@link DefaultCompressionSelector} is used.
+     */
+    public interface Selector
+    {
+        /**
+         * @param keyspace the keyspace for which to select the default compression.
+         * @return the default {@link CompressionParams} to use for new tables and views in the given keyspace.
+         */
+        CompressionParams newTableCompression(String keyspace);
+
+        /**
+         * Selects the {@link CompressionParams} to use when flushing a memtable to an SSTable.
+         * <p>
+         * During a flush, throughput of the compressor is critical: large flushes can queue up and block
+         * writes. Implementations may therefore return a faster or lighter compression scheme than the
+         * table's configured params (e.g. switching to an LZ4 or adaptive compressor).
+         *
+         * @param keyspace    the keyspace whose memtable is being flushed.
+         * @param tableParams the compression params configured on the table being flushed.
+         * @return the compression params that should be written into the flush SSTable.
+         */
+        CompressionParams flushCompression(String keyspace, CompressionParams tableParams);
+
+        /**
+         * Selects the {@link CompressionParams} to use when writing a compaction output SSTable.
+         * <p>
+         * The default implementation returns {@code tableParams} unchanged. Override this method to apply a
+         * per-keyspace compaction compression policy (e.g. in CNDB).
+         *
+         * @param keyspace    the keyspace being compacted.
+         * @param tableParams the compression params configured on the table being compacted.
+         * @return the compression params that should be written into the compaction output SSTable.
+         */
+        CompressionParams compactionCompression(String keyspace, CompressionParams tableParams);
+
+        static Selector fromProperty()
+        {
+            String selectorClass = CassandraRelevantProperties.SSTABLE_COMPRESSION_SELECTOR_CLASS.getString();
+            if (selectorClass.isEmpty())
+            {
+                logger.info("Using default compression selector");
+                return new DefaultCompressionSelector();
+            }
+
+            logger.info("Using compression selector: {}", selectorClass);
+            return FBUtilities.construct(selectorClass, "compression selector");
+        }
+    }
 
     public static final CompressionParams NOOP = new CompressionParams(NoopCompressor.create(Collections.emptyMap()),
                                                                        // 4 KiB is often the underlying disk block size

--- a/src/java/org/apache/cassandra/schema/DefaultCompressionSelector.java
+++ b/src/java/org/apache/cassandra/schema/DefaultCompressionSelector.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.schema;
+
+import java.util.Optional;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.io.compress.ICompressor;
+
+/**
+ * The built-in, cluster-wide {@link CompressionParams.Selector} used when no custom selector class is configured.
+ *
+ * <p>It applies the following policy:
+ * <ul>
+ *   <li><b>Compressor for newly created tables</b> – always {@link CompressionParams#FAST} (LZ4).</li>
+ *   <li><b>Flush compression</b> – derives a write-optimised scheme from the
+ *       {@link org.apache.cassandra.config.Config.FlushCompression flush_compression} cassandra.yaml setting:
+ *       <ul>
+ *         <li>{@code none} – disables compression on flush SSTables ({@link CompressionParams#NOOP}).</li>
+ *         <li>{@code fast} – uses {@link CompressionParams#FAST} (LZ4) unless the table's own compressor
+ *             already supports fast compression, in which case the table params are preserved.</li>
+ *         <li>{@code adaptive} – uses {@link CompressionParams#FAST_ADAPTIVE} (adaptive LZ4) unless the
+ *             table's own compressor already supports fast compression.</li>
+ *         <li>{@code table} (default) – honours the table's configured compression params, preferring
+ *             any fast-compression variant they expose.</li>
+ *       </ul>
+ *   </li>
+ *   <li><b>Compaction compression</b> – always defers to the table's own {@link CompressionParams}
+ *       unchanged.</li>
+ * </ul>
+ *
+ * <p>A different implementation can be substituted at startup by setting the
+ * {@code cassandra.sstable.compression.selector.class} system property (see
+ * {@link CompressionParams.Selector#fromProperty()}).
+ */
+public class DefaultCompressionSelector implements CompressionParams.Selector
+{
+    @Override
+    public CompressionParams newTableCompression(String keyspace)
+    {
+        return CompressionParams.FAST;
+    }
+
+    @Override
+    public CompressionParams flushCompression(String keyspace, CompressionParams tableParams)
+    {
+        final ICompressor compressor = tableParams.getSstableCompressor();
+        if (compressor == null)
+            return tableParams;
+
+        switch (DatabaseDescriptor.getFlushCompression())
+        {
+            case none:
+                return CompressionParams.NOOP;
+            case fast:
+                if (!compressor.recommendedUses().contains(ICompressor.Uses.FAST_COMPRESSION))
+                    return CompressionParams.FAST;
+                // else fall through
+            case adaptive:
+                if (!compressor.recommendedUses().contains(ICompressor.Uses.FAST_COMPRESSION))
+                    return CompressionParams.FAST_ADAPTIVE;
+                // else fall through
+            case table:
+            default:
+                return Optional.ofNullable(tableParams.forUse(ICompressor.Uses.FAST_COMPRESSION))
+                               .orElse(tableParams);
+        }
+    }
+
+    @Override
+    public CompressionParams compactionCompression(String keyspace, CompressionParams tableParams)
+    {
+        return tableParams;
+    }
+}

--- a/src/java/org/apache/cassandra/schema/SchemaKeyspace.java
+++ b/src/java/org/apache/cassandra/schema/SchemaKeyspace.java
@@ -1006,7 +1006,7 @@ public final class SchemaKeyspace
     @VisibleForTesting
     static TableParams createTableParamsFromRow(UntypedResultSet.Row row)
     {
-        return TableParams.builder()
+        return TableParams.builder(SchemaConstants.SCHEMA_KEYSPACE_NAME)
                           .bloomFilterFpChance(row.getDouble("bloom_filter_fp_chance"))
                           .caching(CachingParams.fromMap(row.getFrozenTextMap("caching")))
                           .comment(row.getString("comment"))

--- a/src/java/org/apache/cassandra/schema/TableMetadata.java
+++ b/src/java/org/apache/cassandra/schema/TableMetadata.java
@@ -893,7 +893,7 @@ public class TableMetadata implements SchemaElement
 
         private IPartitioner partitioner;
         private Kind kind = Kind.REGULAR;
-        private TableParams.Builder params = TableParams.builder();
+        private TableParams.Builder params;
 
         // See the comment on Flag.COMPOUND definition for why we (still) inconditionally add this flag.
         private Set<Flag> flags = EnumSet.of(Flag.COMPOUND);
@@ -911,12 +911,14 @@ public class TableMetadata implements SchemaElement
             this.keyspace = keyspace;
             this.name = name;
             this.id = id;
+            this.params = TableParams.builder(keyspace);
         }
 
         private Builder(String keyspace, String name)
         {
             this.keyspace = keyspace;
             this.name = name;
+            this.params = TableParams.builder(keyspace);
         }
 
         public TableMetadata build()

--- a/src/java/org/apache/cassandra/schema/TableParams.java
+++ b/src/java/org/apache/cassandra/schema/TableParams.java
@@ -107,9 +107,15 @@ public final class TableParams
         readRepair = builder.readRepair;
     }
 
-    public static Builder builder()
+
+    /**
+     * Creates a builder pre-seeded with keyspace-specific defaults. Use this when creating new tables via DDL
+     * so that any per-keyspace policy (e.g. a tenant-aware compression selector) takes effect when the
+     * corresponding option is not explicitly specified in the statement.
+     */
+    public static Builder builder(String keyspace)
     {
-        return new Builder();
+        return new Builder().compression(CompressionParams.forNewTables(keyspace));
     }
 
     public static Builder builder(TableParams params)
@@ -326,15 +332,11 @@ public final class TableParams
         private SpeculativeRetryPolicy additionalWritePolicy = PercentileSpeculativeRetryPolicy.NINETY_NINE_P;
         private CachingParams caching = CachingParams.DEFAULT;
         private CompactionParams compaction = CompactionParams.DEFAULT;
-        private CompressionParams compression = CompressionParams.DEFAULT;
+        private CompressionParams compression = CompressionParams.noCompression();
         private MemtableParams memtable = MemtableParams.DEFAULT;
         private ImmutableMap<String, ByteBuffer> extensions = ImmutableMap.of();
         private boolean cdc;
         private ReadRepairStrategy readRepair = ReadRepairStrategy.BLOCKING;
-
-        public Builder()
-        {
-        }
 
         public TableParams build()
         {

--- a/test/unit/org/apache/cassandra/cql3/CQLTester.java
+++ b/test/unit/org/apache/cassandra/cql3/CQLTester.java
@@ -68,8 +68,7 @@ import com.google.common.collect.Iterables;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
-import org.apache.cassandra.io.compress.AdaptiveCompressor;
-import org.apache.cassandra.io.compress.LZ4Compressor;
+import org.apache.cassandra.schema.CompressionParams;
 import org.apache.cassandra.service.ClientWarn;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -3075,11 +3074,9 @@ public abstract class CQLTester
         }
     }
 
-    public static String defaultCompressor()
+    public static String defaultCompressorClassName()
     {
-        return DatabaseDescriptor.shouldUseAdaptiveCompressionByDefault()
-               ? AdaptiveCompressor.class.getName()
-               : LZ4Compressor.class.getName();
+        return CompressionParams.forNewTables(KEYSPACE).getSstableCompressor().getClass().getName();
     }
 
     @FunctionalInterface

--- a/test/unit/org/apache/cassandra/cql3/statements/DescribeStatementTest.java
+++ b/test/unit/org/apache/cassandra/cql3/statements/DescribeStatementTest.java
@@ -1021,7 +1021,7 @@ public class DescribeStatementTest extends CQLTester
                "    AND cdc = false\n" +
                "    AND comment = ''\n" +
                "    AND compaction = " + cqlQuoted(CompactionParams.DEFAULT.asMap()) + "\n" +
-               "    AND compression = {'chunk_length_in_kb': '16', 'class': '" + defaultCompressor() + "'}\n" +
+               "    AND compression = {'chunk_length_in_kb': '16', 'class': '" + defaultCompressorClassName() + "'}\n" +
                "    AND memtable = {}\n" +
                "    AND crc_check_chance = 1.0\n" +
                "    AND default_time_to_live = 0\n" +
@@ -1047,7 +1047,7 @@ public class DescribeStatementTest extends CQLTester
                "    AND cdc = false\n" +
                "    AND comment = ''\n" +
                "    AND compaction = " + cqlQuoted(CompactionParams.DEFAULT.asMap()) + "\n" +
-               "    AND compression = {'chunk_length_in_kb': '16', 'class': '" + defaultCompressor() + "'}\n" +
+               "    AND compression = {'chunk_length_in_kb': '16', 'class': '" + defaultCompressorClassName() + "'}\n" +
                "    AND memtable = {}\n" +
                "    AND crc_check_chance = 1.0\n" +
                "    AND extensions = {}\n" +

--- a/test/unit/org/apache/cassandra/cql3/validation/operations/AlterTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/operations/AlterTest.java
@@ -598,7 +598,7 @@ public class AlterTest extends CQLTester
                                   SchemaKeyspaceTables.TABLES),
                            KEYSPACE,
                            currentTable()),
-                   row(map("chunk_length_in_kb", "16", "class", defaultCompressor())));
+                   row(map("chunk_length_in_kb", "16", "class", defaultCompressorClassName())));
 
         alterTable("ALTER TABLE %s WITH compression = { 'class' : 'SnappyCompressor', 'chunk_length_in_kb' : 32 };");
 

--- a/test/unit/org/apache/cassandra/cql3/validation/operations/CreateTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/operations/CreateTest.java
@@ -806,7 +806,7 @@ public class CreateTest extends CQLTester
                                   SchemaKeyspaceTables.TABLES),
                            KEYSPACE,
                            currentTable()),
-                   row(map("chunk_length_in_kb", "16", "class", defaultCompressor())));
+                   row(map("chunk_length_in_kb", "16", "class", defaultCompressorClassName())));
 
         createTable("CREATE TABLE %s (a text, b int, c int, primary key (a, b))"
                 + " WITH compression = { 'class' : 'SnappyCompressor', 'chunk_length_in_kb' : 32 };");

--- a/test/unit/org/apache/cassandra/db/streaming/CassandraStreamHeaderTest.java
+++ b/test/unit/org/apache/cassandra/db/streaming/CassandraStreamHeaderTest.java
@@ -68,7 +68,8 @@ public class CassandraStreamHeaderTest
         SchemaLoader.prepareServer();
         SchemaLoader.createKeyspace(KEYSPACE,
                                     KeyspaceParams.simple(1),
-                                    SchemaLoader.standardCFMD(KEYSPACE, CF_COMPRESSED).compression(CompressionParams.DEFAULT));
+                                    SchemaLoader.standardCFMD(KEYSPACE, CF_COMPRESSED)
+                                                .compression(CompressionParams.forNewTables(KEYSPACE)));
 
         Keyspace keyspace = Keyspace.open(KEYSPACE);
         store = keyspace.getColumnFamilyStore(CF_COMPRESSED);

--- a/test/unit/org/apache/cassandra/io/compress/CQLCompressionTest.java
+++ b/test/unit/org/apache/cassandra/io/compress/CQLCompressionTest.java
@@ -24,13 +24,13 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.config.Config;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.CQLTester;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.schema.CompressionParams;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;

--- a/test/unit/org/apache/cassandra/io/compress/CompressionSelectorTest.java
+++ b/test/unit/org/apache/cassandra/io/compress/CompressionSelectorTest.java
@@ -1,0 +1,305 @@
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.io.compress;
+
+import java.lang.reflect.Field;
+import java.util.Set;
+
+import org.mockito.Mockito;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.config.Config;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.schema.CompressionParams;
+import org.apache.cassandra.schema.DefaultCompressionSelector;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+public class CompressionSelectorTest extends CQLTester
+{
+    @BeforeClass
+    public static void setupClass()
+    {
+        CQLTester.setUpClass();
+    }
+
+    @Before
+    public void prepare() throws Exception
+    {
+        DatabaseDescriptor.setFlushCompression(null);
+        CassandraRelevantProperties.SSTABLE_COMPRESSION_SELECTOR_CLASS.reset();
+    }
+
+    // --- CompressionParams.Selector loading via system property ---
+
+    @Test
+    public void testFromPropertyLoadsDefaultSelectorWhenPropertyEmpty()
+    {
+        CompressionParams.Selector selector = CompressionParams.Selector.fromProperty();
+        assertSame(DefaultCompressionSelector.class, selector.getClass());
+    }
+
+    @Test
+    public void testFromPropertyLoadsCustomSelectorClass()
+    {
+        System.setProperty(CassandraRelevantProperties.SSTABLE_COMPRESSION_SELECTOR_CLASS.getKey(),
+                           TestCustomSelector.class.getName());
+        CompressionParams.Selector selector = CompressionParams.Selector.fromProperty();
+        assertSame(TestCustomSelector.class, selector.getClass());
+    }
+
+    // --- Most common default configuration ---
+
+    @Test
+    public void testDefaultCompressionWhenNoPropertiesSet()
+    {
+        assertSame(CompressionParams.FAST, CompressionParams.forNewTables("any_keyspace"));
+        assertSame(CompressionParams.FAST, CompressionParams.deflate().forFlush("any_keyspace"));
+    }
+
+    // --- Additional flushCompression tests ---
+
+    @Test
+    public void testFlushCompressionReturnsNoneIfNewTableCompressionNotSet()
+    {
+        assertEquals(CompressionParams.noCompression(),
+                     CompressionParams.noCompression().forFlush("any_keyspace"));
+    }
+
+    @Test
+    public void testFlushCompressionReturnsNoopIfGlobalFlushCompressionSetToNone()
+    {
+        DatabaseDescriptor.setFlushCompression(Config.FlushCompression.none);
+        DefaultCompressionSelector selector = new DefaultCompressionSelector();
+        // regardless of what the table uses, none → NOOP
+        assertSame(CompressionParams.NOOP, selector.flushCompression("ks", CompressionParams.FAST));
+        assertSame(CompressionParams.NOOP, selector.flushCompression("ks", CompressionParams.ADAPTIVE));
+        assertSame(CompressionParams.NOOP, selector.flushCompression("ks", CompressionParams.FAST_ADAPTIVE));
+    }
+
+    @Test
+    public void testFlushCompressionReturnsFastWhenTableCompressorDoesntSupportFastCompression()
+    {
+        // ADAPTIVE (general AdaptiveCompressor) does not advertise FAST_COMPRESSION use
+        DatabaseDescriptor.setFlushCompression(Config.FlushCompression.fast);
+        DefaultCompressionSelector selector = new DefaultCompressionSelector();
+        assertSame(CompressionParams.FAST, selector.flushCompression("ks", CompressionParams.ADAPTIVE));
+    }
+
+    @Test
+    public void testFlushCompressionFallsThroughToTableWhenTableCompressorSupportsFastCompression()
+    {
+        // LZ4 fast compressor advertises FAST_COMPRESSION; forUse returns itself → result is tableParams
+        DatabaseDescriptor.setFlushCompression(Config.FlushCompression.fast);
+        DefaultCompressionSelector selector = new DefaultCompressionSelector();
+        assertSame(CompressionParams.FAST, selector.flushCompression("ks", CompressionParams.FAST));
+
+        DatabaseDescriptor.setFlushCompression(Config.FlushCompression.adaptive);
+        // FAST_ADAPTIVE also advertises FAST_COMPRESSION
+        assertSame(CompressionParams.FAST_ADAPTIVE, selector.flushCompression("ks", CompressionParams.FAST_ADAPTIVE));
+    }
+
+    @Test
+    public void testFlushCompressionAdaptiveReturnsFastAdaptive()
+    {
+        DatabaseDescriptor.setFlushCompression(Config.FlushCompression.adaptive);
+        DefaultCompressionSelector selector = new DefaultCompressionSelector();
+        assertSame(CompressionParams.FAST_ADAPTIVE, selector.flushCompression("ks", CompressionParams.ADAPTIVE));
+    }
+
+    @Test
+    public void testFlushCompressionFallsBackToNewTableCompression()
+    {
+        // Slow compressor + flush compression set to table -> use the table compressor as-is
+        DatabaseDescriptor.setFlushCompression(Config.FlushCompression.table);
+        DefaultCompressionSelector selector = new DefaultCompressionSelector();
+        assertEquals(CompressionParams.deflate(), selector.flushCompression("ks", CompressionParams.deflate()));
+    }
+
+    @Test
+    public void testFlushCompressionUsesFasterVariantOfGeneralCompressionIfAvailable()
+    {
+        // If slow compressor is selected, check we attempt to adapt it for fast operation by callling
+        // forUse(FAST_COMPRESSION).
+        DatabaseDescriptor.setFlushCompression(Config.FlushCompression.table);
+        DefaultCompressionSelector selector = new DefaultCompressionSelector();
+        assertEquals(CompressionParams.ADAPTIVE.forUse(ICompressor.Uses.FAST_COMPRESSION),
+                     selector.flushCompression("ks", CompressionParams.ADAPTIVE));
+    }
+
+    // --- compactionCompression tests ---
+
+    @Test
+    public void testCompactionCompressionDefaultReturnsTableParams()
+    {
+        DefaultCompressionSelector selector = new DefaultCompressionSelector();
+        assertSame(CompressionParams.FAST, selector.compactionCompression("ks", CompressionParams.FAST));
+        assertSame(CompressionParams.ADAPTIVE, selector.compactionCompression("ks", CompressionParams.ADAPTIVE));
+        assertSame(CompressionParams.NOOP, selector.compactionCompression("ks", CompressionParams.NOOP));
+    }
+
+    @Test
+    public void testForCompactionDelegatesToSelector()
+    {
+        assertSame(CompressionParams.FAST, CompressionParams.FAST.forCompaction("any_keyspace"));
+        assertSame(CompressionParams.ADAPTIVE, CompressionParams.ADAPTIVE.forCompaction("any_keyspace"));
+    }
+
+    // --- End-to-end selector integration tests (flush and compaction through real I/O) ---
+
+    @Test
+    public void testCompressionSelectorAppliedToNewTable() throws Throwable
+    {
+        CompressionParams.Selector selector = Mockito.mock(CompressionParams.Selector.class);
+
+        Field selectorField = CompressionParams.class.getDeclaredField("SELECTOR");
+        selectorField.setAccessible(true);
+        CompressionParams.Selector original = (CompressionParams.Selector) selectorField.get(null);
+        try
+        {
+            selectorField.set(null, selector);
+            Mockito.when(selector.newTableCompression(Mockito.any())).thenReturn(CompressionParams.NOOP);
+            createTable("CREATE TABLE %s (k text PRIMARY KEY, v text)");
+            assertSame(CompressionParams.NOOP,
+                       getCurrentColumnFamilyStore().metadata().params.compression);
+
+            var compression = CompressionParams.snappy(8 * 1024);
+            Mockito.when(selector.newTableCompression(Mockito.any())).thenReturn(compression);
+            createTable("CREATE TABLE %s (k text PRIMARY KEY, v text)");
+            assertEquals(compression, getCurrentColumnFamilyStore().metadata().params.compression);
+        }
+        finally
+        {
+            selectorField.set(null, original);
+        }
+    }
+
+    @Test
+    public void testCompressionSelectorAppliedToFlush() throws Throwable
+    {
+        CompressionParams.Selector selector = Mockito.mock(CompressionParams.Selector.class);
+
+        Field selectorField = CompressionParams.class.getDeclaredField("SELECTOR");
+        selectorField.setAccessible(true);
+        CompressionParams.Selector original = (CompressionParams.Selector) selectorField.get(null);
+        try
+        {
+            selectorField.set(null, selector);
+
+            CompressionParams flushParams = CompressionParams.NOOP;
+            Mockito.when(selector.newTableCompression(Mockito.any())).thenReturn(CompressionParams.lz4());
+            Mockito.when(selector.flushCompression(Mockito.any(), Mockito.any())).thenReturn(flushParams);
+
+            createTable("CREATE TABLE %s (k text PRIMARY KEY, v text)");
+            ColumnFamilyStore store = flushTwice();
+
+            // Every flushed SSTable should use the compressor returned by flushCompression()
+            Set<SSTableReader> sstables = store.getLiveSSTables();
+            assertEquals(2, sstables.size());
+            sstables.forEach(sstable ->
+                assertSame(flushParams, sstable.getCompressionMetadata().parameters)
+            );
+        }
+        finally
+        {
+            selectorField.set(null, original);
+        }
+    }
+
+    @Test
+    public void testCompressionSelectorAppliedToCompaction() throws Throwable
+    {
+        CompressionParams.Selector selector = Mockito.mock(CompressionParams.Selector.class);
+
+        Field selectorField = CompressionParams.class.getDeclaredField("SELECTOR");
+        selectorField.setAccessible(true);
+        CompressionParams.Selector original = (CompressionParams.Selector) selectorField.get(null);
+        try
+        {
+            selectorField.set(null, selector);
+
+            CompressionParams compactionParams = CompressionParams.snappy(8 * 1024);
+            Mockito.when(selector.newTableCompression(Mockito.any())).thenReturn(CompressionParams.lz4());
+            Mockito.when(selector.flushCompression(Mockito.any(), Mockito.any())).thenReturn(CompressionParams.lz4());
+            Mockito.when(selector.compactionCompression(Mockito.any(), Mockito.any())).thenReturn(compactionParams);
+
+            createTable("CREATE TABLE %s (k text PRIMARY KEY, v text)");
+            flushTwice();
+
+            // After compaction the single output SSTable should use compactionCompression()
+            compact();
+
+            Set<SSTableReader> sstables = getCurrentColumnFamilyStore().getLiveSSTables();
+            assertEquals(1, sstables.size());
+            sstables.forEach(sstable ->
+                assertEquals(compactionParams, sstable.getCompressionMetadata().parameters)
+            );
+        }
+        finally
+        {
+            selectorField.set(null, original);
+        }
+    }
+
+    private ColumnFamilyStore flushTwice()
+    {
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+
+        execute("INSERT INTO %s (k, v) values (?, ?)", "k1", "v1");
+        flush();
+        assertEquals(1, cfs.getLiveSSTables().size());
+
+        execute("INSERT INTO %s (k, v) values (?, ?)", "k2", "v2");
+        flush();
+        assertEquals(2, cfs.getLiveSSTables().size());
+
+        return cfs;
+    }
+
+    /**
+     * A test-only selector that always returns NOOP compression.
+     * We need this to test if the selector can be picked up by class name;
+     * in other cases mocking does the job.
+     */
+    public static class TestCustomSelector implements CompressionParams.Selector
+    {
+        @Override
+        public CompressionParams newTableCompression(String keyspace)
+        {
+            return CompressionParams.NOOP;
+        }
+
+        @Override
+        public CompressionParams flushCompression(String keyspace, CompressionParams tableParams)
+        {
+            return CompressionParams.NOOP;
+        }
+
+        @Override
+        public CompressionParams compactionCompression(String keyspace, CompressionParams tableParams)
+        {
+            return CompressionParams.NOOP;
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/io/sstable/SSTableReaderTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/SSTableReaderTest.java
@@ -164,7 +164,8 @@ public class SSTableReaderTest
                                                 .maxIndexInterval(8),  // ensure close key count estimation
                                     SchemaLoader.standardCFMD(KEYSPACE1, CF_STANDARD3),
                                     SchemaLoader.standardCFMD(KEYSPACE1, CF_MOVE_AND_OPEN),
-                                    SchemaLoader.standardCFMD(KEYSPACE1, CF_COMPRESSED).compression(CompressionParams.DEFAULT),
+                                    SchemaLoader.standardCFMD(KEYSPACE1, CF_COMPRESSED)
+                                                .compression(CompressionParams.forNewTables(KEYSPACE1)),
                                     SchemaLoader.compositeIndexCFMD(KEYSPACE1, CF_INDEXED, true),
                                     SchemaLoader.standardCFMD(KEYSPACE1, CF_STANDARD_LOW_INDEX_INTERVAL)
                                                 .minIndexInterval(8)

--- a/test/unit/org/apache/cassandra/io/sstable/format/SSTableFlushObserverTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/format/SSTableFlushObserverTest.java
@@ -275,7 +275,7 @@ public class SSTableFlushObserverTest
                                               .addPartitionKeyColumn("id", UTF8Type.instance)
                                               .addClusteringColumn("name", UTF8Type.instance)
                                               .addRegularColumn("age", Int32Type.instance)
-                                              .compression(compression ? CompressionParams.DEFAULT : CompressionParams.noCompression())
+                                              .compression(compression ? CompressionParams.forNewTables(KS_NAME) : CompressionParams.noCompression())
                                               .build();
 
         DeletionTime dt = new DeletionTime(now, nowInSec);

--- a/test/unit/org/apache/cassandra/schema/TableMetadataTest.java
+++ b/test/unit/org/apache/cassandra/schema/TableMetadataTest.java
@@ -156,8 +156,8 @@ public class TableMetadataTest
     {
         String keyspaceName = "ks1";
         String tableName = "tbl1";
-        TableParams noCdcParams = TableParams.builder().cdc(false).build();
-        TableParams cdcParams = TableParams.builder().cdc(true).build();
+        TableParams noCdcParams = TableParams.builder(keyspaceName).cdc(false).build();
+        TableParams cdcParams = TableParams.builder(keyspaceName).cdc(true).build();
 
         TableMetadata metadata = TableMetadata.builder(keyspaceName, tableName)
                                               .addPartitionKeyColumn("key", UTF8Type.instance)

--- a/test/unit/org/apache/cassandra/utils/CassandraGenerators.java
+++ b/test/unit/org/apache/cassandra/utils/CassandraGenerators.java
@@ -154,7 +154,7 @@ public final class CassandraGenerators
                                                      .partitioner(PARTITIONER_GEN.generate(rnd))
                                                      .kind(TABLE_KIND_GEN.generate(rnd))
                                                      .isCounter(BOOLEAN_GEN.generate(rnd))
-                                                     .params(TableParams.builder().build());
+                                                     .params(TableParams.builder(ks).build());
 
         // generate columns
         // must have a non-zero amount of partition columns, but may have 0 for the rest; SMALL_POSSITIVE_SIZE_GEN won't return 0


### PR DESCRIPTION
 Introduces a pluggable CompressionParams.Selector interface (analogous to
    Version.Selector for SAI) that allows the SSTable compression to be
    resolved per-keyspace at table-creation, compaction and flush time,
    rather than being controlled solely by a global JVM property.
    
New classes:
- CompressionParams.Selector: nested interface with methods for selecting
  desired CompressionParams at table creation, at compaction and at flush,
  loaded via the new cassandra.sstable.compression.selector.class system property
- DefaultCompressionSelector: built-in implementation that preserves the
  existing behavior
    
Changes to existing classes:
  - CassandraRelevantProperties: add SSTABLE_COMPRESSION_SELECTOR_CLASS
  - CompressionParams: add SELECTOR field, forNewTables, forCompaction and
    forFlush helper methods
  - TableParams: add builder(String keyspace) factory pre-seeded with
    keyspace-specific defaults; the no-arg builder() is retained for
    schema loading, validation, and metadata copy
  - TableAttributes: add asNewTableParams(String keyspace) overload that
    uses the keyspace-aware builder
  - CreateTableStatement, CreateViewStatement: pass keyspace name into
    asNewTableParams so DDL without explicit WITH compression uses the selector
  - DatabaseDescriptor: add getFlushCompression(String keyspace) overload
    that consults the selector when no explicit flush_compression is configured
  - SortedTableWriter: delegate the selection of the CompressionParams used
    for flush and compaction to the CompressionParams.Selector
    
Because all compression selection logic was moved to the CompressionParams.Selector,
the global property for enabling Adaptive Compression has been removed.
