### PR TITLE
CNDB-18535: Fix CompressionMetadata ref leak in MetadataSerializer.getEncryptor

### DIFF
--- a/src/java/org/apache/cassandra/io/sstable/metadata/MetadataSerializer.java
+++ b/src/java/org/apache/cassandra/io/sstable/metadata/MetadataSerializer.java
@@ -353,15 +353,19 @@ public class MetadataSerializer implements IMetadataSerializer
         try
         {
             // Read the compression metadata from file
-            // We pass a small compressedLength as we only need the parameters, not the actual chunk offsets
-            CompressionMetadata cm = CompressionMetadata.open(compressionFile, 1024, false);
-            // Note: we use only the encryption component, without any compression. The reason for doing this is to
-            // avoid having to allocate (and save the size of) an additional buffer to hold the larger uncompressed
-            // serialization on reads.
-            ICompressor compressor = cm.parameters.getSstableCompressor();
-            if (compressor != null)
-                return compressor.encryptionOnly();
-            return null;
+            // We pass a small compressedLength as we only need the parameters, not the actual chunk offsets.
+            // CompressionMetadata is ref-counted and holds the chunk offsets in off-heap Memory, so it must be
+            // closed once the parameters have been extracted.
+            try (CompressionMetadata cm = CompressionMetadata.open(compressionFile, 1024, false))
+            {
+                // Note: we use only the encryption component, without any compression. The reason for doing this is to
+                // avoid having to allocate (and save the size of) an additional buffer to hold the larger uncompressed
+                // serialization on reads.
+                ICompressor compressor = cm.parameters.getSstableCompressor();
+                if (compressor != null)
+                    return compressor.encryptionOnly();
+                return null;
+            }
         }
         catch (Throwable t)
         {


### PR DESCRIPTION
### What is the issue

getEncryptor(...) (introduced by CNDB-15098 to encrypt the Stats metadata component of TDE'd SSTables) opens the COMPRESSION_INFO component just to extract the table's compression/encryption parameters:

    CompressionMetadata cm = CompressionMetadata.open(compressionFile, 1024, false);
    ICompressor compressor = cm.parameters.getSstableCompressor();

CompressionMetadata is a ref-counted WrappedSharedCloseable holding the chunk-offset index in off-heap Memory (ChunkOffsetMemory), and the method dropped the instance without ever calling close(). Since getEncryptor runs on BOTH metadata paths -- serialize (every flush/compaction/metadata rewrite of an encrypted SSTable) and deserialize (every metadata read) -- each such operation leaked one unreleased Ref, surfacing at GC time as:

    ERROR [Ref] LEAK DETECTED: a reference (class org.apache.cassandra.
    utils.concurrent.WrappedSharedCloseable$Tidy@...:[org.apache.cassandra.
    io.compress.CompressionMetadata$ChunkOffsetMemory@...]) ... was not
    released before the reference was garbage collected


### What does this PR fix and why was it fixed
Close the CompressionMetadata with try-with-resources once the parameters have been read: only cm.parameters is needed, and the ICompressor obtained from it does not reference the off-heap memory. Same pattern SSTableMetadataViewer already uses for the same call.
