### PR TITLE
CNDB-4681: Skip indexes when full primary keys are provided in the query (#2488)

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -954,6 +954,12 @@ public enum CassandraRelevantProperties
     SIZE_RECORDER_INTERVAL("cassandra.size_recorder_interval", "300"),
 
     SKIP_DEFAULT_ROLE_SETUP("cassandra.skip_default_role_setup"),
+    /**
+     * Whether to skip secondary indexes when the query specifies full primary keys.
+     * In principle, there is no reason to prefer using the indexes in such queries,
+     * and this exists just as a feature gate.
+     */
+    SKIP_INDEXES_ON_FULL_PRIMARY_KEYS("cassandra.index.skip_on_full_primary_keys", "true"),
     SKIP_MUTATING_STATS_AFTER_ZCS("cassandra.skip_mutating_stats_after_zcs"),
     /**
      * Do not try to calculate optimal streaming candidates. This can take a lot of time in some configs specially

--- a/src/java/org/apache/cassandra/cql3/restrictions/StatementRestrictions.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/StatementRestrictions.java
@@ -132,6 +132,8 @@ public class StatementRestrictions
     public static final String VECTOR_INDEXES_UNSUPPORTED_OP_MESSAGE = "Vector indexes only support ANN and GEO_DISTANCE queries";
     public static final String ANN_OPTIONS_WITHOUT_ORDER_BY_ANN = "ANN options specified without ORDER BY ... ANN OF ...";
 
+    public static final String INDEX_WITH_IN_ON_PK_MESSAGE = "Select on indexed columns and with IN clause for the PRIMARY KEY are not supported";
+
     /**
      * The Column Family meta data
      */
@@ -721,8 +723,7 @@ public class StatementRestrictions
             }
 
             if (usesSecondaryIndexing)
-                checkFalse(partitionKeyRestrictions.hasIN(),
-                           "Select on indexed columns and with IN clause for the PRIMARY KEY are not supported");
+                checkFalse(partitionKeyRestrictions.hasIN(), INDEX_WITH_IN_ON_PK_MESSAGE);
 
             ImmutableList.Builder<StatementRestrictions> children = ImmutableList.builder();
 

--- a/src/java/org/apache/cassandra/db/SinglePartitionReadCommand.java
+++ b/src/java/org/apache/cassandra/db/SinglePartitionReadCommand.java
@@ -36,6 +36,7 @@ import org.apache.cassandra.cache.IRowCacheEntry;
 import org.apache.cassandra.cache.RowCacheKey;
 import org.apache.cassandra.cache.RowCacheSentinel;
 import org.apache.cassandra.concurrent.Stage;
+import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.CqlBuilder;
 import org.apache.cassandra.db.filter.ClusteringIndexFilter;
@@ -230,7 +231,22 @@ public class SinglePartitionReadCommand extends ReadCommand implements SinglePar
                       limits,
                       partitionKey,
                       clusteringIndexFilter,
-                      findIndexQueryPlan(metadata, rowFilter));
+                      findIndexQueryPlan(metadata, rowFilter, clusteringIndexFilter));
+    }
+
+    private static Index.QueryPlan findIndexQueryPlan(TableMetadata table,
+                                                      RowFilter rowFilter,
+                                                      ClusteringIndexFilter clusteringIndexFilter)
+    {
+        // We can skip the indexes if the query is for a specific set of primary keys, there is no ordering,
+        // and there are no hints telling us otherwise.
+        if (CassandraRelevantProperties.SKIP_INDEXES_ON_FULL_PRIMARY_KEYS.getBoolean()
+            && clusteringIndexFilter instanceof ClusteringIndexNamesFilter
+            && rowFilter.indexHints.included.isEmpty()
+            && !rowFilter.hasOrdering())
+            return null;
+
+        return findIndexQueryPlan(table, rowFilter);
     }
 
     /**

--- a/src/java/org/apache/cassandra/db/filter/RowFilter.java
+++ b/src/java/org/apache/cassandra/db/filter/RowFilter.java
@@ -151,6 +151,19 @@ public class RowFilter
     }
 
     /**
+     * @return {@code true} if this filter contains any expression with an ordering expression, {@code false} otherwise.
+     */
+    public boolean hasOrdering()
+    {
+        for (Expression expression : root.expressions()) // ordering expressions are always on the first tree level
+        {
+            if (expression.isOrderingExpression())
+                return true;
+        }
+        return false;
+    }
+
+    /**
      * Returns a copy of this {@link RowFilter} with ordering expressions removed
      */
     public RowFilter withoutOrderingExpressions()

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/datamodels/MultiNodeQueryTester.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/datamodels/MultiNodeQueryTester.java
@@ -29,6 +29,7 @@ import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.distributed.Cluster;
 import org.apache.cassandra.distributed.shared.Byteman;
 import org.apache.cassandra.distributed.test.TestBaseImpl;
@@ -69,6 +70,7 @@ abstract class MultiNodeQueryTester extends TestBaseImpl
         // Disable guardrails for anonymous users (no client authentication) This allows the test to avoid
         // being affected by guardrails for anonymous users.
         ENABLE_GUARDRAILS_FOR_ANONYMOUS_USER.setBoolean(false);
+        CassandraRelevantProperties.SKIP_INDEXES_ON_FULL_PRIMARY_KEYS.setBoolean(false);
 
         cluster = Cluster.build(3)
                          .withConfig(config -> config.with(NETWORK, GOSSIP)

--- a/test/unit/org/apache/cassandra/index/SkipIndexOnFullPrimaryKeysTester.java
+++ b/test/unit/org/apache/cassandra/index/SkipIndexOnFullPrimaryKeysTester.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.restrictions.StatementRestrictions;
+import org.apache.cassandra.db.ReadCommand;
+import org.apache.cassandra.exceptions.InvalidRequestException;
+import org.apache.cassandra.index.sai.SAITester;
+import org.apache.cassandra.net.MessagingService;
+import org.assertj.core.api.Assertions;
+
+/**
+ * Verifies that queries specifying one or more full primary keys don't use indexes, unless index hints include them.
+ * </p>
+ * Queries with index-based ORDER BY will still use the index, since we don't have a way to run those without the index.
+ * Queries in which the indexes change the semantics of the expression, such as those with analyzers,
+ * will preserve the index semantics, even if the index itself is not read.
+ */
+@RunWith(Parameterized.class)
+public abstract class SkipIndexOnFullPrimaryKeysTester extends SAITester
+{
+    @Parameterized.Parameter
+    public boolean skip;
+
+    @Parameterized.Parameters(name = "skip={0}")
+    public static Collection<Object[]> data()
+    {
+        return Arrays.asList(new Object[] { true}, new Object[] { false});
+    }
+
+    @Before
+    public void setSkip()
+    {
+        CassandraRelevantProperties.SKIP_INDEXES_ON_FULL_PRIMARY_KEYS.setBoolean(skip);
+    }
+
+    @BeforeClass
+    public static void setUpClass()
+    {
+        // Set the messaging version that adds support for the new index hints before starting the server
+        CassandraRelevantProperties.DS_CURRENT_MESSAGING_VERSION.setInt(MessagingService.VERSION_DS_12);
+        CQLTester.setUpClass();
+        CQLTester.enableCoordinatorExecution();
+    }
+
+    protected void assertHasQueryPlan(String query, Object[]... expectedRows)
+    {
+        ReadCommand command = parseReadCommand(formatQuery(query));
+        Index.QueryPlan plan = command.indexQueryPlan();
+        Assertions.assertThat(plan).isNotNull();
+        assertRows(execute(query), expectedRows);
+    }
+
+    protected void assertHasNoQueryPlan(String query, Object[]... expectedRows)
+    {
+        ReadCommand command = parseReadCommand(formatQuery(query));
+        Index.QueryPlan plan = command.indexQueryPlan();
+        if (skip)
+            Assertions.assertThat(plan).isNull();
+        else
+            Assertions.assertThat(plan).isNotNull();
+        assertRows(execute(query), expectedRows);
+    }
+
+    protected void assertUnsupportedINOnPK(String query)
+    {
+        assertInvalidThrowMessage(StatementRestrictions.INDEX_WITH_IN_ON_PK_MESSAGE, InvalidRequestException.class, query);
+    }
+}

--- a/test/unit/org/apache/cassandra/index/internal/SkipIndexOnFullPrimaryKeysTest.java
+++ b/test/unit/org/apache/cassandra/index/internal/SkipIndexOnFullPrimaryKeysTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.internal;
+
+import org.junit.Test;
+
+import org.apache.cassandra.index.SkipIndexOnFullPrimaryKeysTester;
+
+/**
+ * {@link SkipIndexOnFullPrimaryKeysTester} for legacy table-based indexes.
+ */
+public class SkipIndexOnFullPrimaryKeysTest extends SkipIndexOnFullPrimaryKeysTester
+{
+    @Test
+    public void testSkipsIndexSkinny()
+    {
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, n int)");
+        createIndex("CREATE INDEX n_idx ON %s(n)");
+        execute("INSERT INTO %s(k, n) VALUES (0, 0)");
+        execute("INSERT INTO %s(k, n) VALUES (1, 1)");
+        execute("INSERT INTO %s(k, n) VALUES (2, 0)");
+        execute("INSERT INTO %s(k, n) VALUES (3, 1)");
+
+        // range queries, unbounded
+        assertHasQueryPlan("SELECT k FROM %s WHERE n = 0", row(0), row(2));
+        assertHasQueryPlan("SELECT k FROM %s WHERE n = 1", row(1), row(3));
+        assertHasQueryPlan("SELECT k FROM %s WHERE n = 2");
+
+        // range queries, with token range
+        assertHasQueryPlan("SELECT k FROM %s WHERE token(k) >= token(1) AND n = 0", row(0), row(2));
+        assertHasQueryPlan("SELECT k FROM %s WHERE token(k) >= token(1) AND n = 1", row(1), row(3));
+        assertHasQueryPlan("SELECT k FROM %s WHERE token(k) >= token(1) AND n = 2");
+
+        // single-partition queries
+        assertHasNoQueryPlan("SELECT k FROM %s WHERE k = 0 AND n = 0", row(0));
+        assertHasNoQueryPlan("SELECT k FROM %s WHERE k = 0 AND n = 1");
+        assertHasNoQueryPlan("SELECT k FROM %s WHERE k = 0 AND n = 2");
+
+        // single-partition queries with hints
+        assertHasQueryPlan("SELECT k FROM %s WHERE k = 0 AND n = 0 WITH included_indexes = {n_idx}", row(0));
+        assertHasQueryPlan("SELECT k FROM %s WHERE k = 0 AND n = 1 WITH included_indexes = {n_idx}");
+        assertHasQueryPlan("SELECT k FROM %s WHERE k = 0 AND n = 2 WITH included_indexes = {n_idx}");
+
+        // multi-partition queries, which are not supported, but leaving it here in case that changes (CNDB-14044)
+        assertUnsupportedINOnPK("SELECT k FROM %s WHERE k IN (0, 1) AND n = 0");
+        assertUnsupportedINOnPK("SELECT k FROM %s WHERE k IN (0, 1) AND n = 1");
+        assertUnsupportedINOnPK("SELECT k FROM %s WHERE k IN (0, 1) AND n = 2");
+    }
+
+    @Test
+    public void testSkipsIndexWide()
+    {
+        createTable("CREATE TABLE %s (k int, c int, n int, PRIMARY KEY(k, c))");
+        createIndex("CREATE INDEX n_idx ON %s(n)");
+        execute("INSERT INTO %s(k, c, n) VALUES (0, 0, 0)");
+        execute("INSERT INTO %s(k, c, n) VALUES (0, 1, 1)");
+        execute("INSERT INTO %s(k, c, n) VALUES (0, 2, 0)");
+        execute("INSERT INTO %s(k, c, n) VALUES (0, 3, 1)");
+        execute("INSERT INTO %s(k, c, n) VALUES (1, 0, 0)");
+        execute("INSERT INTO %s(k, c, n) VALUES (1, 1, 1)");
+        execute("INSERT INTO %s(k, c, n) VALUES (1, 2, 0)");
+        execute("INSERT INTO %s(k, c, n) VALUES (1, 3, 1)");
+
+        // range queries, unbounded
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE n = 0", row(1, 0), row(1, 2), row(0, 0), row(0, 2));
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE n = 1", row(1, 1), row(1, 3), row(0, 1), row(0, 3));
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE n = 2");
+
+        // range queries, with token range
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE token(k) >= token(1) AND n = 0", row(1, 0), row(1, 2), row(0, 0), row(0, 2));
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE token(k) >= token(1) AND n = 1", row(1, 1), row(1, 3), row(0, 1), row(0, 3));
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE token(k) >= token(1) AND n = 2");
+
+        // single-partition queries
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND n = 0", row(0, 0), row(0, 2));
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND n = 1", row(0, 1), row(0, 3));
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND n = 2");
+
+        // multi-partition queries, which are not supported, but leaving it here in case that changes (CNDB-14044)
+        assertUnsupportedINOnPK("SELECT k, c FROM %s WHERE k IN (0, 1) AND n = 0");
+        assertUnsupportedINOnPK("SELECT k, c FROM %s WHERE k IN (0, 1) AND n = 1");
+        assertUnsupportedINOnPK("SELECT k, c FROM %s WHERE k IN (0, 1) AND n = 2");
+
+        // single-row single-partition queries
+        assertHasNoQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c = 0 AND n = 0", row(0, 0));
+        assertHasNoQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c = 0 AND n = 1");
+
+        // single-row single-partition queries with hints
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c = 0 AND n = 0 WITH included_indexes = {n_idx}", row(0, 0));
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c = 0 AND n = 1 WITH included_indexes = {n_idx}");
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c = 0 AND n = 2 WITH included_indexes = {n_idx}");
+
+        // names single-row queries
+        assertHasNoQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c IN (0, 1) AND n = 0", row(0, 0));
+        assertHasNoQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c IN (0, 1) AND n = 1", row(0, 1));
+        assertHasNoQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c IN (0, 1) AND n = 2");
+
+        // names single-row queries with hints
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c IN (0, 1) AND n = 0 WITH included_indexes = {n_idx}", row(0, 0));
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c IN (0, 1) AND n = 1 WITH included_indexes = {n_idx}", row(0, 1));
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c IN (0, 1) AND n = 3 WITH included_indexes = {n_idx}");
+
+        // slices single-partition queries
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c >= 0 AND c <= 1 AND n = 0", row(0, 0));
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c >= 0 AND c <= 1 AND n = 1", row(0, 1));
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c >= 0 AND c <= 1 AND n = 3");
+
+        // slices single-partition queries with hints
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c >= 0 AND c <= 1 AND n = 0 WITH included_indexes = {n_idx}", row(0, 0));
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c >= 0 AND c <= 1 AND n = 1 WITH included_indexes = {n_idx}", row(0, 1));
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c >= 0 AND c <= 1 AND n = 3 WITH included_indexes = {n_idx}");
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/QueryContextTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/QueryContextTest.java
@@ -23,9 +23,11 @@ import java.util.concurrent.TimeUnit;
 import com.google.common.util.concurrent.Uninterruptibles;
 import org.junit.Assert;
 import org.junit.Assume;
+import org.junit.Before;
 import org.junit.Test;
 
 import org.apache.cassandra.db.ReadCommand;
+import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.db.ReadExecutionController;
 import org.apache.cassandra.db.partitions.UnfilteredPartitionIterator;
 import org.apache.cassandra.db.rows.UnfilteredRowIterator;
@@ -39,6 +41,12 @@ public class QueryContextTest extends SAITester.Versioned
 {
     private static final int EXPIRING_ROW_TTL_SECONDS = 5;
     private static final int EXPIRING_ROW_WAIT_SECONDS = EXPIRING_ROW_TTL_SECONDS + 1;
+
+    @Before
+    public void disableSkipIndexesOnFullPK()
+    {
+        CassandraRelevantProperties.SKIP_INDEXES_ON_FULL_PRIMARY_KEYS.setBoolean(false);
+    }
 
     @Test
     public void testSkinnyTable()

--- a/test/unit/org/apache/cassandra/index/sai/cql/SkipIndexOnFullPrimaryKeysTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/SkipIndexOnFullPrimaryKeysTest.java
@@ -1,0 +1,573 @@
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.cql;
+
+import org.junit.Test;
+
+import org.apache.cassandra.index.SkipIndexOnFullPrimaryKeysTester;
+
+/**
+ * {@link SkipIndexOnFullPrimaryKeysTester} for SAI indexes.
+ */
+public class SkipIndexOnFullPrimaryKeysTest extends SkipIndexOnFullPrimaryKeysTester
+{
+    @Test
+    public void testSkipsIndexSkinny()
+    {
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, n int, t text, v vector<float, 2>)");
+        createIndex("CREATE CUSTOM INDEX n_idx ON %s(n) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX t_idx ON %s(t) USING 'StorageAttachedIndex' WITH OPTIONS = { 'index_analyzer': 'standard' }");
+        createIndex("CREATE CUSTOM INDEX v_idx ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
+        execute("INSERT INTO %s(k, n, v, t) VALUES (0, 0, [0, 1], 'foo')");
+        execute("INSERT INTO %s(k, n, v, t) VALUES (1, 1, [0, 2], 'foo bar')");
+        execute("INSERT INTO %s(k, n, v, t) VALUES (2, 0, [0, 3], 'bar')");
+        execute("INSERT INTO %s(k, n, v, t) VALUES (3, 1, [0, 4], 'foo bar')");
+
+        // range queries, unbounded
+        assertHasQueryPlan("SELECT k FROM %s WHERE n = 0", row(0), row(2));
+        assertHasQueryPlan("SELECT k FROM %s WHERE n = 1", row(1), row(3));
+        assertHasQueryPlan("SELECT k FROM %s WHERE n = 2");
+        assertHasQueryPlan("SELECT k FROM %s WHERE t : 'foo'", row(1), row(0), row(3));
+        assertHasQueryPlan("SELECT k FROM %s WHERE t : 'bar'", row(1), row(2), row(3));
+        assertHasQueryPlan("SELECT k FROM %s WHERE t : 'bob'");
+        assertHasQueryPlan("SELECT k FROM %s WHERE t = 'foo'", row(1), row(0), row(3));
+        assertHasQueryPlan("SELECT k FROM %s WHERE t = 'bar'", row(1), row(2), row(3));
+        assertHasQueryPlan("SELECT k FROM %s WHERE t = 'bob'");
+        assertHasQueryPlan("SELECT k FROM %s ORDER BY t BM25 OF 'foo' LIMIT 2", row(0), row(1));
+        assertHasQueryPlan("SELECT k FROM %s ORDER BY t BM25 OF 'bar' LIMIT 2", row(2), row(1));
+        assertHasQueryPlan("SELECT k FROM %s ORDER BY t BM25 OF 'bob' LIMIT 2");
+        assertHasQueryPlan("SELECT k FROM %s ORDER BY v ANN OF [0, 1] LIMIT 2", row(0), row(1));
+        assertHasQueryPlan("SELECT k FROM %s ORDER BY v ANN OF [0, 9] LIMIT 2", row(3), row(2));
+
+        // range queries, with token range
+        assertHasQueryPlan("SELECT k FROM %s WHERE token(k) >= token(1) AND n = 0", row(0), row(2));
+        assertHasQueryPlan("SELECT k FROM %s WHERE token(k) >= token(1) AND n = 1", row(1), row(3));
+        assertHasQueryPlan("SELECT k FROM %s WHERE token(k) >= token(1) AND n = 2");
+        assertHasQueryPlan("SELECT k FROM %s WHERE token(k) >= token(1) AND t : 'foo'", row(1), row(0), row(3));
+        assertHasQueryPlan("SELECT k FROM %s WHERE token(k) >= token(1) AND t : 'bar'", row(1), row(2), row(3));
+        assertHasQueryPlan("SELECT k FROM %s WHERE token(k) >= token(1) AND t : 'bob'");
+        assertHasQueryPlan("SELECT k FROM %s WHERE token(k) >= token(1) ORDER BY t BM25 OF 'foo' LIMIT 2", row(0), row(1));
+        assertHasQueryPlan("SELECT k FROM %s WHERE token(k) >= token(1) ORDER BY t BM25 OF 'bar' LIMIT 2", row(2), row(1));
+        assertHasQueryPlan("SELECT k FROM %s WHERE token(k) >= token(1) ORDER BY t BM25 OF 'bob' LIMIT 2");
+        assertHasQueryPlan("SELECT k FROM %s WHERE token(k) >= token(1) ORDER BY v ANN OF [0, 1] LIMIT 2", row(0), row(1));
+        assertHasQueryPlan("SELECT k FROM %s WHERE token(k) >= token(1) ORDER BY v ANN OF [0, 9] LIMIT 2", row(3), row(2));
+
+        // single-partition queries
+        assertHasNoQueryPlan("SELECT k FROM %s WHERE k = 0 AND n = 0", row(0));
+        assertHasNoQueryPlan("SELECT k FROM %s WHERE k = 0 AND n = 1");
+        assertHasNoQueryPlan("SELECT k FROM %s WHERE k = 0 AND n = 2");
+        assertHasNoQueryPlan("SELECT k FROM %s WHERE k = 0 AND t : 'foo'", row(0));
+        assertHasNoQueryPlan("SELECT k FROM %s WHERE k = 0 AND t : 'bar'");
+        assertHasNoQueryPlan("SELECT k FROM %s WHERE k = 0 AND t : 'bob'");
+        assertHasNoQueryPlan("SELECT k FROM %s WHERE k = 0 AND t = 'foo'", row(0));
+        assertHasNoQueryPlan("SELECT k FROM %s WHERE k = 0 AND t = 'bar'");
+        assertHasNoQueryPlan("SELECT k FROM %s WHERE k = 0 AND t = 'bob'");
+        assertHasQueryPlan("SELECT k FROM %s WHERE k = 0 ORDER BY t BM25 OF 'foo' LIMIT 2", row(0));
+        assertHasQueryPlan("SELECT k FROM %s WHERE k = 0 ORDER BY t BM25 OF 'bar' LIMIT 2");
+        assertHasQueryPlan("SELECT k FROM %s WHERE k = 0 ORDER BY t BM25 OF 'bob' LIMIT 2");
+        assertHasQueryPlan("SELECT k FROM %s WHERE k = 0 ORDER BY v ANN OF [0, 1] LIMIT 2", row(0));
+        assertHasQueryPlan("SELECT k FROM %s WHERE k = 0 ORDER BY v ANN OF [0, 9] LIMIT 2", row(0));
+
+        // single-partition queries with hints
+        assertHasQueryPlan("SELECT k FROM %s WHERE k = 0 AND n = 0 WITH included_indexes = {n_idx}", row(0));
+        assertHasQueryPlan("SELECT k FROM %s WHERE k = 0 AND n = 1 WITH included_indexes = {n_idx}");
+        assertHasQueryPlan("SELECT k FROM %s WHERE k = 0 AND n = 2 WITH included_indexes = {n_idx}");
+        assertHasQueryPlan("SELECT k FROM %s WHERE k = 0 AND t : 'foo' WITH included_indexes = {t_idx}", row(0));
+        assertHasQueryPlan("SELECT k FROM %s WHERE k = 0 AND t : 'bar' WITH included_indexes = {t_idx}");
+        assertHasQueryPlan("SELECT k FROM %s WHERE k = 0 AND t : 'bob' WITH included_indexes = {t_idx}");
+        assertHasQueryPlan("SELECT k FROM %s WHERE k = 0 AND t = 'foo' WITH included_indexes = {t_idx}", row(0));
+        assertHasQueryPlan("SELECT k FROM %s WHERE k = 0 AND t = 'bar' WITH included_indexes = {t_idx}");
+        assertHasQueryPlan("SELECT k FROM %s WHERE k = 0 AND t = 'bob' WITH included_indexes = {t_idx}");
+        assertHasQueryPlan("SELECT k FROM %s WHERE k = 0 ORDER BY t BM25 OF 'foo' LIMIT 2 WITH included_indexes = {t_idx}", row(0));
+        assertHasQueryPlan("SELECT k FROM %s WHERE k = 0 ORDER BY t BM25 OF 'bar' LIMIT 2 WITH included_indexes = {t_idx}");
+        assertHasQueryPlan("SELECT k FROM %s WHERE k = 0 ORDER BY t BM25 OF 'bob' LIMIT 2 WITH included_indexes = {t_idx}");
+        assertHasQueryPlan("SELECT k FROM %s WHERE k = 0 ORDER BY v ANN OF [0, 1] LIMIT 2 WITH included_indexes = {v_idx}", row(0));
+        assertHasQueryPlan("SELECT k FROM %s WHERE k = 0 ORDER BY v ANN OF [0, 9] LIMIT 2 WITH included_indexes = {v_idx}", row(0));
+
+        // multi-partition queries, which are not supported, but leaving it here in case that changes (CNDB-14044)
+        assertUnsupportedINOnPK("SELECT k FROM %s WHERE k IN (0, 1) AND n = 0");
+        assertUnsupportedINOnPK("SELECT k FROM %s WHERE k IN (0, 1) AND n = 1");
+        assertUnsupportedINOnPK("SELECT k FROM %s WHERE k IN (0, 1) AND n = 2");
+        assertUnsupportedINOnPK("SELECT k FROM %s WHERE k IN (0, 1) AND t : 'foo'");
+        assertUnsupportedINOnPK("SELECT k FROM %s WHERE k IN (0, 1) AND t : 'bar'");
+        assertUnsupportedINOnPK("SELECT k FROM %s WHERE k IN (0, 1) AND t : 'bob'");
+        assertUnsupportedINOnPK("SELECT k FROM %s WHERE k IN (0, 1) AND t = 'foo'");
+        assertUnsupportedINOnPK("SELECT k FROM %s WHERE k IN (0, 1) AND t = 'bar'");
+        assertUnsupportedINOnPK("SELECT k FROM %s WHERE k IN (0, 1) AND t = 'bob'");
+        assertUnsupportedINOnPK("SELECT k FROM %s WHERE k IN (0, 1) ORDER BY t BM25 OF 'foo' LIMIT 2");
+        assertUnsupportedINOnPK("SELECT k FROM %s WHERE k IN (0, 1) ORDER BY t BM25 OF 'bar' LIMIT 2");
+        assertUnsupportedINOnPK("SELECT k FROM %s WHERE k IN (0, 1) ORDER BY t BM25 OF 'bob' LIMIT 2");
+        assertUnsupportedINOnPK("SELECT k FROM %s WHERE k IN (0, 1) ORDER BY v ANN OF [0, 1] LIMIT 2");
+        assertUnsupportedINOnPK("SELECT k FROM %s WHERE k IN (0, 1) ORDER BY v ANN OF [0, 9] LIMIT 2");
+    }
+
+    @Test
+    public void testSkipsIndexWide()
+    {
+        createTable("CREATE TABLE %s (k int, c int, n int, t text, v vector<float, 2>, PRIMARY KEY(k, c))");
+        createIndex("CREATE CUSTOM INDEX n_idx ON %s(n) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX t_idx ON %s(t) USING 'StorageAttachedIndex' WITH OPTIONS = { 'index_analyzer': 'standard' }");
+        createIndex("CREATE CUSTOM INDEX v_idx ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
+        execute("INSERT INTO %s(k, c, n, v, t) VALUES (0, 0, 0, [0, 1], 'foo')");
+        execute("INSERT INTO %s(k, c, n, v, t) VALUES (0, 1, 1, [0, 2], 'foo bar')");
+        execute("INSERT INTO %s(k, c, n, v, t) VALUES (0, 2, 0, [0, 3], 'bar')");
+        execute("INSERT INTO %s(k, c, n, v, t) VALUES (0, 3, 1, [0, 4], 'foo bar')");
+        execute("INSERT INTO %s(k, c, n, v, t) VALUES (1, 0, 0, [0, 5], 'foo')");
+        execute("INSERT INTO %s(k, c, n, v, t) VALUES (1, 1, 1, [0, 6], 'foo bar')");
+        execute("INSERT INTO %s(k, c, n, v, t) VALUES (1, 2, 0, [0, 7], 'bar')");
+        execute("INSERT INTO %s(k, c, n, v, t) VALUES (1, 3, 1, [0, 8], 'foo bar')");
+
+        // range queries, unbounded
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE n = 0", row(1, 0), row(1, 2), row(0, 0), row(0, 2));
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE n = 1", row(1, 1), row(1, 3), row(0, 1), row(0, 3));
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE n = 2");
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE t : 'foo'", row(1, 0), row(1, 1), row(1, 3), row(0, 0), row(0, 1), row(0, 3));
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE t : 'bar'", row(1, 1), row(1, 2), row(1, 3), row(0, 1), row(0, 2), row(0, 3));
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE t : 'bob'");
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE t = 'foo'", row(1, 0), row(1, 1), row(1, 3), row(0, 0), row(0, 1), row(0, 3));
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE t = 'bar'", row(1, 1), row(1, 2), row(1, 3), row(0, 1), row(0, 2), row(0, 3));
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE t = 'bob'");
+        assertHasQueryPlan("SELECT k, c FROM %s ORDER BY t BM25 OF 'foo' LIMIT 2", row(1, 0), row(0, 0));
+        assertHasQueryPlan("SELECT k, c FROM %s ORDER BY t BM25 OF 'bar' LIMIT 2", row(1, 2), row(0, 2));
+        assertHasQueryPlan("SELECT k, c FROM %s ORDER BY t BM25 OF 'bob' LIMIT 2");
+        assertHasQueryPlan("SELECT k, c FROM %s ORDER BY v ANN OF [0, 1] LIMIT 2", row(0, 0), row(0, 1));
+        assertHasQueryPlan("SELECT k, c FROM %s ORDER BY v ANN OF [0, 9] LIMIT 2", row(1, 3), row(1, 2));
+
+        // range queries, with token range
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE token(k) >= token(1) AND n = 0", row(1, 0), row(1, 2), row(0, 0), row(0, 2));
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE token(k) >= token(1) AND n = 1", row(1, 1), row(1, 3), row(0, 1), row(0, 3));
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE token(k) >= token(1) AND n = 2");
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE token(k) >= token(1) AND t : 'foo'", row(1, 0), row(1, 1), row(1, 3), row(0, 0), row(0, 1), row(0, 3));
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE token(k) >= token(1) AND t : 'bar'", row(1, 1), row(1, 2), row(1, 3), row(0, 1), row(0, 2), row(0, 3));
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE token(k) >= token(1) AND t : 'bob'");
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE token(k) >= token(1) AND t = 'foo'", row(1, 0), row(1, 1), row(1, 3), row(0, 0), row(0, 1), row(0, 3));
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE token(k) >= token(1) AND t = 'bar'", row(1, 1), row(1, 2), row(1, 3), row(0, 1), row(0, 2), row(0, 3));
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE token(k) >= token(1) AND t = 'bob'");
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE token(k) >= token(1) ORDER BY t BM25 OF 'foo' LIMIT 2", row(1, 0), row(0, 0));
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE token(k) >= token(1) ORDER BY t BM25 OF 'bar' LIMIT 2", row(1, 2), row(0, 2));
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE token(k) >= token(1) ORDER BY t BM25 OF 'bob' LIMIT 2");
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE token(k) >= token(1) ORDER BY v ANN OF [0, 1] LIMIT 2", row(0, 0), row(0, 1));
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE token(k) >= token(1) ORDER BY v ANN OF [0, 9] LIMIT 2", row(1, 3), row(1, 2));
+
+        // single-partition queries
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND n = 0", row(0, 0), row(0, 2));
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND n = 1", row(0, 1), row(0, 3));
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND n = 2");
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND t : 'foo'", row(0, 0), row(0, 1), row(0, 3));
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND t : 'bar'", row(0, 1), row(0, 2), row(0, 3));
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND t : 'bob'");
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND t = 'foo'", row(0, 0), row(0, 1), row(0, 3));
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND t = 'bar'", row(0, 1), row(0, 2), row(0, 3));
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND t = 'bob'");
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE k = 0 ORDER BY t BM25 OF 'foo' LIMIT 2", row(0, 0), row(0, 1));
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE k = 0 ORDER BY t BM25 OF 'bar' LIMIT 2", row(0, 2), row(0, 1));
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE k = 0 ORDER BY t BM25 OF 'bob' LIMIT 2");
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE k = 0 ORDER BY v ANN OF [0, 1] LIMIT 2", row(0, 0), row(0, 1));
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE k = 0 ORDER BY v ANN OF [0, 9] LIMIT 2", row(0, 3), row(0, 2));
+
+        // multi-partition queries, which are not supported, but leaving it here in case that changes (CNDB-14044)
+        assertUnsupportedINOnPK("SELECT k, c FROM %s WHERE k IN (0, 1) AND n = 0");
+        assertUnsupportedINOnPK("SELECT k, c FROM %s WHERE k IN (0, 1) AND n = 1");
+        assertUnsupportedINOnPK("SELECT k, c FROM %s WHERE k IN (0, 1) AND n = 2");
+        assertUnsupportedINOnPK("SELECT k, c FROM %s WHERE k IN (0, 1) AND t : 'foo'");
+        assertUnsupportedINOnPK("SELECT k, c FROM %s WHERE k IN (0, 1) AND t : 'bar'");
+        assertUnsupportedINOnPK("SELECT k, c FROM %s WHERE k IN (0, 1) AND t : 'bob'");
+        assertUnsupportedINOnPK("SELECT k, c FROM %s WHERE k IN (0, 1) AND t = 'foo'");
+        assertUnsupportedINOnPK("SELECT k, c FROM %s WHERE k IN (0, 1) AND t = 'bar'");
+        assertUnsupportedINOnPK("SELECT k, c FROM %s WHERE k IN (0, 1) AND t = 'bob'");
+        assertUnsupportedINOnPK("SELECT k, c FROM %s WHERE k IN (0, 1) ORDER BY t BM25 OF 'foo' LIMIT 2");
+        assertUnsupportedINOnPK("SELECT k, c FROM %s WHERE k IN (0, 1) ORDER BY t BM25 OF 'bar' LIMIT 2");
+        assertUnsupportedINOnPK("SELECT k, c FROM %s WHERE k IN (0, 1) ORDER BY t BM25 OF 'bob' LIMIT 2");
+        assertUnsupportedINOnPK("SELECT k, c FROM %s WHERE k IN (0, 1) ORDER BY v ANN OF [0, 1] LIMIT 2");
+        assertUnsupportedINOnPK("SELECT k, c FROM %s WHERE k IN (0, 1) ORDER BY v ANN OF [0, 9] LIMIT 2");
+
+        // single-row single-partition queries
+        assertHasNoQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c = 0 AND n = 0", row(0, 0));
+        assertHasNoQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c = 0 AND n = 1");
+        assertHasNoQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c = 0 AND n = 2");
+        assertHasNoQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c = 0 AND t : 'foo'", row(0, 0));
+        assertHasNoQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c = 0 AND t : 'bar'");
+        assertHasNoQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c = 0 AND t = 'foo'", row(0, 0));
+        assertHasNoQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c = 0 AND t = 'bar'");
+
+        // single-row single-partition queries with hints
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c = 0 AND n = 0 WITH included_indexes = {n_idx}", row(0, 0));
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c = 0 AND n = 1 WITH included_indexes = {n_idx}");
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c = 0 AND n = 2 WITH included_indexes = {n_idx}");
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c = 0 AND t : 'foo' WITH included_indexes = {t_idx}", row(0, 0));
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c = 0 AND t : 'bar' WITH included_indexes = {t_idx}");
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c = 0 AND t = 'foo' WITH included_indexes = {t_idx}", row(0, 0));
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c = 0 AND t = 'bar' WITH included_indexes = {t_idx}");
+
+        // names single-row queries
+        assertHasNoQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c IN (0, 1) AND n = 0", row(0, 0));
+        assertHasNoQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c IN (0, 1) AND n = 1", row(0, 1));
+        assertHasNoQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c IN (0, 1) AND n = 2");
+        assertHasNoQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c IN (0, 1) AND t : 'foo'", row(0, 0), row(0, 1));
+        assertHasNoQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c IN (0, 1) AND t : 'bar'", row(0, 1));
+        assertHasNoQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c IN (0, 1) AND t = 'foo'", row(0, 0), row(0, 1));
+        assertHasNoQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c IN (0, 1) AND t = 'bar'", row(0, 1));
+
+        // names single-row queries with hints
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c IN (0, 1) AND n = 0 WITH included_indexes = {n_idx}", row(0, 0));
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c IN (0, 1) AND n = 1 WITH included_indexes = {n_idx}", row(0, 1));
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c IN (0, 1) AND n = 2 WITH included_indexes = {n_idx}");
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c IN (0, 1) AND t : 'foo' WITH included_indexes = {t_idx}", row(0, 0), row(0, 1));
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c IN (0, 1) AND t : 'bar' WITH included_indexes = {t_idx}", row(0, 1));
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c IN (0, 1) AND t = 'foo' WITH included_indexes = {t_idx}", row(0, 0), row(0, 1));
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c IN (0, 1) AND t = 'bar' WITH included_indexes = {t_idx}", row(0, 1));
+
+        // slices single-partition queries
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c >= 0 AND c <= 1 AND n = 0", row(0, 0));
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c >= 0 AND c <= 1 AND n = 1", row(0, 1));
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c >= 0 AND c <= 1 AND n = 2");
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c >= 0 AND c <= 1 AND t : 'foo'", row(0, 0), row(0, 1));
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c >= 0 AND c <= 1 AND t : 'bar'", row(0, 1));
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c >= 0 AND c <= 1 AND t = 'foo'", row(0, 0), row(0, 1));
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c >= 0 AND c <= 1 AND t = 'bar'", row(0, 1));
+
+        // slices single-partition queries with hints
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c >= 0 AND c <= 1 AND n = 0 WITH included_indexes = {n_idx}", row(0, 0));
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c >= 0 AND c <= 1 AND n = 1 WITH included_indexes = {n_idx}", row(0, 1));
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c >= 0 AND c <= 1 AND n = 2 WITH included_indexes = {n_idx}");
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c >= 0 AND c <= 1 AND t : 'foo' WITH included_indexes = {t_idx}", row(0, 0), row(0, 1));
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c >= 0 AND c <= 1 AND t : 'bar' WITH included_indexes = {t_idx}", row(0, 1));
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c >= 0 AND c <= 1 AND t = 'foo' WITH included_indexes = {t_idx}", row(0, 0), row(0, 1));
+        assertHasQueryPlan("SELECT k, c FROM %s WHERE k = 0 AND c >= 0 AND c <= 1 AND t = 'bar' WITH included_indexes = {t_idx}", row(0, 1));
+    }
+
+    @Test
+    public void testSkipsIndexWideMultiClustering()
+    {
+        createTable("CREATE TABLE %s (k int, c1 int, c2 int, n int, PRIMARY KEY(k, c1, c2))");
+        createIndex("CREATE CUSTOM INDEX n_idx ON %s(n) USING 'StorageAttachedIndex'");
+        execute("INSERT INTO %s(k, c1, c2, n) VALUES (0, 0, 0, 0)");
+        execute("INSERT INTO %s(k, c1, c2, n) VALUES (0, 0, 1, 0)");
+        execute("INSERT INTO %s(k, c1, c2, n) VALUES (0, 0, 2, 0)");
+        execute("INSERT INTO %s(k, c1, c2, n) VALUES (0, 1, 0, 0)");
+        execute("INSERT INTO %s(k, c1, c2, n) VALUES (0, 1, 1, 0)");
+        execute("INSERT INTO %s(k, c1, c2, n) VALUES (0, 1, 2, 0)");
+        execute("INSERT INTO %s(k, c1, c2, n) VALUES (1, 0, 0, 0)");
+        execute("INSERT INTO %s(k, c1, c2, n) VALUES (1, 0, 1, 1)");
+        execute("INSERT INTO %s(k, c1, c2, n) VALUES (1, 0, 2, 0)");
+        execute("INSERT INTO %s(k, c1, c2, n) VALUES (1, 1, 0, 1)");
+        execute("INSERT INTO %s(k, c1, c2, n) VALUES (1, 1, 1, 0)");
+        execute("INSERT INTO %s(k, c1, c2, n) VALUES (1, 1, 2, 1)");
+
+        // range queries, unbounded
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE n = 0",
+                           row(1, 0, 0), row(1, 0, 2), row(1, 1, 1),
+                           row(0, 0, 0), row(0, 0, 1), row(0, 0, 2), row(0, 1, 0), row(0, 1, 1), row(0, 1, 2));
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE n = 1", row(1, 0, 1), row(1, 1, 0), row(1, 1, 2));
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE n = 2");
+
+        // single-partition queries
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND n = 0", row(0, 0, 0), row(0, 0, 1), row(0, 0, 2), row(0, 1, 0), row(0, 1, 1), row(0, 1, 2));
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND n = 1");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND n = 2");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND n = 0", row(1, 0, 0), row(1, 0, 2), row(1, 1, 1));
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND n = 1", row(1, 0, 1), row(1, 1, 0), row(1, 1, 2));
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND n = 2");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 2 AND n = 0");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 2 AND n = 1");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 3 AND n = 2");
+
+        // single-partition queries with eq restriction on first clustering column
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 = 0 AND n = 0", row(0, 0, 0), row(0, 0, 1), row(0, 0, 2));
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 = 0 AND n = 1");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 = 0 AND n = 2");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 = 0 AND n = 0", row(1, 0, 0), row(1, 0, 2));
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 = 0 AND n = 1", row(1, 0, 1));
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 = 0 AND n = 2");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 2 AND c1 = 0 AND n = 0");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 2 AND c1 = 0 AND n = 1");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 3 AND c1 = 0 AND n = 2");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 = 1 AND n = 0", row(0, 1, 0), row(0, 1, 1), row(0, 1, 2));
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 = 1 AND n = 1");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 = 1 AND n = 2");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 = 1 AND n = 0", row(1, 1, 1));
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 = 1 AND n = 1", row(1, 1, 0), row(1, 1, 2));
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 = 1 AND n = 2");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 2 AND c1 = 1 AND n = 0");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 2 AND c1 = 1 AND n = 1");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 3 AND c1 = 1 AND n = 2");
+
+        // single-partition queries with gt restriction on first clustering column
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 > 0 AND n = 0", row(0, 1, 0), row(0, 1, 1), row(0, 1, 2));
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 > 0 AND n = 1");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 > 0 AND n = 2");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 > 0 AND n = 0", row(1, 1, 1));
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 > 0 AND n = 1", row(1, 1, 0), row(1, 1, 2));
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 > 0 AND n = 2");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 2 AND c1 > 0 AND n = 0");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 2 AND c1 > 0 AND n = 1");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 3 AND c1 > 0 AND n = 2");
+
+        // single-partition queries with lt restriction on first clustering column
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 < 1 AND n = 0", row(0, 0, 0), row(0, 0, 1), row(0, 0, 2));
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 < 1 AND n = 1");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 < 1 AND n = 2");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 < 1 AND n = 0", row(1, 0, 0), row(1, 0, 2));
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 < 1 AND n = 1", row(1, 0, 1));
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 < 1 AND n = 2");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 2 AND c1 < 1 AND n = 0");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 2 AND c1 < 1 AND n = 1");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 3 AND c1 < 1 AND n = 2");
+
+        // single-partition queries with gte restriction on first clustering column
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 >= 0 AND n = 0", row(0, 0, 0), row(0, 0, 1), row(0, 0, 2), row(0, 1, 0), row(0, 1, 1), row(0, 1, 2));
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 >= 0 AND n = 1");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 >= 0 AND n = 2");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 >= 0 AND n = 0", row(1, 0, 0), row(1, 0, 2), row(1, 1, 1));
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 >= 0 AND n = 1", row(1, 0, 1), row(1, 1, 0), row(1, 1, 2));
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 >= 0 AND n = 2");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 2 AND c1 >= 0 AND n = 0");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 2 AND c1 >= 0 AND n = 1");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 3 AND c1 >= 0 AND n = 2");
+
+        // single-partition queries with lte restriction on first clustering column
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 <= 1 AND n = 0", row(0, 0, 0), row(0, 0, 1), row(0, 0, 2), row(0, 1, 0), row(0, 1, 1), row(0, 1, 2));
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 <= 1 AND n = 1");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 <= 1 AND n = 2");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 <= 1 AND n = 0", row(1, 0, 0), row(1, 0, 2), row(1, 1, 1));
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 <= 1 AND n = 1", row(1, 0, 1), row(1, 1, 0), row(1, 1, 2));
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 <= 1 AND n = 2");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 2 AND c1 <= 1 AND n = 0");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 2 AND c1 <= 1 AND n = 1");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 3 AND c1 <= 1 AND n = 2");
+
+        // single-partition queries with eq restriction on second clustering column
+        assertHasNoQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 = 0 AND c2 = 0 AND n = 0", row(0, 0, 0));
+        assertHasNoQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 = 0 AND c2 = 0 AND n = 1");
+        assertHasNoQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 = 0 AND c2 = 0 AND n = 2");
+        assertHasNoQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 = 0 AND c2 = 1 AND n = 0", row(0, 0, 1));
+        assertHasNoQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 = 0 AND c2 = 1 AND n = 1");
+        assertHasNoQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 = 0 AND c2 = 1 AND n = 2");
+        assertHasNoQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 = 0 AND c2 = 2 AND n = 0", row(0, 0, 2));
+        assertHasNoQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 = 0 AND c2 = 2 AND n = 1");
+        assertHasNoQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 = 0 AND c2 = 2 AND n = 2");
+        assertHasNoQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 = 1 AND c2 = 0 AND n = 0", row(0, 1, 0));
+        assertHasNoQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 = 1 AND c2 = 0 AND n = 1");
+        assertHasNoQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 = 1 AND c2 = 0 AND n = 2");
+        assertHasNoQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 = 1 AND c2 = 1 AND n = 0", row(0, 1, 1));
+        assertHasNoQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 = 1 AND c2 = 1 AND n = 1");
+        assertHasNoQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 = 1 AND c2 = 1 AND n = 2");
+        assertHasNoQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 = 1 AND c2 = 2 AND n = 0", row(0, 1, 2));
+        assertHasNoQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 = 1 AND c2 = 2 AND n = 1");
+        assertHasNoQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 = 1 AND c2 = 2 AND n = 2");
+        assertHasNoQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 = 0 AND c2 = 0 AND n = 0", row(1, 0, 0));
+        assertHasNoQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 = 0 AND c2 = 0 AND n = 1");
+        assertHasNoQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 = 0 AND c2 = 0 AND n = 2");
+        assertHasNoQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 = 0 AND c2 = 1 AND n = 0");
+        assertHasNoQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 = 0 AND c2 = 1 AND n = 1", row(1, 0, 1));
+        assertHasNoQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 = 0 AND c2 = 1 AND n = 2");
+        assertHasNoQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 = 0 AND c2 = 2 AND n = 0", row(1, 0, 2));
+        assertHasNoQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 = 0 AND c2 = 2 AND n = 1");
+        assertHasNoQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 = 0 AND c2 = 2 AND n = 2");
+        assertHasNoQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 = 1 AND c2 = 0 AND n = 0");
+        assertHasNoQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 = 1 AND c2 = 0 AND n = 1", row(1, 1, 0));
+        assertHasNoQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 = 1 AND c2 = 0 AND n = 2");
+        assertHasNoQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 = 1 AND c2 = 1 AND n = 0", row(1, 1, 1));
+        assertHasNoQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 = 1 AND c2 = 1 AND n = 1");
+        assertHasNoQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 = 1 AND c2 = 1 AND n = 2");
+        assertHasNoQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 = 1 AND c2 = 2 AND n = 0");
+        assertHasNoQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 = 1 AND c2 = 2 AND n = 1", row(1, 1, 2));
+        assertHasNoQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 = 1 AND c2 = 2 AND n = 2");
+        assertHasNoQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 2 AND c1 = 0 AND c2 = 0 AND n = 0");
+        assertHasNoQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 2 AND c1 = 0 AND c2 = 0 AND n = 1");
+        assertHasNoQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 2 AND c1 = 0 AND c2 = 1 AND n = 0");
+        assertHasNoQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 2 AND c1 = 0 AND c2 = 1 AND n = 1");
+        assertHasNoQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 2 AND c1 = 0 AND c2 = 2 AND n = 0");
+        assertHasNoQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 2 AND c1 = 0 AND c2 = 2 AND n = 1");
+        assertHasNoQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 2 AND c1 = 1 AND c2 = 0 AND n = 0");
+        assertHasNoQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 2 AND c1 = 1 AND c2 = 0 AND n = 1");
+        assertHasNoQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 2 AND c1 = 1 AND c2 = 1 AND n = 0");
+        assertHasNoQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 2 AND c1 = 1 AND c2 = 1 AND n = 1");
+        assertHasNoQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 2 AND c1 = 1 AND c2 = 2 AND n = 0");
+        assertHasNoQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 2 AND c1 = 1 AND c2 = 2 AND n = 1");
+
+        // single-partition queries with gt restriction on second clustering column
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 = 0 AND c2 > 0 AND n = 0", row(0, 0, 1), row(0, 0, 2));
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 = 0 AND c2 > 0 AND n = 1");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 = 0 AND c2 > 0 AND n = 2");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 = 1 AND c2 > 0 AND n = 0", row(0, 1, 1), row(0, 1, 2));
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 = 1 AND c2 > 0 AND n = 1");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 = 1 AND c2 > 0 AND n = 2");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 = 0 AND c2 > 0 AND n = 0", row(1, 0, 2));
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 = 0 AND c2 > 0 AND n = 1", row(1, 0, 1));
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 = 0 AND c2 > 0 AND n = 2");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 = 1 AND c2 > 0 AND n = 0", row(1, 1, 1));
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 = 1 AND c2 > 0 AND n = 1", row(1, 1, 2));
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 = 1 AND c2 > 0 AND n = 2");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 2 AND c1 = 0 AND c2 > 0 AND n = 0");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 2 AND c1 = 0 AND c2 > 0 AND n = 1");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 2 AND c1 = 1 AND c2 > 0 AND n = 0");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 2 AND c1 = 1 AND c2 > 0 AND n = 1");
+
+        // single-partition queries with lt restriction on second clustering column
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 = 0 AND c2 < 2 AND n = 0", row(0, 0, 0), row(0, 0, 1));
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 = 0 AND c2 < 2 AND n = 1");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 = 0 AND c2 < 2 AND n = 2");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 = 1 AND c2 < 2 AND n = 0", row(0, 1, 0), row(0, 1, 1));
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 = 1 AND c2 < 2 AND n = 1");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 = 1 AND c2 < 2 AND n = 2");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 = 0 AND c2 < 2 AND n = 0", row(1, 0, 0));
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 = 0 AND c2 < 2 AND n = 1", row(1, 0, 1));
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 = 0 AND c2 < 2 AND n = 2");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 = 1 AND c2 < 2 AND n = 0", row(1, 1, 1));
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 = 1 AND c2 < 2 AND n = 1", row(1, 1, 0));
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 = 1 AND c2 < 2 AND n = 2");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 2 AND c1 = 0 AND c2 < 2 AND n = 0");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 2 AND c1 = 0 AND c2 < 2 AND n = 1");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 2 AND c1 = 1 AND c2 < 2 AND n = 0");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 2 AND c1 = 1 AND c2 < 2 AND n = 1");
+
+        // single-partition queries with gte restriction on second clustering column
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 = 0 AND c2 >= 0 AND n = 0", row(0, 0, 0), row(0, 0, 1), row(0, 0, 2));
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 = 0 AND c2 >= 0 AND n = 1");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 = 0 AND c2 >= 0 AND n = 2");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 = 1 AND c2 >= 0 AND n = 0", row(0, 1, 0), row(0, 1, 1), row(0, 1, 2));
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 = 1 AND c2 >= 0 AND n = 1");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 = 1 AND c2 >= 0 AND n = 2");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 = 0 AND c2 >= 0 AND n = 0", row(1, 0, 0), row(1, 0, 2));
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 = 0 AND c2 >= 0 AND n = 1", row(1, 0, 1));
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 = 0 AND c2 >= 0 AND n = 2");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 = 1 AND c2 >= 0 AND n = 0", row(1, 1, 1));
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 = 1 AND c2 >= 0 AND n = 1", row(1, 1, 0), row(1, 1, 2));
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 = 1 AND c2 >= 0 AND n = 2");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 2 AND c1 = 0 AND c2 >= 0 AND n = 0");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 2 AND c1 = 0 AND c2 >= 0 AND n = 1");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 2 AND c1 = 1 AND c2 >= 0 AND n = 0");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 2 AND c1 = 1 AND c2 >= 0 AND n = 1");
+
+        // single-partition queries with lte restriction on second clustering column
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 = 0 AND c2 <= 2 AND n = 0", row(0, 0, 0), row(0, 0, 1), row(0, 0, 2));
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 = 0 AND c2 <= 2 AND n = 1");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 = 0 AND c2 <= 2 AND n = 2");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 = 1 AND c2 <= 2 AND n = 0", row(0, 1, 0), row(0, 1, 1), row(0, 1, 2));
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 = 1 AND c2 <= 2 AND n = 1");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 0 AND c1 = 1 AND c2 <= 2 AND n = 2");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 = 0 AND c2 <= 2 AND n = 0", row(1, 0, 0), row(1, 0, 2));
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 = 0 AND c2 <= 2 AND n = 1", row(1, 0, 1));
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 = 0 AND c2 <= 2 AND n = 2");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 = 1 AND c2 <= 2 AND n = 0", row(1, 1, 1));
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 = 1 AND c2 <= 2 AND n = 1", row(1, 1, 0), row(1, 1, 2));
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 1 AND c1 = 1 AND c2 <= 2 AND n = 2");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 2 AND c1 = 0 AND c2 <= 2 AND n = 0");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 2 AND c1 = 0 AND c2 <= 2 AND n = 1");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 2 AND c1 = 1 AND c2 <= 2 AND n = 0");
+        assertHasQueryPlan("SELECT k, c1, c2 FROM %s WHERE k = 2 AND c1 = 1 AND c2 <= 2 AND n = 1");
+    }
+
+    @Test
+    public void testCollections()
+    {
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, s set<int>, l list<int>, m map<int, int>)");
+        createIndex("CREATE CUSTOM INDEX s_idx ON %s(s) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX l_idx ON %s(l) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX m_k_idx ON %s(KEYS(m)) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX m_v_idx ON %s(VALUES(m)) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX m_e_idx ON %s(ENTRIES(m)) USING 'StorageAttachedIndex'");
+        execute("INSERT INTO %s(k, s, l, m) VALUES (1, {1, 2, 3}, [1, 2, 3], {1:10, 2:20, 3:30})");
+        execute("INSERT INTO %s(k, s, l, m) VALUES (2, {2, 3, 4}, [2, 3, 4], {2:20, 3:30, 4:40})");
+        execute("INSERT INTO %s(k, s, l, m) VALUES (3, {4, 5 ,6}, [4, 5 ,6], {4:40, 5:50 ,6:60})");
+
+        // range queries, unbounded
+        assertHasQueryPlan("SELECT k FROM %s WHERE s CONTAINS 1", row(1));
+        assertHasQueryPlan("SELECT k FROM %s WHERE s CONTAINS 2", row(1), row(2));
+        assertHasQueryPlan("SELECT k FROM %s WHERE s CONTAINS 3", row(1), row(2));
+        assertHasQueryPlan("SELECT k FROM %s WHERE s CONTAINS 4", row(2), row(3));
+        assertHasQueryPlan("SELECT k FROM %s WHERE s NOT CONTAINS 1", row(2), row(3));
+        assertHasQueryPlan("SELECT k FROM %s WHERE s NOT CONTAINS 2", row(3));
+        assertHasQueryPlan("SELECT k FROM %s WHERE s NOT CONTAINS 3", row(3));
+        assertHasQueryPlan("SELECT k FROM %s WHERE s NOT CONTAINS 4", row(1));
+        assertHasQueryPlan("SELECT k FROM %s WHERE l CONTAINS 1", row(1));
+        assertHasQueryPlan("SELECT k FROM %s WHERE l CONTAINS 2", row(1), row(2));
+        assertHasQueryPlan("SELECT k FROM %s WHERE l CONTAINS 3", row(1), row(2));
+        assertHasQueryPlan("SELECT k FROM %s WHERE l CONTAINS 4", row(2), row(3));
+        assertHasQueryPlan("SELECT k FROM %s WHERE l NOT CONTAINS 1", row(2), row(3));
+        assertHasQueryPlan("SELECT k FROM %s WHERE l NOT CONTAINS 2", row(3));
+        assertHasQueryPlan("SELECT k FROM %s WHERE l NOT CONTAINS 3", row(3));
+        assertHasQueryPlan("SELECT k FROM %s WHERE l NOT CONTAINS 4", row(1));
+        assertHasQueryPlan("SELECT k FROM %s WHERE m CONTAINS KEY 1", row(1));
+        assertHasQueryPlan("SELECT k FROM %s WHERE m CONTAINS KEY 2", row(1), row(2));
+        assertHasQueryPlan("SELECT k FROM %s WHERE m CONTAINS KEY 3", row(1), row(2));
+        assertHasQueryPlan("SELECT k FROM %s WHERE m CONTAINS KEY 4", row(2), row(3));
+        assertHasQueryPlan("SELECT k FROM %s WHERE m NOT CONTAINS KEY 1", row(2), row(3));
+        assertHasQueryPlan("SELECT k FROM %s WHERE m NOT CONTAINS KEY 2", row(3));
+        assertHasQueryPlan("SELECT k FROM %s WHERE m NOT CONTAINS KEY 3", row(3));
+        assertHasQueryPlan("SELECT k FROM %s WHERE m NOT CONTAINS KEY 4", row(1));
+        assertHasQueryPlan("SELECT k FROM %s WHERE m CONTAINS 10", row(1));
+        assertHasQueryPlan("SELECT k FROM %s WHERE m CONTAINS 20", row(1), row(2));
+        assertHasQueryPlan("SELECT k FROM %s WHERE m CONTAINS 30", row(1), row(2));
+        assertHasQueryPlan("SELECT k FROM %s WHERE m CONTAINS 40", row(2), row(3));
+        assertHasQueryPlan("SELECT k FROM %s WHERE m NOT CONTAINS 10", row(2), row(3));
+        assertHasQueryPlan("SELECT k FROM %s WHERE m NOT CONTAINS 20", row(3));
+        assertHasQueryPlan("SELECT k FROM %s WHERE m NOT CONTAINS 30", row(3));
+        assertHasQueryPlan("SELECT k FROM %s WHERE m NOT CONTAINS 40", row(1));
+        assertHasQueryPlan("SELECT k FROM %s WHERE m[1] = 10", row(1));
+        assertHasQueryPlan("SELECT k FROM %s WHERE m[2] = 20", row(1), row(2));
+        assertHasQueryPlan("SELECT k FROM %s WHERE m[3] = 30", row(1), row(2));
+        assertHasQueryPlan("SELECT k FROM %s WHERE m[4] = 40", row(2), row(3));
+        assertHasQueryPlan("SELECT k FROM %s WHERE m[1] != 10", row(2), row(3));
+        assertHasQueryPlan("SELECT k FROM %s WHERE m[2] != 20", row(3));
+        assertHasQueryPlan("SELECT k FROM %s WHERE m[3] != 30", row(3));
+        assertHasQueryPlan("SELECT k FROM %s WHERE m[4] != 40", row(1));
+
+        // single-partition queries
+        assertHasNoQueryPlan("SELECT k FROM %s WHERE k = 1 AND s CONTAINS 1", row(1));
+        assertHasNoQueryPlan("SELECT k FROM %s WHERE k = 1 AND s CONTAINS 2", row(1));
+        assertHasNoQueryPlan("SELECT k FROM %s WHERE k = 1 AND s CONTAINS 3", row(1));
+        assertHasNoQueryPlan("SELECT k FROM %s WHERE k = 1 AND s CONTAINS 4");
+        assertHasNoQueryPlan("SELECT k FROM %s WHERE k = 1 AND s NOT CONTAINS 1");
+        assertHasNoQueryPlan("SELECT k FROM %s WHERE k = 1 AND s NOT CONTAINS 2");
+        assertHasNoQueryPlan("SELECT k FROM %s WHERE k = 1 AND s NOT CONTAINS 3");
+        assertHasNoQueryPlan("SELECT k FROM %s WHERE k = 1 AND s NOT CONTAINS 4", row(1));
+        assertHasNoQueryPlan("SELECT k FROM %s WHERE k = 1 AND l CONTAINS 1", row(1));
+        assertHasNoQueryPlan("SELECT k FROM %s WHERE k = 1 AND l CONTAINS 2", row(1));
+        assertHasNoQueryPlan("SELECT k FROM %s WHERE k = 1 AND l CONTAINS 3", row(1));
+        assertHasNoQueryPlan("SELECT k FROM %s WHERE k = 1 AND l CONTAINS 4");
+        assertHasNoQueryPlan("SELECT k FROM %s WHERE k = 1 AND l NOT CONTAINS 1");
+        assertHasNoQueryPlan("SELECT k FROM %s WHERE k = 1 AND l NOT CONTAINS 2");
+        assertHasNoQueryPlan("SELECT k FROM %s WHERE k = 1 AND l NOT CONTAINS 3");
+        assertHasNoQueryPlan("SELECT k FROM %s WHERE k = 1 AND l NOT CONTAINS 4", row(1));
+        assertHasNoQueryPlan("SELECT k FROM %s WHERE k = 1 AND m CONTAINS KEY 1", row(1));
+        assertHasNoQueryPlan("SELECT k FROM %s WHERE k = 1 AND m CONTAINS KEY 2", row(1));
+        assertHasNoQueryPlan("SELECT k FROM %s WHERE k = 1 AND m CONTAINS KEY 3", row(1));
+        assertHasNoQueryPlan("SELECT k FROM %s WHERE k = 1 AND m CONTAINS KEY 4");
+        assertHasNoQueryPlan("SELECT k FROM %s WHERE k = 1 AND m NOT CONTAINS KEY 1");
+        assertHasNoQueryPlan("SELECT k FROM %s WHERE k = 1 AND m NOT CONTAINS KEY 2");
+        assertHasNoQueryPlan("SELECT k FROM %s WHERE k = 1 AND m NOT CONTAINS KEY 3");
+        assertHasNoQueryPlan("SELECT k FROM %s WHERE k = 1 AND m NOT CONTAINS KEY 4", row(1));
+        assertHasNoQueryPlan("SELECT k FROM %s WHERE k = 1 AND m CONTAINS 10", row(1));
+        assertHasNoQueryPlan("SELECT k FROM %s WHERE k = 1 AND m CONTAINS 20", row(1));
+        assertHasNoQueryPlan("SELECT k FROM %s WHERE k = 1 AND m CONTAINS 30", row(1));
+        assertHasNoQueryPlan("SELECT k FROM %s WHERE k = 1 AND m CONTAINS 40");
+        assertHasNoQueryPlan("SELECT k FROM %s WHERE k = 1 AND m NOT CONTAINS 10");
+        assertHasNoQueryPlan("SELECT k FROM %s WHERE k = 1 AND m NOT CONTAINS 20");
+        assertHasNoQueryPlan("SELECT k FROM %s WHERE k = 1 AND m NOT CONTAINS 30");
+        assertHasNoQueryPlan("SELECT k FROM %s WHERE k = 1 AND m NOT CONTAINS 40", row(1));
+        assertHasNoQueryPlan("SELECT k FROM %s WHERE k = 1 AND m[1] = 10", row(1));
+        assertHasNoQueryPlan("SELECT k FROM %s WHERE k = 1 AND m[2] = 20", row(1));
+        assertHasNoQueryPlan("SELECT k FROM %s WHERE k = 1 AND m[3] = 30", row(1));
+        assertHasNoQueryPlan("SELECT k FROM %s WHERE k = 1 AND m[4] = 40");
+        assertHasNoQueryPlan("SELECT k FROM %s WHERE k = 1 AND m[1] != 10");
+        assertHasNoQueryPlan("SELECT k FROM %s WHERE k = 1 AND m[2] != 20");
+        assertHasNoQueryPlan("SELECT k FROM %s WHERE k = 1 AND m[3] != 30");
+        assertHasNoQueryPlan("SELECT k FROM %s WHERE k = 1 AND m[4] != 40", row(1));
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/datamodels/SingleNodeQueryTester.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/datamodels/SingleNodeQueryTester.java
@@ -29,6 +29,7 @@ import org.junit.Ignore;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.index.sai.SAITester;
 import org.apache.cassandra.index.sai.SAIUtil;
 import org.apache.cassandra.index.sai.disk.format.Version;
@@ -57,6 +58,8 @@ abstract class SingleNodeQueryTester extends SAITester
     @Before
     public void setup() throws Throwable
     {
+        CassandraRelevantProperties.SKIP_INDEXES_ON_FULL_PRIMARY_KEYS.setBoolean(false);
+
         SAIUtil.setCurrentVersion(version);
         requireNetwork();
 

--- a/test/unit/org/apache/cassandra/index/sai/metrics/QueryMetricsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/metrics/QueryMetricsTest.java
@@ -29,6 +29,7 @@ import org.junit.rules.ExpectedException;
 
 import com.datastax.driver.core.ResultSet;
 
+import net.openhft.chronicle.core.util.BooleanConsumer;
 import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.cql3.UntypedResultSet;
 import org.apache.cassandra.db.ReadCommand;
@@ -40,6 +41,7 @@ import static org.apache.cassandra.index.sai.metrics.TableQueryMetrics.AbstractQ
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import org.assertj.core.api.Assertions;
 
 public class QueryMetricsTest extends AbstractMetricsTest
 {
@@ -139,6 +141,12 @@ public class QueryMetricsTest extends AbstractMetricsTest
     @Test
     public void testIndexQueryWithPartitionKey()
     {
+        withSkipIndexesOnFullPKs(true, this::testIndexQueryWithPartitionKey);
+        withSkipIndexesOnFullPKs(false, this::testIndexQueryWithPartitionKey);
+    }
+
+    private void testIndexQueryWithPartitionKey(boolean skipIndexesOnFullPKs)
+    {
         String table = "test_range_key_type_with_index";
         String index = "test_range_key_type_with_index_index";
 
@@ -179,7 +187,24 @@ public class QueryMetricsTest extends AbstractMetricsTest
         ObjectName oName = objectNameNoIndex("SSTableIndexesHit", keyspace, table, PER_QUERY_METRIC_TYPE);
         CassandraMetricsRegistry.JmxHistogramMBean o = JMX.newMBeanProxy(jmxConnection, oName, CassandraMetricsRegistry.JmxHistogramMBean.class);
 
-        assertTrue(o.getMean() < 2);
+        if (skipIndexesOnFullPKs)
+            Assertions.assertThat(o.getCount()).isZero();
+        else
+            Assertions.assertThat(o.getMean()).isLessThan(2);
+    }
+
+    private static void withSkipIndexesOnFullPKs(boolean skip, BooleanConsumer consumer)
+    {
+        boolean previous = CassandraRelevantProperties.SKIP_INDEXES_ON_FULL_PRIMARY_KEYS.getBoolean();
+        try
+        {
+            CassandraRelevantProperties.SKIP_INDEXES_ON_FULL_PRIMARY_KEYS.setBoolean(skip);
+            consumer.accept(skip);
+        }
+        finally
+        {
+            CassandraRelevantProperties.SKIP_INDEXES_ON_FULL_PRIMARY_KEYS.setBoolean(previous);
+        }
     }
 
     @Test


### PR DESCRIPTION
Queries with index-based ORDER BY will still use the index, since we don't have a way to run those without the index.

Queries in which the indexes changes the semantics of the expression, such as those with analyzers, will preserve the index semantics, even if the index itself is not read.
