### PR TITLE
HCD-438: Add BatchlogManagerInterceptor hook for batchlog recovery  (cc-5 only)

### DIFF
--- a/src/java/org/apache/cassandra/batchlog/BatchlogManager.java
+++ b/src/java/org/apache/cassandra/batchlog/BatchlogManager.java
@@ -22,8 +22,10 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -76,7 +78,9 @@ import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.service.WriteResponseHandler;
 import org.apache.cassandra.utils.ExecutorUtils;
 import org.apache.cassandra.utils.FBUtilities;
+import org.apache.cassandra.utils.JVMStabilityInspector;
 import org.apache.cassandra.utils.MBeanWrapper;
+import org.apache.cassandra.utils.NoSpamLogger;
 import org.apache.cassandra.utils.StorageCompatibilityMode;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -100,6 +104,15 @@ public class BatchlogManager implements BatchlogManagerMBean
     private volatile long totalBatchesReplayed = 0; // no concurrency protection necessary as only written by replay thread.
     private volatile TimeUUID lastReplayedUuid = TimeUUID.minAtUnixMillis(0);
 
+    // Batches whose mutations have completed (applied locally, acknowledged by remote replicas, or
+    // hinted) in an earlier replay cycle but whose interceptor callback failed, mapped to the hosts
+    // hinted for them. On later cycles only the callback is retried, via a point read of the batch:
+    // the mutations are not re-sent and no new hints are written for them, and the hinted hosts are
+    // fsynced again before the batch is finally deleted. Only accessed by the replay thread. Lost
+    // on restart, in which case the batch (whose row sits behind lastReplayedUuid, itself reset by
+    // the restart) is replayed from scratch, which the at-least-once contract already tolerates.
+    private final Map<TimeUUID, Set<UUID>> batchesAwaitingInterceptor = new HashMap<>();
+
     // Single-thread executor service for scheduling and serializing log replay.
     private final ScheduledExecutorPlus batchlogTasks;
 
@@ -113,6 +126,11 @@ public class BatchlogManager implements BatchlogManagerMBean
     public void start()
     {
         MBeanWrapper.instance.registerMBean(this, MBEAN_NAME);
+
+        // Resolve the interceptor eagerly: a misconfigured custom class fails the node at
+        // startup rather than at the first replay, and operators can see what is installed.
+        BatchlogManagerInterceptor interceptor = BatchlogManagerInterceptor.instance;
+        logger.info("Batchlog interceptor: {}", interceptor.getClass().getName());
 
         batchlogTasks.scheduleWithFixedDelay(this::replayFailedBatches,
                                              StorageService.RING_DELAY_MILLIS,
@@ -188,6 +206,23 @@ public class BatchlogManager implements BatchlogManagerMBean
         return totalBatchesReplayed;
     }
 
+    @VisibleForTesting
+    int countBatchesAwaitingInterceptor()
+    {
+        return batchesAwaitingInterceptor.size();
+    }
+
+    /**
+     * Simulates the effect of a replay cycle that aborted before advancing the scan lower bound:
+     * the next scan covers already-processed rows again, including those of batches awaiting their
+     * interceptor.
+     */
+    @VisibleForTesting
+    void resetLastReplayedUuid()
+    {
+        lastReplayedUuid = TimeUUID.minAtUnixMillis(0);
+    }
+
     public void forceBatchlogReplay() throws Exception
     {
         startBatchlogReplay().get();
@@ -222,15 +257,21 @@ public class BatchlogManager implements BatchlogManagerMBean
         TimeUUID limitUuid = TimeUUID.maxAtUnixMillis(currentTimeMillis() - getBatchlogTimeout());
         ColumnFamilyStore store = Keyspace.open(SchemaConstants.SYSTEM_KEYSPACE_NAME).getColumnFamilyStore(SystemKeyspace.BATCHES);
         int pageSize = calculatePageSize(store);
-        // There cannot be any live content where token(id) <= token(lastReplayedUuid) as every processed batch is
-        // deleted, but the tombstoned content may still be present in the tables. To avoid walking over it we specify
-        // token(id) > token(lastReplayedUuid) as part of the query.
+        // The only live content where token(id) <= token(lastReplayedUuid) are batches retained because
+        // their interceptor callback failed, and those are retried through point reads, not through this
+        // scan; every other processed batch is deleted, but the tombstoned content may still be present
+        // in the tables. To avoid walking over it we specify token(id) > token(lastReplayedUuid) as part
+        // of the query.
         String query = String.format("SELECT id, mutations, version FROM %s.%s WHERE token(id) > token(?) AND token(id) <= token(?)",
                                      SchemaConstants.SYSTEM_KEYSPACE_NAME,
                                      SystemKeyspace.BATCHES);
         UntypedResultSet batches = executeInternalWithPaging(query, PageSize.inRows(pageSize), lastReplayedUuid, limitUuid);
         processBatchlogEntries(batches, pageSize, rateLimiter);
         lastReplayedUuid = limitUuid;
+        if (!batchesAwaitingInterceptor.isEmpty())
+            NoSpamLogger.log(logger, NoSpamLogger.Level.WARN, 1, TimeUnit.MINUTES,
+                             "{} batches whose mutations were replayed are retained in the batchlog awaiting successful interceptor callbacks",
+                             batchesAwaitingInterceptor.size());
         logger.trace("Finished replayFailedBatches");
     }
 
@@ -275,15 +316,27 @@ public class BatchlogManager implements BatchlogManagerMBean
         Exception caughtException = null;
         int skipped = 0;
 
+        // Snapshot before the scan: only batches memoized by EARLIER cycles get their callbacks
+        // retried in this cycle. A callback failing during this cycle's scan is retried on the
+        // next cycle, per the interceptor contract, not immediately.
+        List<Map.Entry<TimeUUID, Set<UUID>>> awaitingInterceptorRetry = new ArrayList<>(batchesAwaitingInterceptor.entrySet());
+
         // Sending out batches for replay without waiting for them, so that one stuck batch doesn't affect others
         for (UntypedResultSet.Row row : batches)
         {
             TimeUUID id = row.getTimeUUID("id");
             int version = row.getInt("version");
+
+            // If a cycle aborts before advancing lastReplayedUuid, the next scan still covers the
+            // batches it left awaiting their interceptor; those are handled by
+            // retryBatchesAwaitingInterceptor later in this cycle, so don't replay them here.
+            if (batchesAwaitingInterceptor.containsKey(id))
+                continue;
+
             try
             {
                 ReplayingBatch batch = new ReplayingBatch(id, version, row.getList("mutations", BytesType.instance));
-                if (batch.replay(rateLimiter, hintedNodes) > 0)
+                if (batch.replay(rateLimiter) > 0)
                 {
                     unfinishedBatches.add(batch);
                 }
@@ -314,14 +367,94 @@ public class BatchlogManager implements BatchlogManagerMBean
         if (positionInPage > 0)
             finishAndClearBatches(unfinishedBatches, hintedNodes, replayedBatches);
 
+        // Retry the callbacks of batches retained by earlier cycles. This runs after the scan, so
+        // replay of new content is not starved by retries, and before the hint fsync barrier below,
+        // which the deferred deletion of the retried batches must share.
+        retryBatchesAwaitingInterceptor(awaitingInterceptorRetry, rateLimiter, hintedNodes, replayedBatches);
+
         if (caughtException != null)
             logger.warn(String.format("Encountered %d unexpected exceptions while sending out batches", skipped), caughtException);
 
         // to preserve batch guarantees, we must ensure that hints (if any) have made it to disk, before deleting the batches
         HintsService.instance.flushAndFsyncBlockingly(hintedNodes);
 
-        // once all generated hints are fsynced, actually delete the batches
-        replayedBatches.forEach(BatchlogManager::remove);
+        // Once all generated hints are fsynced, actually delete the batches. A batch awaiting its
+        // interceptor is forgotten right when its row is deleted (and only counts as replayed now):
+        // had the cycle aborted before its deletion, the batch must go through the callback-only
+        // retry again — not through a full (mutation re-sending, hint re-writing) replay, and
+        // without being counted twice.
+        for (TimeUUID id : replayedBatches)
+        {
+            remove(id);
+            if (batchesAwaitingInterceptor.remove(id) != null)
+                ++totalBatchesReplayed;
+        }
+    }
+
+    /**
+     * Retries the interceptor callbacks of batches whose mutations completed in an earlier cycle.
+     * Batches are looked up individually — their rows sit behind {@code lastReplayedUuid}, outside
+     * the ranges scanned by {@link #replayFailedBatches} — and their mutations are not re-delivered:
+     * on callback success the batch joins {@code replayedBatches}, its previously hinted hosts join
+     * {@code hintedNodes} so the hints are fsynced (again) before the caller deletes the batch, and
+     * the memoized entry itself is dropped (and the batch counted as replayed) by the caller once
+     * the deletion has happened. Re-reads are throttled by the replay rate limiter.
+     */
+    private void retryBatchesAwaitingInterceptor(List<Map.Entry<TimeUUID, Set<UUID>>> awaitingRetry,
+                                                 RateLimiter rateLimiter,
+                                                 Set<UUID> hintedNodes,
+                                                 Set<TimeUUID> replayedBatches)
+    {
+        if (awaitingRetry.isEmpty())
+            return;
+
+        String query = String.format("SELECT id, mutations, version FROM %s.%s WHERE id = ?",
+                                     SchemaConstants.SYSTEM_KEYSPACE_NAME,
+                                     SystemKeyspace.BATCHES);
+        for (Map.Entry<TimeUUID, Set<UUID>> entry : awaitingRetry)
+        {
+            TimeUUID id = entry.getKey();
+            try
+            {
+                UntypedResultSet result = executeInternal(query, id);
+                if (result == null || result.isEmpty())
+                {
+                    // The batch was removed from the batchlog by another path (e.g. its coordinator
+                    // completing the batch): there is no row left to retry the callbacks from.
+                    logger.warn("Batch {} was removed from the batchlog before its interceptor callbacks completed; dropping them", id);
+                    batchesAwaitingInterceptor.remove(id);
+                    ++totalBatchesReplayed;
+                    continue;
+                }
+
+                UntypedResultSet.Row row = result.one();
+                ReplayingBatch batch = new ReplayingBatch(id, row.getInt("version"), row.getList("mutations", BytesType.instance));
+                rateLimiter.acquire(batch.replayedBytes);
+                if (tryNotifyInterceptor(batch))
+                {
+                    hintedNodes.addAll(entry.getValue());
+                    replayedBatches.add(id);
+                }
+            }
+            catch (IOException e)
+            {
+                logger.error("Batch {} was replayed but can no longer be deserialized; its remaining interceptor callbacks are dropped", id, e);
+                // let the deletion share the hint fsync barrier below, like any other replayed batch
+                hintedNodes.addAll(entry.getValue());
+                replayedBatches.add(id);
+            }
+            catch (Throwable t)
+            {
+                // Failing to read one batch back (e.g. a transient local read error) must wedge
+                // neither the other retries nor the scan of new batchlog content: keep the entry
+                // and let a later cycle retry the read. Deliberately, an error we cannot classify
+                // is never grounds for deleting the batch (a corrupt row that keeps failing with
+                // a RuntimeException is retried, and warned about, indefinitely).
+                JVMStabilityInspector.inspectThrowable(t);
+                NoSpamLogger.log(logger, NoSpamLogger.Level.WARN, 1, TimeUnit.MINUTES,
+                                 "Failed to read batch {} back for its interceptor retry; it will be retried", id, t);
+            }
+        }
     }
 
     private void finishAndClearBatches(ArrayList<ReplayingBatch> batches, Set<UUID> hintedNodes, Set<TimeUUID> replayedBatches)
@@ -329,12 +462,46 @@ public class BatchlogManager implements BatchlogManagerMBean
         // schedule hints for timed out deliveries
         for (ReplayingBatch batch : batches)
         {
-            batch.finish(hintedNodes);
-            replayedBatches.add(batch.id);
+            batch.finish();
+            hintedNodes.addAll(batch.hintedNodes());
+            if (tryNotifyInterceptor(batch))
+            {
+                replayedBatches.add(batch.id);
+                ++totalBatchesReplayed;
+            }
+            else
+            {
+                // Don't mark the batch replayed: its batchlog row survives. Its mutations have
+                // completed though, so remember that (along with the hosts hinted for it) and let
+                // later cycles retry the callback alone instead of replaying the whole batch
+                // (and writing another round of hints).
+                batchesAwaitingInterceptor.put(batch.id, batch.hintedNodes());
+            }
         }
 
-        totalBatchesReplayed += batches.size();
         batches.clear();
+    }
+
+    /**
+     * Invokes {@link BatchlogManagerInterceptor#instance} with the batch and all of its mutations.
+     *
+     * @return true if the callback completed, false if the interceptor threw and the batch must be
+     *         retained in the batchlog so the callback is retried on the next replay cycle
+     */
+    private static boolean tryNotifyInterceptor(ReplayingBatch batch)
+    {
+        try
+        {
+            batch.notifyInterceptor();
+            return true;
+        }
+        catch (Throwable t)
+        {
+            JVMStabilityInspector.inspectThrowable(t);
+            NoSpamLogger.log(logger, NoSpamLogger.Level.WARN, 1, TimeUnit.MINUTES,
+                             "Batchlog interceptor failed for batch {}; the callback will be retried", batch.id, t);
+            return false;
+        }
     }
 
     public static long getBatchlogTimeout()
@@ -348,6 +515,7 @@ public class BatchlogManager implements BatchlogManagerMBean
         private final long writtenAt;
         private final List<Mutation> mutations;
         private final int replayedBytes;
+        private final Set<UUID> hintedNodes = new HashSet<>();
 
         private List<ReplayWriteResponseHandler<Mutation>> replayHandlers;
 
@@ -359,7 +527,16 @@ public class BatchlogManager implements BatchlogManagerMBean
             this.replayedBytes = addMutations(version, serializedMutations);
         }
 
-        public int replay(RateLimiter rateLimiter, Set<UUID> hintedNodes) throws IOException
+        /**
+         * @return the hosts hinted while replaying this batch, both for replicas that were down when
+         *         the mutations were sent and for replicas that did not acknowledge them in time
+         */
+        Set<UUID> hintedNodes()
+        {
+            return hintedNodes;
+        }
+
+        public int replay(RateLimiter rateLimiter) throws IOException
         {
             logger.trace("Replaying batch {}", id);
 
@@ -377,7 +554,7 @@ public class BatchlogManager implements BatchlogManagerMBean
             return replayHandlers.size();
         }
 
-        public void finish(Set<UUID> hintedNodes)
+        public void finish()
         {
             for (int i = 0; i < replayHandlers.size(); i++)
             {
@@ -391,10 +568,20 @@ public class BatchlogManager implements BatchlogManagerMBean
                     logger.trace("Failed replaying a batched mutation to a node, will write a hint");
                     logger.trace("Failure was : {}", e.getMessage());
                     // writing hints for the rest to hints, starting from i
-                    writeHintsForUndeliveredEndpoints(i, hintedNodes);
+                    writeHintsForUndeliveredEndpoints(i);
                     return;
                 }
             }
+        }
+
+        /**
+         * Notifies {@link BatchlogManagerInterceptor#instance} of the replayed batch, with all of
+         * its mutations. Exceptions propagate to the caller, which keeps the batch in the batchlog
+         * so its recovery is retried.
+         */
+        void notifyInterceptor()
+        {
+            BatchlogManagerInterceptor.instance.onReplayedBatch(id, writtenAt, Collections.unmodifiableList(mutations));
         }
 
         private int addMutations(int version, List<ByteBuffer> serializedMutations) throws IOException
@@ -425,7 +612,7 @@ public class BatchlogManager implements BatchlogManagerMBean
                 mutations.add(mutation);
         }
 
-        private void writeHintsForUndeliveredEndpoints(int startFrom, Set<UUID> hintedNodes)
+        private void writeHintsForUndeliveredEndpoints(int startFrom)
         {
             int gcgs = gcgs(mutations);
 

--- a/src/java/org/apache/cassandra/batchlog/BatchlogManagerInterceptor.java
+++ b/src/java/org/apache/cassandra/batchlog/BatchlogManagerInterceptor.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.batchlog;
+
+import java.util.List;
+
+import org.apache.cassandra.db.Mutation;
+import org.apache.cassandra.utils.FBUtilities;
+import org.apache.cassandra.utils.TimeUUID;
+
+import static org.apache.cassandra.config.CassandraRelevantProperties.CUSTOM_BATCHLOG_MANAGER_INTERCEPTOR_CLASS;
+
+/**
+ * A pluggable hook that observes the batches replayed by batchlog recovery
+ * ({@link BatchlogManager#replayFailedBatches}).
+ * <br/>
+ * The callback is invoked on the node performing the recovery (the batchlog replica replaying its
+ * local batchlog), on the batchlog replay thread, once per replayed batch, with the complete list
+ * of the batch's mutations — whether they were applied locally, delivered to remote replicas, or
+ * hinted — so implementations can process a batch's mutations together.
+ * <br/>
+ * The interceptor runs as part of the recovery of a batch: it is invoked <b>after</b> the batch's
+ * mutations have completed (applied locally and acknowledged by the remote replicas, or hinted)
+ * and <b>before</b> the batch is removed from the batchlog. If the interceptor throws, the batch
+ * is not removed and the callback — again with the batch's complete mutation list — is retried on
+ * the next replay cycle; the batch's mutations, having already completed, are not re-sent and no
+ * additional hints are written for them. Should the node restart before the callback succeeds,
+ * the whole batch is replayed from scratch, mutations included. Semantics are therefore
+ * at-least-once: the same batch (and thus every mutation in it) may be observed (and, across
+ * restarts, re-applied) multiple times, and implementations must be idempotent. An implementation
+ * should only throw for failures that a later retry can resolve, as a batch whose interceptor
+ * keeps failing is retried indefinitely (and reported by a periodic warning in the log).
+ * <br/>
+ * At-least-once has the same carve-outs as batchlog replay itself: no callback is delivered for a
+ * batch dropped because all its tables were truncated or dropped, or because the batch outlived
+ * its smallest gc_grace_seconds — replay treats those as "delivered, then truncated/expired" and
+ * discards them, before or between callback retries — and mutations whose individual table was
+ * truncated or dropped are excluded from the list. A callback still pending when the batch is
+ * removed from the batchlog by another path (e.g. its coordinator completing the batch after this
+ * node already replayed it) is dropped, with a warning in the log. Callbacks still pending when
+ * the node is decommissioned are lost with the node's batchlog. And since retries happen on later
+ * replay cycles, callbacks are delivered at-least-once, but not necessarily in batch order.
+ * <br/>
+ * The callback cannot alter or veto the mutations themselves. Implementations should be fast and
+ * non-blocking, as they run inline on the replay path.
+ * <br/>
+ * A custom implementation can be provided with the
+ * {@code cassandra.custom_batchlog_manager_interceptor_class} system property; it must have a
+ * public no-argument constructor. By default a no-op implementation is used.
+ */
+public interface BatchlogManagerInterceptor
+{
+    BatchlogManagerInterceptor instance = getCustomOrDefault();
+
+    static BatchlogManagerInterceptor getCustomOrDefault()
+    {
+        if (CUSTOM_BATCHLOG_MANAGER_INTERCEPTOR_CLASS.isPresent())
+        {
+            return FBUtilities.construct(CUSTOM_BATCHLOG_MANAGER_INTERCEPTOR_CLASS.getString(),
+                                         "custom batchlog manager interceptor (set with " + CUSTOM_BATCHLOG_MANAGER_INTERCEPTOR_CLASS.getKey() + ')');
+        }
+        return new Noop();
+    }
+
+    /**
+     * Invoked once for a batch whose replay has completed, before the batch is removed from the
+     * batchlog.
+     *
+     * @param batchId   id of the batchlog entry being replayed
+     * @param writtenAt original write time of the batch, in milliseconds since the epoch
+     * @param mutations all the mutations of the replayed batch; the list is unmodifiable and only
+     *                  valid for the duration of the callback — copy it if it must be retained
+     */
+    void onReplayedBatch(TimeUUID batchId, long writtenAt, List<Mutation> mutations);
+
+    class Noop implements BatchlogManagerInterceptor
+    {
+        @Override
+        public void onReplayedBatch(TimeUUID batchId, long writtenAt, List<Mutation> mutations)
+        {
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -288,6 +288,11 @@ public enum CassandraRelevantProperties
     COUNTER_LOCK_FAIR_LOCK("cassandra.counter_lock.fair_lock", "false"),
     COUNTER_LOCK_NUM_STRIPES_PER_THREAD("cassandra.counter_lock.num_stripes_per_thread", "1024"),
     CRYPTO_PROVIDER_CLASS_NAME("cassandra.crypto_provider_class_name"),
+    /**
+     * Name of a custom implementation of {@link org.apache.cassandra.batchlog.BatchlogManagerInterceptor}
+     * that observes every mutation replayed by batchlog recovery.
+     */
+    CUSTOM_BATCHLOG_MANAGER_INTERCEPTOR_CLASS("cassandra.custom_batchlog_manager_interceptor_class"),
     /** Which class to use for coordinator client request metrics */
     CUSTOM_CLIENT_REQUEST_METRICS_PROVIDER_PROPERTY("cassandra.custom_client_request_metrics_provider_class"),
     /** Which class to use for failure detection */

--- a/test/unit/org/apache/cassandra/batchlog/BatchlogManagerInterceptorTest.java
+++ b/test/unit/org/apache/cassandra/batchlog/BatchlogManagerInterceptorTest.java
@@ -1,0 +1,402 @@
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.batchlog;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.SchemaLoader;
+import org.apache.cassandra.Util;
+import org.apache.cassandra.Util.PartitionerSwitcher;
+import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.cql3.UntypedResultSet;
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.db.Mutation;
+import org.apache.cassandra.db.RowUpdateBuilder;
+import org.apache.cassandra.db.SystemKeyspace;
+import org.apache.cassandra.db.marshal.BytesType;
+import org.apache.cassandra.dht.Murmur3Partitioner;
+import org.apache.cassandra.exceptions.ConfigurationException;
+import org.apache.cassandra.locator.InetAddressAndPort;
+import org.apache.cassandra.locator.TokenMetadata;
+import org.apache.cassandra.metrics.StorageMetrics;
+import org.apache.cassandra.schema.KeyspaceParams;
+import org.apache.cassandra.schema.SchemaConstants;
+import org.apache.cassandra.schema.TableMetadata;
+import org.apache.cassandra.service.StorageService;
+import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.FBUtilities;
+import org.apache.cassandra.utils.TimeUUID;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.apache.cassandra.cql3.QueryProcessor.executeInternal;
+import static org.apache.cassandra.utils.Clock.Global.currentTimeMillis;
+import static org.apache.cassandra.utils.TimeUUID.Generator.atUnixMillis;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+public class BatchlogManagerInterceptorTest
+{
+    static
+    {
+        // Must be set before BatchlogManagerInterceptor is initialized, as the instance field
+        // is resolved once at class-init; unit tests run in their own forked JVM, so nothing
+        // has touched the interface yet.
+        CassandraRelevantProperties.CUSTOM_BATCHLOG_MANAGER_INTERCEPTOR_CLASS.setString(TestInterceptor.class.getName());
+    }
+
+    // Initializes the interface (freezing its instance field) right after the property is set
+    // above, so no test-method ordering can first touch it while the property is cleared.
+    private static final BatchlogManagerInterceptor frozenInstance = BatchlogManagerInterceptor.instance;
+
+    private static final String KEYSPACE1 = "BatchlogManagerInterceptorTest1";
+    private static final String KEYSPACE2 = "BatchlogManagerInterceptorTest2";
+    private static final String CF_STANDARD1 = "Standard1";
+
+    static PartitionerSwitcher sw;
+
+    public static class TestInterceptor implements BatchlogManagerInterceptor
+    {
+        static final List<TimeUUID> observedBatchIds = new CopyOnWriteArrayList<>();
+        static final List<Long> observedWrittenAt = new CopyOnWriteArrayList<>();
+        static final List<List<Mutation>> observedBatches = new CopyOnWriteArrayList<>();
+        static volatile boolean failCallbacks = false;
+
+        @Override
+        public void onReplayedBatch(TimeUUID batchId, long writtenAt, List<Mutation> mutations)
+        {
+            observedBatchIds.add(batchId);
+            observedWrittenAt.add(writtenAt);
+            observedBatches.add(new ArrayList<>(mutations));
+            if (failCallbacks)
+                throw new RuntimeException("simulated interceptor failure");
+        }
+
+        static void reset()
+        {
+            observedBatchIds.clear();
+            observedWrittenAt.clear();
+            observedBatches.clear();
+            failCallbacks = false;
+        }
+    }
+
+    @BeforeClass
+    public static void defineSchema() throws ConfigurationException
+    {
+        DatabaseDescriptor.daemonInitialization();
+        sw = Util.switchPartitioner(Murmur3Partitioner.instance);
+        SchemaLoader.prepareServer();
+        SchemaLoader.createKeyspace(KEYSPACE1,
+                                    KeyspaceParams.simple(1),
+                                    SchemaLoader.standardCFMD(KEYSPACE1, CF_STANDARD1, 1, BytesType.instance));
+        SchemaLoader.createKeyspace(KEYSPACE2,
+                                    KeyspaceParams.simple(2),
+                                    SchemaLoader.standardCFMD(KEYSPACE2, CF_STANDARD1, 1, BytesType.instance));
+    }
+
+    @AfterClass
+    public static void cleanup()
+    {
+        sw.close();
+    }
+
+    @Before
+    public void setUp() throws Exception
+    {
+        // start from a clean ring: some tests add a second (down) endpoint
+        TokenMetadata metadata = StorageService.instance.getTokenMetadata();
+        metadata.clearUnsafe();
+        InetAddressAndPort localhost = InetAddressAndPort.getByName("127.0.0.1");
+        metadata.updateNormalToken(Util.token("A"), localhost);
+        metadata.updateHostId(UUID.randomUUID(), localhost);
+        Keyspace.open(SchemaConstants.SYSTEM_KEYSPACE_NAME).getColumnFamilyStore(SystemKeyspace.BATCHES).truncateBlocking();
+        TestInterceptor.reset();
+    }
+
+    /** Stores (and flushes) a batch of 3 mutations on the given table, old enough to be replayed. */
+    private static TimeUUID storeReplayableBatch(TableMetadata cfm, int key)
+    {
+        List<Mutation> mutations = new ArrayList<>(3);
+        for (int j = 0; j < 3; j++)
+        {
+            mutations.add(new RowUpdateBuilder(cfm, FBUtilities.timestampMicros(), ByteBufferUtil.bytes(key))
+                          .clustering("name" + j)
+                          .add("val", "val" + j)
+                          .build());
+        }
+        long timestamp = currentTimeMillis() - BatchlogManager.getBatchlogTimeout();
+        TimeUUID batchId = atUnixMillis(timestamp, 0);
+        BatchlogManager.store(Batch.createLocal(batchId, timestamp * 1000, mutations));
+        Keyspace.open(SchemaConstants.SYSTEM_KEYSPACE_NAME).getColumnFamilyStore(SystemKeyspace.BATCHES).forceBlockingFlush(ColumnFamilyStore.FlushReason.UNIT_TESTS);
+        return batchId;
+    }
+
+    /** Registers a second, never-gossiped (hence seen as down) node owning part of the ring. */
+    private static void registerDownRemoteNode() throws Exception
+    {
+        TokenMetadata metadata = StorageService.instance.getTokenMetadata();
+        InetAddressAndPort remote = InetAddressAndPort.getByName("127.0.0.2");
+        metadata.updateNormalToken(Util.token("B"), remote);
+        metadata.updateHostId(UUID.randomUUID(), remote);
+    }
+
+    @Test
+    public void testCustomInterceptorConstruction()
+    {
+        assertSame(TestInterceptor.class, frozenInstance.getClass());
+        assertSame(TestInterceptor.class, BatchlogManagerInterceptor.instance.getClass());
+        assertSame(TestInterceptor.class, BatchlogManagerInterceptor.getCustomOrDefault().getClass());
+    }
+
+    @Test
+    public void testDefaultIsNoop()
+    {
+        String key = CassandraRelevantProperties.CUSTOM_BATCHLOG_MANAGER_INTERCEPTOR_CLASS.getKey();
+        String saved = System.clearProperty(key);
+        try
+        {
+            assertSame(BatchlogManagerInterceptor.Noop.class, BatchlogManagerInterceptor.getCustomOrDefault().getClass());
+        }
+        finally
+        {
+            CassandraRelevantProperties.CUSTOM_BATCHLOG_MANAGER_INTERCEPTOR_CLASS.setString(saved);
+        }
+    }
+
+    @Test
+    public void testInterceptorObservesReplayedMutations() throws Exception
+    {
+        TableMetadata cfm = Keyspace.open(KEYSPACE1).getColumnFamilyStore(CF_STANDARD1).metadata();
+
+        // 2 replayable batches of 3 mutations each, plus 1 batch that is not old enough to be replayed.
+        Set<TimeUUID> replayableIds = new HashSet<>();
+        for (int i = 0; i < 3; i++)
+        {
+            List<Mutation> mutations = new ArrayList<>(3);
+            for (int j = 0; j < 3; j++)
+            {
+                mutations.add(new RowUpdateBuilder(cfm, FBUtilities.timestampMicros(), ByteBufferUtil.bytes(i))
+                              .clustering("name" + j)
+                              .add("val", "val" + j)
+                              .build());
+            }
+
+            boolean replayable = i < 2;
+            long timestamp = replayable
+                           ? (currentTimeMillis() - BatchlogManager.getBatchlogTimeout())
+                           : (currentTimeMillis() + BatchlogManager.getBatchlogTimeout());
+            TimeUUID id = atUnixMillis(timestamp, i);
+            if (replayable)
+                replayableIds.add(id);
+            BatchlogManager.store(Batch.createLocal(id, timestamp * 1000, mutations));
+        }
+
+        Keyspace.open(SchemaConstants.SYSTEM_KEYSPACE_NAME).getColumnFamilyStore(SystemKeyspace.BATCHES).forceBlockingFlush(ColumnFamilyStore.FlushReason.UNIT_TESTS);
+
+        BatchlogManager.instance.startBatchlogReplay().get();
+
+        // 2 batches observed, each through a single callback carrying all of its 3 mutations; the
+        // not-yet-replayable batch must not be observed.
+        assertEquals(2, TestInterceptor.observedBatches.size());
+        assertEquals(replayableIds, new HashSet<>(TestInterceptor.observedBatchIds));
+        for (int k = 0; k < TestInterceptor.observedBatches.size(); k++)
+        {
+            List<Mutation> batchMutations = TestInterceptor.observedBatches.get(k);
+            assertEquals(3, batchMutations.size());
+            for (Mutation mutation : batchMutations)
+                assertEquals(KEYSPACE1, mutation.getKeyspaceName());
+            assertEquals(TestInterceptor.observedBatchIds.get(k).unix(MILLISECONDS),
+                         (long) TestInterceptor.observedWrittenAt.get(k));
+        }
+
+        // The interceptor runs after the mutations completed: the replayed rows are readable.
+        for (int i = 0; i < 2; i++)
+        {
+            UntypedResultSet result = executeInternal(String.format("SELECT * FROM \"%s\".\"%s\" WHERE key = int_as_blob(%d)", KEYSPACE1, CF_STANDARD1, i));
+            assertNotNull(result);
+            assertEquals(3, result.size());
+        }
+    }
+
+    @Test
+    public void testThrowingInterceptorForcesRetry() throws Exception
+    {
+        long initialReplayedBatches = BatchlogManager.instance.getTotalBatchesReplayed();
+        TableMetadata cfm = Keyspace.open(KEYSPACE1).getColumnFamilyStore(CF_STANDARD1).metadata();
+        storeReplayableBatch(cfm, 1234);
+
+        TestInterceptor.failCallbacks = true;
+        BatchlogManager.instance.startBatchlogReplay().get();
+
+        // The interceptor was invoked and threw: the batch's mutations were applied, but the
+        // batch must be kept in the batchlog and not counted as replayed, so it is retried.
+        assertTrue(TestInterceptor.observedBatches.size() >= 1);
+        assertEquals(1, BatchlogManager.instance.countAllBatches());
+        assertEquals(1, BatchlogManager.instance.countBatchesAwaitingInterceptor());
+        assertEquals(0, BatchlogManager.instance.getTotalBatchesReplayed() - initialReplayedBatches);
+        UntypedResultSet result = executeInternal(String.format("SELECT * FROM \"%s\".\"%s\" WHERE key = int_as_blob(%d)", KEYSPACE1, CF_STANDARD1, 1234));
+        assertNotNull(result);
+        assertEquals(3, result.size());
+
+        int observedBeforeRetry = TestInterceptor.observedBatches.size();
+        TestInterceptor.failCallbacks = false;
+        BatchlogManager.instance.startBatchlogReplay().get();
+
+        // The retry notifies the interceptor of the batch, with its complete mutation list, again
+        // (their delivery is not repeated: it completed in the first cycle), and this time the
+        // batch is removed and counted as replayed.
+        assertEquals(observedBeforeRetry + 1, TestInterceptor.observedBatches.size());
+        assertEquals(3, TestInterceptor.observedBatches.get(TestInterceptor.observedBatches.size() - 1).size());
+        assertEquals(0, BatchlogManager.instance.countAllBatches());
+        assertEquals(0, BatchlogManager.instance.countBatchesAwaitingInterceptor());
+        assertEquals(1, BatchlogManager.instance.getTotalBatchesReplayed() - initialReplayedBatches);
+    }
+
+    /**
+     * A batch awaiting its interceptor can be removed from the batchlog by another path (e.g. the
+     * write path removing a batch that completed on the coordinator). The retained entry must then
+     * be forgotten, without further callbacks.
+     */
+    @Test
+    public void testBatchRemovedWhileAwaitingInterceptorIsForgotten() throws Exception
+    {
+        long initialReplayedBatches = BatchlogManager.instance.getTotalBatchesReplayed();
+        TableMetadata cfm = Keyspace.open(KEYSPACE1).getColumnFamilyStore(CF_STANDARD1).metadata();
+        TimeUUID batchId = storeReplayableBatch(cfm, 4321);
+
+        TestInterceptor.failCallbacks = true;
+        BatchlogManager.instance.startBatchlogReplay().get();
+        assertEquals(1, BatchlogManager.instance.countBatchesAwaitingInterceptor());
+
+        // the batch is removed from the batchlog behind the replayer's back
+        BatchlogManager.remove(batchId);
+
+        int observedBeforeCleanup = TestInterceptor.observedBatches.size();
+        TestInterceptor.failCallbacks = false;
+        BatchlogManager.instance.startBatchlogReplay().get();
+
+        // The retained entry is forgotten without invoking the interceptor again; the batch still
+        // counts as replayed, as its mutations did complete in the first cycle.
+        assertEquals(0, BatchlogManager.instance.countBatchesAwaitingInterceptor());
+        assertEquals(observedBeforeCleanup, TestInterceptor.observedBatches.size());
+        assertEquals(0, BatchlogManager.instance.countAllBatches());
+        assertEquals(1, BatchlogManager.instance.getTotalBatchesReplayed() - initialReplayedBatches);
+    }
+
+    /**
+     * A failing interceptor must not make the node re-deliver the batch's mutations on every
+     * replay cycle: in particular, hints for a down replica must be written once, not once per
+     * retry cycle, or they would accumulate for as long as the interceptor keeps failing.
+     */
+    @Test
+    public void testFailingInterceptorRetriesCallbackWithoutRewritingHints() throws Exception
+    {
+        long initialReplayedBatches = BatchlogManager.instance.getTotalBatchesReplayed();
+
+        // KEYSPACE2 has RF=2, so the down node is a replica of every mutation and replaying the
+        // batch writes one hint per mutation for it.
+        registerDownRemoteNode();
+        TableMetadata cfm = Keyspace.open(KEYSPACE2).getColumnFamilyStore(CF_STANDARD1).metadata();
+        storeReplayableBatch(cfm, 5678);
+
+        long initialHints = StorageMetrics.totalHints.getCount();
+
+        // First cycle: the mutations are applied locally and hinted to the down replica; the
+        // interceptor throws, so the batch is retained.
+        TestInterceptor.failCallbacks = true;
+        BatchlogManager.instance.startBatchlogReplay().get();
+        assertEquals(3, StorageMetrics.totalHints.getCount() - initialHints);
+        assertEquals(1, BatchlogManager.instance.countAllBatches());
+        assertEquals(1, BatchlogManager.instance.countBatchesAwaitingInterceptor());
+        assertEquals(0, BatchlogManager.instance.getTotalBatchesReplayed() - initialReplayedBatches);
+        int observedAfterFirstCycle = TestInterceptor.observedBatches.size();
+        assertTrue(observedAfterFirstCycle >= 1);
+
+        // Second cycle, interceptor still failing: only the callback is retried; the mutations are
+        // not re-delivered, so no new hints are written for the down replica.
+        BatchlogManager.instance.startBatchlogReplay().get();
+        assertEquals(3, StorageMetrics.totalHints.getCount() - initialHints);
+        assertEquals(1, BatchlogManager.instance.countAllBatches());
+        assertEquals(0, BatchlogManager.instance.getTotalBatchesReplayed() - initialReplayedBatches);
+        assertTrue(TestInterceptor.observedBatches.size() > observedAfterFirstCycle);
+
+        // Third cycle, interceptor recovered: the callback completes with the batch's complete
+        // mutation list, the batch is removed and counted as replayed, and still no new hints
+        // were written.
+        int observedBeforeSuccess = TestInterceptor.observedBatches.size();
+        TestInterceptor.failCallbacks = false;
+        BatchlogManager.instance.startBatchlogReplay().get();
+        assertEquals(3, StorageMetrics.totalHints.getCount() - initialHints);
+        assertEquals(observedBeforeSuccess + 1, TestInterceptor.observedBatches.size());
+        assertEquals(3, TestInterceptor.observedBatches.get(TestInterceptor.observedBatches.size() - 1).size());
+        assertEquals(0, BatchlogManager.instance.countAllBatches());
+        assertEquals(0, BatchlogManager.instance.countBatchesAwaitingInterceptor());
+        assertEquals(1, BatchlogManager.instance.getTotalBatchesReplayed() - initialReplayedBatches);
+
+        // The mutations were applied locally (once, in the first cycle) and are readable.
+        UntypedResultSet result = executeInternal(String.format("SELECT * FROM \"%s\".\"%s\" WHERE key = int_as_blob(%d)", KEYSPACE2, CF_STANDARD1, 5678));
+        assertNotNull(result);
+        assertEquals(3, result.size());
+    }
+
+    /**
+     * If a replay cycle aborts before advancing the scan lower bound, the next scan covers the rows
+     * of batches awaiting their interceptor again: the scan must skip them (they are handled by the
+     * callback-only retry), or their mutations would be re-delivered and their hints duplicated.
+     */
+    @Test
+    public void testScanSkipsBatchesAwaitingInterceptor() throws Exception
+    {
+        registerDownRemoteNode();
+        TableMetadata cfm = Keyspace.open(KEYSPACE2).getColumnFamilyStore(CF_STANDARD1).metadata();
+        storeReplayableBatch(cfm, 9012);
+
+        long initialHints = StorageMetrics.totalHints.getCount();
+        TestInterceptor.failCallbacks = true;
+        BatchlogManager.instance.startBatchlogReplay().get();
+        assertEquals(3, StorageMetrics.totalHints.getCount() - initialHints);
+        assertEquals(1, BatchlogManager.instance.countBatchesAwaitingInterceptor());
+
+        // Simulate a cycle that aborted before advancing the scan bound, so that the next scan
+        // covers the retained batch's row again: the batch must not be replayed a second time.
+        BatchlogManager.instance.resetLastReplayedUuid();
+        BatchlogManager.instance.startBatchlogReplay().get();
+        assertEquals(3, StorageMetrics.totalHints.getCount() - initialHints);
+        assertEquals(1, BatchlogManager.instance.countAllBatches());
+        assertEquals(1, BatchlogManager.instance.countBatchesAwaitingInterceptor());
+
+        // Once the interceptor recovers, the batch is removed, still without new hints.
+        TestInterceptor.failCallbacks = false;
+        BatchlogManager.instance.startBatchlogReplay().get();
+        assertEquals(3, StorageMetrics.totalHints.getCount() - initialHints);
+        assertEquals(0, BatchlogManager.instance.countAllBatches());
+        assertEquals(0, BatchlogManager.instance.countBatchesAwaitingInterceptor());
+    }
+}


### PR DESCRIPTION
### What is the issue

In order to implement correctly the replication of Logged Batches to OpenSearch we need a mechanism to intercept the "recovery" of batches that have not been completely processed by the Coordinator.

See https://datastax.jira.com/browse/HCD-438

### What does this PR fix and why was it fixed
Batchlog recovery (BatchlogManager.replayFailedBatches) re-applies
logged batches after a coordinator failure with no way for plugins to
observe it: the Mutator interface is coordinator-side only and replay
bypasses it on every node.

Add a pluggable BatchlogManagerInterceptor, wired like the custom
Mutator via -Dcassandra.custom_batchlog_manager_interceptor_class, that
is notified on the replaying node once per replayed batch, with the
complete list of the batch's mutations (so implementations can process
a batch's mutations together), after the batch's mutations have
completed — applied locally, acknowledged by remote replicas, or
hinted — and before the batchlog entry is deleted. The default
implementation is a no-op. The interceptor is resolved eagerly at
startup so a misconfigured custom class fails the node immediately
(matching custom_mutator_class behaviour) and the installed
implementation is visible in the startup log.

If the callback throws, the batch is not removed from the batchlog and
the callback is retried on later replay cycles — without re-delivering
the batch. Retained batches are remembered in memory, mapped to the
hosts hinted while replaying them, and retries invoke the callback
alone:

- The batch is re-read individually (a point read by id) instead of
  being kept inside the range scan, so lastReplayedUuid advances
  unconditionally and the scan does not re-walk a growing tombstone
  range while a batch is retained. Without this, a failing callback
  would have re-applied the batch's mutations and written a fresh
  round of hints for every down replica on every 10s replay cycle
  (batchlog replay hints bypass max_hint_window), accumulating hints
  until the batch aged past gc_grace_seconds. The retry pass runs
  after the scan (retries never starve replay of new content) and is
  throttled by the replay rate limiter.
- On callback success the batch's previously hinted hosts rejoin the
  cycle's hint fsync barrier, and the batch is deleted only after that
  fsync — preserving the hints-durable-before-batch-deletion invariant
  even when the original cycle aborted before its own fsync. The
  in-memory entry is dropped, and the batch counted as replayed, only
  once its row is actually deleted, so an aborted cycle can neither
  double-count a batch nor fall back to a full (hint-rewriting)
  replay; the scan skips rows of batches awaiting their callback for
  the same reason.
- Per-entry failure handling in the retry pass: a row removed by
  another path drops the pending callback with a warning (the batch
  still counts as replayed); a row that no longer deserializes
  (IOException) drops it with an error and deletes the row through the
  shared fsync barrier; any other error keeps the entry for a later
  retry, so one bad row cannot wedge batchlog replay node-wide.
- The memory is intentionally not persisted: a restart falls back to
  replaying the whole batch from scratch, which the callback's
  at-least-once contract already tolerates.

Semantics are therefore at-least-once and implementations must be
idempotent; the javadoc spells out the carve-outs (truncated/dropped
tables, gc_grace expiry, removal by another path, decommission) and
that callbacks are not re-delivered in batch order. Repeated callback
failures and the number of retained batches are reported through
NoSpamLogger at a 1-minute interval.

With the default no-op implementation the retained-batches map stays
empty and the retry pass exits before issuing any read: the standard
replay path performs no additional queries or I/O.

Tests cover callback content and ordering relative to mutation
application, retry-until-success with a failing callback, hints for a
down replica being written exactly once across replay cycles (via
StorageMetrics.totalHints, with a registered down replica and an RF=2
keyspace), the scan-skip guard after a simulated aborted cycle, and
externally removed batches being forgotten without further callbacks.


CNDB PR: https://github.com/riptano/cndb/pull/18511