### PR TITLE
HCD-439: Operation-level LWT tracking in the Mutator SPI (Paxos v1 + v2)

### DIFF
--- a/src/java/org/apache/cassandra/service/Mutator.java
+++ b/src/java/org/apache/cassandra/service/Mutator.java
@@ -202,7 +202,7 @@ public interface Mutator
 
     /**
      * Callback invoked AFTER a Paxos commit dispatched by this coordinator has been ACKNOWLEDGED by
-     * a {@code consistencyLevel} quorum of replicas — i.e. that many replicas have applied the
+     * a {@code consistencyLevel} of replicas — i.e. that many replicas have applied the
      * committed {@code PartitionUpdate} to their base table and replied. Unlike {@link #onCasCommit}
      * (which fires <em>before</em> the commit is dispatched, for every <em>decided</em> value), this
      * fires only once the value is durably visible: a read at {@code consistencyLevel} (or stronger)

--- a/src/java/org/apache/cassandra/service/Mutator.java
+++ b/src/java/org/apache/cassandra/service/Mutator.java
@@ -79,6 +79,44 @@ public interface Mutator
     }
 
     /**
+     * Terminal outcome of a commit previously announced via {@link #onCasCommit}. Passed to
+     * {@link #onCasCommitCompleted}. {@link #APPLIED} and {@link #CONFIRMED_BY_PREPARE} are the two
+     * success outcomes (the value is durably visible at {@code consistencyLevel}); {@link #SUPERSEDED}
+     * and {@link #UNCONFIRMED} mean this coordinator did NOT confirm the commit — but the value is
+     * still <em>decided</em> and may become durable via another proposer or a background repair, so
+     * they are "not confirmed here", never "rolled back" (Paxos never un-decides an agreed value).
+     */
+    enum CasCommitOutcome
+    {
+        /**
+         * Acknowledged by a {@code consistencyForCommit} quorum via a standalone, separately-awaited
+         * commit (the strongest confirmation). A read at {@code consistencyLevel} (or stronger) issued
+         * after this callback observes the value. Delivered for CLIENT_OPERATION under both engines,
+         * the v1 in-progress repair, and background Paxos repair.
+         */
+        APPLIED,
+        /**
+         * Inferred-applied: the commit was fused into the following prepare (the v2 {@code begin()}
+         * "commit-and-prepare" optimization used to finish another proposer's round) and that prepare
+         * reached a {@code consistencyForConsensus} (serial) promise-quorum. Every replica applies the
+         * fused commit before answering the prepare, so a promise-quorum implies the commit reached
+         * that same quorum. Slightly weaker than {@link #APPLIED} (serial-quorum, inferred rather than
+         * a directly-awaited commit ack), but still means the value is durably visible.
+         */
+        CONFIRMED_BY_PREPARE,
+        /**
+         * Decided but NOT confirmed by this coordinator: a higher ballot pre-empted the fused
+         * commit-and-prepare before a quorum was reached. Another proposer is finishing the round.
+         */
+        SUPERSEDED,
+        /**
+         * Decided but NOT confirmed: the commit (or the fused prepare) timed out or failed before a
+         * quorum acknowledged it. The value may still be completed later by a repair.
+         */
+        UNCONFIRMED
+    }
+
+    /**
      * Used for handling the given {@code mutations} as a logged batch.
      */
     void mutateAtomically(Collection<Mutation> mutations,
@@ -201,47 +239,51 @@ public interface Mutator
     }
 
     /**
-     * Callback invoked AFTER a Paxos commit dispatched by this coordinator has been ACKNOWLEDGED by
-     * a {@code consistencyLevel} of replicas — i.e. that many replicas have applied the
-     * committed {@code PartitionUpdate} to their base table and replied. Unlike {@link #onCasCommit}
-     * (which fires <em>before</em> the commit is dispatched, for every <em>decided</em> value), this
-     * fires only once the value is durably visible: a read at {@code consistencyLevel} (or stronger)
-     * issued after this callback returns will observe the committed value. Note that if
-     * {@code consistencyLevel} is {@code ONE}, reading at ONE or QUORUM may still not return the
-     * committed value if the acknowledging replica is not the one serving the read.
+     * TERMINAL completion for a commit previously announced via {@link #onCasCommit}: fires once the
+     * fate of that commit is known, carrying the {@link CasCommitOutcome outcome} (success or not).
+     * Where wired (see coverage below) it fires EXACTLY ONCE per {@link #onCasCommit} for the same
+     * ballot, letting an implementation that opened an operation on {@link #onCasCommit} close it out
+     * — pairing every announced commit with a success ({@link CasCommitOutcome#APPLIED} /
+     * {@link CasCommitOutcome#CONFIRMED_BY_PREPARE}) or a not-confirmed
+     * ({@link CasCommitOutcome#SUPERSEDED} / {@link CasCommitOutcome#UNCONFIRMED}) terminal.
      * <p>
-     * Relationship to {@link #onCasCommit}: every delivery of this callback is preceded by a
-     * matching {@link #onCasCommit} for the same ballot, and it fires only on the success path (the
-     * commit was acknowledged). Multiplicity mirrors {@link #onCasCommit}: exactly one per
-     * {@link CasCommitOrigin#CLIENT_OPERATION}; the repair/refresh origins may fire any number of
-     * times (once per completed round, across retries and repair cycles). If a commit times out or
-     * fails (the value is decided and will be completed later by a repair, but no quorum ack was
-     * received), {@link #onCasCommit} still fired but this callback does NOT — absence of this
-     * callback after an {@link #onCasCommit} means "commit not confirmed", not "not decided".
+     * Unlike {@link #onCasCommit} (which fires <em>before</em> dispatch, for every decided value),
+     * this fires once the commit's fate is settled. A success outcome means the value is durably
+     * visible: a read at {@code consistencyLevel} (or stronger) issued after this returns observes it
+     * (with the usual caveat that at {@code ONE} the acknowledging replica may not be the one serving
+     * a later read). A not-confirmed outcome does NOT mean "not decided" (see {@link CasCommitOutcome});
+     * the standard response is a deferred {@code LOCAL_SERIAL}/{@code SERIAL} read, which is
+     * self-correcting and will observe the value if/when it becomes durable.
      * <p>
-     * Coverage — this applied callback is delivered for:
+     * Coverage — a terminal is delivered for:
      * <ul>
-     *   <li>{@link CasCommitOrigin#CLIENT_OPERATION} under both paxos variants (v1 {@code doPaxos}
-     *       after the blocking commit, v2 {@code Paxos.cas} after the commit await): fires on the
-     *       request thread, inside {@link #mutateCas}, after the CLIENT_OPERATION {@link #onCasCommit};</li>
-     *   <li>{@link CasCommitOrigin#REPAIR_IN_PROGRESS} completed by the v1 engine
-     *       ({@code beginAndRepairPaxos}, on the triggering operation's request thread) and by
-     *       background {@code PaxosRepair} (on an arbitrary repair thread);</li>
-     *   <li>{@link CasCommitOrigin#REFRESH_COMMITTED} re-transmitted by background {@code PaxosRepair}.</li>
+     *   <li>{@link CasCommitOrigin#CLIENT_OPERATION} under both engines (v1 {@code doPaxos}, v2
+     *       {@code Paxos.cas}): {@link CasCommitOutcome#APPLIED} when the awaited commit is
+     *       acknowledged, else {@link CasCommitOutcome#UNCONFIRMED} — on the request thread, inside
+     *       {@link #mutateCas}, after the CLIENT_OPERATION {@link #onCasCommit};</li>
+     *   <li>the v2 {@code begin()}-path {@link CasCommitOrigin#REPAIR_IN_PROGRESS} and
+     *       {@link CasCommitOrigin#REFRESH_COMMITTED} sites (commit fused into the following prepare):
+     *       {@link CasCommitOutcome#CONFIRMED_BY_PREPARE} when that prepare reaches a promise-quorum,
+     *       {@link CasCommitOutcome#SUPERSEDED} if pre-empted, else {@link CasCommitOutcome#UNCONFIRMED};</li>
+     *   <li>the v1 in-progress {@link CasCommitOrigin#REPAIR_IN_PROGRESS} repair
+     *       ({@code beginAndRepairPaxos}): {@link CasCommitOutcome#APPLIED} or
+     *       {@link CasCommitOutcome#UNCONFIRMED};</li>
+     *   <li>background {@code PaxosRepair} ({@link CasCommitOrigin#REPAIR_IN_PROGRESS} /
+     *       {@link CasCommitOrigin#REFRESH_COMMITTED}): {@link CasCommitOutcome#APPLIED} only — this
+     *       background state machine retries on failure rather than delivering a negative terminal,
+     *       so a non-success outcome is not reported (best-effort, on an arbitrary repair thread).</li>
      * </ul>
-     * It is NOT delivered (only the dispatched {@link #onCasCommit} is) for the v1
-     * {@link CasCommitOrigin#REFRESH_COMMITTED} site (an asynchronous fire-and-forget
-     * {@code sendCommit} with no awaited ack) nor for the v2 engine's {@code begin()}-path
-     * {@link CasCommitOrigin#REFRESH_COMMITTED}/{@link CasCommitOrigin#REPAIR_IN_PROGRESS} sites
-     * (where the commit piggybacks on the following prepare and has no separable ack). For those,
-     * a deferred {@code LOCAL_SERIAL}/{@code SERIAL} read issued from {@link #onCasCommit} is
-     * self-correcting and will observe the value regardless.
+     * NO terminal is delivered (only the dispatched {@link #onCasCommit} is) for the v1
+     * {@link CasCommitOrigin#REFRESH_COMMITTED} fire-and-forget {@code sendCommit} (no awaited ack),
+     * nor for any commit performed at {@code consistencyForCommit == ANY} (which does not block for a
+     * replica ack). For those, rely on a deferred serial read.
      * <p>
      * Threading and containment mirror {@link #onCasCommit}: implementations should not throw and
      * must not block; a thrown exception is logged and ignored by
-     * {@link MutatorProvider#notifyCasCommitApplied} and never fails the operation, read or repair.
+     * {@link MutatorProvider#notifyCasCommitCompleted} and never fails the operation, read or repair.
      */
-    default void onCasCommitApplied(Commit committed, ConsistencyLevel consistencyLevel, CasCommitOrigin origin)
+    default void onCasCommitCompleted(Commit committed, ConsistencyLevel consistencyLevel,
+                                      CasCommitOrigin origin, CasCommitOutcome outcome)
     {
         // no-op
     }

--- a/src/java/org/apache/cassandra/service/Mutator.java
+++ b/src/java/org/apache/cassandra/service/Mutator.java
@@ -54,6 +54,29 @@ import org.apache.cassandra.utils.TimeUUID;
  */
 public interface Mutator
 {
+    /**
+     * Where a Paxos commit dispatch originated. Passed to {@link #onCasCommit}.
+     */
+    enum CasCommitOrigin
+    {
+        /**
+         * The coordinator's own CAS operation reached the commit phase: the proposal carries the
+         * update this coordinator built and successfully proposed. At most one per
+         * {@link #mutateCas} invocation.
+         */
+        CLIENT_OPERATION,
+        /**
+         * The coordinator witnessed another proposer's accepted-but-uncommitted round and is
+         * completing it on their behalf. The payload is the foreign in-progress update, not
+         * anything this coordinator's client asked for; a SERIAL/LOCAL_SERIAL read can trigger it.
+         */
+        REPAIR_IN_PROGRESS,
+        /**
+         * Re-transmission of an already-committed value to replicas that have not witnessed it
+         * (most-recent-commit refresh). Carries no new decision; the value was agreed earlier.
+         */
+        REFRESH_COMMITTED
+    }
 
     /**
      * Used for handling the given {@code mutations} as a logged batch.
@@ -98,30 +121,6 @@ public interface Mutator
      */
     @Nullable
     AbstractWriteResponseHandler<Commit> mutatePaxos(Commit proposal, ConsistencyLevel consistencyLevel, boolean allowHints, Dispatcher.RequestTime requestTime);
-
-    /**
-     * Where a Paxos commit dispatch originated. Passed to {@link #onCasCommit}.
-     */
-    enum CasCommitOrigin
-    {
-        /**
-         * The coordinator's own CAS operation reached the commit phase: the proposal carries the
-         * update this coordinator built and successfully proposed. At most one per
-         * {@link #mutateCas} invocation.
-         */
-        CLIENT_OPERATION,
-        /**
-         * The coordinator witnessed another proposer's accepted-but-uncommitted round and is
-         * completing it on their behalf. The payload is the foreign in-progress update, not
-         * anything this coordinator's client asked for; a SERIAL/LOCAL_SERIAL read can trigger it.
-         */
-        REPAIR_IN_PROGRESS,
-        /**
-         * Re-transmission of an already-committed value to replicas that have not witnessed it
-         * (most-recent-commit refresh). Carries no new decision; the value was agreed earlier.
-         */
-        REFRESH_COMMITTED
-    }
 
     /**
      * Used for handling a whole CAS (LWT) operation: a single conditional statement or a
@@ -207,7 +206,9 @@ public interface Mutator
      * committed {@code PartitionUpdate} to their base table and replied. Unlike {@link #onCasCommit}
      * (which fires <em>before</em> the commit is dispatched, for every <em>decided</em> value), this
      * fires only once the value is durably visible: a read at {@code consistencyLevel} (or stronger)
-     * issued after this callback returns will observe the committed value.
+     * issued after this callback returns will observe the committed value. Note that if
+     * {@code consistencyLevel} is {@code ONE}, reading at ONE or QUORUM may still not return the
+     * committed value if the acknowledging replica is not the one serving the read.
      * <p>
      * Relationship to {@link #onCasCommit}: every delivery of this callback is preceded by a
      * matching {@link #onCasCommit} for the same ballot, and it fires only on the success path (the

--- a/src/java/org/apache/cassandra/service/Mutator.java
+++ b/src/java/org/apache/cassandra/service/Mutator.java
@@ -23,15 +23,24 @@ import javax.annotation.Nullable;
 
 import org.apache.cassandra.db.ConsistencyLevel;
 import org.apache.cassandra.db.CounterMutation;
+import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.IMutation;
 import org.apache.cassandra.db.Mutation;
 import org.apache.cassandra.db.WriteType;
+import org.apache.cassandra.db.rows.RowIterator;
+import org.apache.cassandra.exceptions.CasWriteUnknownResultException;
+import org.apache.cassandra.exceptions.InvalidRequestException;
+import org.apache.cassandra.exceptions.IsBootstrappingException;
 import org.apache.cassandra.exceptions.OverloadedException;
+import org.apache.cassandra.exceptions.RequestFailureException;
+import org.apache.cassandra.exceptions.RequestTimeoutException;
 import org.apache.cassandra.exceptions.UnavailableException;
 import org.apache.cassandra.exceptions.WriteTimeoutException;
 import org.apache.cassandra.locator.ReplicaPlan;
 import org.apache.cassandra.metrics.ClientRequestsMetrics;
+import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.service.paxos.Commit;
+import org.apache.cassandra.service.paxos.Paxos;
 import org.apache.cassandra.transport.Dispatcher;
 import org.apache.cassandra.utils.TimeUUID;
 
@@ -89,6 +98,152 @@ public interface Mutator
      */
     @Nullable
     AbstractWriteResponseHandler<Commit> mutatePaxos(Commit proposal, ConsistencyLevel consistencyLevel, boolean allowHints, Dispatcher.RequestTime requestTime);
+
+    /**
+     * Where a Paxos commit dispatch originated. Passed to {@link #onCasCommit}.
+     */
+    enum CasCommitOrigin
+    {
+        /**
+         * The coordinator's own CAS operation reached the commit phase: the proposal carries the
+         * update this coordinator built and successfully proposed. At most one per
+         * {@link #mutateCas} invocation.
+         */
+        CLIENT_OPERATION,
+        /**
+         * The coordinator witnessed another proposer's accepted-but-uncommitted round and is
+         * completing it on their behalf. The payload is the foreign in-progress update, not
+         * anything this coordinator's client asked for; a SERIAL/LOCAL_SERIAL read can trigger it.
+         */
+        REPAIR_IN_PROGRESS,
+        /**
+         * Re-transmission of an already-committed value to replicas that have not witnessed it
+         * (most-recent-commit refresh). Carries no new decision; the value was agreed earlier.
+         */
+        REFRESH_COMMITTED
+    }
+
+    /**
+     * Used for handling a whole CAS (LWT) operation: a single conditional statement or a
+     * conditional batch. This is the operation-level Paxos entry point, called exactly once per
+     * client operation regardless of the configured {@code paxos_variant} (the default
+     * implementation dispatches to the v2 engine or the legacy v1 flow), of internal
+     * prepare/propose retries under contention, and of the outcome.
+     * <p>
+     * Completion is the return or throw of this call, on the calling thread:
+     * <ul>
+     *   <li>returns {@code null}: the update applied;</li>
+     *   <li>returns a {@link RowIterator}: the condition did not match (payload = current values);</li>
+     *   <li>throws {@link CasWriteUnknownResultException}: the update's fate is unknown (a partial
+     *       propose under the v1 engine). NOTE: the v2 engine does not throw this exception — its
+     *       fate-unknown cases (a proposal superseded with possible side effects, or a partially
+     *       accepted propose that times out) surface as plain timeout/failure exceptions with no
+     *       distinguishing marker, so on v2 a propose-phase timeout must be treated as
+     *       possibly-durable: a minority-accepted value can still be completed by a later repair;</li>
+     *   <li>throws after {@link #onCasCommit} fired with {@link CasCommitOrigin#CLIENT_OPERATION}:
+     *       the update was agreed by a quorum and its commit dispatched but not acknowledged in
+     *       time. An agreed value is decided: it WILL be completed (by the dispatched commit, or
+     *       by any later operation or repair touching the partition) even though this operation
+     *       reported failure to the client;</li>
+     *   <li>throws otherwise: this coordinator dispatched no commit (but see the v2 caveat above
+     *       for propose-phase timeouts).</li>
+     * </ul>
+     */
+    default RowIterator mutateCas(TableMetadata metadata,
+                                  DecoratedKey key,
+                                  CASRequest request,
+                                  ConsistencyLevel consistencyForPaxos,
+                                  ConsistencyLevel consistencyForCommit,
+                                  ClientState clientState,
+                                  long nowInSeconds,
+                                  Dispatcher.RequestTime requestTime)
+    throws UnavailableException, IsBootstrappingException, RequestFailureException, RequestTimeoutException,
+           InvalidRequestException, CasWriteUnknownResultException
+    {
+        return Paxos.useV2()
+               ? Paxos.cas(key, request, consistencyForPaxos, consistencyForCommit, clientState)
+               : StorageProxy.legacyCas(metadata.keyspace, metadata.name, key, request, consistencyForPaxos,
+                                        consistencyForCommit, clientState, nowInSeconds, requestTime);
+    }
+
+    /**
+     * Callback invoked when a Paxos commit is DISPATCHED by this coordinator, under either Paxos
+     * engine (v1 or v2). Dispatched, not acknowledged: replicas may still miss it, in which case a
+     * later operation re-issues it (reported as {@link CasCommitOrigin#REFRESH_COMMITTED}).
+     * <p>
+     * Multiplicity and threading: {@link CasCommitOrigin#CLIENT_OPERATION} fires at most once per
+     * {@link #mutateCas} call, inside that call, on the SAME thread, before the commit is
+     * dispatched/awaited — a wrapper can correlate the two without inspecting ballots (both
+     * engines invoke the whole operation synchronously on the request thread; any future
+     * refactoring of the engines must preserve this for CLIENT_OPERATION). The repair origins
+     * carry payloads this coordinator never originated and can fire any number of times, from CAS
+     * writes and SERIAL/LOCAL_SERIAL reads (on the request thread, while completing in-progress
+     * rounds they witness) and from background Paxos repair (on ARBITRARY threads, including
+     * messaging/response threads) — implementations must not assume request-thread context for
+     * repair origins.
+     * <p>
+     * {@code consistencyLevel} is the consistency the commit is performed at for
+     * {@link CasCommitOrigin#CLIENT_OPERATION} and the v1/PaxosRepair repair sites; for the v2
+     * engine's internal repair sites (where the commit piggybacks on the prepare exchange and has
+     * no commit consistency of its own) it is the consensus consistency (SERIAL/LOCAL_SERIAL) of
+     * the operation that triggered the repair.
+     * <p>
+     * Empty proposals (serial reads, non-applying CAS) are never committed by either engine, so
+     * they never produce this callback. Low-level re-transmissions inside the v2 prepare exchange
+     * ({@code PaxosPrepareRefresh}) are transport details and are not reported.
+     * <p>
+     * Implementations should not throw and must not block. Throwing is contained by the caller
+     * ({@link MutatorProvider#notifyCasCommit}): the exception is logged and ignored, never
+     * failing the operation, read or repair dispatching the commit.
+     */
+    default void onCasCommit(Commit committed, ConsistencyLevel consistencyLevel, CasCommitOrigin origin)
+    {
+        // no-op
+    }
+
+    /**
+     * Callback invoked AFTER a Paxos commit dispatched by this coordinator has been ACKNOWLEDGED by
+     * a {@code consistencyLevel} quorum of replicas — i.e. that many replicas have applied the
+     * committed {@code PartitionUpdate} to their base table and replied. Unlike {@link #onCasCommit}
+     * (which fires <em>before</em> the commit is dispatched, for every <em>decided</em> value), this
+     * fires only once the value is durably visible: a read at {@code consistencyLevel} (or stronger)
+     * issued after this callback returns will observe the committed value.
+     * <p>
+     * Relationship to {@link #onCasCommit}: every delivery of this callback is preceded by a
+     * matching {@link #onCasCommit} for the same ballot, and it fires only on the success path (the
+     * commit was acknowledged). Multiplicity mirrors {@link #onCasCommit}: exactly one per
+     * {@link CasCommitOrigin#CLIENT_OPERATION}; the repair/refresh origins may fire any number of
+     * times (once per completed round, across retries and repair cycles). If a commit times out or
+     * fails (the value is decided and will be completed later by a repair, but no quorum ack was
+     * received), {@link #onCasCommit} still fired but this callback does NOT — absence of this
+     * callback after an {@link #onCasCommit} means "commit not confirmed", not "not decided".
+     * <p>
+     * Coverage — this applied callback is delivered for:
+     * <ul>
+     *   <li>{@link CasCommitOrigin#CLIENT_OPERATION} under both paxos variants (v1 {@code doPaxos}
+     *       after the blocking commit, v2 {@code Paxos.cas} after the commit await): fires on the
+     *       request thread, inside {@link #mutateCas}, after the CLIENT_OPERATION {@link #onCasCommit};</li>
+     *   <li>{@link CasCommitOrigin#REPAIR_IN_PROGRESS} completed by the v1 engine
+     *       ({@code beginAndRepairPaxos}, on the triggering operation's request thread) and by
+     *       background {@code PaxosRepair} (on an arbitrary repair thread);</li>
+     *   <li>{@link CasCommitOrigin#REFRESH_COMMITTED} re-transmitted by background {@code PaxosRepair}.</li>
+     * </ul>
+     * It is NOT delivered (only the dispatched {@link #onCasCommit} is) for the v1
+     * {@link CasCommitOrigin#REFRESH_COMMITTED} site (an asynchronous fire-and-forget
+     * {@code sendCommit} with no awaited ack) nor for the v2 engine's {@code begin()}-path
+     * {@link CasCommitOrigin#REFRESH_COMMITTED}/{@link CasCommitOrigin#REPAIR_IN_PROGRESS} sites
+     * (where the commit piggybacks on the following prepare and has no separable ack). For those,
+     * a deferred {@code LOCAL_SERIAL}/{@code SERIAL} read issued from {@link #onCasCommit} is
+     * self-correcting and will observe the value regardless.
+     * <p>
+     * Threading and containment mirror {@link #onCasCommit}: implementations should not throw and
+     * must not block; a thrown exception is logged and ignored by
+     * {@link MutatorProvider#notifyCasCommitApplied} and never fails the operation, read or repair.
+     */
+    default void onCasCommitApplied(Commit committed, ConsistencyLevel consistencyLevel, CasCommitOrigin origin)
+    {
+        // no-op
+    }
 
     /**
      * Used to persist the given batch of mutations. Usually invoked as part of

--- a/src/java/org/apache/cassandra/service/MutatorProvider.java
+++ b/src/java/org/apache/cassandra/service/MutatorProvider.java
@@ -18,6 +18,8 @@
 
 package org.apache.cassandra.service;
 
+import java.util.concurrent.TimeUnit;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,6 +27,7 @@ import org.apache.cassandra.db.ConsistencyLevel;
 import org.apache.cassandra.service.paxos.Commit;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.JVMStabilityInspector;
+import org.apache.cassandra.utils.NoSpamLogger;
 
 import static org.apache.cassandra.config.CassandraRelevantProperties.CUSTOM_MUTATOR_CLASS;
 
@@ -38,6 +41,7 @@ import static org.apache.cassandra.config.CassandraRelevantProperties.CUSTOM_MUT
 public abstract class MutatorProvider
 {
     private static final Logger logger = LoggerFactory.getLogger(MutatorProvider.class);
+    private static final NoSpamLogger noSpamLogger = NoSpamLogger.getLogger(logger, 1, TimeUnit.MINUTES);
 
     // public so that the paxos engines (org.apache.cassandra.service.paxos) can reach the
     // installed singleton for Mutator.onCasCommit notifications without re-constructing it
@@ -58,12 +62,12 @@ public abstract class MutatorProvider
         {
             // Let fatal errors (OOM etc.) reach the JVM failure policy before we swallow.
             JVMStabilityInspector.inspectThrowable(t);
-            logger.warn("Custom mutator onCasCommit({}) failed; ignoring", origin, t);
+            noSpamLogger.warn("Custom mutator onCasCommit({}) failed; ignoring", origin, t);
         }
     }
 
     /**
-     * Notifies the installed Mutator that a commit has been acknowledged by a quorum (see
+     * Notifies the installed Mutator that a commit has been acknowledged by given consistency level (see
      * {@link Mutator#onCasCommitApplied}), containing any exception a misbehaving implementation
      * throws: a notification failure must never abort the paxos operation, serial read or repair.
      */
@@ -77,7 +81,7 @@ public abstract class MutatorProvider
         {
             // Let fatal errors (OOM etc.) reach the JVM failure policy before we swallow.
             JVMStabilityInspector.inspectThrowable(t);
-            logger.warn("Custom mutator onCasCommitApplied({}) failed; ignoring", origin, t);
+            noSpamLogger.warn("Custom mutator onCasCommitApplied({}) failed; ignoring", origin, t);
         }
     }
 

--- a/src/java/org/apache/cassandra/service/MutatorProvider.java
+++ b/src/java/org/apache/cassandra/service/MutatorProvider.java
@@ -67,21 +67,22 @@ public abstract class MutatorProvider
     }
 
     /**
-     * Notifies the installed Mutator that a commit has been acknowledged by given consistency level (see
-     * {@link Mutator#onCasCommitApplied}), containing any exception a misbehaving implementation
+     * Notifies the installed Mutator of the terminal outcome of a previously-announced commit (see
+     * {@link Mutator#onCasCommitCompleted}), containing any exception a misbehaving implementation
      * throws: a notification failure must never abort the paxos operation, serial read or repair.
      */
-    public static void notifyCasCommitApplied(Commit committed, ConsistencyLevel consistencyLevel, Mutator.CasCommitOrigin origin)
+    public static void notifyCasCommitCompleted(Commit committed, ConsistencyLevel consistencyLevel,
+                                                Mutator.CasCommitOrigin origin, Mutator.CasCommitOutcome outcome)
     {
         try
         {
-            instance.onCasCommitApplied(committed, consistencyLevel, origin);
+            instance.onCasCommitCompleted(committed, consistencyLevel, origin, outcome);
         }
         catch (Throwable t)
         {
             // Let fatal errors (OOM etc.) reach the JVM failure policy before we swallow.
             JVMStabilityInspector.inspectThrowable(t);
-            noSpamLogger.warn("Custom mutator onCasCommitApplied({}) failed; ignoring", origin, t);
+            noSpamLogger.warn("Custom mutator onCasCommitCompleted({}, {}) failed; ignoring", origin, outcome, t);
         }
     }
 

--- a/src/java/org/apache/cassandra/service/MutatorProvider.java
+++ b/src/java/org/apache/cassandra/service/MutatorProvider.java
@@ -18,7 +18,13 @@
 
 package org.apache.cassandra.service;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.cassandra.db.ConsistencyLevel;
+import org.apache.cassandra.service.paxos.Commit;
 import org.apache.cassandra.utils.FBUtilities;
+import org.apache.cassandra.utils.JVMStabilityInspector;
 
 import static org.apache.cassandra.config.CassandraRelevantProperties.CUSTOM_MUTATOR_CLASS;
 
@@ -31,7 +37,49 @@ import static org.apache.cassandra.config.CassandraRelevantProperties.CUSTOM_MUT
  */
 public abstract class MutatorProvider
 {
-    static final Mutator instance = getCustomOrDefault();
+    private static final Logger logger = LoggerFactory.getLogger(MutatorProvider.class);
+
+    // public so that the paxos engines (org.apache.cassandra.service.paxos) can reach the
+    // installed singleton for Mutator.onCasCommit notifications without re-constructing it
+    public static final Mutator instance = getCustomOrDefault();
+
+    /**
+     * Notifies the installed Mutator of a commit dispatch (see {@link Mutator#onCasCommit}),
+     * containing any exception a misbehaving implementation throws: a notification failure must
+     * never abort the paxos operation, serial read or repair that is dispatching the commit.
+     */
+    public static void notifyCasCommit(Commit committed, ConsistencyLevel consistencyLevel, Mutator.CasCommitOrigin origin)
+    {
+        try
+        {
+            instance.onCasCommit(committed, consistencyLevel, origin);
+        }
+        catch (Throwable t)
+        {
+            // Let fatal errors (OOM etc.) reach the JVM failure policy before we swallow.
+            JVMStabilityInspector.inspectThrowable(t);
+            logger.warn("Custom mutator onCasCommit({}) failed; ignoring", origin, t);
+        }
+    }
+
+    /**
+     * Notifies the installed Mutator that a commit has been acknowledged by a quorum (see
+     * {@link Mutator#onCasCommitApplied}), containing any exception a misbehaving implementation
+     * throws: a notification failure must never abort the paxos operation, serial read or repair.
+     */
+    public static void notifyCasCommitApplied(Commit committed, ConsistencyLevel consistencyLevel, Mutator.CasCommitOrigin origin)
+    {
+        try
+        {
+            instance.onCasCommitApplied(committed, consistencyLevel, origin);
+        }
+        catch (Throwable t)
+        {
+            // Let fatal errors (OOM etc.) reach the JVM failure policy before we swallow.
+            JVMStabilityInspector.inspectThrowable(t);
+            logger.warn("Custom mutator onCasCommitApplied({}) failed; ignoring", origin, t);
+        }
+    }
 
     public static Mutator getCustomOrDefault()
     {

--- a/src/java/org/apache/cassandra/service/StorageProxy.java
+++ b/src/java/org/apache/cassandra/service/StorageProxy.java
@@ -776,11 +776,22 @@ public class StorageProxy implements StorageProxyMBean
                     if (!proposal.update.isEmpty())
                     {
                         MutatorProvider.notifyCasCommit(proposal, consistencyForCommit, Mutator.CasCommitOrigin.CLIENT_OPERATION);
-                        commitPaxos(proposal, consistencyForCommit, true, requestTime, casMetrics);
+                        try
+                        {
+                            commitPaxos(proposal, consistencyForCommit, true, requestTime, casMetrics);
+                        }
+                        catch (WriteTimeoutException e)
+                        {
+                            // decided but the commit was not acknowledged in time: report UNCONFIRMED before the
+                            // failure surfaces to the client. (At CL=ANY commitPaxos does not block, so it does not
+                            // throw here; that case delivers no terminal, only the dispatched onCasCommit.)
+                            MutatorProvider.notifyCasCommitCompleted(proposal, consistencyForCommit, Mutator.CasCommitOrigin.CLIENT_OPERATION, Mutator.CasCommitOutcome.UNCONFIRMED);
+                            throw e;
+                        }
                         // commitPaxos blocks until a consistencyForCommit quorum acknowledged the commit
                         // (unless CL=ANY); reaching here means the value is now readable at that CL.
                         if (consistencyForCommit != ConsistencyLevel.ANY)
-                            MutatorProvider.notifyCasCommitApplied(proposal, consistencyForCommit, Mutator.CasCommitOrigin.CLIENT_OPERATION);
+                            MutatorProvider.notifyCasCommitCompleted(proposal, consistencyForCommit, Mutator.CasCommitOrigin.CLIENT_OPERATION, Mutator.CasCommitOutcome.APPLIED);
                     }
                     RowIterator result = proposalPair.right;
                     if (result != null)
@@ -892,11 +903,21 @@ public class StorageProxy implements StorageProxyMBean
                     if (proposePaxos(refreshedInProgress, paxosPlan, false, requestTime, casMetrics))
                     {
                         MutatorProvider.notifyCasCommit(refreshedInProgress, consistencyForCommit, Mutator.CasCommitOrigin.REPAIR_IN_PROGRESS);
-                        commitPaxos(refreshedInProgress, consistencyForCommit, false, requestTime, casMetrics);
+                        try
+                        {
+                            commitPaxos(refreshedInProgress, consistencyForCommit, false, requestTime, casMetrics);
+                        }
+                        catch (WriteTimeoutException e)
+                        {
+                            // recovered value decided but the commit was not acknowledged in time: report UNCONFIRMED
+                            // before the failure propagates. (CL=ANY does not block/throw here; no terminal then.)
+                            MutatorProvider.notifyCasCommitCompleted(refreshedInProgress, consistencyForCommit, Mutator.CasCommitOrigin.REPAIR_IN_PROGRESS, Mutator.CasCommitOutcome.UNCONFIRMED);
+                            throw e;
+                        }
                         // commitPaxos blocks until a consistencyForCommit quorum acknowledged the commit
                         // (unless CL=ANY); reaching here means the recovered value is now readable at that CL.
                         if (consistencyForCommit != ConsistencyLevel.ANY)
-                            MutatorProvider.notifyCasCommitApplied(refreshedInProgress, consistencyForCommit, Mutator.CasCommitOrigin.REPAIR_IN_PROGRESS);
+                            MutatorProvider.notifyCasCommitCompleted(refreshedInProgress, consistencyForCommit, Mutator.CasCommitOrigin.REPAIR_IN_PROGRESS, Mutator.CasCommitOutcome.APPLIED);
                     }
                     else
                     {

--- a/src/java/org/apache/cassandra/service/StorageProxy.java
+++ b/src/java/org/apache/cassandra/service/StorageProxy.java
@@ -521,9 +521,12 @@ public class StorageProxy implements StorageProxyMBean
                                                             key.toString(), keyspaceName, cfName));
         }
 
-        return Paxos.useV2()
-                ? Paxos.cas(key, request, consistencyForPaxos, consistencyForCommit, clientState)
-                : legacyCas(keyspaceName, cfName, key, request, consistencyForPaxos, consistencyForCommit, clientState, nowInSeconds, requestTime);
+        // Delegate the whole operation through the Mutator SPI so a custom Mutator observes the
+        // begin and the completion of every CAS operation, whichever paxos_variant is configured
+        // (the default implementation dispatches to Paxos.cas or legacyCas).
+        TableMetadata metadata = Schema.instance.validateTable(keyspaceName, cfName);
+        return mutator.mutateCas(metadata, key, request, consistencyForPaxos, consistencyForCommit,
+                                 clientState, nowInSeconds, requestTime);
     }
 
     public static RowIterator legacyCas(String keyspaceName,
@@ -771,7 +774,14 @@ public class StorageProxy implements StorageProxyMBean
                     // comment there). As empty update are somewhat common (serial reads and non-applying CAS propose
                     // them), this is worth bothering.
                     if (!proposal.update.isEmpty())
+                    {
+                        MutatorProvider.notifyCasCommit(proposal, consistencyForCommit, Mutator.CasCommitOrigin.CLIENT_OPERATION);
                         commitPaxos(proposal, consistencyForCommit, true, requestTime, casMetrics);
+                        // commitPaxos blocks until a consistencyForCommit quorum acknowledged the commit
+                        // (unless CL=ANY); reaching here means the value is now readable at that CL.
+                        if (consistencyForCommit != ConsistencyLevel.ANY)
+                            MutatorProvider.notifyCasCommitApplied(proposal, consistencyForCommit, Mutator.CasCommitOrigin.CLIENT_OPERATION);
+                    }
                     RowIterator result = proposalPair.right;
                     if (result != null)
                         Tracing.trace("CAS did not apply");
@@ -881,7 +891,12 @@ public class StorageProxy implements StorageProxyMBean
                     Commit refreshedInProgress = Commit.newProposal(ballot, inProgress.update);
                     if (proposePaxos(refreshedInProgress, paxosPlan, false, requestTime, casMetrics))
                     {
+                        MutatorProvider.notifyCasCommit(refreshedInProgress, consistencyForCommit, Mutator.CasCommitOrigin.REPAIR_IN_PROGRESS);
                         commitPaxos(refreshedInProgress, consistencyForCommit, false, requestTime, casMetrics);
+                        // commitPaxos blocks until a consistencyForCommit quorum acknowledged the commit
+                        // (unless CL=ANY); reaching here means the recovered value is now readable at that CL.
+                        if (consistencyForCommit != ConsistencyLevel.ANY)
+                            MutatorProvider.notifyCasCommitApplied(refreshedInProgress, consistencyForCommit, Mutator.CasCommitOrigin.REPAIR_IN_PROGRESS);
                     }
                     else
                     {
@@ -903,6 +918,7 @@ public class StorageProxy implements StorageProxyMBean
                 {
                     Tracing.trace("Repairing replicas that missed the most recent commit");
                     casMetrics.missingMostRecentCommit.inc(missingMRCSize);
+                    MutatorProvider.notifyCasCommit(mostRecent, consistencyForCommit, Mutator.CasCommitOrigin.REFRESH_COMMITTED);
                     sendCommit(mostRecent, missingMRC);
                     // TODO: provided commits don't invalid the prepare we just did above (which they don't), we could just wait
                     // for all the missingMRC to acknowledge this commit and then move on with proposing our value. But that means

--- a/src/java/org/apache/cassandra/service/StorageProxy.java
+++ b/src/java/org/apache/cassandra/service/StorageProxy.java
@@ -780,11 +780,13 @@ public class StorageProxy implements StorageProxyMBean
                         {
                             commitPaxos(proposal, consistencyForCommit, true, requestTime, casMetrics);
                         }
-                        catch (WriteTimeoutException e)
+                        catch (RuntimeException e)
                         {
-                            // decided but the commit was not acknowledged in time: report UNCONFIRMED before the
-                            // failure surfaces to the client. (At CL=ANY commitPaxos does not block, so it does not
-                            // throw here; that case delivers no terminal, only the dispatched onCasCommit.)
+                            // proposePaxos already returned true, so the value is DECIDED; any failure to confirm
+                            // the commit here (timeout, replica failure, interruption surfaced as
+                            // UncheckedInterruptedException) leaves it decided-but-not-confirmed: report UNCONFIRMED
+                            // before the failure surfaces to the client. (At CL=ANY commitPaxos does not block, so it
+                            // does not throw here; that case delivers no terminal, only the dispatched onCasCommit.)
                             MutatorProvider.notifyCasCommitCompleted(proposal, consistencyForCommit, Mutator.CasCommitOrigin.CLIENT_OPERATION, Mutator.CasCommitOutcome.UNCONFIRMED);
                             throw e;
                         }

--- a/src/java/org/apache/cassandra/service/paxos/CommitVerbHandler.java
+++ b/src/java/org/apache/cassandra/service/paxos/CommitVerbHandler.java
@@ -50,7 +50,7 @@ public class CommitVerbHandler implements IVerbHandler<Commit>
         sensors.incrementSensor(context, Type.INTERNODE_BYTES, message.payloadSize(MessagingService.current_version));
         RequestTracker.instance.set(sensors);
 
-        PaxosState.commitDirect(message.payload, p -> MutatorProvider.getCustomOrDefault().onAppliedProposal(p));
+        PaxosState.commitDirect(message.payload, p -> MutatorProvider.instance.onAppliedProposal(p));
 
         Tracing.trace("Enqueuing acknowledge to {}", message.from());
         Message.Builder<NoPayload> reply = message.emptyResponseBuilder();

--- a/src/java/org/apache/cassandra/service/paxos/Paxos.java
+++ b/src/java/org/apache/cassandra/service/paxos/Paxos.java
@@ -93,6 +93,9 @@ import org.apache.cassandra.metrics.ClientRequestMetrics;
 import org.apache.cassandra.service.CASRequest;
 import org.apache.cassandra.service.ClientState;
 import org.apache.cassandra.service.FailureRecordingCallback.AsMap;
+import org.apache.cassandra.service.Mutator;
+import org.apache.cassandra.service.MutatorProvider;
+import org.apache.cassandra.service.paxos.Commit.Agreed;
 import org.apache.cassandra.service.paxos.Commit.Proposal;
 import org.apache.cassandra.service.paxos.cleanup.PaxosRepairState;
 import org.apache.cassandra.service.reads.DataResolver;
@@ -682,6 +685,7 @@ public class Paxos
         try (PaxosOperationLock lock = PaxosState.lock(partitionKey, metadata, proposeDeadline, consistencyForConsensus, true))
         {
             Paxos.Async<PaxosCommit.Status> commit = null;
+            Agreed committedAgreed = null; // the value behind 'commit', for the onCasCommitApplied notification
             done: while (true)
             {
                 // read the current values and check they validate the conditions
@@ -774,7 +778,12 @@ public class Paxos
                         //   1) reached a majority, in which case it was agreed, had no effect and we can do nothing; or
                         //   2) did not reach a majority, was not agreed, and was not user visible as a result so we can ignore it
                         if (!proposal.update.isEmpty())
-                            commit = commit(proposal.agreed(), participants, consistencyForConsensus, consistencyForCommit, true);
+                        {
+                            Agreed agreed = proposal.agreed();
+                            MutatorProvider.notifyCasCommit(agreed, consistencyForCommit, Mutator.CasCommitOrigin.CLIENT_OPERATION);
+                            commit = commit(agreed, participants, consistencyForConsensus, consistencyForCommit, true);
+                            committedAgreed = agreed;
+                        }
 
                         break done;
                     }
@@ -809,6 +818,8 @@ public class Paxos
                 PaxosCommit.Status result = commit.awaitUntil(commitDeadline);
                 if (!result.isSuccess())
                     throw result.maybeFailure().markAndThrowAsTimeoutOrFailure(true, consistencyForCommit, failedAttemptsDueToContention, metrics);
+                // the commit reached a consistencyForCommit quorum: the value is now readable at that CL
+                MutatorProvider.notifyCasCommitApplied(committedAgreed, consistencyForCommit, Mutator.CasCommitOrigin.CLIENT_OPERATION);
             }
             Tracing.trace("CAS successful");
             return null;
@@ -1009,6 +1020,7 @@ public class Paxos
                 {
                     FoundIncompleteCommitted incomplete = prepare.incompleteCommitted();
                     Tracing.trace("Repairing replicas that missed the most recent commit");
+                    MutatorProvider.notifyCasCommit(incomplete.committed, consistencyForConsensus, Mutator.CasCommitOrigin.REFRESH_COMMITTED);
                     retry = commitAndPrepare(incomplete.committed, incomplete.participants, query, isWrite, acceptEarlyReadPermission);
                     break;
                 }
@@ -1037,8 +1049,12 @@ public class Paxos
                             throw proposeResult.maybeFailure().markAndThrowAsTimeoutOrFailure(isWrite, consistencyForConsensus, failedAttemptsDueToContention, metrics);
 
                         case SUCCESS:
-                            retry = commitAndPrepare(repropose.agreed(), inProgress.participants, query, isWrite, acceptEarlyReadPermission);
+                        {
+                            Agreed reproposeAgreed = repropose.agreed();
+                            MutatorProvider.notifyCasCommit(reproposeAgreed, consistencyForConsensus, Mutator.CasCommitOrigin.REPAIR_IN_PROGRESS);
+                            retry = commitAndPrepare(reproposeAgreed, inProgress.participants, query, isWrite, acceptEarlyReadPermission);
                             break retry;
+                        }
 
                         case SUPERSEDED:
                             // since we are proposing a previous value that was maybe superseded by us before completion

--- a/src/java/org/apache/cassandra/service/paxos/Paxos.java
+++ b/src/java/org/apache/cassandra/service/paxos/Paxos.java
@@ -685,7 +685,7 @@ public class Paxos
         try (PaxosOperationLock lock = PaxosState.lock(partitionKey, metadata, proposeDeadline, consistencyForConsensus, true))
         {
             Paxos.Async<PaxosCommit.Status> commit = null;
-            Agreed committedAgreed = null; // the value behind 'commit', for the onCasCommitApplied notification
+            Agreed committedAgreed = null; // the value behind 'commit', for the onCasCommitCompleted notification
             done: while (true)
             {
                 // read the current values and check they validate the conditions
@@ -817,14 +817,20 @@ public class Paxos
             {
                 PaxosCommit.Status result = commit.awaitUntil(commitDeadline);
                 if (!result.isSuccess())
+                {
+                    // decided (agreed by a quorum) but the commit was not acknowledged in time: report the
+                    // terminal as UNCONFIRMED before surfacing the failure to the client. The value may still
+                    // be completed by a later operation or repair.
+                    MutatorProvider.notifyCasCommitCompleted(committedAgreed, consistencyForCommit, Mutator.CasCommitOrigin.CLIENT_OPERATION, Mutator.CasCommitOutcome.UNCONFIRMED);
                     throw result.maybeFailure().markAndThrowAsTimeoutOrFailure(true, consistencyForCommit, failedAttemptsDueToContention, metrics);
+                }
                 // the commit reached a consistencyForCommit quorum: the value is now readable at that CL.
                 // Note that, unlike the v1 path in StorageProxy, we do not need to special case CL=ANY here:
                 // v1 does not block at all for ANY (it fires the commits off and returns), so it must suppress
                 // this notification; here we always await PaxosCommit, which requires blockForWrite(ANY) == 1
                 // genuine replica acknowledgement (hints are not counted as accepts), so reaching this point
                 // means the commit really was applied on at least the replicas that consistencyForCommit requires.
-                MutatorProvider.notifyCasCommitApplied(committedAgreed, consistencyForCommit, Mutator.CasCommitOrigin.CLIENT_OPERATION);
+                MutatorProvider.notifyCasCommitCompleted(committedAgreed, consistencyForCommit, Mutator.CasCommitOrigin.CLIENT_OPERATION, Mutator.CasCommitOutcome.APPLIED);
             }
             Tracing.trace("CAS successful");
             return null;
@@ -1011,11 +1017,33 @@ public class Paxos
         initialParticipants.assureSufficientLiveNodes(isWrite);
         PaxosPrepare preparing = prepare(minimumBallot, initialParticipants, query, isWrite, acceptEarlyReadPermission);
         ClientRequestsMetrics metrics = ClientRequestsMetricsProvider.instance.metrics(query.metadata().keyspace);
+        // A commit fused into the following prepare (commitAndPrepare, used to finish another proposer's
+        // round) has no separable ack; its fate is only known when that prepare resolves at the next
+        // awaitUntil below. Stash it here so we can deliver a terminal onCasCommitCompleted then.
+        Commit pendingFused = null;
+        Mutator.CasCommitOrigin pendingFusedOrigin = null;
         while (true)
         {
             // prepare
             PaxosPrepare retry = null;
-            PaxosPrepare.Status prepare = preparing.awaitUntil(deadline);
+            PaxosPrepare.Status prepare;
+            try
+            {
+                prepare = preparing.awaitUntil(deadline);
+            }
+            catch (Throwable t)
+            {
+                // the fused prepare (and its batched commit) did not resolve: report it as not confirmed
+                if (pendingFused != null)
+                    MutatorProvider.notifyCasCommitCompleted(pendingFused, consistencyForConsensus, pendingFusedOrigin, Mutator.CasCommitOutcome.UNCONFIRMED);
+                throw t;
+            }
+            if (pendingFused != null)
+            {
+                MutatorProvider.notifyCasCommitCompleted(pendingFused, consistencyForConsensus, pendingFusedOrigin, fusedCommitOutcome(prepare.outcome));
+                pendingFused = null;
+                pendingFusedOrigin = null;
+            }
             boolean isPromised = false;
             retry: switch (prepare.outcome)
             {
@@ -1027,6 +1055,8 @@ public class Paxos
                     Tracing.trace("Repairing replicas that missed the most recent commit");
                     MutatorProvider.notifyCasCommit(incomplete.committed, consistencyForConsensus, Mutator.CasCommitOrigin.REFRESH_COMMITTED);
                     retry = commitAndPrepare(incomplete.committed, incomplete.participants, query, isWrite, acceptEarlyReadPermission);
+                    pendingFused = incomplete.committed;           // terminal delivered when 'retry' resolves
+                    pendingFusedOrigin = Mutator.CasCommitOrigin.REFRESH_COMMITTED;
                     break;
                 }
                 case FOUND_INCOMPLETE_ACCEPTED:
@@ -1058,6 +1088,8 @@ public class Paxos
                             Agreed reproposeAgreed = repropose.agreed();
                             MutatorProvider.notifyCasCommit(reproposeAgreed, consistencyForConsensus, Mutator.CasCommitOrigin.REPAIR_IN_PROGRESS);
                             retry = commitAndPrepare(reproposeAgreed, inProgress.participants, query, isWrite, acceptEarlyReadPermission);
+                            pendingFused = reproposeAgreed;        // terminal delivered when 'retry' resolves
+                            pendingFusedOrigin = Mutator.CasCommitOrigin.REPAIR_IN_PROGRESS;
                             break retry;
                         }
 
@@ -1137,6 +1169,29 @@ public class Paxos
         return (includesRead ? EndpointsForToken.natural(keyspace, key.getToken())
                              : ReplicaLayout.forTokenWriteLiveAndDown(keyspace, key.getToken()).all()
         ).contains(getBroadcastAddressAndPort());
+    }
+
+    /**
+     * Maps the outcome of a fused commit-and-prepare (the prepare that carried a batched commit) to the
+     * terminal {@link Mutator.CasCommitOutcome} for that commit. A promise-quorum outcome
+     * (PROMISED/READ_PERMITTED, or FOUND_INCOMPLETE_* which likewise require a quorum of promises) implies
+     * the batched commit reached that quorum, because each replica applies the commit before answering the
+     * prepare; SUPERSEDED means pre-empted before a quorum; anything else is not confirmed.
+     */
+    private static Mutator.CasCommitOutcome fusedCommitOutcome(PaxosPrepare.Status.Outcome outcome)
+    {
+        switch (outcome)
+        {
+            case PROMISED:
+            case READ_PERMITTED:
+            case FOUND_INCOMPLETE_ACCEPTED:
+            case FOUND_INCOMPLETE_COMMITTED:
+                return Mutator.CasCommitOutcome.CONFIRMED_BY_PREPARE;
+            case SUPERSEDED:
+                return Mutator.CasCommitOutcome.SUPERSEDED;
+            default: // MAYBE_FAILURE, ELECTORATE_MISMATCH
+                return Mutator.CasCommitOutcome.UNCONFIRMED;
+        }
     }
 
     static ConsistencyLevel nonSerial(ConsistencyLevel serial)

--- a/src/java/org/apache/cassandra/service/paxos/Paxos.java
+++ b/src/java/org/apache/cassandra/service/paxos/Paxos.java
@@ -818,7 +818,12 @@ public class Paxos
                 PaxosCommit.Status result = commit.awaitUntil(commitDeadline);
                 if (!result.isSuccess())
                     throw result.maybeFailure().markAndThrowAsTimeoutOrFailure(true, consistencyForCommit, failedAttemptsDueToContention, metrics);
-                // the commit reached a consistencyForCommit quorum: the value is now readable at that CL
+                // the commit reached a consistencyForCommit quorum: the value is now readable at that CL.
+                // Note that, unlike the v1 path in StorageProxy, we do not need to special case CL=ANY here:
+                // v1 does not block at all for ANY (it fires the commits off and returns), so it must suppress
+                // this notification; here we always await PaxosCommit, which requires blockForWrite(ANY) == 1
+                // genuine replica acknowledgement (hints are not counted as accepts), so reaching this point
+                // means the commit really was applied on at least the replicas that consistencyForCommit requires.
                 MutatorProvider.notifyCasCommitApplied(committedAgreed, consistencyForCommit, Mutator.CasCommitOrigin.CLIENT_OPERATION);
             }
             Tracing.trace("CAS successful");

--- a/src/java/org/apache/cassandra/service/paxos/PaxosRepair.java
+++ b/src/java/org/apache/cassandra/service/paxos/PaxosRepair.java
@@ -410,7 +410,7 @@ public class PaxosRepair extends AbstractPaxosRepair
             if (!input.isSuccess())
                 return retry(this);
             // the commit reached a commitConsistency() quorum: the recovered value is now readable
-            MutatorProvider.notifyCasCommitApplied(committed, commitConsistency(), origin);
+            MutatorProvider.notifyCasCommitCompleted(committed, commitConsistency(), origin, Mutator.CasCommitOutcome.APPLIED);
             return DONE;
         }
     }
@@ -430,7 +430,7 @@ public class PaxosRepair extends AbstractPaxosRepair
         public State execute(PaxosCommit.Status input)
         {
             if (input.isSuccess())
-                MutatorProvider.notifyCasCommitApplied(committed, commitConsistency(), origin);
+                MutatorProvider.notifyCasCommitCompleted(committed, commitConsistency(), origin, Mutator.CasCommitOutcome.APPLIED);
             return restart(this);
         }
     }

--- a/src/java/org/apache/cassandra/service/paxos/PaxosRepair.java
+++ b/src/java/org/apache/cassandra/service/paxos/PaxosRepair.java
@@ -56,6 +56,8 @@ import org.apache.cassandra.repair.SharedContext;
 import org.apache.cassandra.schema.Schema;
 import org.apache.cassandra.schema.TableId;
 import org.apache.cassandra.schema.TableMetadata;
+import org.apache.cassandra.service.Mutator;
+import org.apache.cassandra.service.MutatorProvider;
 import org.apache.cassandra.utils.CassandraVersion;
 import org.apache.cassandra.utils.ExecutorUtils;
 import org.apache.cassandra.utils.FBUtilities;
@@ -243,10 +245,11 @@ public class PaxosRepair extends AbstractPaxosRepair
 
                 // we have a new enough commit, but it might not have reached enough participants; make sure it has before terminating
                 // note: we could send to only those we know haven't witnessed it, but this is a rare operation so a small amount of redundant work is fine
-                return oldestCommitted.equals(latestCommitted.ballot)
-                        ? DONE
-                        : PaxosCommit.commit(latestCommitted, participants, paxosConsistency, commitConsistency(), true,
-                                             new CommittingRepair());
+                if (oldestCommitted.equals(latestCommitted.ballot))
+                    return DONE;
+                MutatorProvider.notifyCasCommit(latestCommitted, commitConsistency(), Mutator.CasCommitOrigin.REFRESH_COMMITTED);
+                return PaxosCommit.commit(latestCommitted, participants, paxosConsistency, commitConsistency(), true,
+                                          new CommittingRepair(latestCommitted, Mutator.CasCommitOrigin.REFRESH_COMMITTED));
             }
             else if (isAcceptedButNotCommitted && !isPromisedButNotAccepted && !reproposalMayBeRejected)
             {
@@ -329,8 +332,9 @@ public class PaxosRepair extends AbstractPaxosRepair
                     // finish the in-progress commit
                     FoundIncompleteCommitted incomplete = input.incompleteCommitted();
                     logger.trace("PaxosRepair of {} found in progress {}", partitionKey(), incomplete.committed);
+                    MutatorProvider.notifyCasCommit(incomplete.committed, commitConsistency(), Mutator.CasCommitOrigin.REFRESH_COMMITTED);
                     return PaxosCommit.commit(incomplete.committed, participants, paxosConsistency, commitConsistency(), true,
-                                              new CommitAndRestart()); // we don't know if we're done, so we must restart
+                                              new CommitAndRestart(incomplete.committed, Mutator.CasCommitOrigin.REFRESH_COMMITTED)); // we don't know if we're done, so we must restart
                 }
 
                 case PROMISED:
@@ -377,8 +381,10 @@ public class PaxosRepair extends AbstractPaxosRepair
                     }
 
                     logger.trace("PaxosRepair of {} committing successful proposal {}", partitionKey(), proposal);
-                    return PaxosCommit.commit(proposal.agreed(), participants, paxosConsistency, commitConsistency(), true,
-                                              new CommittingRepair());
+                    Agreed agreed = proposal.agreed();
+                    MutatorProvider.notifyCasCommit(agreed, commitConsistency(), Mutator.CasCommitOrigin.REPAIR_IN_PROGRESS);
+                    return PaxosCommit.commit(agreed, participants, paxosConsistency, commitConsistency(), true,
+                                              new CommittingRepair(agreed, Mutator.CasCommitOrigin.REPAIR_IN_PROGRESS));
 
                 default:
                     throw new IllegalStateException();
@@ -388,19 +394,43 @@ public class PaxosRepair extends AbstractPaxosRepair
 
     private class CommittingRepair extends ConsumerState<PaxosCommit.Status>
     {
+        private final Agreed committed;
+        private final Mutator.CasCommitOrigin origin;
+
+        private CommittingRepair(Agreed committed, Mutator.CasCommitOrigin origin)
+        {
+            this.committed = committed;
+            this.origin = origin;
+        }
+
         @Override
         public State execute(PaxosCommit.Status input)
         {
             logger.trace("PaxosRepair of {} {}", partitionKey(), input);
-            return input.isSuccess() ? DONE : retry(this);
+            if (!input.isSuccess())
+                return retry(this);
+            // the commit reached a commitConsistency() quorum: the recovered value is now readable
+            MutatorProvider.notifyCasCommitApplied(committed, commitConsistency(), origin);
+            return DONE;
         }
     }
 
     private class CommitAndRestart extends ConsumerState<PaxosCommit.Status>
     {
+        private final Agreed committed;
+        private final Mutator.CasCommitOrigin origin;
+
+        private CommitAndRestart(Agreed committed, Mutator.CasCommitOrigin origin)
+        {
+            this.committed = committed;
+            this.origin = origin;
+        }
+
         @Override
         public State execute(PaxosCommit.Status input)
         {
+            if (input.isSuccess())
+                MutatorProvider.notifyCasCommitApplied(committed, commitConsistency(), origin);
             return restart(this);
         }
     }

--- a/test/unit/org/apache/cassandra/service/MutatorCasTest.java
+++ b/test/unit/org/apache/cassandra/service/MutatorCasTest.java
@@ -84,22 +84,35 @@ public class MutatorCasTest
     /** Monotonic stamp so tests can assert relative ordering of dispatched vs applied callbacks. */
     static final AtomicInteger sequence = new AtomicInteger();
 
-    /** One record per {@link Mutator#onCasCommit} / {@link Mutator#onCasCommitApplied} callback. */
+    /** One record per {@link Mutator#onCasCommit} / {@link Mutator#onCasCommitCompleted} callback. */
     static final class CommitRecord
     {
         final Commit commit;
         final ConsistencyLevel consistencyLevel;
         final Mutator.CasCommitOrigin origin;
+        final Mutator.CasCommitOutcome outcome; // null for onCasCommit (dispatch) records
         final Thread thread;
         final int seq;
 
         CommitRecord(Commit commit, ConsistencyLevel consistencyLevel, Mutator.CasCommitOrigin origin)
         {
+            this(commit, consistencyLevel, origin, null);
+        }
+
+        CommitRecord(Commit commit, ConsistencyLevel consistencyLevel, Mutator.CasCommitOrigin origin,
+                     Mutator.CasCommitOutcome outcome)
+        {
             this.commit = commit;
             this.consistencyLevel = consistencyLevel;
             this.origin = origin;
+            this.outcome = outcome;
             this.thread = Thread.currentThread();
             this.seq = sequence.incrementAndGet();
+        }
+
+        boolean isSuccess()
+        {
+            return outcome == Mutator.CasCommitOutcome.APPLIED || outcome == Mutator.CasCommitOutcome.CONFIRMED_BY_PREPARE;
         }
     }
 
@@ -113,7 +126,7 @@ public class MutatorCasTest
         static final AtomicInteger casCompleted = new AtomicInteger();
         static final AtomicInteger mutatePaxosCalls = new AtomicInteger();
         static final List<CommitRecord> commits = new CopyOnWriteArrayList<>();
-        static final List<CommitRecord> applied = new CopyOnWriteArrayList<>();
+        static final List<CommitRecord> completed = new CopyOnWriteArrayList<>();
 
         private final Mutator delegate = new StorageProxy.DefaultMutator();
 
@@ -123,7 +136,7 @@ public class MutatorCasTest
             casCompleted.set(0);
             mutatePaxosCalls.set(0);
             commits.clear();
-            applied.clear();
+            completed.clear();
             sequence.set(0);
         }
 
@@ -132,9 +145,9 @@ public class MutatorCasTest
             return withOrigin(commits, origin);
         }
 
-        static List<CommitRecord> appliedWithOrigin(Mutator.CasCommitOrigin origin)
+        static List<CommitRecord> completedWithOrigin(Mutator.CasCommitOrigin origin)
         {
-            return withOrigin(applied, origin);
+            return withOrigin(completed, origin);
         }
 
         private static List<CommitRecord> withOrigin(List<CommitRecord> records, Mutator.CasCommitOrigin origin)
@@ -175,9 +188,9 @@ public class MutatorCasTest
         }
 
         @Override
-        public void onCasCommitApplied(Commit committed, ConsistencyLevel consistencyLevel, CasCommitOrigin origin)
+        public void onCasCommitCompleted(Commit committed, ConsistencyLevel consistencyLevel, CasCommitOrigin origin, CasCommitOutcome outcome)
         {
-            applied.add(new CommitRecord(committed, consistencyLevel, origin));
+            completed.add(new CommitRecord(committed, consistencyLevel, origin, outcome));
         }
 
         @Override
@@ -352,19 +365,22 @@ public class MutatorCasTest
         assertThat(commit.thread)
             .as("CLIENT_OPERATION must fire on the mutateCas caller thread (the documented correlation contract)")
             .isSameAs(Thread.currentThread());
-        // The applied callback fires once, after the dispatched one, on the same (request) thread,
-        // once the commit is acknowledged at the commit CL -- under both paxos variants.
-        List<CommitRecord> clientApplied = RecordingMutator.appliedWithOrigin(Mutator.CasCommitOrigin.CLIENT_OPERATION);
-        assertThat(clientApplied).as("exactly one CLIENT_OPERATION applied callback for an applied CAS").hasSize(1);
-        CommitRecord applied = clientApplied.get(0);
+        // The terminal completion fires once, after the dispatched one, on the same (request) thread,
+        // once the commit is acknowledged at the commit CL -- under both paxos variants, with the APPLIED
+        // outcome (a standalone, separately-awaited commit).
+        List<CommitRecord> clientCompleted = RecordingMutator.completedWithOrigin(Mutator.CasCommitOrigin.CLIENT_OPERATION);
+        assertThat(clientCompleted).as("exactly one CLIENT_OPERATION completion callback for an applied CAS").hasSize(1);
+        CommitRecord applied = clientCompleted.get(0);
+        assertThat(applied.outcome)
+            .as("an acknowledged client commit completes as APPLIED").isEqualTo(Mutator.CasCommitOutcome.APPLIED);
         assertThat(applied.commit.update.partitionKey()).isEqualTo(key);
         assertThat(applied.commit.update.isEmpty()).isFalse();
         assertThat(applied.consistencyLevel).isEqualTo(ConsistencyLevel.QUORUM);
         assertThat(applied.thread)
-            .as("onCasCommitApplied fires on the mutateCas caller thread for CLIENT_OPERATION")
+            .as("onCasCommitCompleted fires on the mutateCas caller thread for CLIENT_OPERATION")
             .isSameAs(Thread.currentThread());
         assertThat(applied.seq)
-            .as("onCasCommitApplied fires AFTER the dispatched onCasCommit")
+            .as("onCasCommitCompleted fires AFTER the dispatched onCasCommit")
             .isGreaterThan(commit.seq);
         // Backward compatibility: moving the engine dispatch into Mutator.mutateCas must not
         // change when the legacy hook fires -- existing implementations overriding mutatePaxos
@@ -384,8 +400,8 @@ public class MutatorCasTest
         assertThat(RecordingMutator.casCompleted.get()).isEqualTo(1);
         assertThat(RecordingMutator.commitsWithOrigin(Mutator.CasCommitOrigin.CLIENT_OPERATION))
             .as("a non-applying CAS must not dispatch a CLIENT_OPERATION commit").isEmpty();
-        assertThat(RecordingMutator.applied)
-            .as("a non-applying CAS commits nothing, so no applied callback fires").isEmpty();
+        assertThat(RecordingMutator.completed)
+            .as("a non-applying CAS commits nothing, so no completion callback fires").isEmpty();
         assertThat(RecordingMutator.mutatePaxosCalls.get())
             .as("a non-applying CAS commits nothing, so the legacy hook must not fire either")
             .isZero();
@@ -425,7 +441,7 @@ public class MutatorCasTest
         assertThat(RecordingMutator.casBegun.get()).isEqualTo(1);
         assertThat(RecordingMutator.casCompleted.get()).as("completion also fires on failure").isEqualTo(1);
         assertThat(RecordingMutator.commits).as("no commit was dispatched").isEmpty();
-        assertThat(RecordingMutator.applied).as("no commit dispatched, so none applied").isEmpty();
+        assertThat(RecordingMutator.completed).as("no commit dispatched, so none completed").isEmpty();
         assertThat(RecordingMutator.mutatePaxosCalls.get()).isZero();
     }
 
@@ -464,7 +480,7 @@ public class MutatorCasTest
         assertThat(RecordingMutator.casBegun.get()).isEqualTo(1);
         assertThat(RecordingMutator.casCompleted.get()).as("completion also fires on failure").isEqualTo(1);
         assertThat(RecordingMutator.commits).as("no commit was dispatched").isEmpty();
-        assertThat(RecordingMutator.applied).as("no commit dispatched, so none applied").isEmpty();
+        assertThat(RecordingMutator.completed).as("no commit dispatched, so none completed").isEmpty();
         assertThat(RecordingMutator.mutatePaxosCalls.get()).isZero();
     }
 
@@ -510,26 +526,28 @@ public class MutatorCasTest
         assertThat(RecordingMutator.commitsWithOrigin(Mutator.CasCommitOrigin.CLIENT_OPERATION))
             .as("the non-applying operation itself must not commit").isEmpty();
 
-        // Applied-callback coverage for recovery: the v1 engine completes the foreign round with a
-        // blocking commitPaxos, so REPAIR_IN_PROGRESS also produces an applied callback (with the
-        // foreign payload, once the recovered value reached a commit-CL quorum). The v2 engine
-        // completes it in-line via begin()'s commitAndPrepare, where the commit piggybacks on the
-        // following prepare and has no separable ack -- that path is dispatched-only by design, so
-        // no applied callback fires here.
-        List<CommitRecord> repairApplied = RecordingMutator.appliedWithOrigin(Mutator.CasCommitOrigin.REPAIR_IN_PROGRESS);
+        // Terminal-completion coverage for recovery: every dispatched REPAIR_IN_PROGRESS commit is now
+        // paired with a terminal onCasCommitCompleted. The v1 engine completes the foreign round with a
+        // blocking commitPaxos, so the terminal is APPLIED (the recovered value reached a commit-CL
+        // quorum). The v2 engine completes it in-line via begin()'s commitAndPrepare: the commit is fused
+        // into the following prepare, whose promise-quorum implies the commit landed, so the terminal is
+        // CONFIRMED_BY_PREPARE (or APPLIED if the PaxosRepair machinery drove it instead) -- a success
+        // outcome either way. This is the behaviour that previously delivered NO callback on v2.
+        List<CommitRecord> repairCompleted = RecordingMutator.completedWithOrigin(Mutator.CasCommitOrigin.REPAIR_IN_PROGRESS);
+        assertThat(repairCompleted).as("the recovered foreign round must produce a terminal completion").isNotEmpty();
+        CommitRecord repairTerminal = repairCompleted.get(0);
+        assertThat(repairTerminal.commit.update.partitionKey()).isEqualTo(key);
+        assertThat(repairTerminal.seq)
+            .as("the completion fires after the dispatched one").isGreaterThan(repairs.get(0).seq);
+        assertThat(repairTerminal.isSuccess())
+            .as("a recovered, quorum-confirmed foreign round completes as a success outcome").isTrue();
         if (variant == Config.PaxosVariant.v1)
-        {
-            assertThat(repairApplied).as("v1 repair commit is awaited, so an applied callback fires").isNotEmpty();
-            assertThat(repairApplied.get(0).commit.update.partitionKey()).isEqualTo(key);
-            assertThat(repairApplied.get(0).seq)
-                .as("the applied callback fires after the dispatched one").isGreaterThan(repairs.get(0).seq);
-        }
+            assertThat(repairTerminal.outcome)
+                .as("v1 awaits a standalone commit, so the terminal is APPLIED").isEqualTo(Mutator.CasCommitOutcome.APPLIED);
         else
-        {
-            assertThat(repairApplied)
-                .as("v2 begin()-path repair is dispatched-only; no applied callback for this recovery route")
-                .isEmpty();
-        }
+            assertThat(repairTerminal.outcome)
+                .as("v2 confirms via the fused prepare (or APPLIED via PaxosRepair)")
+                .isIn(Mutator.CasCommitOutcome.CONFIRMED_BY_PREPARE, Mutator.CasCommitOutcome.APPLIED);
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/service/MutatorCasTest.java
+++ b/test/unit/org/apache/cassandra/service/MutatorCasTest.java
@@ -497,7 +497,7 @@ public class MutatorCasTest
         assertThat(RecordingMutator.casBegun.get()).isEqualTo(1);
         assertThat(RecordingMutator.casCompleted.get()).isEqualTo(1);
         List<CommitRecord> repairs = RecordingMutator.commitsWithOrigin(Mutator.CasCommitOrigin.REPAIR_IN_PROGRESS);
-        assertThat(repairs).as("the foreign in-progress round must be reported as REPAIR_IN_PROGRESS").isNotEmpty();
+        assertThat(repairs).as("the foreign in-progress round must be reported as REPAIR_IN_PROGRESS").hasSize(1);
         assertThat(repairs.get(0).commit.update.partitionKey()).isEqualTo(key);
         // Documented CL semantics: the v1 repair commit is performed at the operation's commit CL
         // (QUORUM here) -- exactly. Under v2 the completion can take two routes -- the in-engine

--- a/test/unit/org/apache/cassandra/service/MutatorCasTest.java
+++ b/test/unit/org/apache/cassandra/service/MutatorCasTest.java
@@ -1,0 +1,547 @@
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.service;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.Nullable;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.SchemaLoader;
+import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.config.Config;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.db.ConsistencyLevel;
+import org.apache.cassandra.db.CounterMutation;
+import org.apache.cassandra.db.DecoratedKey;
+import org.apache.cassandra.db.IMutation;
+import org.apache.cassandra.db.Mutation;
+import org.apache.cassandra.db.SinglePartitionReadCommand;
+import org.apache.cassandra.db.SystemKeyspace;
+import org.apache.cassandra.db.WriteType;
+import org.apache.cassandra.db.partitions.FilteredPartition;
+import org.apache.cassandra.db.partitions.PartitionUpdate;
+import org.apache.cassandra.db.rows.RowIterator;
+import org.apache.cassandra.dht.ByteOrderedPartitioner;
+import org.apache.cassandra.dht.Token;
+import org.apache.cassandra.exceptions.UnavailableException;
+import org.apache.cassandra.locator.ReplicaPlan;
+import org.apache.cassandra.metrics.ClientRequestsMetrics;
+import org.apache.cassandra.schema.KeyspaceParams;
+import org.apache.cassandra.schema.Schema;
+import org.apache.cassandra.schema.TableMetadata;
+import org.apache.cassandra.service.paxos.Ballot;
+import org.apache.cassandra.service.paxos.BallotGenerator;
+import org.apache.cassandra.service.paxos.Commit;
+import org.apache.cassandra.service.paxos.PaxosState;
+import org.apache.cassandra.transport.Dispatcher;
+import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.FBUtilities;
+import org.apache.cassandra.utils.TimeUUID;
+
+import static org.apache.cassandra.Util.dk;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Exercises the operation-level CAS surface of the {@link Mutator} SPI: {@link Mutator#mutateCas}
+ * and {@link Mutator#onCasCommit}, under both {@code paxos_variant} v1 and v2, on a single-node
+ * (RF=1) in-process cluster.
+ *
+ * The custom mutator is installed the same way a real deployment does it (the
+ * {@code cassandra.custom_mutator_class} system property, read once at {@link MutatorProvider}
+ * class-init), so the static block below must run before any server class is touched.
+ */
+public class MutatorCasTest
+{
+    static
+    {
+        CassandraRelevantProperties.CUSTOM_MUTATOR_CLASS.setString(RecordingMutator.class.getName());
+    }
+
+    private static final String KEYSPACE = "mutator_cas_test";
+    private static final String KEYSPACE_RF2 = "mutator_cas_test_rf2";
+    private static final String TABLE = "table_cas";
+
+    /** Monotonic stamp so tests can assert relative ordering of dispatched vs applied callbacks. */
+    static final AtomicInteger sequence = new AtomicInteger();
+
+    /** One record per {@link Mutator#onCasCommit} / {@link Mutator#onCasCommitApplied} callback. */
+    static final class CommitRecord
+    {
+        final Commit commit;
+        final ConsistencyLevel consistencyLevel;
+        final Mutator.CasCommitOrigin origin;
+        final Thread thread;
+        final int seq;
+
+        CommitRecord(Commit commit, ConsistencyLevel consistencyLevel, Mutator.CasCommitOrigin origin)
+        {
+            this.commit = commit;
+            this.consistencyLevel = consistencyLevel;
+            this.origin = origin;
+            this.thread = Thread.currentThread();
+            this.seq = sequence.incrementAndGet();
+        }
+    }
+
+    /**
+     * Wraps the default engine dispatch ({@code Mutator.super.mutateCas}) exactly the way a real
+     * custom Mutator would, recording begin/completion and every commit callback.
+     */
+    public static class RecordingMutator implements Mutator
+    {
+        static final AtomicInteger casBegun = new AtomicInteger();
+        static final AtomicInteger casCompleted = new AtomicInteger();
+        static final AtomicInteger mutatePaxosCalls = new AtomicInteger();
+        static final List<CommitRecord> commits = new CopyOnWriteArrayList<>();
+        static final List<CommitRecord> applied = new CopyOnWriteArrayList<>();
+
+        private final Mutator delegate = new StorageProxy.DefaultMutator();
+
+        static void reset()
+        {
+            casBegun.set(0);
+            casCompleted.set(0);
+            mutatePaxosCalls.set(0);
+            commits.clear();
+            applied.clear();
+            sequence.set(0);
+        }
+
+        static List<CommitRecord> commitsWithOrigin(Mutator.CasCommitOrigin origin)
+        {
+            return withOrigin(commits, origin);
+        }
+
+        static List<CommitRecord> appliedWithOrigin(Mutator.CasCommitOrigin origin)
+        {
+            return withOrigin(applied, origin);
+        }
+
+        private static List<CommitRecord> withOrigin(List<CommitRecord> records, Mutator.CasCommitOrigin origin)
+        {
+            List<CommitRecord> result = new CopyOnWriteArrayList<>();
+            for (CommitRecord r : records)
+                if (r.origin == origin)
+                    result.add(r);
+            return result;
+        }
+
+        @Override
+        public RowIterator mutateCas(TableMetadata metadata,
+                                     DecoratedKey key,
+                                     CASRequest request,
+                                     ConsistencyLevel consistencyForPaxos,
+                                     ConsistencyLevel consistencyForCommit,
+                                     ClientState clientState,
+                                     long nowInSeconds,
+                                     Dispatcher.RequestTime requestTime)
+        {
+            casBegun.incrementAndGet();
+            try
+            {
+                return Mutator.super.mutateCas(metadata, key, request, consistencyForPaxos, consistencyForCommit,
+                                               clientState, nowInSeconds, requestTime);
+            }
+            finally
+            {
+                casCompleted.incrementAndGet();
+            }
+        }
+
+        @Override
+        public void onCasCommit(Commit committed, ConsistencyLevel consistencyLevel, CasCommitOrigin origin)
+        {
+            commits.add(new CommitRecord(committed, consistencyLevel, origin));
+        }
+
+        @Override
+        public void onCasCommitApplied(Commit committed, ConsistencyLevel consistencyLevel, CasCommitOrigin origin)
+        {
+            applied.add(new CommitRecord(committed, consistencyLevel, origin));
+        }
+
+        @Override
+        public AbstractWriteResponseHandler<IMutation> mutateStandard(Mutation mutation,
+                                                                      ConsistencyLevel consistencyLevel,
+                                                                      String localDataCenter,
+                                                                      StorageProxy.WritePerformer writePerformer,
+                                                                      Runnable callback,
+                                                                      WriteType writeType,
+                                                                      Dispatcher.RequestTime requestTime)
+        {
+            return delegate.mutateStandard(mutation, consistencyLevel, localDataCenter, writePerformer, callback,
+                                           writeType, requestTime);
+        }
+
+        @Override
+        public void mutateAtomically(Collection<Mutation> mutations,
+                                     ConsistencyLevel consistencyLevel,
+                                     boolean requireQuorumForRemove,
+                                     Dispatcher.RequestTime requestTime,
+                                     ClientRequestsMetrics metrics,
+                                     ClientState clientState)
+        {
+            delegate.mutateAtomically(mutations, consistencyLevel, requireQuorumForRemove, requestTime, metrics,
+                                      clientState);
+        }
+
+        @Override
+        public AbstractWriteResponseHandler<IMutation> mutateCounter(CounterMutation cm, String localDataCenter,
+                                                                     Dispatcher.RequestTime requestTime)
+        {
+            return delegate.mutateCounter(cm, localDataCenter, requestTime);
+        }
+
+        @Override
+        public AbstractWriteResponseHandler<IMutation> mutateCounterOnLeader(CounterMutation mutation,
+                                                                             String localDataCenter,
+                                                                             StorageProxy.WritePerformer performer,
+                                                                             Runnable callback,
+                                                                             Dispatcher.RequestTime requestTime)
+        {
+            return delegate.mutateCounterOnLeader(mutation, localDataCenter, performer, callback, requestTime);
+        }
+
+        @Nullable
+        @Override
+        public AbstractWriteResponseHandler<Commit> mutatePaxos(Commit proposal, ConsistencyLevel consistencyLevel,
+                                                                boolean allowHints, Dispatcher.RequestTime requestTime)
+        {
+            // Counted to pin backward compatibility: implementations that rely on the legacy v1
+            // commit-transport hook must keep receiving it unchanged through the new dispatch.
+            mutatePaxosCalls.incrementAndGet();
+            return delegate.mutatePaxos(proposal, consistencyLevel, allowHints, requestTime);
+        }
+
+        @Override
+        public void persistBatchlog(Collection<Mutation> mutations, Dispatcher.RequestTime requestTime,
+                                    ReplicaPlan.ForWrite replicaPlan, TimeUUID batchUUID)
+        {
+            delegate.persistBatchlog(mutations, requestTime, replicaPlan, batchUUID);
+        }
+
+        @Override
+        public void clearBatchlog(String keyspace, Dispatcher.RequestTime requestTime,
+                                  ReplicaPlan.ForWrite replicaPlan, TimeUUID batchUUID)
+        {
+            delegate.clearBatchlog(keyspace, requestTime, replicaPlan, batchUUID);
+        }
+    }
+
+    @BeforeClass
+    public static void defineSchema()
+    {
+        SchemaLoader.prepareServer();
+        SchemaLoader.createKeyspace(KEYSPACE,
+                                    KeyspaceParams.simple(1),
+                                    SchemaLoader.standardCFMD(KEYSPACE, TABLE));
+        SchemaLoader.createKeyspace(KEYSPACE_RF2,
+                                    KeyspaceParams.simple(2),
+                                    SchemaLoader.standardCFMD(KEYSPACE_RF2, TABLE));
+
+        Token token = ByteOrderedPartitioner.instance.getToken(ByteBufferUtil.bytes(1));
+        StorageService.instance.getTokenMetadata().updateNormalToken(token, FBUtilities.getBroadcastAddressAndPort());
+
+        // The whole point of the test: the SPI singleton must be our recording implementation.
+        assertThat(MutatorProvider.instance).isInstanceOf(RecordingMutator.class);
+    }
+
+    /**
+     * Paxos.setPaxosVariant, NOT DatabaseDescriptor.setPaxosVariant: useV2() reads Paxos's own
+     * volatile snapshot, which only the former updates (the latter just sets the config field).
+     */
+    private static void setPaxosVariant(Config.PaxosVariant variant)
+    {
+        org.apache.cassandra.service.paxos.Paxos.setPaxosVariant(variant);
+    }
+
+    @Before
+    public void resetRecorder()
+    {
+        RecordingMutator.reset();
+    }
+
+    /**
+     * A CAS on {@code (KEYSPACE, TABLE, key)} whose condition is "the partition is empty" and whose
+     * update inserts one row {@code (name='r1', val=value)}.
+     */
+    private static CASRequest ifEmptyInsert(TableMetadata metadata, DecoratedKey key, String value)
+    {
+        return new CASRequest()
+        {
+            @Override
+            public SinglePartitionReadCommand readCommand(long nowInSec)
+            {
+                return SinglePartitionReadCommand.fullPartitionRead(metadata, nowInSec, key);
+            }
+
+            @Override
+            public boolean appliesTo(FilteredPartition current)
+            {
+                return current.rowCount() == 0;
+            }
+
+            @Override
+            public PartitionUpdate makeUpdates(FilteredPartition current, ClientState clientState, Ballot ballot)
+            {
+                return insertRow(metadata, key, value, ballot.unixMicros());
+            }
+        };
+    }
+
+    private static PartitionUpdate insertRow(TableMetadata metadata, DecoratedKey key, String value, long timestampMicros)
+    {
+        PartitionUpdate.SimpleBuilder builder = PartitionUpdate.simpleBuilder(metadata, key);
+        builder.timestamp(timestampMicros);
+        builder.row("r1").add("val", value);
+        return builder.build();
+    }
+
+    private static RowIterator cas(String keyspace, DecoratedKey key, CASRequest request)
+    {
+        return StorageProxy.cas(keyspace,
+                                TABLE,
+                                key,
+                                request,
+                                ConsistencyLevel.SERIAL,
+                                ConsistencyLevel.QUORUM,
+                                ClientState.forInternalCalls(),
+                                FBUtilities.nowInSeconds(),
+                                Dispatcher.RequestTime.forImmediateExecution());
+    }
+
+    private void appliedAndNotApplied(Config.PaxosVariant variant, String keyName) throws Exception
+    {
+        setPaxosVariant(variant);
+        TableMetadata metadata = Schema.instance.getTableMetadata(KEYSPACE, TABLE);
+        DecoratedKey key = dk(keyName);
+
+        // Applied: empty partition matches the condition.
+        try (RowIterator result = cas(KEYSPACE, key, ifEmptyInsert(metadata, key, "v-" + variant)))
+        {
+            assertThat(result).as("applied CAS returns null").isNull();
+        }
+        assertThat(RecordingMutator.casBegun.get()).isEqualTo(1);
+        assertThat(RecordingMutator.casCompleted.get()).isEqualTo(1);
+        List<CommitRecord> clientCommits = RecordingMutator.commitsWithOrigin(Mutator.CasCommitOrigin.CLIENT_OPERATION);
+        assertThat(clientCommits).as("exactly one CLIENT_OPERATION commit for an applied CAS").hasSize(1);
+        CommitRecord commit = clientCommits.get(0);
+        assertThat(commit.commit.update.partitionKey()).isEqualTo(key);
+        assertThat(commit.commit.update.isEmpty()).isFalse();
+        assertThat(commit.consistencyLevel).isEqualTo(ConsistencyLevel.QUORUM);
+        assertThat(commit.thread)
+            .as("CLIENT_OPERATION must fire on the mutateCas caller thread (the documented correlation contract)")
+            .isSameAs(Thread.currentThread());
+        // The applied callback fires once, after the dispatched one, on the same (request) thread,
+        // once the commit is acknowledged at the commit CL -- under both paxos variants.
+        List<CommitRecord> clientApplied = RecordingMutator.appliedWithOrigin(Mutator.CasCommitOrigin.CLIENT_OPERATION);
+        assertThat(clientApplied).as("exactly one CLIENT_OPERATION applied callback for an applied CAS").hasSize(1);
+        CommitRecord applied = clientApplied.get(0);
+        assertThat(applied.commit.update.partitionKey()).isEqualTo(key);
+        assertThat(applied.commit.update.isEmpty()).isFalse();
+        assertThat(applied.consistencyLevel).isEqualTo(ConsistencyLevel.QUORUM);
+        assertThat(applied.thread)
+            .as("onCasCommitApplied fires on the mutateCas caller thread for CLIENT_OPERATION")
+            .isSameAs(Thread.currentThread());
+        assertThat(applied.seq)
+            .as("onCasCommitApplied fires AFTER the dispatched onCasCommit")
+            .isGreaterThan(commit.seq);
+        // Backward compatibility: moving the engine dispatch into Mutator.mutateCas must not
+        // change when the legacy hook fires -- existing implementations overriding mutatePaxos
+        // still see exactly one call per applied v1 CAS (from commitPaxos), and still none
+        // under v2 (which never invoked it).
+        assertThat(RecordingMutator.mutatePaxosCalls.get())
+            .isEqualTo(variant == Config.PaxosVariant.v1 ? 1 : 0);
+
+        // Not applied: the row just written violates the "partition is empty" condition. No new
+        // commit may be dispatched for this operation (empty proposals are never committed).
+        RecordingMutator.reset();
+        try (RowIterator result = cas(KEYSPACE, key, ifEmptyInsert(metadata, key, "unused")))
+        {
+            assertThat(result).as("non-applying CAS returns the current values").isNotNull();
+        }
+        assertThat(RecordingMutator.casBegun.get()).isEqualTo(1);
+        assertThat(RecordingMutator.casCompleted.get()).isEqualTo(1);
+        assertThat(RecordingMutator.commitsWithOrigin(Mutator.CasCommitOrigin.CLIENT_OPERATION))
+            .as("a non-applying CAS must not dispatch a CLIENT_OPERATION commit").isEmpty();
+        assertThat(RecordingMutator.applied)
+            .as("a non-applying CAS commits nothing, so no applied callback fires").isEmpty();
+        assertThat(RecordingMutator.mutatePaxosCalls.get())
+            .as("a non-applying CAS commits nothing, so the legacy hook must not fire either")
+            .isZero();
+    }
+
+    @Test
+    public void appliedAndNotAppliedV1() throws Exception
+    {
+        appliedAndNotApplied(Config.PaxosVariant.v1, "cas_v1");
+    }
+
+    @Test
+    public void appliedAndNotAppliedV2() throws Exception
+    {
+        appliedAndNotApplied(Config.PaxosVariant.v2, "cas_v2");
+    }
+
+    /**
+     * v1 only: v1's ReplicaPlans.forPaxos sizes the required paxos participants from the
+     * REPLICATION FACTOR (RF=2 -> quorum 2), so a single live node is unavailable. The v2 engine
+     * sizes its consensus quorum from the actual electorate, and a single-node ring with RF=2 has
+     * an electorate of one -- the operation legitimately succeeds, so this scenario cannot
+     * reproduce under v2 here (v2's exceptional completion is covered by
+     * {@link #throwingConditionCompletesExceptionallyV2}).
+     */
+    @Test
+    public void unavailableCompletesExceptionallyV1()
+    {
+        setPaxosVariant(Config.PaxosVariant.v1);
+        TableMetadata metadata = Schema.instance.getTableMetadata(KEYSPACE_RF2, TABLE);
+        DecoratedKey key = dk("cas_unavailable_v1");
+
+        // RF=2 with a single live node: SERIAL needs 2 promises, the operation is unavailable.
+        assertThatThrownBy(() -> cas(KEYSPACE_RF2, key, ifEmptyInsert(metadata, key, "unused")))
+            .isInstanceOf(UnavailableException.class);
+
+        assertThat(RecordingMutator.casBegun.get()).isEqualTo(1);
+        assertThat(RecordingMutator.casCompleted.get()).as("completion also fires on failure").isEqualTo(1);
+        assertThat(RecordingMutator.commits).as("no commit was dispatched").isEmpty();
+        assertThat(RecordingMutator.applied).as("no commit dispatched, so none applied").isEmpty();
+        assertThat(RecordingMutator.mutatePaxosCalls.get()).isZero();
+    }
+
+    /** v2 exceptional completion: a condition that throws mid-operation still completes exactly once. */
+    @Test
+    public void throwingConditionCompletesExceptionallyV2()
+    {
+        setPaxosVariant(Config.PaxosVariant.v2);
+        TableMetadata metadata = Schema.instance.getTableMetadata(KEYSPACE, TABLE);
+        DecoratedKey key = dk("cas_throwing_v2");
+
+        CASRequest poisoned = new CASRequest()
+        {
+            @Override
+            public SinglePartitionReadCommand readCommand(long nowInSec)
+            {
+                return SinglePartitionReadCommand.fullPartitionRead(metadata, nowInSec, key);
+            }
+
+            @Override
+            public boolean appliesTo(FilteredPartition current)
+            {
+                throw new org.apache.cassandra.exceptions.InvalidRequestException("poisoned condition");
+            }
+
+            @Override
+            public PartitionUpdate makeUpdates(FilteredPartition current, ClientState clientState, Ballot ballot)
+            {
+                throw new AssertionError("unreachable: the condition throws first");
+            }
+        };
+
+        assertThatThrownBy(() -> cas(KEYSPACE, key, poisoned))
+            .hasMessageContaining("poisoned condition");
+
+        assertThat(RecordingMutator.casBegun.get()).isEqualTo(1);
+        assertThat(RecordingMutator.casCompleted.get()).as("completion also fires on failure").isEqualTo(1);
+        assertThat(RecordingMutator.commits).as("no commit was dispatched").isEmpty();
+        assertThat(RecordingMutator.applied).as("no commit dispatched, so none applied").isEmpty();
+        assertThat(RecordingMutator.mutatePaxosCalls.get()).isZero();
+    }
+
+    /**
+     * Leaves an accepted-but-uncommitted proposal in the paxos table (as if another coordinator
+     * died between propose and commit), then runs a CAS on the same partition and asserts the
+     * foreign round's completion is reported as REPAIR_IN_PROGRESS — not as this operation's own
+     * commit.
+     */
+    private void inProgressRoundIsReportedAsRepair(Config.PaxosVariant variant, String keyName)
+    {
+        setPaxosVariant(variant);
+        TableMetadata metadata = Schema.instance.getTableMetadata(KEYSPACE, TABLE);
+        DecoratedKey key = dk(keyName);
+
+        Ballot foreignBallot = BallotGenerator.Global.nextBallot(Ballot.Flag.GLOBAL);
+        PartitionUpdate foreignUpdate = insertRow(metadata, key, "foreign", foreignBallot.unixMicros());
+        SystemKeyspace.savePaxosProposal(Commit.newProposal(foreignBallot, foreignUpdate));
+        // Drop the in-memory paxos state so the next prepare reloads the injected proposal from disk.
+        PaxosState.unsafeReset();
+
+        // The repair replays the foreign update, so the partition is no longer empty and our own
+        // CAS does not apply — exactly the phantom scenario: the only commit this operation
+        // dispatches is the foreign round's, and it must be labeled as repair.
+        try (RowIterator result = cas(KEYSPACE, key, ifEmptyInsert(metadata, key, "unused")))
+        {
+            assertThat(result).as("CAS must not apply after the foreign round is replayed").isNotNull();
+        }
+
+        assertThat(RecordingMutator.casBegun.get()).isEqualTo(1);
+        assertThat(RecordingMutator.casCompleted.get()).isEqualTo(1);
+        List<CommitRecord> repairs = RecordingMutator.commitsWithOrigin(Mutator.CasCommitOrigin.REPAIR_IN_PROGRESS);
+        assertThat(repairs).as("the foreign in-progress round must be reported as REPAIR_IN_PROGRESS").isNotEmpty();
+        assertThat(repairs.get(0).commit.update.partitionKey()).isEqualTo(key);
+        // Documented CL semantics: the v1 repair commit is performed at the operation's commit CL
+        // (QUORUM here) -- exactly. Under v2 the completion can take two routes -- the in-engine
+        // begin() repair (reports the operation's consensus CL, SERIAL here) or the PaxosRepair
+        // machinery (reports its own commit CL, QUORUM for a SERIAL operation) -- so accept either.
+        if (variant == Config.PaxosVariant.v1)
+            assertThat(repairs.get(0).consistencyLevel).isEqualTo(ConsistencyLevel.QUORUM);
+        else
+            assertThat(repairs.get(0).consistencyLevel).isIn(ConsistencyLevel.QUORUM, ConsistencyLevel.SERIAL);
+        assertThat(RecordingMutator.commitsWithOrigin(Mutator.CasCommitOrigin.CLIENT_OPERATION))
+            .as("the non-applying operation itself must not commit").isEmpty();
+
+        // Applied-callback coverage for recovery: the v1 engine completes the foreign round with a
+        // blocking commitPaxos, so REPAIR_IN_PROGRESS also produces an applied callback (with the
+        // foreign payload, once the recovered value reached a commit-CL quorum). The v2 engine
+        // completes it in-line via begin()'s commitAndPrepare, where the commit piggybacks on the
+        // following prepare and has no separable ack -- that path is dispatched-only by design, so
+        // no applied callback fires here.
+        List<CommitRecord> repairApplied = RecordingMutator.appliedWithOrigin(Mutator.CasCommitOrigin.REPAIR_IN_PROGRESS);
+        if (variant == Config.PaxosVariant.v1)
+        {
+            assertThat(repairApplied).as("v1 repair commit is awaited, so an applied callback fires").isNotEmpty();
+            assertThat(repairApplied.get(0).commit.update.partitionKey()).isEqualTo(key);
+            assertThat(repairApplied.get(0).seq)
+                .as("the applied callback fires after the dispatched one").isGreaterThan(repairs.get(0).seq);
+        }
+        else
+        {
+            assertThat(repairApplied)
+                .as("v2 begin()-path repair is dispatched-only; no applied callback for this recovery route")
+                .isEmpty();
+        }
+    }
+
+    @Test
+    public void inProgressRoundIsReportedAsRepairV1()
+    {
+        inProgressRoundIsReportedAsRepair(Config.PaxosVariant.v1, "cas_repair_v1");
+    }
+
+    @Test
+    public void inProgressRoundIsReportedAsRepairV2()
+    {
+        inProgressRoundIsReportedAsRepair(Config.PaxosVariant.v2, "cas_repair_v2");
+    }
+}

--- a/test/unit/org/apache/cassandra/service/MutatorCasTest.java
+++ b/test/unit/org/apache/cassandra/service/MutatorCasTest.java
@@ -29,7 +29,6 @@ import org.junit.Test;
 import org.apache.cassandra.SchemaLoader;
 import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.config.Config;
-import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.ConsistencyLevel;
 import org.apache.cassandra.db.CounterMutation;
 import org.apache.cassandra.db.DecoratedKey;

--- a/test/unit/org/apache/cassandra/service/MutatorCasTest.java
+++ b/test/unit/org/apache/cassandra/service/MutatorCasTest.java
@@ -17,6 +17,7 @@
 package org.apache.cassandra.service;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -43,8 +44,10 @@ import org.apache.cassandra.db.rows.RowIterator;
 import org.apache.cassandra.dht.ByteOrderedPartitioner;
 import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.exceptions.UnavailableException;
+import org.apache.cassandra.exceptions.WriteFailureException;
 import org.apache.cassandra.locator.ReplicaPlan;
 import org.apache.cassandra.metrics.ClientRequestsMetrics;
+import org.apache.cassandra.net.Message;
 import org.apache.cassandra.schema.KeyspaceParams;
 import org.apache.cassandra.schema.Schema;
 import org.apache.cassandra.schema.TableMetadata;
@@ -56,6 +59,7 @@ import org.apache.cassandra.transport.Dispatcher;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.TimeUUID;
+import org.apache.cassandra.utils.concurrent.UncheckedInterruptedException;
 
 import static org.apache.cassandra.Util.dk;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -128,6 +132,12 @@ public class MutatorCasTest
         static final List<CommitRecord> commits = new CopyOnWriteArrayList<>();
         static final List<CommitRecord> completed = new CopyOnWriteArrayList<>();
 
+        /**
+         * When non-null, {@link #mutatePaxos} returns a handler whose {@code get()} throws this instead
+         * of dispatching a real commit -- lets a test drive the commit-phase failure path in doPaxos.
+         */
+        static volatile RuntimeException commitFailure;
+
         private final Mutator delegate = new StorageProxy.DefaultMutator();
 
         static void reset()
@@ -137,6 +147,7 @@ public class MutatorCasTest
             mutatePaxosCalls.set(0);
             commits.clear();
             completed.clear();
+            commitFailure = null;
             sequence.set(0);
         }
 
@@ -243,7 +254,39 @@ public class MutatorCasTest
             // Counted to pin backward compatibility: implementations that rely on the legacy v1
             // commit-transport hook must keep receiving it unchanged through the new dispatch.
             mutatePaxosCalls.incrementAndGet();
+            RuntimeException failure = commitFailure;
+            if (failure != null)
+                return throwingCommitHandler(failure);
             return delegate.mutatePaxos(proposal, consistencyLevel, allowHints, requestTime);
+        }
+
+        /**
+         * A commit response handler whose {@code get()} fails with {@code failure} -- simulating a
+         * commit that could not be confirmed (replica failure, timeout, interruption). Only
+         * {@code get()} is exercised by commitPaxos, so the other members are inert.
+         */
+        private static AbstractWriteResponseHandler<Commit> throwingCommitHandler(RuntimeException failure)
+        {
+            return new AbstractWriteResponseHandler<Commit>(null, null, WriteType.SIMPLE, null,
+                                                            Dispatcher.RequestTime.forImmediateExecution())
+            {
+                @Override
+                public void get()
+                {
+                    throw failure;
+                }
+
+                @Override
+                public int ackCount()
+                {
+                    return 0;
+                }
+
+                @Override
+                public void onResponse(Message<Commit> msg)
+                {
+                }
+            };
         }
 
         @Override
@@ -560,5 +603,66 @@ public class MutatorCasTest
     public void inProgressRoundIsReportedAsRepairV2()
     {
         inProgressRoundIsReportedAsRepair(Config.PaxosVariant.v2, "cas_repair_v2");
+    }
+
+    /**
+     * A commit that fails after the proposal was accepted must still be paired with a terminal.
+     * {@code doPaxos} announces the client commit (onCasCommit), then commitPaxos throws; because
+     * the proposal already succeeded the value is DECIDED, so the terminal is UNCONFIRMED (decided
+     * but not confirmed here) and the original exception still surfaces to the caller.
+     *
+     * <p>This is the v1 path: only v1 drives the operation's commit through {@code commitPaxos}
+     * (hence {@code mutatePaxos}); v2 confirms via its fused commit-and-prepare, covered elsewhere.
+     * Two failure modes are exercised to justify catching {@code RuntimeException} rather than just
+     * {@code WriteTimeoutException}: a {@link WriteFailureException} (replicas answered with errors,
+     * not a timeout -- a different branch of the exception hierarchy) and an
+     * {@link UncheckedInterruptedException} (the request thread was interrupted while awaiting the
+     * commit ack). Neither is a {@code WriteTimeoutException}, so the pre-fix catch would have
+     * dropped the terminal.
+     */
+    private void commitFailureCompletesUnconfirmed(RuntimeException failure, String keyName)
+    {
+        setPaxosVariant(Config.PaxosVariant.v1);
+        TableMetadata metadata = Schema.instance.getTableMetadata(KEYSPACE, TABLE);
+        DecoratedKey key = dk(keyName);
+
+        RecordingMutator.commitFailure = failure;
+        // The empty partition matches the condition, so the proposal is accepted and the commit is
+        // attempted -- where our injected handler fails it. The original exception must surface.
+        assertThatThrownBy(() -> cas(KEYSPACE, key, ifEmptyInsert(metadata, key, "v-" + keyName)))
+            .isSameAs(failure);
+
+        List<CommitRecord> clientCommits = RecordingMutator.commitsWithOrigin(Mutator.CasCommitOrigin.CLIENT_OPERATION);
+        assertThat(clientCommits).as("the applying CAS announces exactly one client commit").hasSize(1);
+
+        List<CommitRecord> clientCompleted = RecordingMutator.completedWithOrigin(Mutator.CasCommitOrigin.CLIENT_OPERATION);
+        assertThat(clientCompleted)
+            .as("a failed commit still pairs the announcement with exactly one terminal").hasSize(1);
+        CommitRecord terminal = clientCompleted.get(0);
+        assertThat(terminal.outcome)
+            .as("a decided-but-unconfirmed commit completes as UNCONFIRMED")
+            .isEqualTo(Mutator.CasCommitOutcome.UNCONFIRMED);
+        assertThat(terminal.isSuccess()).as("UNCONFIRMED is not a success outcome").isFalse();
+        assertThat(terminal.commit.update.partitionKey()).isEqualTo(key);
+        assertThat(terminal.consistencyLevel).isEqualTo(ConsistencyLevel.QUORUM);
+        assertThat(terminal.thread)
+            .as("the terminal fires on the mutateCas caller thread for CLIENT_OPERATION")
+            .isSameAs(Thread.currentThread());
+        assertThat(terminal.seq)
+            .as("the terminal fires after the announced commit").isGreaterThan(clientCommits.get(0).seq);
+    }
+
+    @Test
+    public void commitWriteFailureCompletesUnconfirmedV1()
+    {
+        WriteFailureException failure = new WriteFailureException(ConsistencyLevel.QUORUM, 0, 2, WriteType.SIMPLE,
+                                                                 Collections.emptyMap());
+        commitFailureCompletesUnconfirmed(failure, "cas_commit_fail_v1");
+    }
+
+    @Test
+    public void commitInterruptedCompletesUnconfirmedV1()
+    {
+        commitFailureCompletesUnconfirmed(new UncheckedInterruptedException(), "cas_commit_interrupt_v1");
     }
 }


### PR DESCRIPTION
### What is the issue

The Mutator SPI's only Paxos hook, mutatePaxos, is a commit-phase transport
hook of the v1 engine: with paxos_variant=v2 LWTs bypass the Mutator entirely,
and even on v1 a custom Mutator cannot observe the begin or the completion of a
CAS operation (condition-not-met, unknown-result, CL=ANY commits and pre-commit
failures are all invisible), while repairs of other proposers' in-progress
rounds fire mutatePaxos indistinguishably from client traffic.

CNDB Issue: https://github.com/riptano/cndb/issues/18612
CNDB PR: https://github.com/riptano/cndb/pull/18613
HCD Issue: https://datastax.jira.com/browse/HCD-439
HCD PR: https://github.com/riptano/hcd/pull/262 (not ready yet)


### What does this PR fix and why was it fixed

Add an operation-level surface to the SPI, in three default methods so existing
implementations stay source- and binary-compatible:

- Mutator.mutateCas: called by StorageProxy.cas exactly once per client CAS
  operation (single conditional statement or conditional batch). The default
  implementation performs the existing engine dispatch
  (Paxos.useV2() ? Paxos.cas : legacyCas), so wrapping implementations get
  begin/completion for both paxos variants, across live variant flips, with the
  outcome derivable from the return value (null = applied, rows = condition not
  met) or the thrown exception. The javadoc spells out the v2 caveat that
  fate-unknown propose failures surface as plain timeout/failure exceptions
  (only the v1 engine throws CasWriteUnknownResultException).

- Mutator.onCasCommit(Commit, ConsistencyLevel, CasCommitOrigin): fired BEFORE
  every coordinator commit dispatch of both engines and of background
  PaxosRepair, for every decided value, always through
  MutatorProvider.notifyCasCommit, which contains (logs and ignores, after
  JVMStabilityInspector) implementation exceptions so a misbehaving Mutator can
  never abort a paxos operation, serial read or repair. CLIENT_OPERATION fires
  at most once per mutateCas, inside that call, on the same thread, before the
  commit is dispatched, so implementations can correlate the two without ballot
  inspection. REPAIR_IN_PROGRESS labels the completion of another proposer's
  accepted round (including via SERIAL reads and background paxos repair, which
  may run on messaging threads); REFRESH_COMMITTED labels re-transmissions of
  already-committed values. Empty proposals are never committed and produce no
  callback. Because it fires before dispatch, a read issued from this callback
  sees the pre-commit value; use onCasCommitApplied (below) or a deferred
  SERIAL read to observe the committed value.

- Mutator.onCasCommitApplied(Commit, ConsistencyLevel, CasCommitOrigin): fired
  AFTER a dispatched commit has been acknowledged by a consistencyLevel quorum,
  i.e. once the value is durably readable at that CL, always after the matching
  onCasCommit for the same ballot and only on the success path. If the commit
  times out or fails (the value is decided and will be completed later by a
  repair, but no quorum ack was received) onCasCommit still fires and this one
  does not: absence after an onCasCommit means "commit not confirmed", not "not
  decided". Routed through MutatorProvider.notifyCasCommitApplied with the same
  exception containment. It is delivered for CLIENT_OPERATION under both engines
  (on the request thread, inside mutateCas), for v1 REPAIR_IN_PROGRESS, and for
  all three background PaxosRepair commit sites; it is intentionally NOT
  delivered (only the dispatched onCasCommit is) for the v1 REFRESH_COMMITTED
  site (asynchronous fire-and-forget sendCommit with no awaited ack) nor for the
  v2 engine's begin()-path REFRESH_COMMITTED / REPAIR_IN_PROGRESS sites (where
  the commit piggybacks on the following prepare via commitAndPrepare and has no
  separable ack). For those, a deferred LOCAL_SERIAL/SERIAL read issued from
  onCasCommit is self-correcting and observes the value regardless. The javadoc
  documents this coverage in full.

Call sites: v1 doPaxos and beginAndRepairPaxos (StorageProxy) fire the applied
callback after the blocking commitPaxos returns (guarded on
consistencyForCommit != ANY, which does not block); v2 Paxos.cas fires it after
commit.awaitUntil succeeds (a committedAgreed local carries the value from the
propose SUCCESS branch to the await point); the three PaxosRepair commit
dispatches thread the committed value and origin into their completion callbacks
(CommittingRepair / CommitAndRestart) and fire the applied callback when the
commit status is success. MutatorProvider.instance is now public so the paxos
package reaches the installed singleton; CommitVerbHandler (currently not
registered for any verb in this tree) now uses that singleton instead of
constructing a new custom Mutator per invocation.

Backward compatibility: existing Mutator implementations -- including those
overriding mutatePaxos -- require no changes. mutateCas, onCasCommit and
onCasCommitApplied are default methods, so third-party implementations stay
source- and binary-compatible, and the default mutateCas performs exactly the
dispatch StorageProxy.cas used to perform inline. The v1 commit phase still
invokes mutatePaxos on the installed Mutator at the same point as before
(commitPaxos is untouched), and the v2 engine did not invoke mutatePaxos before
and still does not. mutatePaxos and onAppliedProposal semantics are unchanged.

MutatorCasTest covers both variants on a single node (via Paxos.setPaxosVariant
-- DatabaseDescriptor.setPaxosVariant alone does not update the engine's own
volatile snapshot read by useV2()): applied and non-applying operations (exactly
one begin/completion, at most one CLIENT_OPERATION dispatched commit -- asserted
to fire on the calling thread -- and none for non-applying), a v1 unavailable
operation and a v2 throwing-condition operation completing exceptionally with no
commit, and an injected accepted-but-uncommitted round whose completion by a
later operation is reported as REPAIR_IN_PROGRESS with the foreign payload. The
applied callback is pinned with a monotonic sequence stamp: exactly one
CLIENT_OPERATION applied per applied CAS under both variants, on the calling
thread, sequenced after the dispatched onCasCommit; none for non-applying or
exceptional operations; and, for the injected repair, an applied callback for
the v1 completion route (after its blocking commit) but none for the v2
begin()-path completion (dispatched-only by design).

Backward compatibility:

existing Mutator implementations -- including those overriding mutatePaxos -- **require no changes**.

`mutateCas` and `onCasCommit` are default methods, so third-party implementations stay source- and binary-compatible, and the default mutateCas performs exactly the dispatch StorageProxy.cas used to perform inline.

The v1 commit phase still invokes mutatePaxos on the installed Mutator at the same point as before (commitPaxos is untouched), and the v2 engine did not invoke mutatePaxos before and still does not.

MutatorCasTest pins this: its recording Mutator counts mutatePaxos invocations and asserts exactly one per applied v1 CAS, none for non-applying operations, and none under v2. mutatePaxos and onAppliedProposal semantics are unchanged.

MutatorCasTest covers both variants on a single node (via Paxos.setPaxosVariant -- DatabaseDescriptor.setPaxosVariant alone does not update the engine's own volatile snapshot read by useV2()): applied and non-applying operations (exactly one begin/completion, at most one CLIENT_OPERATION commit -- asserted to fire on the calling thread -- and none for non-applying), a v1 unavailable operation and a v2 throwing-condition operation completing exceptionally with no commit (the RF=2 unavailability scenario cannot reproduce under v2, whose consensus quorum is sized from the actual electorate), and an injected accepted-but-uncommitted round whose completion by a later operation is reported as REPAIR_IN_PROGRESS with the foreign payload.



