### PR TITLE
CNDB-17947 use final on members in constructor of PrimaryKeyMapFactory

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/v1/PartitionAwarePrimaryKeyMap.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/PartitionAwarePrimaryKeyMap.java
@@ -62,44 +62,48 @@ public class PartitionAwarePrimaryKeyMap implements PrimaryKeyMap
         private final IndexComponents.ForRead perSSTableComponents;
         private final LongArray.Factory tokenReaderFactory;
         private final LongArray.Factory offsetReaderFactory;
-        private final MetadataSource metadata;
         private final KeyFetcher keyFetcher;
         private final IPartitioner partitioner;
         private final PrimaryKey.Factory primaryKeyFactory;
         private final SSTableId<?> sstableId;
         private final long count;
 
-        private FileHandle token = null;
-        private FileHandle offset = null;
+        private final FileHandle token;
+        private final FileHandle offset;
 
         public PartitionAwarePrimaryKeyMapFactory(IndexComponents.ForRead perSSTableComponents, SSTableReader sstable, PrimaryKey.Factory primaryKeyFactory)
         {
+            FileHandle token = null;
+            FileHandle offset = null;
+
+            IndexComponent.ForRead offsetsComponent = perSSTableComponents.get(IndexComponentType.OFFSETS_VALUES);
+            IndexComponent.ForRead tokensComponent = perSSTableComponents.get(IndexComponentType.TOKEN_VALUES);
+
             try
             {
-                this.perSSTableComponents = perSSTableComponents;
-                this.metadata = MetadataSource.loadMetadata(perSSTableComponents);
+                MetadataSource metadata = MetadataSource.loadMetadata(perSSTableComponents);
 
-                IndexComponent.ForRead offsetsComponent = perSSTableComponents.get(IndexComponentType.OFFSETS_VALUES);
-                IndexComponent.ForRead tokensComponent = perSSTableComponents.get(IndexComponentType.TOKEN_VALUES);
+                NumericValuesMeta offsetsMeta = new NumericValuesMeta(metadata.get(offsetsComponent));
+                NumericValuesMeta tokensMeta = new NumericValuesMeta(metadata.get(tokensComponent));
+                this.count = tokensMeta.valueCount;
 
-                NumericValuesMeta offsetsMeta = new NumericValuesMeta(this.metadata.get(offsetsComponent));
-                NumericValuesMeta tokensMeta = new NumericValuesMeta(this.metadata.get(tokensComponent));
-
-                count = tokensMeta.valueCount;
                 token = tokensComponent.createFileHandle();
                 offset = offsetsComponent.createFileHandle();
 
                 this.tokenReaderFactory = new BlockPackedReader(token, tokensMeta);
                 this.offsetReaderFactory = new MonotonicBlockPackedReader(offset, offsetsMeta);
-                this.partitioner = sstable.metadata().partitioner;
-                this.keyFetcher = new KeyFetcher(sstable);
-                this.primaryKeyFactory = primaryKeyFactory;
-                this.sstableId = sstable.getId();
             }
             catch (Throwable t)
             {
                 throw Throwables.unchecked(Throwables.close(t, token, offset));
             }
+            this.perSSTableComponents = perSSTableComponents;
+            this.token = token;
+            this.offset = offset;
+            this.partitioner = sstable.metadata().partitioner;
+            this.keyFetcher = new KeyFetcher(sstable);
+            this.primaryKeyFactory = primaryKeyFactory;
+            this.sstableId = sstable.getId();
         }
 
         @Override

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/RowAwarePrimaryKeyMap.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/RowAwarePrimaryKeyMap.java
@@ -75,10 +75,10 @@ public class RowAwarePrimaryKeyMap implements PrimaryKeyMap
         private final LongArray.Factory tokenReaderFactory;
         private final SortedTermsReader sortedTermsReader;
         private final long count;
-        private FileHandle token = null;
-        private FileHandle termsDataBlockOffsets = null;
-        private FileHandle termsData = null;
-        private FileHandle termsTrie = null;
+        private final FileHandle token;
+        private final FileHandle termsDataBlockOffsets;
+        private final FileHandle termsData;
+        private final FileHandle termsTrie;
         private final IPartitioner partitioner;
         private final ClusteringComparator clusteringComparator;
         private final RowAwarePrimaryKeyFactory primaryKeyFactory;
@@ -87,31 +87,42 @@ public class RowAwarePrimaryKeyMap implements PrimaryKeyMap
 
         public RowAwarePrimaryKeyMapFactory(IndexComponents.ForRead perSSTableComponents, RowAwarePrimaryKeyFactory primaryKeyFactory, SSTableReader sstable)
         {
+            FileHandle token = null;
+            FileHandle termsDataBlockOffsets = null;
+            FileHandle termsData = null;
+            FileHandle termsTrie = null;
+
             try
             {
-                this.perSSTableComponents = perSSTableComponents;
                 MetadataSource metadataSource = MetadataSource.loadMetadata(perSSTableComponents);
                 NumericValuesMeta tokensMeta = new NumericValuesMeta(metadataSource.get(perSSTableComponents.get(IndexComponentType.TOKEN_VALUES)));
-                count = tokensMeta.valueCount;
+                this.count = tokensMeta.valueCount;
+
                 SortedTermsMeta sortedTermsMeta = new SortedTermsMeta(metadataSource.get(perSSTableComponents.get(IndexComponentType.PRIMARY_KEY_BLOCKS)));
                 NumericValuesMeta blockOffsetsMeta = new NumericValuesMeta(metadataSource.get(perSSTableComponents.get(IndexComponentType.PRIMARY_KEY_BLOCK_OFFSETS)));
 
                 token = perSSTableComponents.get(IndexComponentType.TOKEN_VALUES).createFileHandle();
                 this.tokenReaderFactory = new BlockPackedReader(token, tokensMeta);
-                this.termsDataBlockOffsets = perSSTableComponents.get(IndexComponentType.PRIMARY_KEY_BLOCK_OFFSETS).createFileHandle();
-                this.termsData = perSSTableComponents.get(IndexComponentType.PRIMARY_KEY_BLOCKS).createFileHandle();
-                this.termsTrie = perSSTableComponents.get(IndexComponentType.PRIMARY_KEY_TRIE).createFileHandle();
+
+                termsDataBlockOffsets = perSSTableComponents.get(IndexComponentType.PRIMARY_KEY_BLOCK_OFFSETS).createFileHandle();
+                termsData = perSSTableComponents.get(IndexComponentType.PRIMARY_KEY_BLOCKS).createFileHandle();
+                termsTrie = perSSTableComponents.get(IndexComponentType.PRIMARY_KEY_TRIE).createFileHandle();
                 this.sortedTermsReader = new SortedTermsReader(termsData, termsDataBlockOffsets, termsTrie, sortedTermsMeta, blockOffsetsMeta);
-                this.partitioner = sstable.metadata().partitioner;
-                this.primaryKeyFactory = primaryKeyFactory;
-                this.clusteringComparator = sstable.metadata().comparator;
-                this.sstableId = sstable.getId();
-                this.hasStaticColumns = sstable.metadata().hasStaticColumns();
             }
             catch (Throwable t)
             {
                 throw Throwables.unchecked(Throwables.close(t, token, termsData, termsDataBlockOffsets, termsTrie));
             }
+            this.perSSTableComponents = perSSTableComponents;
+            this.token = token;
+            this.termsDataBlockOffsets = termsDataBlockOffsets;
+            this.termsData = termsData;
+            this.termsTrie = termsTrie;
+            this.partitioner = sstable.metadata().partitioner;
+            this.primaryKeyFactory = primaryKeyFactory;
+            this.clusteringComparator = sstable.metadata().comparator;
+            this.sstableId = sstable.getId();
+            this.hasStaticColumns = sstable.metadata().hasStaticColumns();
         }
 
         @Override


### PR DESCRIPTION

### What is the issue
Several members of PrimaryKeyMap.Factory are initialized in the constructor and not modified outside, however, they are not final allowing to unexpectedly modify them in future changes.

### What does this PR fix and why was it fixed

Fixes https://github.com/riptano/cndb/issues/17947

Refactors the constructors of PrimaryKeyMap.Factory implementations to have all constructed members final. Reduces the scope of the try block.
