### PR TITLE
HCD-549: Allow trusted custom index implementations to be referenced by simple class name

### DIFF
--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -2059,6 +2059,12 @@ drop_compact_storage_enabled: false
 # sai_indexes_total_warn_threshold: -1
 # sai_indexes_total_fail_threshold: 100
 #
+# Guardrail to warn or fail when creating more trusted custom indexes (cassandra.trusted_index_implementations)
+# per table than threshold, counted per implementation class.
+# The two thresholds default to -1 to disable.
+# trusted_indexes_per_table_warn_threshold: -1
+# trusted_indexes_per_table_fail_threshold: -1
+#
 # Guardrail to warn or fail when creating more materialized views per table than threshold.
 # The two thresholds default to -1 to disable.
 # materialized_views_per_table_warn_threshold: -1

--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -1111,8 +1111,8 @@ public enum CassandraRelevantProperties
     /**
      * Comma-separated list of fully qualified class names of custom index implementations that are trusted by the
      * operator. Each listed class can be referenced in {@code CREATE CUSTOM INDEX ... USING} by its simple class
-     * name (case-insensitively), like it is possible for {@code StorageAttachedIndex}, and its creation is allowed
-     * even when the {@code secondary_indexes_enabled} guardrail is disabled.
+     * name (case-insensitively), like it is possible for {@code StorageAttachedIndex}, and is limited by the
+     * {@code trusted_indexes_per_table} guardrail.
      */
     TRUSTED_INDEX_IMPLEMENTATIONS("cassandra.trusted_index_implementations"),
     TYPE_UDT_CONFLICT_BEHAVIOR("cassandra.type.udt.conflict_behavior"),

--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -1108,6 +1108,13 @@ public enum CassandraRelevantProperties
      * To provide a provider to a different implementation of the truncate statement.
      */
     TRUNCATE_STATEMENT_PROVIDER("cassandra.truncate_statement_provider"),
+    /**
+     * Comma-separated list of fully qualified class names of custom index implementations that are trusted by the
+     * operator. Each listed class can be referenced in {@code CREATE CUSTOM INDEX ... USING} by its simple class
+     * name (case-insensitively), like it is possible for {@code StorageAttachedIndex}, and its creation is allowed
+     * even when the {@code secondary_indexes_enabled} guardrail is disabled.
+     */
+    TRUSTED_INDEX_IMPLEMENTATIONS("cassandra.trusted_index_implementations"),
     TYPE_UDT_CONFLICT_BEHAVIOR("cassandra.type.udt.conflict_behavior"),
     // See org.apache.cassandra.db.compaction.unified.Controller for the definition of the UCS parameters
     UCS_ADAPTIVE_COSTS_READ_MULTIPLIER("unified_compaction.costs_read_multiplier", "0.1"),

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -895,6 +895,9 @@ public class Config
     public volatile int sai_indexes_per_table_fail_threshold = -1;
     public volatile int sai_indexes_total_warn_threshold = -1;
     public volatile int sai_indexes_total_fail_threshold = -1;
+    // Trusted custom index implementations guardrail (cassandra.trusted_index_implementations)
+    public volatile int trusted_indexes_per_table_warn_threshold = -1;
+    public volatile int trusted_indexes_per_table_fail_threshold = -1;
     public volatile int materialized_views_per_table_warn_threshold = -1;
     public volatile int materialized_views_per_table_fail_threshold = -1;
     public volatile int page_size_warn_threshold = -1;

--- a/src/java/org/apache/cassandra/config/GuardrailsOptions.java
+++ b/src/java/org/apache/cassandra/config/GuardrailsOptions.java
@@ -185,7 +185,7 @@ public class GuardrailsOptions implements GuardrailsConfig
         enforceDefault("columns_per_table_fail_threshold", v -> config.columns_per_table_fail_threshold = v, -1, 50, 200);
 
         // For secondary indexes: use node-level flag to control feature blocking
-        enforceDefault("secondary_indexes_enabled", v -> config.secondary_indexes_enabled = v, true, true, false);
+        enforceDefault("secondary_indexes_enabled", v -> config.secondary_indexes_enabled = v, true, true, true);
         enforceDefault("secondary_indexes_per_table_fail_threshold", v -> config.secondary_indexes_per_table_fail_threshold = v, NO_LIMIT, 1, NO_LIMIT);
 
         // For SASI indexes: use node-level flag (deprecated in CC5, will throw startup exception if enabled)

--- a/src/java/org/apache/cassandra/config/GuardrailsOptions.java
+++ b/src/java/org/apache/cassandra/config/GuardrailsOptions.java
@@ -91,6 +91,7 @@ public class GuardrailsOptions implements GuardrailsConfig
         validateMaxIntThreshold(config.secondary_indexes_per_table_warn_threshold, config.secondary_indexes_per_table_fail_threshold, "secondary_indexes_per_table");
         validateMaxIntThreshold(config.sai_indexes_per_table_warn_threshold, config.sai_indexes_per_table_fail_threshold, "sai_indexes_per_table");
         validateMaxIntThreshold(config.sai_indexes_total_warn_threshold, config.sai_indexes_total_fail_threshold, "sai_indexes_total");
+        validateMaxIntThreshold(config.trusted_indexes_per_table_warn_threshold, config.trusted_indexes_per_table_fail_threshold, "trusted_indexes_per_table");
         validateMaxIntThreshold(config.sasi_indexes_per_table_warn_threshold, config.sasi_indexes_per_table_fail_threshold, "sasi_indexes_per_table");
         validateMaxIntThreshold(config.materialized_views_per_table_warn_threshold, config.materialized_views_per_table_fail_threshold, "materialized_views_per_table");
         config.table_properties_warned = validateTableProperties(config.table_properties_warned, "table_properties_warned");
@@ -234,6 +235,9 @@ public class GuardrailsOptions implements GuardrailsConfig
             config.sai_indexes_total_fail_threshold = overrideTotalFailureThreshold;
         else
             enforceDefault("sai_indexes_total_fail_threshold", v -> config.sai_indexes_total_fail_threshold = v, DEFAULT_INDEXES_TOTAL_THRESHOLD, DEFAULT_INDEXES_TOTAL_THRESHOLD, DEFAULT_INDEXES_TOTAL_THRESHOLD);
+
+        // For trusted custom index implementations (cassandra.trusted_index_implementations)
+        enforceDefault("trusted_indexes_per_table_fail_threshold", v -> config.trusted_indexes_per_table_fail_threshold = v, NO_LIMIT, NO_LIMIT, DEFAULT_INDEXES_PER_TABLE_THRESHOLD);
 
         enforceDefault("offset_rows_warn_threshold", v -> config.offset_rows_warn_threshold = v, 10000, 10000, 10000);
         enforceDefault("offset_rows_fail_threshold", v -> config.offset_rows_fail_threshold = v, 20000, 20000, 20000);
@@ -480,6 +484,31 @@ public class GuardrailsOptions implements GuardrailsConfig
                                   fail,
                                   () -> config.sai_indexes_total_fail_threshold,
                                   x -> config.sai_indexes_total_fail_threshold = x);
+    }
+
+    @Override
+    public int getTrustedIndexesPerTableWarnThreshold()
+    {
+        return config.trusted_indexes_per_table_warn_threshold;
+    }
+
+    @Override
+    public int getTrustedIndexesPerTableFailThreshold()
+    {
+        return config.trusted_indexes_per_table_fail_threshold;
+    }
+
+    public void setTrustedIndexesPerTableThreshold(int warn, int fail)
+    {
+        validateMaxIntThreshold(warn, fail, "trusted_indexes_per_table");
+        updatePropertyWithLogging("trusted_indexes_per_table_warn_threshold",
+                                  warn,
+                                  () -> config.trusted_indexes_per_table_warn_threshold,
+                                  x -> config.trusted_indexes_per_table_warn_threshold = x);
+        updatePropertyWithLogging("trusted_indexes_per_table_fail_threshold",
+                                  fail,
+                                  () -> config.trusted_indexes_per_table_fail_threshold,
+                                  x -> config.trusted_indexes_per_table_fail_threshold = x);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateIndexStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateIndexStatement.java
@@ -168,9 +168,7 @@ public final class CreateIndexStatement extends AlterSchemaStatement
         attrs.maybeApplyDefaultIndex();
         attrs.validate();
 
-        // Trusted custom index implementations can be created even when secondary indexes are disabled
-        if (!(attrs.isCustom && IndexMetadata.isTrustedIndexImplementation(attrs.customClass)))
-            Guardrails.createSecondaryIndexesEnabled.ensureEnabled("Creating secondary indexes", state);
+        Guardrails.createSecondaryIndexesEnabled.ensureEnabled("Creating secondary indexes", state);
 
         KeyspaceMetadata keyspace = schema.getNullable(keyspaceName);
         if (null == keyspace)

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateIndexStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateIndexStatement.java
@@ -168,7 +168,9 @@ public final class CreateIndexStatement extends AlterSchemaStatement
         attrs.maybeApplyDefaultIndex();
         attrs.validate();
 
-        Guardrails.createSecondaryIndexesEnabled.ensureEnabled("Creating secondary indexes", state);
+        // Trusted custom index implementations can be created even when secondary indexes are disabled
+        if (!(attrs.isCustom && IndexMetadata.isTrustedIndexImplementation(attrs.customClass)))
+            Guardrails.createSecondaryIndexesEnabled.ensureEnabled("Creating secondary indexes", state);
 
         KeyspaceMetadata keyspace = schema.getNullable(keyspaceName);
         if (null == keyspace)
@@ -295,7 +297,7 @@ public final class CreateIndexStatement extends AlterSchemaStatement
         {
             // mimic what IndexMetadata.validate(..) does
             if (attrs.isCustom)
-                FBUtilities.classForName(attrs.customClass, "custom indexer");
+                FBUtilities.classForName(IndexMetadata.expandAliases(attrs.customClass), "custom indexer");
             return false;
         }
         catch (ConfigurationException ex)
@@ -450,6 +452,7 @@ public final class CreateIndexStatement extends AlterSchemaStatement
     {
         LEGACY(Guardrails.secondaryIndexesPerTable, null),
         SAI(Guardrails.saiIndexesPerTable, Guardrails.saiIndexesTotal),
+        TRUSTED(Guardrails.trustedIndexesPerTable, null),
         UNKNOWN(null, null);
 
         final Threshold perTableThreshold;
@@ -480,7 +483,7 @@ public final class CreateIndexStatement extends AlterSchemaStatement
                 case "org.apache.cassandra.index.sai.StorageAttachedIndex":
                     return IndexGuardrails.SAI;
                 default:
-                    return IndexGuardrails.UNKNOWN;
+                    return IndexMetadata.isTrustedIndexImplementation(className) ? IndexGuardrails.TRUSTED : IndexGuardrails.UNKNOWN;
             }
         }
 

--- a/src/java/org/apache/cassandra/db/guardrails/Guardrails.java
+++ b/src/java/org/apache/cassandra/db/guardrails/Guardrails.java
@@ -142,6 +142,20 @@ public final class Guardrails implements GuardrailsMBean
                                         threshold, what));
 
     /**
+     * Guardrail on the number of trusted custom secondary indexes per table, counted per implementation class.
+     */
+    public static final MaxThreshold trustedIndexesPerTable =
+    new MaxThreshold("trusted_indexes_per_table",
+                     null,
+                     state -> CONFIG_PROVIDER.getOrCreate(state).getTrustedIndexesPerTableWarnThreshold(),
+                     state -> CONFIG_PROVIDER.getOrCreate(state).getTrustedIndexesPerTableFailThreshold(),
+                     (isWarning, what, value, threshold) ->
+                     isWarning ? format("Creating trusted custom secondary index %s, current number of indexes of the same class %s exceeds warning threshold of %s.",
+                                        what, value, threshold)
+                               : format("Tables cannot have more than %s trusted custom secondary indexes of the same class, aborting the creation of secondary index %s",
+                                        threshold, what));
+
+    /**
      * Guardrail disabling user's ability to create secondary indexes
      */
     public static final EnableFlag createSecondaryIndexesEnabled =
@@ -801,6 +815,24 @@ public final class Guardrails implements GuardrailsMBean
     public void setStorageAttachedIndexesTotalThreshold(int warn, int fail)
     {
         DEFAULT_CONFIG.setStorageAttachedIndexesTotalThreshold(warn, fail);
+    }
+
+    @Override
+    public int getTrustedIndexesPerTableWarnThreshold()
+    {
+        return DEFAULT_CONFIG.getTrustedIndexesPerTableWarnThreshold();
+    }
+
+    @Override
+    public int getTrustedIndexesPerTableFailThreshold()
+    {
+        return DEFAULT_CONFIG.getTrustedIndexesPerTableFailThreshold();
+    }
+
+    @Override
+    public void setTrustedIndexesPerTableThreshold(int warn, int fail)
+    {
+        DEFAULT_CONFIG.setTrustedIndexesPerTableThreshold(warn, fail);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/guardrails/GuardrailsConfig.java
+++ b/src/java/org/apache/cassandra/db/guardrails/GuardrailsConfig.java
@@ -125,6 +125,16 @@ public interface GuardrailsConfig
     int getStorageAttachedIndexesTotalFailThreshold();
 
     /**
+     * @return The threshold to warn when creating more trusted custom indexes per table than threshold.
+     */
+    int getTrustedIndexesPerTableWarnThreshold();
+
+    /**
+     * @return The threshold to fail when creating more trusted custom indexes per table than threshold.
+     */
+    int getTrustedIndexesPerTableFailThreshold();
+
+    /**
      * @return The threshold to warn when creating more materialized views per table than threshold.
      */
     int getMaterializedViewsPerTableWarnThreshold();

--- a/src/java/org/apache/cassandra/db/guardrails/GuardrailsMBean.java
+++ b/src/java/org/apache/cassandra/db/guardrails/GuardrailsMBean.java
@@ -149,6 +149,22 @@ public interface GuardrailsMBean
     void setStorageAttachedIndexesTotalThreshold(int warn, int fail);
 
     /**
+     * @return The threshold to warn when creating more trusted custom indexes per table than threshold. -1 means disabled.
+     */
+    int getTrustedIndexesPerTableWarnThreshold();
+
+    /**
+     * @return The threshold to prevent creating more trusted custom indexes per table than threshold. -1 means disabled.
+     */
+    int getTrustedIndexesPerTableFailThreshold();
+
+    /**
+     * @param warn The threshold to warn when creating more trusted custom indexes per table than threshold. -1 means disabled.
+     * @param fail The threshold to prevent creating more trusted custom indexes per table than threshold. -1 means disabled.
+     */
+    void setTrustedIndexesPerTableThreshold(int warn, int fail);
+
+    /**
      * @return The threshold to warn when creating more materialized views per table than threshold.
      * -1 means disabled.
      */

--- a/src/java/org/apache/cassandra/schema/IndexMetadata.java
+++ b/src/java/org/apache/cassandra/schema/IndexMetadata.java
@@ -30,6 +30,7 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
@@ -37,6 +38,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.cql3.ColumnIdentifier;
 import org.apache.cassandra.cql3.CqlBuilder;
 import org.apache.cassandra.cql3.statements.schema.IndexTarget;
@@ -71,10 +73,17 @@ public final class IndexMetadata
      */
     private static final Map<String, String> indexNameAliases = new ConcurrentHashMap<>();
 
+    /**
+     * The fully qualified class names of the custom index implementations listed in the
+     * {@link CassandraRelevantProperties#TRUSTED_INDEX_IMPLEMENTATIONS} system property.
+     */
+    private static final Set<String> trustedIndexImplementations = ConcurrentHashMap.newKeySet();
+
     static
     {
         indexNameAliases.put(StorageAttachedIndex.NAME, StorageAttachedIndex.class.getCanonicalName());
         indexNameAliases.put(StorageAttachedIndex.class.getSimpleName().toLowerCase(), StorageAttachedIndex.class.getCanonicalName());
+        loadTrustedIndexImplementations(CassandraRelevantProperties.TRUSTED_INDEX_IMPLEMENTATIONS.getString());
     }
 
     public enum Kind
@@ -191,6 +200,57 @@ public final class IndexMetadata
     public static String expandAliases(String className)
     {
         return indexNameAliases.getOrDefault(className.toLowerCase(), className);
+    }
+
+    /**
+     * (Re)loads the trusted custom index implementations from the given comma-separated list of fully qualified
+     * class names, registering for each of them an alias by its simple class name so that users can reference it
+     * in {@code CREATE CUSTOM INDEX ... USING} without the package name.
+     */
+    @VisibleForTesting
+    public static void loadTrustedIndexImplementations(String classNames)
+    {
+        for (String className : trustedIndexImplementations)
+            indexNameAliases.remove(simpleClassName(className).toLowerCase(), className);
+        trustedIndexImplementations.clear();
+
+        if (classNames == null)
+            return;
+
+        for (String className : classNames.split(","))
+        {
+            className = className.trim();
+            if (className.isEmpty())
+                continue;
+
+            String simpleName = simpleClassName(className);
+            if (simpleName.equals(className))
+            {
+                logger.warn("Ignoring trusted index implementation '{}' declared in the {} system property: " +
+                            "a fully qualified class name is required",
+                            className, CassandraRelevantProperties.TRUSTED_INDEX_IMPLEMENTATIONS.getKey());
+                continue;
+            }
+
+            trustedIndexImplementations.add(className);
+            indexNameAliases.put(simpleName.toLowerCase(), className);
+        }
+    }
+
+    /**
+     * Tells whether the given index class name, either fully qualified or an alias, is one of the custom index
+     * implementations trusted through the {@link CassandraRelevantProperties#TRUSTED_INDEX_IMPLEMENTATIONS} system
+     * property. Trusted implementations can be created even when the {@code secondary_indexes_enabled} guardrail
+     * disables the creation of secondary indexes.
+     */
+    public static boolean isTrustedIndexImplementation(String className)
+    {
+        return className != null && trustedIndexImplementations.contains(expandAliases(className));
+    }
+
+    private static String simpleClassName(String className)
+    {
+        return className.substring(className.lastIndexOf('.') + 1);
     }
 
     private void validateCustomIndexOptions(TableMetadata table, Class<? extends Index> indexerClass, Map<String, String> options)

--- a/src/java/org/apache/cassandra/schema/IndexMetadata.java
+++ b/src/java/org/apache/cassandra/schema/IndexMetadata.java
@@ -240,8 +240,7 @@ public final class IndexMetadata
     /**
      * Tells whether the given index class name, either fully qualified or an alias, is one of the custom index
      * implementations trusted through the {@link CassandraRelevantProperties#TRUSTED_INDEX_IMPLEMENTATIONS} system
-     * property. Trusted implementations can be created even when the {@code secondary_indexes_enabled} guardrail
-     * disables the creation of secondary indexes.
+     * property. Trusted implementations are limited by the {@code trusted_indexes_per_table} guardrail.
      */
     public static boolean isTrustedIndexImplementation(String className)
     {

--- a/src/java/org/apache/cassandra/schema/IndexMetadata.java
+++ b/src/java/org/apache/cassandra/schema/IndexMetadata.java
@@ -234,6 +234,7 @@ public final class IndexMetadata
 
             trustedIndexImplementations.add(className);
             indexNameAliases.put(simpleName.toLowerCase(), className);
+            logger.info("Registered a trusted secondary implementation {}", className);
         }
     }
 

--- a/test/unit/org/apache/cassandra/db/guardrails/GuardrailSecondaryIndexTest.java
+++ b/test/unit/org/apache/cassandra/db/guardrails/GuardrailSecondaryIndexTest.java
@@ -21,6 +21,10 @@ package org.apache.cassandra.db.guardrails;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.apache.cassandra.index.StubIndex;
+import org.apache.cassandra.index.internal.CustomCassandraIndex;
+import org.apache.cassandra.schema.IndexMetadata;
+
 import static java.lang.String.format;
 
 /**
@@ -66,6 +70,29 @@ public class GuardrailSecondaryIndexTest extends GuardrailTester
 
         setGuardrail(true);
         dropIndex(format("DROP INDEX %s.%s", keyspace(), "v2_idx"));
+    }
+
+    @Test
+    public void testTrustedCustomIndex() throws Throwable
+    {
+        IndexMetadata.loadTrustedIndexImplementations(StubIndex.class.getName());
+        try
+        {
+            setGuardrail(false);
+
+            // trusted implementations can be created by simple name or fully qualified name
+            assertValid(format("CREATE CUSTOM INDEX ON %%s (%s) USING 'StubIndex'", "v1"));
+            assertValid(format("CREATE CUSTOM INDEX ON %%s (%s) USING '%s'", "v2", StubIndex.class.getName()));
+
+            // any other index is still guarded
+            assertFails(format("CREATE INDEX ON %%s (%s)", "v3"), "Creating secondary indexes");
+            assertFails(format("CREATE CUSTOM INDEX ON %%s (%s) USING '%s'", "v4", CustomCassandraIndex.class.getName()),
+                        "Creating secondary indexes");
+        }
+        finally
+        {
+            IndexMetadata.loadTrustedIndexImplementations(null);
+        }
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/db/guardrails/GuardrailSecondaryIndexTest.java
+++ b/test/unit/org/apache/cassandra/db/guardrails/GuardrailSecondaryIndexTest.java
@@ -21,10 +21,6 @@ package org.apache.cassandra.db.guardrails;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.apache.cassandra.index.StubIndex;
-import org.apache.cassandra.index.internal.CustomCassandraIndex;
-import org.apache.cassandra.schema.IndexMetadata;
-
 import static java.lang.String.format;
 
 /**
@@ -70,29 +66,6 @@ public class GuardrailSecondaryIndexTest extends GuardrailTester
 
         setGuardrail(true);
         dropIndex(format("DROP INDEX %s.%s", keyspace(), "v2_idx"));
-    }
-
-    @Test
-    public void testTrustedCustomIndex() throws Throwable
-    {
-        IndexMetadata.loadTrustedIndexImplementations(StubIndex.class.getName());
-        try
-        {
-            setGuardrail(false);
-
-            // trusted implementations can be created by simple name or fully qualified name
-            assertValid(format("CREATE CUSTOM INDEX ON %%s (%s) USING 'StubIndex'", "v1"));
-            assertValid(format("CREATE CUSTOM INDEX ON %%s (%s) USING '%s'", "v2", StubIndex.class.getName()));
-
-            // any other index is still guarded
-            assertFails(format("CREATE INDEX ON %%s (%s)", "v3"), "Creating secondary indexes");
-            assertFails(format("CREATE CUSTOM INDEX ON %%s (%s) USING '%s'", "v4", CustomCassandraIndex.class.getName()),
-                        "Creating secondary indexes");
-        }
-        finally
-        {
-            IndexMetadata.loadTrustedIndexImplementations(null);
-        }
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/db/guardrails/GuardrailTrustedIndexesPerTableTest.java
+++ b/test/unit/org/apache/cassandra/db/guardrails/GuardrailTrustedIndexesPerTableTest.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.guardrails;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.index.StubIndex;
+import org.apache.cassandra.schema.IndexMetadata;
+
+import static java.lang.String.format;
+
+/**
+ * Tests the guardrail for the number of trusted custom indexes in a table, {@link Guardrails#trustedIndexesPerTable}.
+ * The threshold is counted per implementation class.
+ */
+public class GuardrailTrustedIndexesPerTableTest extends ThresholdTester
+{
+    private static final int INDEXES_PER_TABLE_WARN_THRESHOLD = 1;
+    private static final int INDEXES_PER_TABLE_FAIL_THRESHOLD = 3;
+
+    public GuardrailTrustedIndexesPerTableTest()
+    {
+        super(INDEXES_PER_TABLE_WARN_THRESHOLD,
+              INDEXES_PER_TABLE_FAIL_THRESHOLD,
+              Guardrails.trustedIndexesPerTable,
+              Guardrails::setTrustedIndexesPerTableThreshold,
+              Guardrails::getTrustedIndexesPerTableWarnThreshold,
+              Guardrails::getTrustedIndexesPerTableFailThreshold);
+    }
+
+    @Before
+    public void setupTrustedIndexImplementations()
+    {
+        IndexMetadata.loadTrustedIndexImplementations(StubIndex.class.getName() + ',' + OtherStubIndex.class.getName());
+    }
+
+    @After
+    public void restoreTrustedIndexImplementations()
+    {
+        IndexMetadata.loadTrustedIndexImplementations(null);
+    }
+
+    @Override
+    protected long currentValue()
+    {
+        return getCurrentColumnFamilyStore().indexManager.listIndexes().stream()
+                                            .filter(index -> index.getClass() == StubIndex.class)
+                                            .count();
+    }
+
+    @Test
+    public void testCreateIndex() throws Throwable
+    {
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v1 int, v2 int, v3 int, v4 int, v5 int)");
+        assertCreateIndexSucceeds("v1", "v1_idx");
+        assertCurrentValue(1);
+
+        assertCreateIndexWarns("v2", "");
+        assertCreateIndexWarns("v3", "v3_idx");
+        assertCreateIndexFails("v4", "");
+        assertCreateIndexFails("v2", "v2_idx");
+        assertCurrentValue(3);
+
+        // the count is per implementation class: an index of another trusted class is not affected by the
+        // indexes created above
+        assertValid(format("CREATE CUSTOM INDEX other_idx ON %s.%s(v5) USING '%s'",
+                           keyspace(), currentTable(), OtherStubIndex.class.getName()));
+
+        // drop an index, we should be able to create new indexes again
+        dropIndex(format("DROP INDEX %s.%s", keyspace(), "v3_idx"));
+        assertCurrentValue(2);
+
+        assertCreateIndexWarns("v3", "");
+        assertCurrentValue(3);
+
+        // previous guardrail should not apply to another base table
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v1 int, v2 int, v3 int, v4 int)");
+        assertCreateIndexSucceeds("v4", "");
+        assertCreateIndexWarns("v3", "");
+        assertCreateIndexWarns("v2", "");
+        assertCreateIndexFails("v1", "");
+        assertCurrentValue(3);
+    }
+
+    @Test
+    public void testAppliesWhenSecondaryIndexesDisabled() throws Throwable
+    {
+        // trusted implementations bypass the secondary_indexes_enabled guardrail, but not this threshold
+        guardrails().setSecondaryIndexesEnabled(false);
+        try
+        {
+            createTable("CREATE TABLE %s (k int PRIMARY KEY, v1 int, v2 int, v3 int, v4 int)");
+            assertCreateIndexSucceeds("v1", "");
+            assertCreateIndexWarns("v2", "");
+            assertCreateIndexWarns("v3", "");
+            assertCreateIndexFails("v4", "");
+            assertCurrentValue(3);
+        }
+        finally
+        {
+            guardrails().setSecondaryIndexesEnabled(true);
+        }
+    }
+
+    @Test
+    public void testExcludedUsers() throws Throwable
+    {
+        createTable("CREATE TABLE %s (k int primary key, v1 int, v2 int)");
+        testExcludedUsers(() -> "CREATE CUSTOM INDEX excluded_1 ON %s(v1) USING 'StubIndex'",
+                          () -> "CREATE CUSTOM INDEX excluded_2 ON %s(v2) USING 'StubIndex'",
+                          () -> "DROP INDEX excluded_1",
+                          () -> "DROP INDEX excluded_2");
+    }
+
+    private void assertCreateIndexSucceeds(String column, String indexName) throws Throwable
+    {
+        assertMaxThresholdValid(format("CREATE CUSTOM INDEX %s ON %s.%s(%s) USING 'StubIndex'",
+                                       indexName, keyspace(), currentTable(), column));
+    }
+
+    private void assertCreateIndexWarns(String column, String indexName) throws Throwable
+    {
+        assertThresholdWarns(format("CREATE CUSTOM INDEX %s ON %%s(%s) USING 'StubIndex'", indexName, column),
+                             format("Creating trusted custom secondary index %son table %s, current number of indexes of the same class %s exceeds warning threshold of %s.",
+                                    indexName.isEmpty() ? "" : indexName + ' ',
+                                    currentTable(),
+                                    currentValue() + 1,
+                                    guardrails().getTrustedIndexesPerTableWarnThreshold())
+        );
+    }
+
+    private void assertCreateIndexFails(String column, String indexName) throws Throwable
+    {
+        assertThresholdFails(format("CREATE CUSTOM INDEX %s ON %%s(%s) USING 'StubIndex'", indexName, column),
+                             format("aborting the creation of secondary index %son table %s",
+                                    indexName.isEmpty() ? "" : indexName + ' ', currentTable())
+        );
+    }
+
+    /**
+     * A second trusted implementation, used to verify that the guardrail is counted per implementation class.
+     */
+    public static final class OtherStubIndex extends StubIndex
+    {
+        public OtherStubIndex(ColumnFamilyStore baseCfs, IndexMetadata metadata)
+        {
+            super(baseCfs, metadata);
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/db/guardrails/GuardrailTrustedIndexesPerTableTest.java
+++ b/test/unit/org/apache/cassandra/db/guardrails/GuardrailTrustedIndexesPerTableTest.java
@@ -102,26 +102,6 @@ public class GuardrailTrustedIndexesPerTableTest extends ThresholdTester
     }
 
     @Test
-    public void testAppliesWhenSecondaryIndexesDisabled() throws Throwable
-    {
-        // trusted implementations bypass the secondary_indexes_enabled guardrail, but not this threshold
-        guardrails().setSecondaryIndexesEnabled(false);
-        try
-        {
-            createTable("CREATE TABLE %s (k int PRIMARY KEY, v1 int, v2 int, v3 int, v4 int)");
-            assertCreateIndexSucceeds("v1", "");
-            assertCreateIndexWarns("v2", "");
-            assertCreateIndexWarns("v3", "");
-            assertCreateIndexFails("v4", "");
-            assertCurrentValue(3);
-        }
-        finally
-        {
-            guardrails().setSecondaryIndexesEnabled(true);
-        }
-    }
-
-    @Test
     public void testExcludedUsers() throws Throwable
     {
         createTable("CREATE TABLE %s (k int primary key, v1 int, v2 int)");

--- a/test/unit/org/apache/cassandra/db/guardrails/GuardrailsConfigDefaultsTest.java
+++ b/test/unit/org/apache/cassandra/db/guardrails/GuardrailsConfigDefaultsTest.java
@@ -131,7 +131,7 @@ public class GuardrailsConfigDefaultsTest
 
     private void verifyFeatureDefaults(Config config, ProfileType profileType)
     {
-        assertEquals("secondary_indexes_enabled", profileType != ProfileType.HCD, config.secondary_indexes_enabled);
+        assertEquals("secondary_indexes_enabled", true, config.secondary_indexes_enabled);
         assertEquals("sasi_indexes_enabled", false, config.sasi_indexes_enabled);
         assertEquals("materialized_views_enabled", profileType != ProfileType.HCD, config.materialized_views_enabled);
     }

--- a/test/unit/org/apache/cassandra/db/guardrails/GuardrailsConfigDefaultsTest.java
+++ b/test/unit/org/apache/cassandra/db/guardrails/GuardrailsConfigDefaultsTest.java
@@ -187,6 +187,10 @@ public class GuardrailsConfigDefaultsTest
         assertEquals("sai_indexes_per_table_fail_threshold", GuardrailsOptions.DEFAULT_INDEXES_PER_TABLE_THRESHOLD, guardrails.getStorageAttachedIndexesPerTableFailThreshold());
         assertEquals("sai_indexes_total_fail_threshold", GuardrailsOptions.DEFAULT_INDEXES_TOTAL_THRESHOLD, guardrails.getStorageAttachedIndexesTotalFailThreshold());
 
+        // Trusted custom indexes guardrail
+        assertEquals("trusted_indexes_per_table_warn_threshold", GuardrailsOptions.NO_LIMIT, guardrails.getTrustedIndexesPerTableWarnThreshold());
+        assertEquals("trusted_indexes_per_table_fail_threshold", GuardrailsOptions.NO_LIMIT, guardrails.getTrustedIndexesPerTableFailThreshold());
+
         // Offset guardrails
         assertEquals("offset_rows_warn_threshold", 10000, guardrails.getOffsetRowsWarnThreshold());
         assertEquals("offset_rows_fail_threshold", 20000, guardrails.getOffsetRowsFailThreshold());
@@ -250,6 +254,10 @@ public class GuardrailsConfigDefaultsTest
         assertEquals("sai_indexes_per_table_fail_threshold", GuardrailsOptions.DEFAULT_INDEXES_PER_TABLE_THRESHOLD, guardrails.getStorageAttachedIndexesPerTableFailThreshold());
         assertEquals("sai_indexes_total_fail_threshold", GuardrailsOptions.DEFAULT_INDEXES_TOTAL_THRESHOLD, guardrails.getStorageAttachedIndexesTotalFailThreshold());
 
+        // Trusted custom indexes guardrail
+        assertEquals("trusted_indexes_per_table_warn_threshold", GuardrailsOptions.NO_LIMIT, guardrails.getTrustedIndexesPerTableWarnThreshold());
+        assertEquals("trusted_indexes_per_table_fail_threshold", GuardrailsOptions.NO_LIMIT, guardrails.getTrustedIndexesPerTableFailThreshold());
+
         // Offset guardrails
         assertEquals("offset_rows_warn_threshold", 10000, guardrails.getOffsetRowsWarnThreshold());
         assertEquals("offset_rows_fail_threshold", 20000, guardrails.getOffsetRowsFailThreshold());
@@ -310,6 +318,10 @@ public class GuardrailsConfigDefaultsTest
         // SAI indexes guardrails
         assertEquals("sai_indexes_per_table_fail_threshold", GuardrailsOptions.DEFAULT_INDEXES_PER_TABLE_THRESHOLD, guardrails.getStorageAttachedIndexesPerTableFailThreshold());
         assertEquals("sai_indexes_total_fail_threshold", GuardrailsOptions.DEFAULT_INDEXES_TOTAL_THRESHOLD, guardrails.getStorageAttachedIndexesTotalFailThreshold());
+
+        // Trusted custom indexes guardrail
+        assertEquals("trusted_indexes_per_table_warn_threshold", GuardrailsOptions.NO_LIMIT, guardrails.getTrustedIndexesPerTableWarnThreshold());
+        assertEquals("trusted_indexes_per_table_fail_threshold", GuardrailsOptions.DEFAULT_INDEXES_PER_TABLE_THRESHOLD, guardrails.getTrustedIndexesPerTableFailThreshold());
 
         // Offset guardrails
         assertEquals("offset_rows_warn_threshold", 10000, guardrails.getOffsetRowsWarnThreshold());

--- a/test/unit/org/apache/cassandra/index/TrustedIndexImplementationsTest.java
+++ b/test/unit/org/apache/cassandra/index/TrustedIndexImplementationsTest.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index;
+
+import org.junit.After;
+import org.junit.Test;
+
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.exceptions.ConfigurationException;
+import org.apache.cassandra.index.internal.CustomCassandraIndex;
+import org.apache.cassandra.index.sai.StorageAttachedIndex;
+import org.apache.cassandra.schema.IndexMetadata;
+
+import static java.lang.String.format;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests the {@code cassandra.trusted_index_implementations} system property, which allows referencing the listed
+ * custom index implementations in {@code CREATE CUSTOM INDEX ... USING} by their simple class name.
+ */
+public class TrustedIndexImplementationsTest extends CQLTester
+{
+    @After
+    public void restoreTrustedIndexImplementations()
+    {
+        IndexMetadata.loadTrustedIndexImplementations(null);
+    }
+
+    @Test
+    public void shouldCreateTrustedIndexBySimpleName() throws Throwable
+    {
+        IndexMetadata.loadTrustedIndexImplementations(StubIndex.class.getName());
+
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v1 int, v2 int, v3 int, v4 int)");
+        createIndex("CREATE CUSTOM INDEX idx1 ON %s(v1) USING 'StubIndex'");
+        createIndex("CREATE CUSTOM INDEX idx2 ON %s(v2) USING 'stubindex'");
+        createIndex("CREATE CUSTOM INDEX idx3 ON %s(v3) USING 'STUBINDEX'");
+        createIndex("CREATE CUSTOM INDEX idx4 ON %s(v4) USING 'org.apache.cassandra.index.StubIndex'");
+
+        SecondaryIndexManager indexManager = getCurrentColumnFamilyStore().indexManager;
+        for (String index : new String[]{ "idx1", "idx2", "idx3", "idx4" })
+            assertTrue(indexManager.getIndexByName(index) instanceof StubIndex);
+    }
+
+    @Test
+    public void shouldRejectSimpleNameWhenNotTrusted() throws Throwable
+    {
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v int)");
+        assertInvalidThrowMessage("Unable to find custom indexer class 'StubIndex'",
+                                  ConfigurationException.class,
+                                  "CREATE CUSTOM INDEX ON %s(v) USING 'StubIndex'");
+    }
+
+    @Test
+    public void shouldParsePropertyValue()
+    {
+        // entries are trimmed, empty entries are skipped, aliases are case-insensitive
+        IndexMetadata.loadTrustedIndexImplementations(format(" %s , , %s ", StubIndex.class.getName(), CustomCassandraIndex.class.getName()));
+        assertTrue(IndexMetadata.isTrustedIndexImplementation("StubIndex"));
+        assertTrue(IndexMetadata.isTrustedIndexImplementation("stubindex"));
+        assertTrue(IndexMetadata.isTrustedIndexImplementation(StubIndex.class.getName()));
+        assertTrue(IndexMetadata.isTrustedIndexImplementation("CustomCassandraIndex"));
+        assertEquals(StubIndex.class.getName(), IndexMetadata.expandAliases("stubindex"));
+
+        // reloading clears the previously registered implementations and aliases
+        IndexMetadata.loadTrustedIndexImplementations(CustomCassandraIndex.class.getName());
+        assertFalse(IndexMetadata.isTrustedIndexImplementation(StubIndex.class.getName()));
+        assertEquals("stubindex", IndexMetadata.expandAliases("stubindex"));
+        assertTrue(IndexMetadata.isTrustedIndexImplementation("CustomCassandraIndex"));
+
+        // entries without a package name are ignored
+        IndexMetadata.loadTrustedIndexImplementations("StubIndex");
+        assertFalse(IndexMetadata.isTrustedIndexImplementation("StubIndex"));
+
+        for (String value : new String[]{ null, "", " , " })
+        {
+            IndexMetadata.loadTrustedIndexImplementations(value);
+            assertFalse(IndexMetadata.isTrustedIndexImplementation(StubIndex.class.getName()));
+            assertFalse(IndexMetadata.isTrustedIndexImplementation(CustomCassandraIndex.class.getName()));
+        }
+
+        // the built-in StorageAttachedIndex aliases are unaffected, but SAI is not implicitly trusted
+        assertEquals(StorageAttachedIndex.class.getName(), IndexMetadata.expandAliases("sai"));
+        assertEquals(StorageAttachedIndex.class.getName(), IndexMetadata.expandAliases("StorageAttachedIndex"));
+        assertFalse(IndexMetadata.isTrustedIndexImplementation(StorageAttachedIndex.class.getName()));
+        assertFalse(IndexMetadata.isTrustedIndexImplementation("sai"));
+    }
+}

--- a/test/unit/org/apache/cassandra/tools/nodetool/GuardrailsConfigCommandsTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/GuardrailsConfigCommandsTest.java
@@ -246,6 +246,7 @@ public class GuardrailsConfigCommandsTest extends CQLTester
     "sai_vector_term_size_threshold            [32KiB, 16KiB]\n" +
     "secondary_indexes_per_table_threshold     [-1, -1]      \n" +
     "tables_threshold                          [-1, -1]      \n" +
+    "trusted_indexes_per_table_threshold       [-1, -1]      \n" +
     "vector_dimensions_threshold               [8192, -1]      \n";
 
     private static final String ALL_THRESHOLDS_GETTER_VERBOSE_OUTPUT =
@@ -307,6 +308,8 @@ public class GuardrailsConfigCommandsTest extends CQLTester
     "secondary_indexes_per_table_warn_threshold   -1   \n" +
     "tables_fail_threshold                        -1   \n" +
     "tables_warn_threshold                        -1   \n" +
+    "trusted_indexes_per_table_fail_threshold     -1   \n" +
+    "trusted_indexes_per_table_warn_threshold     -1   \n" +
     "vector_dimensions_fail_threshold             8192 \n" +
     "vector_dimensions_warn_threshold             -1   \n";
 


### PR DESCRIPTION

### What is the issue
In HCD we have a new custom Index Type com.datastax.opensearch.OpenSearchIndex that indexes data on OpenSearch.

We want to make it userfriendly to create the index:
`CREATE CUSTOM INDEX .... USING 'OpenSearchIndex' WITH OPTIONS ...`

We also want that users do not need to allow all the secondary indexes in cassandra.yaml (in HCD secondary_indexes_enabled is disabled by default)

See HCD-459.

HCD  PR here: https://github.com/riptano/hcd/pull/243
CNDB PR here: https://github.com/riptano/cndb/pull/18508

### What does this PR fix and why was it fixed

Add the `cassandra.trusted_index_implementations ` system property, a comma-separated list of fully qualified custom index class names.

Each listed class is registered as an index name alias, so users can create it with `CREATE CUSTOM INDEX ... USING '<SimpleClassName>'` without the package name, like it is already possible for StorageAttachedIndex.

Trusted implementations are also exempted from the `secondary_indexes_enabled` guardrail: they can be created even when the creation of secondary indexes is disabled.

To keep their number under control, the new `trusted_indexes_per_table` guardrail limits how many indexes of each trusted implementation class can be created on a table (warn/fail thresholds, counted per implementation class, exposed through nodetool and `JMX` like the other index guardrails). It defaults to a failure threshold of 10 under the HCD guardrails profile and is disabled under the other profiles.

Also expand index name aliases in
CreateIndexStatement.isUnknownCustomIndexCreateStatement(), so that aliased index classes are not misreported as unknown when cassandra.index.unknown_custom_class.ignore is set.
