### PR TITLE
CNDB-18201: support streaming with mixed MS versions

### DIFF
--- a/src/java/org/apache/cassandra/db/streaming/CassandraIncomingFile.java
+++ b/src/java/org/apache/cassandra/db/streaming/CassandraIncomingFile.java
@@ -81,7 +81,7 @@ public class CassandraIncomingFile implements IncomingStream
         else if (streamHeader.isCompressed())
             reader = new CassandraCompressedStreamReader(header, streamHeader, session);
         else
-            reader = new CassandraStreamReader(header, streamHeader, session);
+            reader = new CassandraStreamReader(header, streamHeader, session, version);
 
         size = streamHeader.size();
         sstable = reader.read(in);

--- a/src/java/org/apache/cassandra/db/streaming/CassandraOutgoingFile.java
+++ b/src/java/org/apache/cassandra/db/streaming/CassandraOutgoingFile.java
@@ -170,10 +170,16 @@ public class CassandraOutgoingFile implements OutgoingStream
             CassandraStreamHeader.serializer.serialize(header, out, version);
             out.flush();
 
-            CassandraStreamWriter writer = header.isCompressed() ?
-                                           new CassandraCompressedStreamWriter(sstable, header, session) :
-                                           new CassandraStreamWriter(sstable, header, session);
-            writer.write(out);
+            if (header.isCompressed())
+            {
+                CassandraCompressedStreamWriter writer = new CassandraCompressedStreamWriter(sstable, header, session);
+                writer.write(out);
+            }
+            else
+            {
+                CassandraStreamWriter writer = new CassandraStreamWriter(sstable, header, session);
+                writer.write(out, version);
+            }
         }
     }
 

--- a/src/java/org/apache/cassandra/db/streaming/CassandraStreamReader.java
+++ b/src/java/org/apache/cassandra/db/streaming/CassandraStreamReader.java
@@ -88,8 +88,14 @@ public class CassandraStreamReader implements IStreamReader
     protected final int sstableLevel;
     protected final SerializationHeader.Component header;
     protected final int fileSeqNum;
+    protected final int protocolVersion;
 
     public CassandraStreamReader(StreamMessageHeader header, CassandraStreamHeader streamHeader, StreamSession session)
+    {
+        this(header, streamHeader, session, current_version);
+    }
+
+    public CassandraStreamReader(StreamMessageHeader header, CassandraStreamHeader streamHeader, StreamSession session, int protocolVersion)
     {
         if (session.getPendingRepair() != null)
         {
@@ -107,6 +113,7 @@ public class CassandraStreamReader implements IStreamReader
         this.sstableLevel = streamHeader.sstableLevel;
         this.header = streamHeader.serializationHeader;
         this.fileSeqNum = header.sequenceNumber;
+        this.protocolVersion = protocolVersion;
     }
 
     /**
@@ -130,7 +137,7 @@ public class CassandraStreamReader implements IStreamReader
 
         StreamDeserializer deserializer = null;
         SSTableMultiWriter writer = null;
-        try (StreamCompressionInputStream streamCompressionInputStream = new StreamCompressionInputStream(inputPlus, current_version))
+        try (StreamCompressionInputStream streamCompressionInputStream = new StreamCompressionInputStream(inputPlus, protocolVersion))
         {
             TrackedDataInputPlus in = new TrackedDataInputPlus(streamCompressionInputStream);
             writer = createWriter(cfs, totalSize, repairedAt, pendingRepair, inputVersion.format);

--- a/src/java/org/apache/cassandra/db/streaming/CassandraStreamWriter.java
+++ b/src/java/org/apache/cassandra/db/streaming/CassandraStreamWriter.java
@@ -75,6 +75,11 @@ public class CassandraStreamWriter
      */
     public void write(StreamingDataOutputPlus out) throws IOException
     {
+        write(out, current_version);
+    }
+
+    public void write(StreamingDataOutputPlus out, int version) throws IOException
+    {
         long totalSize = totalSize();
         logger.debug("[Stream #{}] Start streaming file {} to {}, repairedAt = {}, totalSize = {}", session.planId(),
                      sstable.getFilename(), session.peer, sstable.getSSTableMetadata().repairedAt, totalSize);
@@ -104,7 +109,7 @@ public class CassandraStreamWriter
                 while (bytesRead < length)
                 {
                     int toTransfer = (int) Math.min(bufferSize, length - bytesRead);
-                    long lastBytesRead = write(proxy, validator, out, start, transferOffset, toTransfer, bufferSize);
+                    long lastBytesRead = write(proxy, validator, out, start, transferOffset, toTransfer, bufferSize, version);
                     start += lastBytesRead;
                     bytesRead += lastBytesRead;
                     long delta = lastBytesRead - transferOffset;
@@ -139,7 +144,7 @@ public class CassandraStreamWriter
      *
      * @throws java.io.IOException on any I/O error
      */
-    protected long write(ChannelProxy proxy, ChecksumValidator validator, StreamingDataOutputPlus output, long start, int transferOffset, int toTransfer, int bufferSize) throws IOException
+    protected long write(ChannelProxy proxy, ChecksumValidator validator, StreamingDataOutputPlus output, long start, int transferOffset, int toTransfer, int bufferSize, int version) throws IOException
     {
         // the count of bytes to read off disk
         int minReadable = (int) Math.min(bufferSize, proxy.size() - (start - sstable.getDataFileSliceDescriptor().sliceStart));
@@ -161,7 +166,7 @@ public class CassandraStreamWriter
 
             buffer.position(transferOffset);
             buffer.limit(transferOffset + (toTransfer - transferOffset));
-            output.writeToChannel(StreamCompressionSerializer.serialize(compressor, buffer, current_version), limiter);
+            output.writeToChannel(StreamCompressionSerializer.serialize(compressor, buffer, version), limiter);
         }
         finally
         {

--- a/src/java/org/apache/cassandra/net/InboundConnectionInitiator.java
+++ b/src/java/org/apache/cassandra/net/InboundConnectionInitiator.java
@@ -356,7 +356,7 @@ public class InboundConnectionInitiator
             else
             {
                 if (initiate.type.isStreaming())
-                    setupStreamingPipeline(initiate.from, ctx);
+                    setupStreamingPipeline(initiate.from, useMessagingVersion, ctx);
                 else
                     setupMessagingPipeline(initiate.from, useMessagingVersion, initiate.acceptVersions.max, ctx.pipeline());
             }
@@ -428,7 +428,7 @@ public class InboundConnectionInitiator
             }
         }
 
-        private void setupStreamingPipeline(InetAddressAndPort from, ChannelHandlerContext ctx)
+        private void setupStreamingPipeline(InetAddressAndPort from, int streamingVersion, ChannelHandlerContext ctx)
         {
             handshakeTimeout.cancel(true);
             assert initiate.framing == Framing.UNPROTECTED;
@@ -447,10 +447,11 @@ public class InboundConnectionInitiator
             // we can't infer the type of streaming connection at this point,
             // so we use CONTROL unconditionally; it's ugly but does what we want
             // (establishes an AsyncStreamingInputPlus)
+            channel.attr(NettyStreamingChannel.STREAMING_VERSION_ATTR).set(streamingVersion);
             NettyStreamingChannel streamingChannel = new NettyStreamingChannel(channel, StreamingChannel.Kind.CONTROL);
             pipeline.replace(this, "streamInbound", streamingChannel);
             executorFactory().startThread(String.format("Stream-Deserializer-%s-%s", from, channel.id()),
-                                          new StreamDeserializingTask(null, streamingChannel, current_version));
+                                          new StreamDeserializingTask(null, streamingChannel, streamingVersion));
 
             logger.info("{} streaming connection established, version = {}, framing = {}, encryption = {}",
                         SocketFactory.channelId(from,
@@ -459,7 +460,7 @@ public class InboundConnectionInitiator
                                                 (InetSocketAddress) channel.localAddress(),
                                                 ConnectionType.STREAMING,
                                                 channel.id().asShortText()),
-                        current_version,
+                        streamingVersion,
                         initiate.framing,
                         SocketFactory.encryptionConnectionSummary(pipeline.channel()));
         }

--- a/src/java/org/apache/cassandra/net/InboundConnectionSettings.java
+++ b/src/java/org/apache/cassandra/net/InboundConnectionSettings.java
@@ -120,7 +120,7 @@ public class InboundConnectionSettings
                                              acceptMessaging, acceptStreaming, socketFactory, handlers);
     }
 
-    public InboundConnectionSettings withAcceptStreaming(AcceptVersions acceptMessaging)
+    public InboundConnectionSettings withAcceptStreaming(AcceptVersions acceptStreaming)
     {
         return new InboundConnectionSettings(authenticator, bindAddress, encryption,
                                              socketReceiveBufferSizeInBytes, applicationReceiveQueueCapacityInBytes,

--- a/src/java/org/apache/cassandra/net/MessagingService.java
+++ b/src/java/org/apache/cassandra/net/MessagingService.java
@@ -242,11 +242,12 @@ public class MessagingService extends MessagingServiceMBeanImpl implements Messa
             this.supportsExtendedDeletionTime = extendedDeletionTime;
         }
 
+        @VisibleForTesting
         public static List<Version> supportedVersions()
         {
             List<Version> versions = Lists.newArrayList();
             for (Version version : values())
-                if (minimum_version <= version.value)
+                if (minimum_version <= version.value && version.value <= current_version)
                     versions.add(version);
 
             return Collections.unmodifiableList(versions);
@@ -289,12 +290,15 @@ public class MessagingService extends MessagingServiceMBeanImpl implements Messa
         if (DatabaseDescriptor.isClientInitialized())
         {
             accept_messaging = new AcceptVersions(minimum_version, maximum_version);
-            accept_streaming = new AcceptVersions(minimum_version, maximum_version);
+            accept_streaming = new AcceptVersions(Math.min(VERSION_40, maximum_version), maximum_version);
         }
         else
         {
             accept_messaging = new AcceptVersions(minimum_version, current_version);
-            accept_streaming = new AcceptVersions(minimum_version, current_version);
+            // Streaming negotiates any common version in [VERSION_40, current_version]; this is only safe because every
+            // streaming serializer (stream headers, control/file messages, compressed payloads) is wire-compatible across
+            // that range.
+            accept_streaming = new AcceptVersions(Math.min(VERSION_40, current_version), current_version);
         }
     }
     static Map<Integer, Integer> versionOrdinalMap = Arrays.stream(Version.values()).collect(Collectors.toMap(v -> v.value, Enum::ordinal));

--- a/src/java/org/apache/cassandra/streaming/async/NettyStreamingChannel.java
+++ b/src/java/org/apache/cassandra/streaming/async/NettyStreamingChannel.java
@@ -59,6 +59,9 @@ public class NettyStreamingChannel extends ChannelInboundHandlerAdapter implemen
 
     @VisibleForTesting
     static final AttributeKey<Boolean> TRANSFERRING_FILE_ATTR = valueOf("transferringFile");
+
+    public static final AttributeKey<Integer> STREAMING_VERSION_ATTR = valueOf("streamingVersion");
+
     final Channel channel;
 
     /**
@@ -122,6 +125,12 @@ public class NettyStreamingChannel extends ChannelInboundHandlerAdapter implemen
     public StreamingDataInputPlus in()
     {
         return in;
+    }
+
+    int streamingVersion(int defaultVersion)
+    {
+        Integer channelStreamingVersion = channel.attr(STREAMING_VERSION_ATTR).get();
+        return channelStreamingVersion == null ? defaultVersion : channelStreamingVersion;
     }
 
     public StreamingDataOutputPlus acquireOut()

--- a/src/java/org/apache/cassandra/streaming/async/NettyStreamingConnectionFactory.java
+++ b/src/java/org/apache/cassandra/streaming/async/NettyStreamingConnectionFactory.java
@@ -65,7 +65,9 @@ public class NettyStreamingConnectionFactory implements StreamingChannel.Factory
                 result.awaitUninterruptibly(); // initiate has its own timeout, so this is "guaranteed" to return relatively promptly
                 if (result.isSuccess())
                 {
-                    Channel channel = result.getNow().success().channel;
+                    StreamingSuccess success = result.getNow().success();
+                    Channel channel = success.channel;
+                    channel.attr(NettyStreamingChannel.STREAMING_VERSION_ATTR).set(success.messagingVersion);
                     NettyStreamingChannel streamingChannel = new NettyStreamingChannel(channel, kind);
                     if (kind == StreamingChannel.Kind.CONTROL)
                     {

--- a/src/java/org/apache/cassandra/streaming/async/StreamCompressionSerializer.java
+++ b/src/java/org/apache/cassandra/streaming/async/StreamCompressionSerializer.java
@@ -29,8 +29,6 @@ import net.jpountz.lz4.LZ4SafeDecompressor;
 import org.apache.cassandra.io.util.DataInputPlus;
 import org.apache.cassandra.streaming.StreamingDataOutputPlus;
 
-import static org.apache.cassandra.net.MessagingService.current_version;
-
 /**
  * A serialiazer for stream compressed files (see package-level documentation). Much like a typical compressed
  * output stream, this class operates on buffers or chunks of the data at a a time. The format for each compressed
@@ -56,7 +54,6 @@ public class StreamCompressionSerializer
 
     public static StreamingDataOutputPlus.Write serialize(LZ4Compressor compressor, ByteBuffer in, int version)
     {
-        assert version == current_version;
         return bufferSupplier -> {
             int uncompressedLength = in.remaining();
             int maxLength = compressor.maxCompressedLength(uncompressedLength);

--- a/src/java/org/apache/cassandra/streaming/async/StreamingMultiplexedChannel.java
+++ b/src/java/org/apache/cassandra/streaming/async/StreamingMultiplexedChannel.java
@@ -170,7 +170,7 @@ public class StreamingMultiplexedChannel
 
         StreamingChannel channel = factory.create(to, messagingVersion, StreamingChannel.Kind.CONTROL);
         executorFactory().startThread(String.format("Stream-Deserializer-%s-%s", to.toString(), channel.id()),
-                                      new StreamDeserializingTask(session, channel, messagingVersion));
+                                      new StreamDeserializingTask(session, channel, streamingVersion(channel)));
 
         session.attachInbound(channel);
         session.attachOutbound(channel);
@@ -227,7 +227,8 @@ public class StreamingMultiplexedChannel
         {
             Future<?> promise = channel.send(outSupplier -> {
                 // we anticipate that the control messages are rather small, so allocating a ByteBuf shouldn't  blow out of memory.
-                long messageSize = serializedSize(message, messagingVersion);
+                int channelStreamingVersion = streamingVersion(channel);
+                long messageSize = serializedSize(message, channelStreamingVersion);
                 if (messageSize > 1 << 30)
                 {
                     throw new IllegalStateException(format("%s something is seriously wrong with the calculated stream control message's size: %d bytes, type is %s",
@@ -235,7 +236,7 @@ public class StreamingMultiplexedChannel
                 }
                 try (StreamingDataOutputPlus out = outSupplier.apply((int) messageSize))
                 {
-                    StreamMessage.serialize(message, out, messagingVersion, session);
+                    StreamMessage.serialize(message, out, channelStreamingVersion, session);
                 }
             });
             promise.addListener(future -> onMessageComplete(future, message));
@@ -317,7 +318,7 @@ public class StreamingMultiplexedChannel
                 // close the DataOutputStreamPlus as we're done with it - but don't close the channel
                 try (StreamingDataOutputPlus out = channel.acquireOut())
                 {
-                    serialize(msg, out, messagingVersion, session);
+                    serialize(msg, out, streamingVersion(channel), session);
                 }
             }
             catch (Exception e)
@@ -497,6 +498,13 @@ public class StreamingMultiplexedChannel
     int semaphoreAvailablePermits()
     {
         return fileTransferSemaphore.permits();
+    }
+
+    private int streamingVersion(StreamingChannel channel)
+    {
+        return channel instanceof NettyStreamingChannel
+               ? ((NettyStreamingChannel) channel).streamingVersion(messagingVersion)
+               : messagingVersion;
     }
 
     public boolean connected()

--- a/test/distributed/org/apache/cassandra/distributed/test/StreamingTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/StreamingTest.java
@@ -34,14 +34,18 @@ import com.google.common.annotations.VisibleForTesting;
 import org.junit.Assert;
 import org.junit.Test;
 
+import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.distributed.Cluster;
 import org.apache.cassandra.distributed.api.IInvokableInstance;
+import org.apache.cassandra.distributed.shared.WithProperties;
 import org.apache.cassandra.locator.InetAddressAndPort;
+import org.apache.cassandra.net.MessagingService;
 import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.streaming.StreamSession;
 import org.apache.cassandra.streaming.messages.StreamMessage;
 
 import static org.apache.cassandra.distributed.api.Feature.NETWORK;
+import static org.apache.cassandra.distributed.shared.AssertUtils.assertRow;
 import static org.apache.cassandra.streaming.StreamSession.State.PREPARING;
 import static org.apache.cassandra.streaming.StreamSession.State.STREAMING;
 import static org.apache.cassandra.streaming.StreamSession.State.WAIT_COMPLETE;
@@ -82,7 +86,7 @@ public class StreamingTest extends TestBaseImpl
             cluster.get(nodes).runOnInstance(() -> StorageService.instance.rebuild(null, KEYSPACE, null, null));
             {
                 Object[][] results = cluster.get(nodes).executeInternal(String.format("SELECT k, c1, c2 FROM %s.cf;", KEYSPACE));
-                Assert.assertEquals(1000, results.length);
+                Assert.assertEquals(rowCount, results.length);
                 Arrays.sort(results, Comparator.comparingInt(a -> Integer.parseInt((String) a[0])));
                 for (int i = 0 ; i < results.length ; ++i)
                 {
@@ -98,6 +102,81 @@ public class StreamingTest extends TestBaseImpl
     public void test() throws Throwable
     {
         testStreaming(2, 2, 1000, "LeveledCompactionStrategy");
+    }
+
+    @Test
+    public void testMixedMessagingVersionStreamingDs11ToDs12() throws Throwable
+    {
+        testMixedMessagingVersionStreaming(MessagingService.VERSION_DS_11, MessagingService.VERSION_DS_12, false);
+    }
+
+    @Test
+    public void testMixedMessagingVersionStreamingDs12ToDs11() throws Throwable
+    {
+        testMixedMessagingVersionStreaming(MessagingService.VERSION_DS_12, MessagingService.VERSION_DS_11, false);
+    }
+
+    @Test
+    public void testMixedMessagingVersionUncompressedStreamingDs11ToDs12() throws Throwable
+    {
+        testMixedMessagingVersionStreaming(MessagingService.VERSION_DS_11, MessagingService.VERSION_DS_12, true);
+    }
+
+    @Test
+    public void testMixedMessagingVersionUncompressedStreamingDs12ToDs11() throws Throwable
+    {
+        testMixedMessagingVersionStreaming(MessagingService.VERSION_DS_12, MessagingService.VERSION_DS_11, true);
+    }
+
+    private void testMixedMessagingVersionStreaming(int sourceVersion, int targetVersion, boolean uncompressed) throws Throwable
+    {
+        int rowCount = 1000;
+        String keyspace = KEYSPACE + '_' + sourceVersion + '_' + targetVersion + (uncompressed ? "_uncompressed" : "");
+        try (Cluster cluster = builder().withNodes(2)
+                                       .withDataDirCount(1)
+                                       // disable entire sstable streaming so the per-section CassandraStreamReader/Writer path is used
+                                       .withConfig(config -> config.with(NETWORK).set("stream_entire_sstables", !uncompressed))
+                                       .withInstanceInitializer((classLoader, node) -> initializeMessagingVersion(classLoader, node == 1 ? sourceVersion : targetVersion))
+                                       .start())
+        {
+            Assert.assertEquals(sourceVersion, (int) cluster.get(1).callOnInstance(() -> MessagingService.current_version));
+            Assert.assertEquals(targetVersion, (int) cluster.get(2).callOnInstance(() -> MessagingService.current_version));
+
+            // disable sstable compression so the uncompressed stream path is exercised
+            String compression = uncompressed ? " AND compression = {'enabled': 'false'}" : "";
+            int schemaCoordinator = sourceVersion <= targetVersion ? 1 : 2;
+            cluster.schemaChange("CREATE KEYSPACE " + keyspace + " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 2};", false, cluster.get(schemaCoordinator));
+            cluster.schemaChange(String.format("CREATE TABLE %s.cf (k text, c1 text, c2 text, PRIMARY KEY (k)) WITH compaction = {'class': 'LeveledCompactionStrategy', 'enabled': 'true'}%s", keyspace, compression), false, cluster.get(schemaCoordinator));
+
+            for (int i = 0 ; i < rowCount ; ++i)
+                cluster.get(1).executeInternal(String.format("INSERT INTO %s.cf (k, c1, c2) VALUES (?, 'value1', 'value2');", keyspace), Integer.toString(i));
+
+            cluster.get(2).executeInternal("TRUNCATE system.available_ranges;");
+            Assert.assertEquals(0, cluster.get(2).executeInternal(String.format("SELECT k, c1, c2 FROM %s.cf;", keyspace)).length);
+
+            registerSink(cluster, 2);
+            cluster.get(2).runOnInstance(() -> StorageService.instance.rebuild(null, keyspace, null, null));
+
+            Object[][] results = cluster.get(2).executeInternal(String.format("SELECT k, c1, c2 FROM %s.cf;", keyspace));
+            Assert.assertEquals(rowCount, results.length);
+            Arrays.sort(results, Comparator.comparingInt(a -> Integer.parseInt((String) a[0])));
+            for (int i = 0 ; i < results.length ; ++i)
+            {
+                assertRow(results[i], Integer.toString(i), "value1", "value2");
+            }
+        }
+    }
+
+    private static void initializeMessagingVersion(ClassLoader classLoader, int version)
+    {
+        try (WithProperties properties = new WithProperties().set(CassandraRelevantProperties.DS_CURRENT_MESSAGING_VERSION, version))
+        {
+            Class.forName(MessagingService.class.getName(), true, classLoader).getField("current_version").getInt(null);
+        }
+        catch (ReflectiveOperationException e)
+        {
+            throw new RuntimeException(e);
+        }
     }
 
     public static void registerSink(Cluster cluster, int initiatorNodeId)

--- a/test/unit/org/apache/cassandra/db/streaming/CassandraStreamHeaderTest.java
+++ b/test/unit/org/apache/cassandra/db/streaming/CassandraStreamHeaderTest.java
@@ -39,10 +39,12 @@ import org.apache.cassandra.db.streaming.CassandraStreamHeader.CassandraStreamHe
 import org.apache.cassandra.dht.Murmur3Partitioner;
 import org.apache.cassandra.dht.Range;
 import org.apache.cassandra.dht.Token;
+import org.apache.cassandra.io.IVersionedSerializer;
 import org.apache.cassandra.io.sstable.Component;
 import org.apache.cassandra.io.sstable.format.SSTableFormat.Components;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.util.DataInputPlus;
+import org.apache.cassandra.net.MessagingService;
 import org.apache.cassandra.schema.CompressionParams;
 import org.apache.cassandra.schema.KeyspaceParams;
 import org.apache.cassandra.schema.TableMetadata;
@@ -99,7 +101,7 @@ public class CassandraStreamHeaderTest
         header.compressionInfo.chunks();
         assertEquals(transferedSize, header.calculateSize());
 
-        SerializationUtils.assertSerializationCycle(header, CassandraStreamHeader.serializer);
+        assertSerializationCycleForStreamingVersions(header, CassandraStreamHeader.serializer);
     }
 
     @Test
@@ -115,7 +117,7 @@ public class CassandraStreamHeaderTest
         header.compressionInfo.chunks();
         assertEquals(transferedSize, header.calculateSize());
 
-        SerializationUtils.assertSerializationCycle(header, CassandraStreamHeader.serializer);
+        assertSerializationCycleForStreamingVersions(header, CassandraStreamHeader.serializer);
     }
 
     @Test
@@ -128,7 +130,7 @@ public class CassandraStreamHeaderTest
         assertEquals(sstable.uncompressedLength(), transferedSize);
         assertEquals(transferedSize, header.calculateSize());
 
-        SerializationUtils.assertSerializationCycle(header, CassandraStreamHeader.serializer);
+        assertSerializationCycleForStreamingVersions(header, CassandraStreamHeader.serializer);
     }
 
     private CassandraStreamHeader header(boolean entireSSTable, boolean compressed)
@@ -174,7 +176,7 @@ public class CassandraStreamHeaderTest
                                  .withTableId(metadata.id)
                                  .build();
 
-        SerializationUtils.assertSerializationCycle(header, CassandraStreamHeader.serializer);
+        assertSerializationCycleForStreamingVersions(header, CassandraStreamHeader.serializer);
     }
 
     @Test
@@ -198,7 +200,16 @@ public class CassandraStreamHeaderTest
                                  .withTableId(metadata.id)
                                  .build();
 
-        SerializationUtils.assertSerializationCycle(header, new TestableCassandraStreamHeaderSerializer());
+        assertSerializationCycleForStreamingVersions(header, new TestableCassandraStreamHeaderSerializer());
+    }
+
+    private static void assertSerializationCycleForStreamingVersions(CassandraStreamHeader header, IVersionedSerializer<CassandraStreamHeader> serializer)
+    {
+        for (MessagingService.Version version : MessagingService.Version.supportedVersions())
+        {
+            if (version.value >= MessagingService.VERSION_40 && version.value <= MessagingService.current_version)
+                SerializationUtils.assertSerializationCycle(header, serializer, version.value);
+        }
     }
 
     private static class TestableCassandraStreamHeaderSerializer extends CassandraStreamHeaderSerializer

--- a/test/unit/org/apache/cassandra/db/streaming/StreamRequestTest.java
+++ b/test/unit/org/apache/cassandra/db/streaming/StreamRequestTest.java
@@ -43,7 +43,6 @@ public class StreamRequestTest
 {
     private static InetAddressAndPort local;
     private final String ks = "keyspace";
-    private final int version = MessagingService.current_version;
 
     @BeforeClass
     public static void setUp() throws Throwable
@@ -62,19 +61,22 @@ public class StreamRequestTest
                                                           Arrays.asList(range(5, 6), range(7, 8))),
                                                Arrays.asList("a", "b", "c"));
 
-        int expectedSize = (int) StreamRequest.serializer.serializedSize(orig, version);
-        try (DataOutputBuffer out = new DataOutputBuffer(expectedSize))
+        for (MessagingService.Version version : MessagingService.Version.supportedVersions())
         {
-            StreamRequest.serializer.serialize(orig, out, version);
-            Assert.assertEquals(expectedSize, out.buffer().limit());
-            try (DataInputBuffer in = new DataInputBuffer(out.buffer(), false))
+            int expectedSize = (int) StreamRequest.serializer.serializedSize(orig, version.value);
+            try (DataOutputBuffer out = new DataOutputBuffer(expectedSize))
             {
-                StreamRequest decoded = StreamRequest.serializer.deserialize(in, version);
+                StreamRequest.serializer.serialize(orig, out, version.value);
+                Assert.assertEquals(expectedSize, out.buffer().limit());
+                try (DataInputBuffer in = new DataInputBuffer(out.buffer(), false))
+                {
+                    StreamRequest decoded = StreamRequest.serializer.deserialize(in, version.value);
 
-                Assert.assertEquals(orig.keyspace, decoded.keyspace);
-                Util.assertRCEquals(orig.full, decoded.full);
-                Util.assertRCEquals(orig.transientReplicas, decoded.transientReplicas);
-                Assert.assertEquals(orig.columnFamilies, decoded.columnFamilies);
+                    Assert.assertEquals(orig.keyspace, decoded.keyspace);
+                    Util.assertRCEquals(orig.full, decoded.full);
+                    Util.assertRCEquals(orig.transientReplicas, decoded.transientReplicas);
+                    Assert.assertEquals(orig.columnFamilies, decoded.columnFamilies);
+                }
             }
         }
     }

--- a/test/unit/org/apache/cassandra/net/HandshakeTest.java
+++ b/test/unit/org/apache/cassandra/net/HandshakeTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
@@ -37,6 +38,7 @@ import org.apache.cassandra.db.commitlog.CommitLog;
 import org.apache.cassandra.gms.GossipDigestSyn;
 import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.net.OutboundConnectionInitiator.Result.MessagingSuccess;
+import org.apache.cassandra.net.OutboundConnectionInitiator.Result.StreamingSuccess;
 import org.apache.cassandra.security.DefaultSslContextFactory;
 import org.apache.cassandra.utils.concurrent.AsyncPromise;
 
@@ -48,6 +50,7 @@ import org.junit.Test;
 import io.netty.channel.EventLoop;
 import io.netty.util.concurrent.Future;
 
+import static org.apache.cassandra.net.MessagingService.VERSION_40;
 import static org.apache.cassandra.net.MessagingService.current_version;
 import static org.apache.cassandra.net.MessagingService.minimum_version;
 import static org.apache.cassandra.net.ConnectionType.SMALL_MESSAGES;
@@ -116,6 +119,72 @@ public class HandshakeTest
         }
     }
 
+    private Result streamingHandshake(int outMin, int outMax, int inMin, int inMax) throws ExecutionException, InterruptedException
+    {
+        InboundSockets inbound = new InboundSockets(new InboundConnectionSettings().withAcceptStreaming(new AcceptVersions(inMin, inMax)));
+        try
+        {
+            inbound.open();
+            InetAddressAndPort endpoint = inbound.sockets().stream().map(s -> s.settings.bindAddress).findFirst().get();
+            EventLoop eventLoop = factory.defaultGroup().next();
+            Future<Result<StreamingSuccess>> future =
+            initiateStreaming(eventLoop,
+                              new OutboundConnectionSettings(endpoint)
+                                                    .withAcceptVersions(new AcceptVersions(outMin, outMax))
+                                                    .withDefaults(ConnectionCategory.STREAMING),
+                              SslFallbackConnectionType.SERVER_CONFIG);
+            return future.get(20, TimeUnit.SECONDS);
+        }
+        catch (TimeoutException e)
+        {
+            throw new RuntimeException(e);
+        }
+        finally
+        {
+            inbound.close().await(1L, TimeUnit.SECONDS);
+        }
+    }
+
+    private static int latestStreamingVersionBeforeCurrent()
+    {
+        List<MessagingService.Version> versions = MessagingService.Version.supportedVersions();
+        int previousVersion = -1;
+        for (MessagingService.Version version : versions)
+        {
+            if (version.value >= VERSION_40 && version.value < current_version)
+                previousVersion = version.value;
+        }
+        Assert.assertTrue(previousVersion >= VERSION_40);
+        return previousVersion;
+    }
+
+    @Test
+    public void testStreamingNegotiatesCommonVersion() throws InterruptedException, ExecutionException
+    {
+        int previousVersion = latestStreamingVersionBeforeCurrent();
+        Result result = streamingHandshake(VERSION_40, current_version, VERSION_40, previousVersion);
+        Assert.assertEquals(Result.Outcome.SUCCESS, result.outcome);
+        Assert.assertEquals(previousVersion, result.success().messagingVersion);
+        result.success().channel.close();
+    }
+
+    @Test
+    public void testStreamingNegotiatesCommonVersionReversed() throws InterruptedException, ExecutionException
+    {
+        int previousVersion = latestStreamingVersionBeforeCurrent();
+        Result result = streamingHandshake(VERSION_40, previousVersion, VERSION_40, current_version);
+        Assert.assertEquals(Result.Outcome.SUCCESS, result.outcome);
+        Assert.assertEquals(previousVersion, result.success().messagingVersion);
+        result.success().channel.close();
+    }
+
+    @Test
+    public void testStreamingIncompatibleVersions() throws InterruptedException, ExecutionException
+    {
+        int previousVersion = latestStreamingVersionBeforeCurrent();
+        Result result = streamingHandshake(current_version, current_version, VERSION_40, previousVersion);
+        Assert.assertEquals(Result.Outcome.INCOMPATIBLE, result.outcome);
+    }
 
     @Test
     public void testBothCurrentVersion() throws InterruptedException, ExecutionException

--- a/test/unit/org/apache/cassandra/streaming/async/StreamCompressionSerializerTest.java
+++ b/test/unit/org/apache/cassandra/streaming/async/StreamCompressionSerializerTest.java
@@ -42,7 +42,6 @@ import org.apache.cassandra.net.MessagingService;
 
 public class StreamCompressionSerializerTest
 {
-    private static final int VERSION = MessagingService.current_version;
     private static final Random random = new Random(2347623847623L);
 
     private final ByteBufAllocator allocator = PooledByteBufAllocator.DEFAULT;
@@ -63,22 +62,43 @@ public class StreamCompressionSerializerTest
     @After
     public void tearDown()
     {
+        releaseBuffers();
+    }
+
+    private void releaseBuffers()
+    {
         if (input != null)
+        {
             FileUtils.clean(input);
+            input = null;
+        }
         if (compressed != null)
+        {
             FileUtils.clean(compressed);
+            compressed = null;
+        }
         if (output != null && output.refCnt() > 0)
+        {
             output.release(output.refCnt());
+            output = null;
+        }
     }
 
     @Test
     public void roundTrip_HappyPath_NotReadabaleByteBuffer() throws IOException
     {
-        populateInput();
-        StreamCompressionSerializer.serialize(compressor, input, VERSION).write(size -> compressed = ByteBuffer.allocateDirect(size));
-        input.flip();
-        output = serializer.deserialize(decompressor, new DataInputBuffer(compressed, false), VERSION);
-        validateResults();
+        for (MessagingService.Version version : MessagingService.Version.supportedVersions())
+        {
+            if (!isStreamingVersion(version.value))
+                continue;
+
+            releaseBuffers();
+            populateInput();
+            StreamCompressionSerializer.serialize(compressor, input, version.value).write(size -> compressed = ByteBuffer.allocateDirect(size));
+            input.flip();
+            output = serializer.deserialize(decompressor, new DataInputBuffer(compressed, false), version.value);
+            validateResults();
+        }
     }
 
     private void populateInput()
@@ -100,16 +120,24 @@ public class StreamCompressionSerializerTest
     @Test
     public void roundTrip_HappyPath_ReadabaleByteBuffer() throws IOException
     {
-        populateInput();
-        StreamCompressionSerializer.serialize(compressor, input, VERSION)
-                                   .write(size -> {
-                                       if (compressed != null)
-                                           FileUtils.clean(compressed);
-                                       return compressed = ByteBuffer.allocateDirect(size);
-                                   });
-        input.flip();
-        output = serializer.deserialize(decompressor, new ByteBufRCH(Unpooled.wrappedBuffer(compressed)), VERSION);
-        validateResults();
+        for (MessagingService.Version version : MessagingService.Version.supportedVersions())
+        {
+            if (!isStreamingVersion(version.value))
+                continue;
+
+            releaseBuffers();
+            populateInput();
+            StreamCompressionSerializer.serialize(compressor, input, version.value)
+                                       .write(size -> compressed = ByteBuffer.allocateDirect(size));
+            input.flip();
+            output = serializer.deserialize(decompressor, new ByteBufRCH(Unpooled.wrappedBuffer(compressed)), version.value);
+            validateResults();
+        }
+    }
+
+    private static boolean isStreamingVersion(int version)
+    {
+        return version >= MessagingService.VERSION_40 && version <= MessagingService.current_version;
     }
 
     private static class ByteBufRCH extends DataInputBuffer implements ReadableByteChannel


### PR DESCRIPTION
MessagingService.accept_streaming now accepts a range between VERSION_40 and current_version. Inbound streaming uses the negotiated version and outbound streaming stores it as a Netty channel attribute that control/file messages use for serialization.
