### PR TITLE
CNDB-18353: revert additions of allRequests outside of QueryEvents

### DIFF
--- a/src/java/org/apache/cassandra/metrics/ClientRequestsMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/ClientRequestsMetrics.java
@@ -87,7 +87,6 @@ public class ClientRequestsMetrics
         writeMetrics.release();
         casWriteMetrics.release();
         casReadMetrics.release();
-        allRequestsMetrics.release();
         readMetricsMap.values().forEach(ClientRequestMetrics::release);
         writeMetricsMap.values().forEach(ClientRequestMetrics::release);
     }

--- a/src/java/org/apache/cassandra/service/StorageProxy.java
+++ b/src/java/org/apache/cassandra/service/StorageProxy.java
@@ -630,7 +630,6 @@ public class StorageProxy implements StorageProxyMBean
         }
         catch (CasWriteTimeoutException wte)
         {
-            metrics.allRequestsMetrics.timeouts.mark();
             metrics.casWriteMetrics.timeouts.mark();
             metrics.writeMetricsForLevel(consistencyForPaxos).timeouts.mark();
             lwtTracker.onError(wte);
@@ -638,7 +637,6 @@ public class StorageProxy implements StorageProxyMBean
         }
         catch (ReadTimeoutException e)
         {
-            metrics.allRequestsMetrics.timeouts.mark();
             metrics.casWriteMetrics.timeouts.mark();
             metrics.writeMetricsForLevel(consistencyForPaxos).timeouts.mark();
             lwtTracker.onError(e);
@@ -646,14 +644,12 @@ public class StorageProxy implements StorageProxyMBean
         }
         catch (ReadAbortException e)
         {
-            metrics.allRequestsMetrics.markAbort(e);
             metrics.casWriteMetrics.markAbort(e);
             metrics.writeMetricsForLevel(consistencyForPaxos).markAbort(e);
             throw e;
         }
         catch (WriteFailureException | ReadFailureException e)
         {
-            metrics.allRequestsMetrics.failures.mark();
             metrics.casWriteMetrics.failures.mark();
             metrics.writeMetricsForLevel(consistencyForPaxos).failures.mark();
             lwtTracker.onError(e);
@@ -661,7 +657,6 @@ public class StorageProxy implements StorageProxyMBean
         }
         catch (UnavailableException e)
         {
-            metrics.allRequestsMetrics.unavailables.mark();
             metrics.casWriteMetrics.unavailables.mark();
             metrics.writeMetricsForLevel(consistencyForPaxos).unavailables.mark();
             lwtTracker.onError(e);
@@ -674,8 +669,6 @@ public class StorageProxy implements StorageProxyMBean
             long latency = nanoTime() - requestTime.startedAtNanos();
             metrics.casWriteMetrics.executionTimeMetrics.addNano(latency);
             metrics.casWriteMetrics.serviceTimeMetrics.addNano(latency);
-            metrics.allRequestsMetrics.executionTimeMetrics.addNano(latency);
-            metrics.allRequestsMetrics.serviceTimeMetrics.addNano(latency);
             metrics.writeMetricsForLevel(consistencyForPaxos).executionTimeMetrics.addNano(latency);
             metrics.writeMetricsForLevel(consistencyForPaxos).serviceTimeMetrics.addNano(latency);
             Keyspace.openAndGetStore(metadata).metric.coordinatorCasWriteLatency.update(latency, NANOSECONDS);
@@ -2266,7 +2259,6 @@ public class StorageProxy implements StorageProxyMBean
         }
         catch (ReadTimeoutException e)
         {
-            metrics.allRequestsMetrics.timeouts.mark();
             metrics.readMetrics.timeouts.mark();
             metrics.casReadMetrics.timeouts.mark();
             metrics.readMetricsForLevel(consistencyLevel).timeouts.mark();
@@ -2276,7 +2268,6 @@ public class StorageProxy implements StorageProxyMBean
         }
         catch (ReadAbortException e)
         {
-            metrics.allRequestsMetrics.markAbort(e);
             metrics.readMetrics.markAbort(e);
             metrics.casReadMetrics.markAbort(e);
             metrics.readMetricsForLevel(consistencyLevel).markAbort(e);
@@ -2285,7 +2276,6 @@ public class StorageProxy implements StorageProxyMBean
         }
         catch (ReadFailureException e)
         {
-            metrics.allRequestsMetrics.failures.mark();
             metrics.readMetrics.failures.mark();
             metrics.casReadMetrics.failures.mark();
             metrics.readMetricsForLevel(consistencyLevel).failures.mark();
@@ -2305,8 +2295,6 @@ public class StorageProxy implements StorageProxyMBean
             metrics.readMetrics.serviceTimeMetrics.addNano(serviceLatency);
             metrics.casReadMetrics.executionTimeMetrics.addNano(latency);
             metrics.casReadMetrics.serviceTimeMetrics.addNano(serviceLatency);
-            metrics.allRequestsMetrics.executionTimeMetrics.addNano(latency);
-            metrics.allRequestsMetrics.serviceTimeMetrics.addNano(serviceLatency);
             metrics.readMetricsForLevel(consistencyLevel).executionTimeMetrics.addNano(latency);
             metrics.readMetricsForLevel(consistencyLevel).serviceTimeMetrics.addNano(serviceLatency);
             ColumnFamilyStore cfs = Keyspace.open(metadata.keyspace).getColumnFamilyStore(metadata.name);

--- a/src/java/org/apache/cassandra/service/paxos/Paxos.java
+++ b/src/java/org/apache/cassandra/service/paxos/Paxos.java
@@ -826,7 +826,6 @@ public class Paxos
 
 
             metrics.casWriteMetrics.executionTimeMetrics.addNano(latency);
-            metrics.allRequestsMetrics.executionTimeMetrics.addNano(latency);
             metrics.writeMetricsForLevel(consistencyForConsensus).executionTimeMetrics.addNano(latency);
         }
     }
@@ -928,7 +927,6 @@ public class Paxos
             long latency = nanoTime() - start;
             metrics.readMetrics.executionTimeMetrics.addNano(latency);
             metrics.casReadMetrics.executionTimeMetrics.addNano(latency);
-            metrics.allRequestsMetrics.executionTimeMetrics.addNano(latency);
             metrics.readMetricsForLevel(consistencyForConsensus).executionTimeMetrics.addNano(latency);
             TableMetadata table = read.metadata();
             ColumnFamilyStore cfs = Keyspace.open(table.keyspace).getColumnFamilyStore(table.name);
@@ -1132,7 +1130,6 @@ public class Paxos
 
     private static void mark(boolean isWrite, Function<ClientRequestMetrics, Meter> toMark, ConsistencyLevel consistency, ClientRequestsMetrics metrics)
     {
-        toMark.apply(metrics.allRequestsMetrics).mark();
         if (isWrite)
         {
             toMark.apply(metrics.casWriteMetrics).mark();

--- a/test/unit/org/apache/cassandra/metrics/ClientRequestMetricsLatenciesTest.java
+++ b/test/unit/org/apache/cassandra/metrics/ClientRequestMetricsLatenciesTest.java
@@ -160,21 +160,18 @@ public class ClientRequestMetricsLatenciesTest
                                                   clientMetrics.readMetrics,
                                                   clientMetrics.readMetricsForLevel(QUORUM),
                                                   clientMetrics.casWriteMetrics,
-                                                  clientMetrics.allRequestsMetrics,
                                                   clientMetrics.writeMetricsForLevel(SERIAL));
             processQueryAndCheckMetricsWereBumped("UPDATE %1$s.%2$s SET v2=123 WHERE k=7 AND v1=7 IF v2=71;",
                                                   cl,
                                                   clientMetrics.readMetrics,
                                                   clientMetrics.readMetricsForLevel(QUORUM),
                                                   clientMetrics.casWriteMetrics,
-                                                  clientMetrics.allRequestsMetrics,
                                                   clientMetrics.writeMetricsForLevel(SERIAL));
             processQueryAndCheckMetricsWereBumped("UPDATE %1$s.%2$s SET v2=123 WHERE k=7 AND v1=7 IF v2=7;",
                                                   cl,
                                                   clientMetrics.readMetrics,
                                                   clientMetrics.readMetricsForLevel(QUORUM),
                                                   clientMetrics.casWriteMetrics,
-                                                  clientMetrics.allRequestsMetrics,
                                                   clientMetrics.writeMetricsForLevel(SERIAL));
         });
     }
@@ -185,13 +182,11 @@ public class ClientRequestMetricsLatenciesTest
         processQueryAndCheckMetricsWereBumped("SELECT * FROM %1$s.%2$s WHERE k=7 AND v1=7;",
                                               SERIAL,
                                               clientMetrics.casReadMetrics,
-                                              clientMetrics.allRequestsMetrics,
                                               clientMetrics.readMetrics,
                                               clientMetrics.readMetricsForLevel(SERIAL));
         processQueryAndCheckMetricsWereBumped("SELECT * FROM %1$s.%2$s WHERE k=7 AND v1=7;",
                                               LOCAL_SERIAL,
                                               clientMetrics.casReadMetrics,
-                                              clientMetrics.allRequestsMetrics,
                                               clientMetrics.readMetrics,
                                               clientMetrics.readMetricsForLevel(LOCAL_SERIAL));
     }
@@ -226,7 +221,6 @@ public class ClientRequestMetricsLatenciesTest
                                                       clientMetrics.readMetrics,
                                                       clientMetrics.readMetricsForLevel(QUORUM),
                                                       clientMetrics.casWriteMetrics,
-                                                      clientMetrics.allRequestsMetrics,
                                                       clientMetrics.writeMetricsForLevel(SERIAL),
                                                       clientMetrics.viewWriteMetrics);
                 processQueryAndCheckMetricsWereBumped("UPDATE %1$s.%2$s SET v2=123 WHERE k=7 AND v1=7 IF v2=7;",
@@ -234,7 +228,6 @@ public class ClientRequestMetricsLatenciesTest
                                                       clientMetrics.readMetrics,
                                                       clientMetrics.readMetricsForLevel(QUORUM),
                                                       clientMetrics.casWriteMetrics,
-                                                      clientMetrics.allRequestsMetrics,
                                                       clientMetrics.writeMetricsForLevel(SERIAL),
                                                       clientMetrics.viewWriteMetrics);
 
@@ -244,14 +237,12 @@ public class ClientRequestMetricsLatenciesTest
                                                       clientMetrics.readMetrics,
                                                       clientMetrics.readMetricsForLevel(QUORUM),
                                                       clientMetrics.casWriteMetrics,
-                                                      clientMetrics.allRequestsMetrics,
                                                       clientMetrics.writeMetricsForLevel(SERIAL));
                 processQueryAndCheckMetricsWereBumped("UPDATE %1$s.%2$s SET v2=123 WHERE k=7 AND v1=7 IF v2=7;",
                                                       cl,
                                                       clientMetrics.readMetrics,
                                                       clientMetrics.readMetricsForLevel(QUORUM),
                                                       clientMetrics.casWriteMetrics,
-                                                      clientMetrics.allRequestsMetrics,
                                                       clientMetrics.writeMetricsForLevel(SERIAL));
 
             });


### PR DESCRIPTION
### What is the issue

Previously additions were made for allRequest failures outside of QueryEvents, but this duplicates them.

### What does this PR fix and why was it fixed

Remove allRequest failure increments outside of QueryEvents to match main
