### PR TITLE
Fix flush writeBarrier deadlock when memtable writes block on pool allocation while holding a shard lock

### DIFF
--- a/src/java/org/apache/cassandra/db/memtable/TrieMemtable.java
+++ b/src/java/org/apache/cassandra/db/memtable/TrieMemtable.java
@@ -639,6 +639,13 @@ public class TrieMemtable extends AbstractAllocatorMemtable
 
         public long put(PartitionUpdate update, UpdateTransaction indexer, OpOrder.Group opGroup)
         {
+            // Apply memory back-pressure BEFORE taking the shard lock. A thread parked for
+            // pool room while holding the lock cannot be released by Barrier.markBlocking(),
+            // and pre-barrier writers queued behind the lock then deadlock the flush's
+            // writeBarrier (shard-lock / flush-barrier deadlock). Parked here, this op is
+            // releasable by markBlocking() exactly like an allocate() waiter.
+            allocator.onHeap().throttle(opGroup);
+            allocator.offHeap().throttle(opGroup);
             TriePartitionUpdater updater = new TriePartitionUpdater(allocator.cloner(opGroup), indexer, metadata.get(), this);
             boolean locked = writeLock.tryLock();
             if (locked)
@@ -654,6 +661,10 @@ public class TrieMemtable extends AbstractAllocatorMemtable
             }
             try
             {
+                // While holding the shard lock, allocations overshoot rather than park
+                // (see MemtableAllocator.setMustNotBlockForRoom): back-pressure was
+                // applied above, before the lock. this is a thread-local state.
+                MemtableAllocator.setMustNotBlockForRoom(true);
                 try
                 {
                     indexer.start();
@@ -691,6 +702,7 @@ public class TrieMemtable extends AbstractAllocatorMemtable
             }
             finally
             {
+                MemtableAllocator.setMustNotBlockForRoom(false);
                 writeLock.unlock();
             }
             return updater.colUpdateTimeDelta;

--- a/src/java/org/apache/cassandra/utils/memory/MemtableAllocator.java
+++ b/src/java/org/apache/cassandra/utils/memory/MemtableAllocator.java
@@ -29,6 +29,28 @@ import org.github.jamm.Unmetered;
 
 public abstract class MemtableAllocator
 {
+    /**
+     * Being defensive against programmatic errors, 
+     * set while the current thread performs allocations under a memtable-internal lock
+     * (e.g. TrieMemtable's shard write lock). Such allocations must never park waiting
+     * for pool room: a thread parked in allocate() while holding the lock cannot be
+     * released by OpOrder.Barrier.markBlocking(), and pre-barrier writers queued on the
+     * lock deadlock the flush's writeBarrier. Back-pressure for these writers is applied
+     * by SubAllocator.throttle() before the lock is taken; under the lock, allocations
+     * overshoot the limit instead -- the same overshoot markBlocking() grants.
+     */
+    private static final ThreadLocal<Boolean> MUST_NOT_BLOCK_FOR_ROOM = ThreadLocal.withInitial(() -> Boolean.FALSE);
+
+    public static void setMustNotBlockForRoom(boolean value)
+    {
+        MUST_NOT_BLOCK_FOR_ROOM.set(value);
+    }
+
+    static boolean mustNotBlockForRoom()
+    {
+        return MUST_NOT_BLOCK_FOR_ROOM.get();
+    }
+
     private static final Logger logger = LoggerFactory.getLogger(MemtableAllocator.class);
 
     private final SubAllocator onHeap;
@@ -182,7 +204,7 @@ public abstract class MemtableAllocator
                     acquired(size);
                     return;
                 }
-                if (opGroup.isBlocking())
+                if (opGroup.isBlocking() || mustNotBlockForRoom())
                 {
                     allocated(size);
                     return;
@@ -200,6 +222,32 @@ public abstract class MemtableAllocator
                 }
                 else
                     signal.awaitUninterruptibly();
+            }
+        }
+
+        /**
+         * Wait, if necessary, until the parent pool is below its limit, without reserving
+         * any memory. This is the back-pressure point for writers that will subsequently
+         * allocate while holding a memtable-internal lock: parked here, a pre-barrier op
+         * is released by Barrier.markBlocking() exactly as in allocate(); parked inside
+         * the lock it cannot be, and the flush writeBarrier deadlocks behind the lock queue.
+         */
+        public void throttle(OpOrder.Group opGroup)
+        {
+            while (true)
+            {
+                if (parent.belowLimit() || opGroup.isBlocking())
+                    return;
+
+                WaitQueue.Signal signal = opGroup
+                    .isBlockingSignal(parent.hasRoom().register(parent.markMemoryBlockedOnAllocating()));
+
+                if (parent.belowLimit() || opGroup.isBlocking())
+                {
+                    signal.cancel();
+                    return;
+                }
+                signal.awaitUninterruptibly();
             }
         }
 

--- a/src/java/org/apache/cassandra/utils/memory/MemtablePool.java
+++ b/src/java/org/apache/cassandra/utils/memory/MemtablePool.java
@@ -154,6 +154,12 @@ public abstract class MemtablePool
 
         /** Methods to allocate space **/
 
+        /** True if the pool is under its limit; reserves nothing. See SubAllocator.throttle(). */
+        boolean belowLimit()
+        {
+            return allocated < limit;
+        }
+
         boolean tryAllocate(long size)
         {
             while (true)

--- a/test/unit/org/apache/cassandra/utils/memory/TrieMemtableShardLockDeadlockTest.java
+++ b/test/unit/org/apache/cassandra/utils/memory/TrieMemtableShardLockDeadlockTest.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cassandra.utils.memory;
+
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.commitlog.CommitLogPosition;
+import org.apache.cassandra.db.marshal.BytesType;
+import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.db.memtable.AbstractAllocatorMemtable;
+import org.apache.cassandra.db.memtable.Memtable;
+import org.apache.cassandra.db.memtable.ShardBoundaries;
+import org.apache.cassandra.db.memtable.TrieMemtable;
+import org.apache.cassandra.db.partitions.PartitionUpdate;
+import org.apache.cassandra.index.transactions.UpdateTransaction;
+import org.apache.cassandra.schema.TableMetadata;
+import org.apache.cassandra.schema.TableMetadataRef;
+import org.apache.cassandra.utils.concurrent.OpOrder;
+
+import static org.junit.Assert.fail;
+
+/**
+ * Regression test for the TrieMemtable shard-lock / flush-barrier deadlock.
+ *
+ * Will print the deadlocked stacks when TrieMemtable blocks on pool allocation while holding a shard
+ * writeLock (or the barrier can otherwise complete past lock-queued pre-barrier ops).
+ *
+ * Cycle reproduced: the barrier waits on pre-barrier op W1; W1 queues on the (single)
+ * MemtableShard writeLock; the lock is held by post-barrier op W2, parked in
+ * SubAllocator.allocate (isBlocking == false, correctly); memory is freed only by the
+ * flush; the flush waits on the barrier. markBlocking() releases only allocator waiters,
+ * never lock waiters, so the barrier cannot complete.
+ *
+ * The flush machinery is replaced by the three calls ColumnFamilyStore.Flush.run makes
+ * (issue, markBlocking, await); pool exhaustion is synthetic (claim the whole SubPool
+ * limit, restored in a finally so the shared pool is clean for other tests).
+ * The setup checkpoints tolerate a fixed build: if W1/W2 complete instead of wedging,
+ * the test proceeds to the barrier join and goes green.
+ */
+public class TrieMemtableShardLockDeadlockTest
+{
+    @BeforeClass
+    public static void setup()
+    {
+        DatabaseDescriptor.daemonInitialization();
+    }
+
+
+    /** put() touches none of this beyond construction; single shard, no scheduled flush. */
+    private static final OpOrder READ_ORDER = new OpOrder();
+    
+    private static final Memtable.Owner OWNER = new Memtable.Owner()
+    {
+        public ListenableFuture<CommitLogPosition> signalFlushRequired(Memtable m, ColumnFamilyStore.FlushReason r) { return null; }
+        public Memtable getCurrentMemtable() { return null; }
+        public Iterable<Memtable> getIndexMemtables() { return Collections.emptyList(); }
+        public ShardBoundaries localRangeSplits(int shardCount) { return ShardBoundaries.NONE; }
+        public OpOrder readOrdering() { return READ_ORDER; }
+        public int getMemtableFlushPeriodInMs() { return 0; }
+    };
+
+    @Test(timeout = 60_000)
+    public void writeBarrierMustCompleteDespiteShardLockQueue() throws Exception
+    {
+        TableMetadata tm = TableMetadata.builder("ks", "t")
+                                        .addPartitionKeyColumn("pk", Int32Type.instance)
+                                        .addRegularColumn("v", BytesType.instance)
+                                        .build();
+
+        Memtable.Factory factory = TrieMemtable.FACTORY;
+
+        Memtable mt = factory.create(new AtomicReference<>(CommitLogPosition.NONE),
+                                     TableMetadataRef.forOfflineTools(tm),
+                                     OWNER);
+
+        OpOrder order = new OpOrder(); // stands in for Keyspace.writeOrder
+        MemtablePool pool = AbstractAllocatorMemtable.MEMORY_POOL;
+
+        OpOrder.Group g1 = order.start();          // W1's op: PRE-barrier
+
+        OpOrder.Barrier barrier = order.newBarrier();
+        barrier.issue();
+        barrier.markBlocking();                    // exactly what ColumnFamilyStore.Flush.run does
+
+        pool.onHeap.allocated(pool.onHeap.limit);  // synthetic exhaustion: next allocate parks
+        pool.offHeap.allocated(pool.offHeap.limit);
+        try
+        {
+            OpOrder.Group g2 = order.start();      // W2's op: POST-barrier
+            Thread w2 = run("w2", () -> { mt.put(update(tm), UpdateTransaction.NO_OP, g2); g2.close(); });
+            waitUntilBlockedAtOrDone(w2, "MemtableShard", "SubAllocator"); // lock holder, parked in allocate
+
+            Thread w1 = run("w1", () -> { mt.put(update(tm), UpdateTransaction.NO_OP, g1); g1.close(); });
+            waitUntilBlockedAtOrDone(w1, "MemtableShard", "ReentrantLock");// queued on the same (only) lock
+
+            // A flush's writeBarrier.await() must complete: markBlocking() has run, and the
+            // design guarantees pre-barrier ops can always make progress. On current main
+            // it never returns -- W1 is on a lock, invisible to the valve.
+            Thread flush = run("flush", barrier::await);
+            flush.join(15_000);
+
+            if (flush.isAlive())
+                fail("DEADLOCK: writeBarrier.await() did not complete in 15s.\n" + dump(flush, w1, w2));
+        }
+        finally
+        {
+            pool.onHeap.released(pool.onHeap.limit);   // restore the shared pool for other tests;
+            pool.offHeap.released(pool.offHeap.limit); // also drains the wedged daemon threads
+        }
+    }
+
+    private static PartitionUpdate update(TableMetadata tm)
+    {
+        PartitionUpdate.SimpleBuilder b = PartitionUpdate.simpleBuilder(tm, 42);
+        b.row().add("v", ByteBuffer.allocate(64));
+        return b.build();
+    }
+
+    private static Thread run(String name, Runnable r)
+    {
+        Thread t = new Thread(r, name);
+        t.setDaemon(true);
+        t.start();
+        return t;
+    }
+
+    /** Wait until the thread's stack shows all substrings (wedged, the bug) or the thread ends (fixed build). */
+    private static void waitUntilBlockedAtOrDone(Thread t, String... frameSubstrings) throws InterruptedException
+    {
+        for (long deadline = System.nanoTime() + 30_000_000_000L; System.nanoTime() < deadline; Thread.sleep(50))
+        {
+            if (!t.isAlive())
+                return;
+
+            String stack = java.util.Arrays.toString(t.getStackTrace());
+            boolean all = true;
+
+            for (String s : frameSubstrings)
+                all &= stack.contains(s);
+
+            if (all)
+                return;
+        }
+        throw new AssertionError(t.getName() + " neither finished nor reached " + String.join("+", frameSubstrings));
+    }
+
+    /** ~jstack of the deadlock participants for the failure message. */
+    private static String dump(Thread... threads)
+    {
+        StringBuilder sb = new StringBuilder();
+        for (Thread t : threads)
+        {
+            sb.append('"').append(t.getName()).append("\" ").append(t.getState()).append('\n');
+            StackTraceElement[] stack = t.getStackTrace();
+
+            for (int i = 0; i < Math.min(stack.length, 12); i++)
+                sb.append("    at ").append(stack[i]).append('\n');
+        }
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
### What is the issue


`TrieMemtable` (and `ShardedSkipListMemtable` with `serialize_writes: true`) performs **blocking memory allocations while holding a per-shard write lock**: the cloner allocates during `data.apply`, and `allocator.onHeap()/offHeap().adjust(..., opGroup)` runs before the lock is released. When the memtable pool is at its limit, this deadlocks flushes:

1. A **post-barrier** write takes a shard lock and parks in `SubAllocator.allocate()` waiting for pool room (`isBlocking == false`, since the flush barrier does not wait on it).
2. A **pre-barrier** write: one the flush's `writeBarrier` *does* wait on; queues behind that lock.
3. `Flush.run`'s `writeBarrier.markBlocking()` cannot help: it only releases threads parked **in the allocator**, never threads parked on a lock or monitor.
4. Pool memory is reclaimed only when the flush completes → the flush waits on the barrier → the barrier waits on the lock queue → the lock holder waits on the memory. **Permanent deadlock.**

Because `Keyspace.writeOrder` is node-global while memtable switching is per-CFS, pre- and post-barrier writes routinely share shard locks on every table *not* being flushed, no special interleaving is needed beyond memory pressure.

Observed in production as a total write stall requiring a node restart:

- all MutationStage threads parked in `SubAllocator.allocate` or on shard `ReentrantLock`s,
- `MemtableFlushWriter` at `OpOrder$Barrier.await`, `MemtablePostFlush` behind it.

Heap-dump analysis confirmed the cycle: the barrier group held N unfinished ops, **all** queued on shard locks, each lock owned by a post-barrier writer parked in the allocator.


### What does this PR fix and why was it fixed

Two coupled changes that break the cycle while preserving write back-pressure:

1. **Back-pressure moves in front of the lock.** New `SubAllocator.throttle(opGroup)` waits for the pool to drop below its limit *without reserving memory*, using the same wait loop, `isBlockingSignal` registration, and blocked-on-allocation metric as `allocate()`. `MemtableShard.put` calls it **before** acquiring the shard lock. Parked there, a writer holds nothing, and `markBlocking()` releases pre-barrier ops exactly as designed.
2. **Allocations under the lock never park.** `MemtableAllocator.setMustNotBlockForRoom(true)` is set for the locked section (cleared in the same `finally` as `unlock()`); `SubAllocator.allocate()` treats it as an extension of the existing `opGroup.isBlocking()` overshoot branch. This closes the window where the pool fills between the throttle check and the allocation.

**Why this shape:** overshoot-when-parking-would-deadlock-a-flush is already the codebase's sanctioned pattern, `markBlocking()` grants it to every pre-barrier writer on every flush, and `MemtableShard.put` already defers initial-size accounting for the same stated reason (*"may cause the allocator to block while we are trying to flush a memtable and become a deadlock"*). This PR extends the same license one call deeper. The overshoot is bounded by `concurrent lock holders × one partition update's allocations`, the same class of excess `markBlocking` already authorizes.

Includes a regression test that deterministically reproduces the deadlock on unpatched code (the barrier never completes; the test fails printing the three participating stacks) and passes with this change. The same treatment applies to `ShardedSkipListMemtable.Locking.put` (monitor instead of `ReentrantLock`; mechanism identical), *included here / follow-up, per review scope*.
