### PR TITLE
CNDB-18523: Avoid abrupt commitlog allocator shutdown

### DIFF
--- a/src/java/org/apache/cassandra/db/commitlog/AbstractCommitLogSegmentManager.java
+++ b/src/java/org/apache/cassandra/db/commitlog/AbstractCommitLogSegmentManager.java
@@ -623,7 +623,7 @@ public abstract class AbstractCommitLogSegmentManager
      */
     public void shutdown()
     {
-        executor.shutdownNow();
+        executor.shutdown();
         // Release the management thread and delete prepared segment.
         // Do not block as another thread may claim the segment (this can happen during unit test initialization).
         discardAvailableSegment();


### PR DESCRIPTION
### What is the issue
Fixes #18523

AbstractCommitLogSegmentManager can interrupt discardAvailableSegment

### What does this PR fix and why was it fixed
Use graceful shutdown for the commitlog segment allocator instead of shutdownNow(), allowing the allocator to run its shutdown path and discard the prepared segment cooperatively.
