### PR TITLE
CNDB-18111 fixes names in LongArray to be agnostic in 5.0 (#2510)

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/v1/LongArray.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/LongArray.java
@@ -39,20 +39,22 @@ public interface LongArray extends Closeable
 
 
     /**
-     * @param targetToken Token to look up.  Must not be smaller than previous value queried
+     * @param targetValue Value to look up.  Must not be smaller than previous value queried
      *                    (the method is stateful)
-     * @return The row ID of the first token equal to or greater than the target,
-     *         or negative value if target token is greater than all tokens
+     * @return The index of the first value equal to or greater than the target,
+     *         or negative value if target value is greater than all values
      */
-    long ceilingRowId(long targetToken);
+    long ceilingIndex(long targetValue);
 
     /**
-     * Using the given value returns the first index corresponding to the value.
+     * Using the target value returns the first index corresponding to the value.
      *
-     * @param value Value to lookup, and it must not be smaller than previous value
-     * @return The index of the given value or negative value if target value is greater than all values
+     * @param targetValue Value to lookup, and it must not be smaller than previous value
+     * @return The index of the target value,
+     *         or negative index for a bigger value closest to the target,
+     *         or Long.MIN_VALUE if target value is greater than all values
      */
-    long indexOf(long value);
+    long indexOf(long targetValue);
 
     @Override
     default void close() throws IOException { }
@@ -84,17 +86,17 @@ public interface LongArray extends Closeable
         }
 
         @Override
-        public long ceilingRowId(long targetToken)
+        public long ceilingIndex(long targetValue)
         {
             open();
-            return longArray.ceilingRowId(targetToken);
+            return longArray.ceilingIndex(targetValue);
         }
 
         @Override
-        public long indexOf(long targetToken)
+        public long indexOf(long targetValue)
         {
             open();
-            return longArray.indexOf(targetToken);
+            return longArray.indexOf(targetValue);
         }
 
         @Override

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/PartitionAwarePrimaryKeyMap.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/PartitionAwarePrimaryKeyMap.java
@@ -179,7 +179,7 @@ public class PartitionAwarePrimaryKeyMap implements PrimaryKeyMap
     @Override
     public long ceiling(PrimaryKey key)
     {
-        return rowIdToToken.ceilingRowId(key.token().getLongValue());
+        return rowIdToToken.ceilingIndex(key.token().getLongValue());
     }
 
     @Override

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/bitpack/AbstractBlockPackedReader.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/bitpack/AbstractBlockPackedReader.java
@@ -78,14 +78,14 @@ public abstract class AbstractBlockPackedReader implements LongArray
     }
 
     @Override
-    public long ceilingRowId(long targetValue)
+    public long ceilingIndex(long targetValue)
     {
         // already out of range
         if (isOutOfRangeState())
             return -1;
 
-        long rowId = findBlockRowId(targetValue);
-        lastIndex = rowId >= 0 ? rowId : -rowId - 1;
+        long index = findBlockIndex(targetValue);
+        lastIndex = index >= 0 ? index : -index - 1;
         return isOutOfRangeState() ? -1 : lastIndex;
     }
 
@@ -96,9 +96,9 @@ public abstract class AbstractBlockPackedReader implements LongArray
         if (isOutOfRangeState())
             return Long.MIN_VALUE;
 
-        long rowId = findBlockRowId(targetValue);
-        lastIndex = rowId >= 0 ? rowId : -rowId - 1;
-        return isOutOfRangeState() ? Long.MIN_VALUE : rowId;
+        long index = findBlockIndex(targetValue);
+        lastIndex = index >= 0 ? index : -index - 1;
+        return isOutOfRangeState() ? Long.MIN_VALUE : index;
     }
 
     private boolean isOutOfRangeState()
@@ -106,7 +106,7 @@ public abstract class AbstractBlockPackedReader implements LongArray
         return lastIndex >= valueCount;
     }
 
-    private long findBlockRowId(long targetValue)
+    private long findBlockIndex(long targetValue)
     {
         // We keep track previous returned value in lastIndex, so searching backward will not return correct result.
         // Also it's logically wrong to search backward during token iteration in PostingListKeyRangeIterator.
@@ -136,7 +136,7 @@ public abstract class AbstractBlockPackedReader implements LongArray
         }
 
         // Find the global (not block-specific) index of the target token, which is equivalent to its row ID:
-        return findBlockRowID(targetValue, blockIndex, exactMatch);
+        return findBlockIndex(targetValue, blockIndex, exactMatch);
     }
 
     /**
@@ -206,7 +206,7 @@ public abstract class AbstractBlockPackedReader implements LongArray
         return -low; // no exact match found
     }
 
-    private long findBlockRowID(long targetValue, long blockIdx, boolean exactMatch)
+    private long findBlockIndex(long targetValue, long blockIdx, boolean exactMatch)
     {
         // Calculate the global offset for the selected block:
         long offset = blockIdx << blockShift;

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/bitpack/MonotonicBlockPackedReader.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/bitpack/MonotonicBlockPackedReader.java
@@ -106,13 +106,13 @@ public class MonotonicBlockPackedReader implements LongArray.Factory
             }
 
             @Override
-            public long ceilingRowId(long targetValue)
+            public long ceilingIndex(long targetValue)
             {
                throw new UnsupportedOperationException();
             }
 
             @Override
-            public long indexOf(long targetToken)
+            public long indexOf(long targetValue)
             {
                 throw new UnsupportedOperationException();
             }

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/postings/PostingsReader.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/postings/PostingsReader.java
@@ -203,13 +203,13 @@ public class PostingsReader implements OrdinalPostingList
             }
 
             @Override
-            public long ceilingRowId(long value)
+            public long ceilingIndex(long targetValue)
             {
                 throw new UnsupportedOperationException();
             }
 
             @Override
-            public long indexOf(long targetToken)
+            public long indexOf(long targetValue)
             {
                 throw new UnsupportedOperationException();
             }

--- a/test/microbench/org/apache/cassandra/test/microbench/index/sai/v1/BlockPackedReaderBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/index/sai/v1/BlockPackedReaderBench.java
@@ -107,7 +107,7 @@ public class BlockPackedReaderBench extends AbstractOnDiskBench
     {
         for (int i = 0; i < tokenValues.length;)
         {
-            bh.consume(rowIdToToken.ceilingRowId(tokenValues[i]));
+            bh.consume(rowIdToToken.ceilingIndex(tokenValues[i]));
             i++;
         }
     }

--- a/test/microbench/org/apache/cassandra/test/microbench/index/sai/v1/PostingsReaderBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/index/sai/v1/PostingsReaderBench.java
@@ -97,7 +97,7 @@ public class PostingsReaderBench extends AbstractOnDiskBench
         {
             long token = tokenValues[i];
             if (rowId < 0)
-                rowId = (int) rowIdToToken.ceilingRowId(token);
+                rowId = (int) rowIdToToken.ceilingIndex(token);
             bh.consume(reader.advance(rowId));
             rowId = -1;
 

--- a/test/microbench/org/apache/cassandra/test/microbench/index/sai/v2/sortedbytes/SortedTermsBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/index/sai/v2/sortedbytes/SortedTermsBench.java
@@ -281,7 +281,7 @@ public class SortedTermsBench extends AbstractOnDiskBench
     {
         for (int i = 0; i < NUM_INVOCATIONS; i++)
         {
-            bh.consume(rowIdToToken.ceilingRowId(tokenValues[i * skippingDistance]));
+            bh.consume(rowIdToToken.ceilingIndex(tokenValues[i * skippingDistance]));
         }
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/bitpack/NumericValuesTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/bitpack/NumericValuesTest.java
@@ -107,9 +107,9 @@ public class NumericValuesTest extends SaiRandomizedTest
 
             for (int x = 0; x < array.length; x++)
             {
-                long rowId = reader.ceilingRowId(array[x]);
+                long rowId = reader.ceilingIndex(array[x]);
                 assertEquals("rowID=" + x + " token=" + array[x], x, rowId);
-                assertEquals(rowId, reader.ceilingRowId(array[x]));
+                assertEquals(rowId, reader.ceilingIndex(array[x]));
             }
         }
 
@@ -121,9 +121,9 @@ public class NumericValuesTest extends SaiRandomizedTest
 
             for (int x = 0; x < array.length; x++)
             {
-                long rowId = reader.ceilingRowId(array[x] - 1);
+                long rowId = reader.ceilingIndex(array[x] - 1);
                 assertEquals("rowID=" + x + " matched token=" + array[x] + " target token="+(array[x] - 1), x, rowId);
-                assertEquals(rowId, reader.ceilingRowId(array[x] - 1));
+                assertEquals(rowId, reader.ceilingIndex(array[x] - 1));
             }
         }
     }
@@ -143,7 +143,7 @@ public class NumericValuesTest extends SaiRandomizedTest
         {
             for (int x = 0; x < length; x++)
             {
-                long rowID = reader.ceilingRowId(1000L);
+                long rowID = reader.ceilingIndex(1000L);
 
                 assertEquals(0, rowID);
             }


### PR DESCRIPTION
While `LongArray` is an utility for indexing long values, and it and its implementations are agnostic to the usage, names of methods and variables are named according to the usage, e.g., containing token and rowId.

This fixes the names to be agnostic by only using Value/TargetValue and Index instead of Token and RowId.
