### PR TITLE
HCD-549: Allow trusted custom index implementations to be referenced by simple name

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -1108,6 +1108,13 @@ public enum CassandraRelevantProperties
      * To provide a provider to a different implementation of the truncate statement.
      */
     TRUNCATE_STATEMENT_PROVIDER("cassandra.truncate_statement_provider"),
+    /**
+     * Comma-separated list of fully qualified class names of custom index implementations that are trusted by the
+     * operator. Each listed class can be referenced in {@code CREATE CUSTOM INDEX ... USING} by its simple class
+     * name (case-insensitively), like it is possible for {@code StorageAttachedIndex}, and its creation is allowed
+     * even when the {@code secondary_indexes_enabled} guardrail is disabled.
+     */
+    TRUSTED_INDEX_IMPLEMENTATIONS("cassandra.trusted_index_implementations"),
     TYPE_UDT_CONFLICT_BEHAVIOR("cassandra.type.udt.conflict_behavior"),
     // See org.apache.cassandra.db.compaction.unified.Controller for the definition of the UCS parameters
     UCS_ADAPTIVE_COSTS_READ_MULTIPLIER("unified_compaction.costs_read_multiplier", "0.1"),

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateIndexStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateIndexStatement.java
@@ -168,7 +168,9 @@ public final class CreateIndexStatement extends AlterSchemaStatement
         attrs.maybeApplyDefaultIndex();
         attrs.validate();
 
-        Guardrails.createSecondaryIndexesEnabled.ensureEnabled("Creating secondary indexes", state);
+        // Trusted custom index implementations can be created even when secondary indexes are disabled
+        if (!(attrs.isCustom && IndexMetadata.isTrustedIndexImplementation(attrs.customClass)))
+            Guardrails.createSecondaryIndexesEnabled.ensureEnabled("Creating secondary indexes", state);
 
         KeyspaceMetadata keyspace = schema.getNullable(keyspaceName);
         if (null == keyspace)
@@ -295,7 +297,7 @@ public final class CreateIndexStatement extends AlterSchemaStatement
         {
             // mimic what IndexMetadata.validate(..) does
             if (attrs.isCustom)
-                FBUtilities.classForName(attrs.customClass, "custom indexer");
+                FBUtilities.classForName(IndexMetadata.expandAliases(attrs.customClass), "custom indexer");
             return false;
         }
         catch (ConfigurationException ex)

--- a/src/java/org/apache/cassandra/schema/IndexMetadata.java
+++ b/src/java/org/apache/cassandra/schema/IndexMetadata.java
@@ -30,6 +30,7 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
@@ -37,6 +38,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.cql3.ColumnIdentifier;
 import org.apache.cassandra.cql3.CqlBuilder;
 import org.apache.cassandra.cql3.statements.schema.IndexTarget;
@@ -71,10 +73,17 @@ public final class IndexMetadata
      */
     private static final Map<String, String> indexNameAliases = new ConcurrentHashMap<>();
 
+    /**
+     * The fully qualified class names of the custom index implementations listed in the
+     * {@link CassandraRelevantProperties#TRUSTED_INDEX_IMPLEMENTATIONS} system property.
+     */
+    private static final Set<String> trustedIndexImplementations = ConcurrentHashMap.newKeySet();
+
     static
     {
         indexNameAliases.put(StorageAttachedIndex.NAME, StorageAttachedIndex.class.getCanonicalName());
         indexNameAliases.put(StorageAttachedIndex.class.getSimpleName().toLowerCase(), StorageAttachedIndex.class.getCanonicalName());
+        loadTrustedIndexImplementations(CassandraRelevantProperties.TRUSTED_INDEX_IMPLEMENTATIONS.getString());
     }
 
     public enum Kind
@@ -191,6 +200,57 @@ public final class IndexMetadata
     public static String expandAliases(String className)
     {
         return indexNameAliases.getOrDefault(className.toLowerCase(), className);
+    }
+
+    /**
+     * (Re)loads the trusted custom index implementations from the given comma-separated list of fully qualified
+     * class names, registering for each of them an alias by its simple class name so that users can reference it
+     * in {@code CREATE CUSTOM INDEX ... USING} without the package name.
+     */
+    @VisibleForTesting
+    public static void loadTrustedIndexImplementations(String classNames)
+    {
+        for (String className : trustedIndexImplementations)
+            indexNameAliases.remove(simpleClassName(className).toLowerCase(), className);
+        trustedIndexImplementations.clear();
+
+        if (classNames == null)
+            return;
+
+        for (String className : classNames.split(","))
+        {
+            className = className.trim();
+            if (className.isEmpty())
+                continue;
+
+            String simpleName = simpleClassName(className);
+            if (simpleName.equals(className))
+            {
+                logger.warn("Ignoring trusted index implementation '{}' declared in the {} system property: " +
+                            "a fully qualified class name is required",
+                            className, CassandraRelevantProperties.TRUSTED_INDEX_IMPLEMENTATIONS.getKey());
+                continue;
+            }
+
+            trustedIndexImplementations.add(className);
+            indexNameAliases.put(simpleName.toLowerCase(), className);
+        }
+    }
+
+    /**
+     * Tells whether the given index class name, either fully qualified or an alias, is one of the custom index
+     * implementations trusted through the {@link CassandraRelevantProperties#TRUSTED_INDEX_IMPLEMENTATIONS} system
+     * property. Trusted implementations can be created even when the {@code secondary_indexes_enabled} guardrail
+     * disables the creation of secondary indexes.
+     */
+    public static boolean isTrustedIndexImplementation(String className)
+    {
+        return className != null && trustedIndexImplementations.contains(expandAliases(className));
+    }
+
+    private static String simpleClassName(String className)
+    {
+        return className.substring(className.lastIndexOf('.') + 1);
     }
 
     private void validateCustomIndexOptions(TableMetadata table, Class<? extends Index> indexerClass, Map<String, String> options)

--- a/test/unit/org/apache/cassandra/db/guardrails/GuardrailSecondaryIndexTest.java
+++ b/test/unit/org/apache/cassandra/db/guardrails/GuardrailSecondaryIndexTest.java
@@ -21,6 +21,10 @@ package org.apache.cassandra.db.guardrails;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.apache.cassandra.index.StubIndex;
+import org.apache.cassandra.index.internal.CustomCassandraIndex;
+import org.apache.cassandra.schema.IndexMetadata;
+
 import static java.lang.String.format;
 
 /**
@@ -66,6 +70,29 @@ public class GuardrailSecondaryIndexTest extends GuardrailTester
 
         setGuardrail(true);
         dropIndex(format("DROP INDEX %s.%s", keyspace(), "v2_idx"));
+    }
+
+    @Test
+    public void testTrustedCustomIndex() throws Throwable
+    {
+        IndexMetadata.loadTrustedIndexImplementations(StubIndex.class.getName());
+        try
+        {
+            setGuardrail(false);
+
+            // trusted implementations can be created by simple name or fully qualified name
+            assertValid(format("CREATE CUSTOM INDEX ON %%s (%s) USING 'StubIndex'", "v1"));
+            assertValid(format("CREATE CUSTOM INDEX ON %%s (%s) USING '%s'", "v2", StubIndex.class.getName()));
+
+            // any other index is still guarded
+            assertFails(format("CREATE INDEX ON %%s (%s)", "v3"), "Creating secondary indexes");
+            assertFails(format("CREATE CUSTOM INDEX ON %%s (%s) USING '%s'", "v4", CustomCassandraIndex.class.getName()),
+                        "Creating secondary indexes");
+        }
+        finally
+        {
+            IndexMetadata.loadTrustedIndexImplementations(null);
+        }
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/index/TrustedIndexImplementationsTest.java
+++ b/test/unit/org/apache/cassandra/index/TrustedIndexImplementationsTest.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index;
+
+import org.junit.After;
+import org.junit.Test;
+
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.exceptions.ConfigurationException;
+import org.apache.cassandra.index.internal.CustomCassandraIndex;
+import org.apache.cassandra.index.sai.StorageAttachedIndex;
+import org.apache.cassandra.schema.IndexMetadata;
+
+import static java.lang.String.format;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests the {@code cassandra.trusted_index_implementations} system property, which allows referencing the listed
+ * custom index implementations in {@code CREATE CUSTOM INDEX ... USING} by their simple class name.
+ */
+public class TrustedIndexImplementationsTest extends CQLTester
+{
+    @After
+    public void restoreTrustedIndexImplementations()
+    {
+        IndexMetadata.loadTrustedIndexImplementations(null);
+    }
+
+    @Test
+    public void shouldCreateTrustedIndexBySimpleName() throws Throwable
+    {
+        IndexMetadata.loadTrustedIndexImplementations(StubIndex.class.getName());
+
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v1 int, v2 int, v3 int, v4 int)");
+        createIndex("CREATE CUSTOM INDEX idx1 ON %s(v1) USING 'StubIndex'");
+        createIndex("CREATE CUSTOM INDEX idx2 ON %s(v2) USING 'stubindex'");
+        createIndex("CREATE CUSTOM INDEX idx3 ON %s(v3) USING 'STUBINDEX'");
+        createIndex("CREATE CUSTOM INDEX idx4 ON %s(v4) USING 'org.apache.cassandra.index.StubIndex'");
+
+        SecondaryIndexManager indexManager = getCurrentColumnFamilyStore().indexManager;
+        for (String index : new String[]{ "idx1", "idx2", "idx3", "idx4" })
+            assertTrue(indexManager.getIndexByName(index) instanceof StubIndex);
+    }
+
+    @Test
+    public void shouldRejectSimpleNameWhenNotTrusted() throws Throwable
+    {
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v int)");
+        assertInvalidThrowMessage("Unable to find custom indexer class 'StubIndex'",
+                                  ConfigurationException.class,
+                                  "CREATE CUSTOM INDEX ON %s(v) USING 'StubIndex'");
+    }
+
+    @Test
+    public void shouldParsePropertyValue()
+    {
+        // entries are trimmed, empty entries are skipped, aliases are case-insensitive
+        IndexMetadata.loadTrustedIndexImplementations(format(" %s , , %s ", StubIndex.class.getName(), CustomCassandraIndex.class.getName()));
+        assertTrue(IndexMetadata.isTrustedIndexImplementation("StubIndex"));
+        assertTrue(IndexMetadata.isTrustedIndexImplementation("stubindex"));
+        assertTrue(IndexMetadata.isTrustedIndexImplementation(StubIndex.class.getName()));
+        assertTrue(IndexMetadata.isTrustedIndexImplementation("CustomCassandraIndex"));
+        assertEquals(StubIndex.class.getName(), IndexMetadata.expandAliases("stubindex"));
+
+        // reloading clears the previously registered implementations and aliases
+        IndexMetadata.loadTrustedIndexImplementations(CustomCassandraIndex.class.getName());
+        assertFalse(IndexMetadata.isTrustedIndexImplementation(StubIndex.class.getName()));
+        assertEquals("stubindex", IndexMetadata.expandAliases("stubindex"));
+        assertTrue(IndexMetadata.isTrustedIndexImplementation("CustomCassandraIndex"));
+
+        // entries without a package name are ignored
+        IndexMetadata.loadTrustedIndexImplementations("StubIndex");
+        assertFalse(IndexMetadata.isTrustedIndexImplementation("StubIndex"));
+
+        for (String value : new String[]{ null, "", " , " })
+        {
+            IndexMetadata.loadTrustedIndexImplementations(value);
+            assertFalse(IndexMetadata.isTrustedIndexImplementation(StubIndex.class.getName()));
+            assertFalse(IndexMetadata.isTrustedIndexImplementation(CustomCassandraIndex.class.getName()));
+        }
+
+        // the built-in StorageAttachedIndex aliases are unaffected, but SAI is not implicitly trusted
+        assertEquals(StorageAttachedIndex.class.getName(), IndexMetadata.expandAliases("sai"));
+        assertEquals(StorageAttachedIndex.class.getName(), IndexMetadata.expandAliases("StorageAttachedIndex"));
+        assertFalse(IndexMetadata.isTrustedIndexImplementation(StorageAttachedIndex.class.getName()));
+        assertFalse(IndexMetadata.isTrustedIndexImplementation("sai"));
+    }
+}


### PR DESCRIPTION
### What is the issue
In HCD we have a new custom Index Type com.datastax.opensearch.OpenSearchIndex that indexes data on OpenSearch.

We want to make it userfriendly to create the index:
`CREATE CUSTOM INDEX .... USING 'OpenSearchIndex' WITH OPTIONS ...`

We also want that users do not need to allow all the secondary indexes in cassandra.yaml (in HCD secondary_indexes_enabled is disabled by default)

See HCD-459.

### What does this PR fix and why was it fixed
Add the `cassandra.trusted_index_implementations` system property, a comma-separated list of fully qualified custom index class names. Each listed class is registered as an index name alias, so users can create it with CREATE CUSTOM INDEX ... USING '<SimpleClassName>' without the package name, like it is already possible for StorageAttachedIndex.

Trusted implementations are also exempted from the secondary_indexes_enabled guardrail: they can be created even when the creation of secondary indexes is disabled.

Also expand index name aliases in
CreateIndexStatement.isUnknownCustomIndexCreateStatement(), so that aliased index classes are not misreported as unknown when cassandra.index.unknown_custom_class.ignore is set.