### PR TITLE
CNDB-18493: Add FB index format to decouple FusedPQ from index version

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -459,11 +459,14 @@ public enum CassandraRelevantProperties
     // Use non-positive value to disable it. Period in millis to trigger a flush for SAI vector memtable index.
     SAI_VECTOR_FLUSH_PERIOD_IN_MILLIS("cassandra.sai.vector_flush_period_in_millis", "-1"),
     /**
-     * @deprecated This property is deprecated and no longer has any effect. FusedPQ is now automatically enabled
-     * for all indexes using version FA or later (jvector file format version 6+). The property cannot be used to
-     * disable FusedPQ for FA+ versions.
+     * Whether compaction should build vector indexes using a fused graph, i.e. a graph where the quantized vectors
+     * are stored inline with the graph nodes (FusedPQ). This is an experimental feature that significantly increases
+     * disk usage and should only be enabled where it makes sense.
+     * See: https://github.com/riptano/cndb/issues/17471
+     * <p>
+     * Note: for indexes using version FA (jvector file format version 6), FusedPQ is always enabled regardless
+     * of this property. For version FB and later, this property controls whether FusedPQ is used.
      */
-    @Deprecated
     SAI_VECTOR_ENABLE_FUSED("cassandra.sai.vector.enable_fused", "false"),
     // Use nvq when building graphs in compaction. Disabled by default for now. Enabling will reduce recall slightly
     // while also reducing the storage footprint.

--- a/src/java/org/apache/cassandra/index/sai/disk/format/Version.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/Version.java
@@ -78,10 +78,12 @@ public class Version implements Comparable<Version>
     public static final Version ED = new Version("ed", V7OnDiskFormat.instance, (c, i, g) -> stargazerFileNameFormat(c, i, g, "ed"));
     // jvector file format version 6 (skipped 5)
     public static final Version FA = new Version("fa", V8OnDiskFormat.instance, (c, i, g) -> stargazerFileNameFormat(c, i, g, "fa"));
+    // FB format: same jvector file format version 6 as FA, but FusedPQ is opt-in via cassandra.sai.vector.enable_fused
+    public static final Version FB = new Version("fb", V8OnDiskFormat.instance, (c, i, g) -> stargazerFileNameFormat(c, i, g, "fb"));
 
     // These are in reverse-chronological order so that the latest version is first. Version matching tests
     // are more likely to match the latest version, so we want to test that one first.
-    public static final List<Version> ALL = Lists.newArrayList(FA, ED, EC, EB, DC, DB, CA, BA, AA);
+    public static final List<Version> ALL = Lists.newArrayList(FB, FA, ED, EC, EB, DC, DB, CA, BA, AA);
 
     public static final Version EARLIEST = AA;
     public static final Version VECTOR_EARLIEST = BA;

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/JVectorVersionUtil.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/JVectorVersionUtil.java
@@ -22,9 +22,11 @@ import org.apache.cassandra.index.sai.disk.format.Version;
 public class JVectorVersionUtil
 {
     /**
+     * Whether to fuse quantized vectors into the graph when writing indexes, assuming all other conditions are met.
      * Variables are volatile to allow for changing in unit tests. They are only accessed on flush and compaction,
      * so their access is infrequent.
      */
+    public static volatile boolean ENABLE_FUSED = CassandraRelevantProperties.SAI_VECTOR_ENABLE_FUSED.getBoolean();
     public static volatile boolean ENABLE_NVQ = CassandraRelevantProperties.SAI_VECTOR_ENABLE_NVQ.getBoolean();
     public static final int NUM_SUB_VECTORS = CassandraRelevantProperties.SAI_VECTOR_NVQ_NUM_SUB_VECTORS.getInt();
 
@@ -51,16 +53,18 @@ public class JVectorVersionUtil
      * does not take into account whether the graph has enough information to build a quantization, as that depends on
      * external factors.
      * <p>
-     * FusedPQ is automatically enabled for all indexes using version FA or later (jvector file format version 6+).
-     * The deprecated ENABLE_FUSED property is ignored for these versions.
+     * For version FA, FusedPQ is always enabled regardless of {@code ENABLE_FUSED}.
+     * For version FB and later, FusedPQ is opt-in via {@code cassandra.sai.vector.enable_fused}.
      *
      * @param version the SAI on disk format to use when writing to disk
      * @return true if conditions are met, false otherwise
      */
     public static boolean shouldWriteFused(Version version)
     {
-        // For FA version and later, FusedPQ is always enabled (tied to the version)
-        return versionSupportsFused(version);
+        if (!versionSupportsFused(version))
+            return false;
+        // FA always uses FusedPQ; FB+ requires the flag to be set
+        return version.equals(Version.FA) || ENABLE_FUSED;
     }
 
     public static boolean versionSupportsFused(Version version)

--- a/test/unit/org/apache/cassandra/index/sai/SAIUtil.java
+++ b/test/unit/org/apache/cassandra/index/sai/SAIUtil.java
@@ -100,6 +100,24 @@ public class SAIUtil
         }
     }
 
+    public static void setEnableFused(boolean enableFused)
+    {
+        try
+        {
+            CassandraRelevantProperties.SAI_VECTOR_ENABLE_FUSED.setBoolean(enableFused);
+            Field field = JVectorVersionUtil.class.getDeclaredField("ENABLE_FUSED");
+            field.setAccessible(true);
+            Field modifiersField = ReflectionUtils.getField(Field.class, "modifiers");
+            modifiersField.setAccessible(true);
+            modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+            field.set(null, enableFused);
+        }
+        catch (Exception e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+
     public static void setEnableNVQ(boolean enableNVQ)
     {
         try

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorCompactionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorCompactionTest.java
@@ -407,11 +407,12 @@ abstract public class VectorCompactionTest extends VectorTester
                             }
                             else if (numRows >= MIN_PQ_ROWS)
                             {
-                                // With FA + fused PQ, PQ metadata is present and used by the graph, but there is no
-                                // standalone CompressedVectors instance to validate against.
-                                // TODO: further investigate what other checks are needed here
-                                assertEquals("Expected fused PQ path only for FA+", Version.FA, version);
-                                assertNotNull("Expected PQ metadata for FA fused PQ", searcher.getPQ());
+                                // With fused PQ (FA always; GA+ only when enabled), PQ metadata is stored inline
+                                // with the graph nodes — there is no standalone CompressedVectors to validate against.
+                                // Without fused PQ (GA+ default, pre-FA), we should never reach this branch.
+                                assertTrue("Found " + numRows + " rows without CompressedVectors; expected fused PQ for version " + version,
+                                           JVectorVersionUtil.shouldWriteFused(version));
+                                assertNotNull("Expected PQ metadata for fused PQ on version " + version, searcher.getPQ());
                             }
                         }
                     }

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorMetricsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorMetricsTest.java
@@ -100,8 +100,9 @@ public class VectorMetricsTest extends VectorTester
             execute("INSERT INTO %s (pk, val) VALUES (?, ?)", i, vector(1 + i, 2 + i, 3 + i));
         flush();
 
-        // FusedPQ is tied to version: enabled for FA+, disabled for pre-FA
-        boolean fusedPQ = JVectorVersionUtil.versionSupportsFused(version);
+        // FA always uses FusedPQ; FB+ uses it only when cassandra.sai.vector.enable_fused=true (default false).
+        // Pre-FA versions never use FusedPQ.
+        boolean fusedPQ = JVectorVersionUtil.shouldWriteFused(version);
         long pqMemoryAfterFlush = vectorMetrics.quantizationMemoryBytes.sum();
 
         if (fusedPQ)
@@ -116,7 +117,7 @@ public class VectorMetricsTest extends VectorTester
             assertTrue("Version " + version + " should have PQ memory without FusedPQ",
                       pqMemoryAfterFlush > 0);
         }
-        
+
         assertEquals(0, vectorMetrics.ordinalsMapMemoryBytes.sum()); // unique vectors means no cache required
         assertEquals(1, vectorMetrics.onDiskGraphsCount.sum());
         assertEquals(CassandraOnHeapGraph.MIN_PQ_ROWS, vectorMetrics.onDiskGraphVectorsCount.sum());

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorTester.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorTester.java
@@ -191,7 +191,10 @@ public class VectorTester extends SAITester
         @Parameterized.Parameter(1)
         public boolean ENABLE_NVQ;
 
-        @Parameterized.Parameters(name = "{0} {1}")
+        @Parameterized.Parameter(2)
+        public boolean ENABLE_FUSED;
+
+        @Parameterized.Parameters(name = "version={0} enableNVQ={1} enableFused={2}")
         public static Collection<Object[]> data()
         {
             // See Version file for explanation of changes associated with each version
@@ -201,7 +204,17 @@ public class VectorTester extends SAITester
                                   var enableNVQ = JVectorVersionUtil.versionSupportsNVQ(v)
                                                   ? new Boolean[]{ true, false }
                                                   : new Boolean[]{ false };
-                                  return Arrays.stream(enableNVQ).map(nvq -> new Object[]{ v, nvq });
+                                  // FA always uses FusedPQ regardless of the flag, so only test enableFused=true there.
+                                  // FB+ allows toggling the flag, so test both values.
+                                  // Pre-FA versions don't support FusedPQ at all.
+                                  var enableFused = v.onOrAfter(Version.FB)
+                                                    ? new Boolean[]{ true, false }
+                                                    : JVectorVersionUtil.versionSupportsFused(v)
+                                                      ? new Boolean[]{ true }   // FA: always-on
+                                                      : new Boolean[]{ false };  // pre-FA: unsupported
+                                  return Arrays.stream(enableNVQ).flatMap(nvq ->
+                                      Arrays.stream(enableFused).map(fused -> new Object[]{ v, nvq, fused })
+                                  );
                               }).collect(Collectors.toList());
         }
 
@@ -215,6 +228,12 @@ public class VectorTester extends SAITester
         public void setEnableNVQ()
         {
             SAIUtil.setEnableNVQ(ENABLE_NVQ);
+        }
+
+        @Before
+        public void setEnableFused()
+        {
+            SAIUtil.setEnableFused(ENABLE_FUSED);
         }
     }
 

--- a/test/unit/org/apache/cassandra/index/sai/disk/vector/JVectorVersionUtilTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/vector/JVectorVersionUtilTest.java
@@ -54,17 +54,18 @@ public class JVectorVersionUtilTest extends SAITester
     @Test
     public void testFusedPQSupport()
     {
-        // FusedPQ requires jvector format 6 or later (FA+)
+        // versionSupportsFused: true for FA and FB (jvector format 6+), false for pre-FA
         int jvectorFormat = version.onDiskFormat().jvectorFileFormatVersion();
         boolean expectedSupport = jvectorFormat >= JVECTOR_FORMAT_FUSED_PQ;
-        
+
         assertEquals(String.format("Version %s (jvector format %d) FusedPQ support mismatch", version, jvectorFormat),
                      expectedSupport,
                      JVectorVersionUtil.versionSupportsFused(version));
-        
-        // For FA+, FusedPQ is always enabled (tied to version)
-        assertEquals(String.format("Version %s (jvector format %d) shouldWriteFused mismatch", version, jvectorFormat),
-                     expectedSupport,
+
+        // shouldWriteFused: FA always on; FB+ requires ENABLE_FUSED flag (default false); pre-FA always false
+        boolean expectedWrite = version.equals(Version.FA);  // default flag is false, so only FA is unconditionally on
+        assertEquals(String.format("Version %s (jvector format %d) shouldWriteFused mismatch (ENABLE_FUSED=false)", version, jvectorFormat),
+                     expectedWrite,
                      JVectorVersionUtil.shouldWriteFused(version));
     }
 


### PR DESCRIPTION
### What is the issue
...
#18493
### What does this PR fix and why was it fixed
...
Introduce version FB (reusing V8OnDiskFormat/jvector format 6) as the
new default SAI format. Unlike FA where FusedPQ is always enabled,
FB makes FusedPQ opt-in via `cassandra.sai.vector.enable_fused` (default
false), restoring the pre-CNDB-17871 behaviour for new indexes.

FA retains its always-on FusedPQ semantics unchanged.

