### PR TITLE
CNDB-18493: Add FB index format to decouple FusedPQ from index version

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -476,7 +476,7 @@ public enum CassandraRelevantProperties
      * Whether compaction should build vector indexes using a fused graph, i.e. a graph where the quantized vectors
      * are stored inline with the graph nodes (FusedPQ). This is an experimental feature that significantly increases
      * disk usage and should only be enabled where it makes sense.
-     * See: https://github.com/riptano/cndb/issues/17471
+     * See: <a href="https://github.com/riptano/cndb/issues/17471">CNDB-17471</a>
      * <p>
      * Note: for indexes using version FA (jvector file format version 6), FusedPQ is always enabled regardless
      * of this property. For version FB and later, this property controls whether FusedPQ is used.

--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -473,11 +473,14 @@ public enum CassandraRelevantProperties
     // Use non-positive value to disable it. Period in millis to trigger a flush for SAI vector memtable index.
     SAI_VECTOR_FLUSH_PERIOD_IN_MILLIS("cassandra.sai.vector_flush_period_in_millis", "-1"),
     /**
-     * @deprecated This property is deprecated and no longer has any effect. FusedPQ is now automatically enabled
-     * for all indexes using version FA or later (jvector file format version 6+). The property cannot be used to
-     * disable FusedPQ for FA+ versions.
+     * Whether compaction should build vector indexes using a fused graph, i.e. a graph where the quantized vectors
+     * are stored inline with the graph nodes (FusedPQ). This is an experimental feature that significantly increases
+     * disk usage and should only be enabled where it makes sense.
+     * See: https://github.com/riptano/cndb/issues/17471
+     * <p>
+     * Note: for indexes using version FA (jvector file format version 6), FusedPQ is always enabled regardless
+     * of this property. For version FB and later, this property controls whether FusedPQ is used.
      */
-    @Deprecated
     SAI_VECTOR_ENABLE_FUSED("cassandra.sai.vector.enable_fused", "false"),
     // Use nvq when building graphs in compaction. Disabled by default for now. Enabling will reduce recall slightly
     // while also reducing the storage footprint.

--- a/src/java/org/apache/cassandra/index/sai/disk/format/Version.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/Version.java
@@ -78,10 +78,12 @@ public class Version implements Comparable<Version>
     public static final Version ED = new Version("ed", V7OnDiskFormat.instance, (c, i, g) -> stargazerFileNameFormat(c, i, g, "ed"));
     // jvector file format version 6 (skipped 5)
     public static final Version FA = new Version("fa", V8OnDiskFormat.instance, (c, i, g) -> stargazerFileNameFormat(c, i, g, "fa"));
+    // FB format: same jvector file format version 6 as FA, but FusedPQ is opt-in via cassandra.sai.vector.enable_fused
+    public static final Version FB = new Version("fb", V8OnDiskFormat.instance, (c, i, g) -> stargazerFileNameFormat(c, i, g, "fb"));
 
     // These are in reverse-chronological order so that the latest version is first. Version matching tests
     // are more likely to match the latest version, so we want to test that one first.
-    public static final List<Version> ALL = Lists.newArrayList(FA, ED, EC, EB, DC, DB, CA, BA, AA);
+    public static final List<Version> ALL = Lists.newArrayList(FB, FA, ED, EC, EB, DC, DB, CA, BA, AA);
 
     public static final Version EARLIEST = AA;
     public static final Version VECTOR_EARLIEST = BA;

--- a/src/java/org/apache/cassandra/index/sai/disk/format/Version.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/format/Version.java
@@ -76,7 +76,7 @@ public class Version implements Comparable<Version>
     public static final Version EC = new Version("ec", V7OnDiskFormat.instance, (c, i, g) -> stargazerFileNameFormat(c, i, g, "ec"));
     // total terms count serialization in index metadata, enables ANN_USE_SYNTHETIC_SCORE by default
     public static final Version ED = new Version("ed", V7OnDiskFormat.instance, (c, i, g) -> stargazerFileNameFormat(c, i, g, "ed"));
-    // jvector file format version 6 (skipped 5)
+    // jvector file format version 6 (skipped 5). FusedPQ is always enabled regardless of cassandra.sai.vector.enable_fused. cassandra.sai.vector.enable_fused is ignored
     public static final Version FA = new Version("fa", V8OnDiskFormat.instance, (c, i, g) -> stargazerFileNameFormat(c, i, g, "fa"));
     // FB format: same jvector file format version 6 as FA, but FusedPQ is opt-in via cassandra.sai.vector.enable_fused
     public static final Version FB = new Version("fb", V8OnDiskFormat.instance, (c, i, g) -> stargazerFileNameFormat(c, i, g, "fb"));

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/JVectorVersionUtil.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/JVectorVersionUtil.java
@@ -22,9 +22,11 @@ import org.apache.cassandra.index.sai.disk.format.Version;
 public class JVectorVersionUtil
 {
     /**
+     * Whether to fuse quantized vectors into the graph when writing indexes, assuming all other conditions are met.
      * Variables are volatile to allow for changing in unit tests. They are only accessed on flush and compaction,
      * so their access is infrequent.
      */
+    public static volatile boolean ENABLE_FUSED = CassandraRelevantProperties.SAI_VECTOR_ENABLE_FUSED.getBoolean();
     public static volatile boolean ENABLE_NVQ = CassandraRelevantProperties.SAI_VECTOR_ENABLE_NVQ.getBoolean();
     public static final int NUM_SUB_VECTORS = CassandraRelevantProperties.SAI_VECTOR_NVQ_NUM_SUB_VECTORS.getInt();
 
@@ -51,16 +53,18 @@ public class JVectorVersionUtil
      * does not take into account whether the graph has enough information to build a quantization, as that depends on
      * external factors.
      * <p>
-     * FusedPQ is automatically enabled for all indexes using version FA or later (jvector file format version 6+).
-     * The deprecated ENABLE_FUSED property is ignored for these versions.
+     * For version FA, FusedPQ is always enabled regardless of {@code ENABLE_FUSED}.
+     * For version FB and later, FusedPQ is opt-in via {@code cassandra.sai.vector.enable_fused}.
      *
      * @param version the SAI on disk format to use when writing to disk
      * @return true if conditions are met, false otherwise
      */
     public static boolean shouldWriteFused(Version version)
     {
-        // For FA version and later, FusedPQ is always enabled (tied to the version)
-        return versionSupportsFused(version);
+        if (!versionSupportsFused(version))
+            return false;
+        // FA always uses FusedPQ; FB+ requires the flag to be set
+        return version.equals(Version.FA) || ENABLE_FUSED;
     }
 
     public static boolean versionSupportsFused(Version version)

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/JVectorVersionUtil.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/JVectorVersionUtil.java
@@ -21,11 +21,12 @@ import org.apache.cassandra.index.sai.disk.format.Version;
 
 public class JVectorVersionUtil
 {
-    /**
-     * Whether to fuse quantized vectors into the graph when writing indexes, assuming all other conditions are met.
-     * Variables are volatile to allow for changing in unit tests. They are only accessed on flush and compaction,
+    /*
+     * Some attributes are volatile to allow for changing in unit tests. Thery are only accessed on flush and compaction,
      * so their access is infrequent.
      */
+
+    /** Whether to fuse quantized vectors into the graph when writing indexes, assuming all other conditions are met. */
     public static volatile boolean ENABLE_FUSED = CassandraRelevantProperties.SAI_VECTOR_ENABLE_FUSED.getBoolean();
     public static volatile boolean ENABLE_NVQ = CassandraRelevantProperties.SAI_VECTOR_ENABLE_NVQ.getBoolean();
     public static final int NUM_SUB_VECTORS = CassandraRelevantProperties.SAI_VECTOR_NVQ_NUM_SUB_VECTORS.getInt();
@@ -53,6 +54,7 @@ public class JVectorVersionUtil
      * does not take into account whether the graph has enough information to build a quantization, as that depends on
      * external factors.
      * <p>
+     * FusedPQ is not supported in versions before FA, so it is not enabled regardless of any config.
      * For version FA, FusedPQ is always enabled regardless of {@code ENABLE_FUSED}.
      * For version FB and later, FusedPQ is opt-in via {@code cassandra.sai.vector.enable_fused}.
      *

--- a/test/unit/org/apache/cassandra/index/sai/SAIUtil.java
+++ b/test/unit/org/apache/cassandra/index/sai/SAIUtil.java
@@ -100,6 +100,24 @@ public class SAIUtil
         }
     }
 
+    public static void setEnableFused(boolean enableFused)
+    {
+        try
+        {
+            CassandraRelevantProperties.SAI_VECTOR_ENABLE_FUSED.setBoolean(enableFused);
+            Field field = JVectorVersionUtil.class.getDeclaredField("ENABLE_FUSED");
+            field.setAccessible(true);
+            Field modifiersField = ReflectionUtils.getField(Field.class, "modifiers");
+            modifiersField.setAccessible(true);
+            modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+            field.set(null, enableFused);
+        }
+        catch (Exception e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+
     public static void setEnableNVQ(boolean enableNVQ)
     {
         try

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorCompactionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorCompactionTest.java
@@ -407,11 +407,12 @@ abstract public class VectorCompactionTest extends VectorTester
                             }
                             else if (numRows >= MIN_PQ_ROWS)
                             {
-                                // With FA + fused PQ, PQ metadata is present and used by the graph, but there is no
-                                // standalone CompressedVectors instance to validate against.
-                                // TODO: further investigate what other checks are needed here
-                                assertEquals("Expected fused PQ path only for FA+", Version.FA, version);
-                                assertNotNull("Expected PQ metadata for FA fused PQ", searcher.getPQ());
+                                // With fused PQ (FA always; GA+ only when enabled), PQ metadata is stored inline
+                                // with the graph nodes — there is no standalone CompressedVectors to validate against.
+                                // Without fused PQ (GA+ default, pre-FA), we should never reach this branch.
+                                assertTrue("Found " + numRows + " rows without CompressedVectors; expected fused PQ for version " + version,
+                                           JVectorVersionUtil.shouldWriteFused(version));
+                                assertNotNull("Expected PQ metadata for fused PQ on version " + version, searcher.getPQ());
                             }
                         }
                     }

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorIndexMixedVersionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorIndexMixedVersionTest.java
@@ -28,6 +28,8 @@ import org.apache.cassandra.index.sai.SAIUtil;
 import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.index.sai.disk.vector.CassandraOnHeapGraph;
 
+import static org.junit.Assert.assertEquals;
+
 // We do not parameterize this test because it is not intended to run multiple versions at once.
 public class VectorIndexMixedVersionTest extends VectorTester
 {
@@ -45,7 +47,7 @@ public class VectorIndexMixedVersionTest extends VectorTester
     }
 
     @Test
-    public void testMultiVersionJVectorCompatibility() throws Throwable
+    public void testMultiVersionJVectorCompatibility()
     {
         createTable("CREATE TABLE %s (pk int, vec vector<float, 4>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(vec) USING 'StorageAttachedIndex'");
@@ -65,10 +67,10 @@ public class VectorIndexMixedVersionTest extends VectorTester
         }
 
         // Run basic query to confirm we can, no need to validate results
-        execute("SELECT pk FROM %s ORDER BY vec ANN OF [2.0, 2.0, 3.0, 4.0] LIMIT 2");
+        assertEquals(2, execute("SELECT pk FROM %s ORDER BY vec ANN OF [2.0, 2.0, 3.0, 4.0] LIMIT 2").size());
 
         // Confirm we can compact them all and run a query too
         compact();
-        execute("SELECT pk FROM %s ORDER BY vec ANN OF [2.0, 2.0, 3.0, 4.0] LIMIT 2");
+        assertEquals(2, execute("SELECT pk FROM %s ORDER BY vec ANN OF [2.0, 2.0, 3.0, 4.0] LIMIT 2").size());
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorMetricsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorMetricsTest.java
@@ -100,8 +100,9 @@ public class VectorMetricsTest extends VectorTester
             execute("INSERT INTO %s (pk, val) VALUES (?, ?)", i, vector(1 + i, 2 + i, 3 + i));
         flush();
 
-        // FusedPQ is tied to version: enabled for FA+, disabled for pre-FA
-        boolean fusedPQ = JVectorVersionUtil.versionSupportsFused(version);
+        // FA always uses FusedPQ; FB+ uses it only when cassandra.sai.vector.enable_fused=true (default false).
+        // Pre-FA versions never use FusedPQ.
+        boolean fusedPQ = JVectorVersionUtil.shouldWriteFused(version);
         long pqMemoryAfterFlush = vectorMetrics.quantizationMemoryBytes.sum();
 
         if (fusedPQ)
@@ -116,7 +117,7 @@ public class VectorMetricsTest extends VectorTester
             assertTrue("Version " + version + " should have PQ memory without FusedPQ",
                       pqMemoryAfterFlush > 0);
         }
-        
+
         assertEquals(0, vectorMetrics.ordinalsMapMemoryBytes.sum()); // unique vectors means no cache required
         assertEquals(1, vectorMetrics.onDiskGraphsCount.sum());
         assertEquals(CassandraOnHeapGraph.MIN_PQ_ROWS, vectorMetrics.onDiskGraphVectorsCount.sum());

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorTester.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorTester.java
@@ -191,7 +191,10 @@ public class VectorTester extends SAITester
         @Parameterized.Parameter(1)
         public boolean ENABLE_NVQ;
 
-        @Parameterized.Parameters(name = "{0} {1}")
+        @Parameterized.Parameter(2)
+        public boolean ENABLE_FUSED;
+
+        @Parameterized.Parameters(name = "version={0} enableNVQ={1} enableFused={2}")
         public static Collection<Object[]> data()
         {
             // See Version file for explanation of changes associated with each version
@@ -201,7 +204,17 @@ public class VectorTester extends SAITester
                                   var enableNVQ = JVectorVersionUtil.versionSupportsNVQ(v)
                                                   ? new Boolean[]{ true, false }
                                                   : new Boolean[]{ false };
-                                  return Arrays.stream(enableNVQ).map(nvq -> new Object[]{ v, nvq });
+                                  // FA always uses FusedPQ regardless of the flag, so only test enableFused=true there.
+                                  // FB+ allows toggling the flag, so test both values.
+                                  // Pre-FA versions don't support FusedPQ at all.
+                                  var enableFused = v.onOrAfter(Version.FB)
+                                                    ? new Boolean[]{ true, false }
+                                                    : JVectorVersionUtil.versionSupportsFused(v)
+                                                      ? new Boolean[]{ true }   // FA: always-on
+                                                      : new Boolean[]{ false };  // pre-FA: unsupported
+                                  return Arrays.stream(enableNVQ).flatMap(nvq ->
+                                      Arrays.stream(enableFused).map(fused -> new Object[]{ v, nvq, fused })
+                                  );
                               }).collect(Collectors.toList());
         }
 
@@ -215,6 +228,12 @@ public class VectorTester extends SAITester
         public void setEnableNVQ()
         {
             SAIUtil.setEnableNVQ(ENABLE_NVQ);
+        }
+
+        @Before
+        public void setEnableFused()
+        {
+            SAIUtil.setEnableFused(ENABLE_FUSED);
         }
     }
 

--- a/test/unit/org/apache/cassandra/index/sai/disk/vector/JVectorVersionUtilTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/vector/JVectorVersionUtilTest.java
@@ -54,17 +54,18 @@ public class JVectorVersionUtilTest extends SAITester
     @Test
     public void testFusedPQSupport()
     {
-        // FusedPQ requires jvector format 6 or later (FA+)
+        // versionSupportsFused: true for FA and FB (jvector format 6+), false for pre-FA
         int jvectorFormat = version.onDiskFormat().jvectorFileFormatVersion();
         boolean expectedSupport = jvectorFormat >= JVECTOR_FORMAT_FUSED_PQ;
-        
+
         assertEquals(String.format("Version %s (jvector format %d) FusedPQ support mismatch", version, jvectorFormat),
                      expectedSupport,
                      JVectorVersionUtil.versionSupportsFused(version));
-        
-        // For FA+, FusedPQ is always enabled (tied to version)
-        assertEquals(String.format("Version %s (jvector format %d) shouldWriteFused mismatch", version, jvectorFormat),
-                     expectedSupport,
+
+        // shouldWriteFused: FA always on; FB+ requires ENABLE_FUSED flag (default false); pre-FA always false
+        boolean expectedWrite = version.equals(Version.FA);  // default flag is false, so only FA is unconditionally on
+        assertEquals(String.format("Version %s (jvector format %d) shouldWriteFused mismatch (ENABLE_FUSED=false)", version, jvectorFormat),
+                     expectedWrite,
                      JVectorVersionUtil.shouldWriteFused(version));
     }
 

--- a/test/unit/org/apache/cassandra/index/sai/functional/VectorFormatDiskUsageTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/functional/VectorFormatDiskUsageTest.java
@@ -22,6 +22,7 @@ import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.SAIUtil;
 import org.apache.cassandra.index.sai.SSTableIndex;
 import org.apache.cassandra.index.sai.StorageAttachedIndex;
@@ -253,17 +254,17 @@ public class VectorFormatDiskUsageTest extends VectorTester
         final long metaBytes;
         final long postingListsBytes;
         final long completionMarkerBytes;
-        final int  segmentCount; // total segments across all SSTables
+        final int segmentCount; // total segments across all SSTables
 
         private DiskMeasurement(Builder b)
         {
-            this.totalBytes            = b.totalBytes;
-            this.termsDataBytes        = b.termsDataBytes;
-            this.pqBytes               = b.pqBytes;
-            this.metaBytes             = b.metaBytes;
-            this.postingListsBytes     = b.postingListsBytes;
+            this.totalBytes = b.totalBytes;
+            this.termsDataBytes = b.termsDataBytes;
+            this.pqBytes = b.pqBytes;
+            this.metaBytes = b.metaBytes;
+            this.postingListsBytes = b.postingListsBytes;
             this.completionMarkerBytes = b.completionMarkerBytes;
-            this.segmentCount          = b.segmentCount;
+            this.segmentCount = b.segmentCount;
         }
 
         static class Builder
@@ -274,17 +275,54 @@ public class VectorFormatDiskUsageTest extends VectorTester
             long metaBytes;
             long postingListsBytes;
             long completionMarkerBytes;
-            int  segmentCount;
+            int segmentCount;
 
-            Builder totalBytes(long v)            { this.totalBytes            = v; return this; }
-            Builder termsDataBytes(long v)        { this.termsDataBytes        = v; return this; }
-            Builder pqBytes(long v)               { this.pqBytes               = v; return this; }
-            Builder metaBytes(long v)             { this.metaBytes             = v; return this; }
-            Builder postingListsBytes(long v)     { this.postingListsBytes     = v; return this; }
-            Builder completionMarkerBytes(long v) { this.completionMarkerBytes = v; return this; }
-            Builder segmentCount(int v)           { this.segmentCount          = v; return this; }
+            Builder totalBytes(long v)
+            {
+                this.totalBytes = v;
+                return this;
+            }
 
-            DiskMeasurement build()               { return new DiskMeasurement(this); }
+            Builder termsDataBytes(long v)
+            {
+                this.termsDataBytes = v;
+                return this;
+            }
+
+            Builder pqBytes(long v)
+            {
+                this.pqBytes = v;
+                return this;
+            }
+
+            Builder metaBytes(long v)
+            {
+                this.metaBytes = v;
+                return this;
+            }
+
+            Builder postingListsBytes(long v)
+            {
+                this.postingListsBytes = v;
+                return this;
+            }
+
+            Builder completionMarkerBytes(long v)
+            {
+                this.completionMarkerBytes = v;
+                return this;
+            }
+
+            Builder segmentCount(int v)
+            {
+                this.segmentCount = v;
+                return this;
+            }
+
+            DiskMeasurement build()
+            {
+                return new DiskMeasurement(this);
+            }
         }
     }
 
@@ -313,15 +351,15 @@ public class VectorFormatDiskUsageTest extends VectorTester
         if (compact)
             compact();
 
-        var sai = (StorageAttachedIndex) getCurrentColumnFamilyStore().indexManager.getIndexByName(indexName);
+        StorageAttachedIndex sai = (StorageAttachedIndex) getCurrentColumnFamilyStore().indexManager.getIndexByName(indexName);
         assertNotNull("Index not found: " + indexName, sai);
-        var indexContext = sai.getIndexContext();
+        IndexContext indexContext = sai.getIndexContext();
 
-        long totalDiskBytes        = indexContext.diskUsage();
-        long graphComponentBytes   = componentSize(indexContext, IndexComponentType.TERMS_DATA);
-        long pqComponentBytes      = componentSize(indexContext, IndexComponentType.PQ);
-        long metaComponentBytes    = componentSize(indexContext, IndexComponentType.META);
-        long postingListsBytes     = componentSize(indexContext, IndexComponentType.POSTING_LISTS);
+        long totalDiskBytes = indexContext.diskUsage();
+        long graphComponentBytes = componentSize(indexContext, IndexComponentType.TERMS_DATA);
+        long pqComponentBytes = componentSize(indexContext, IndexComponentType.PQ);
+        long metaComponentBytes = componentSize(indexContext, IndexComponentType.META);
+        long postingListsBytes = componentSize(indexContext, IndexComponentType.POSTING_LISTS);
         long completionMarkerBytes = componentSize(indexContext, IndexComponentType.COLUMN_COMPLETION_MARKER);
 
         List<SSTableIndex> sstableIndexes = List.copyOf(indexContext.getView().getIndexes());
@@ -348,7 +386,7 @@ public class VectorFormatDiskUsageTest extends VectorTester
                .build();
     }
 
-    private long componentSize(org.apache.cassandra.index.sai.IndexContext indexContext,
+    private long componentSize(IndexContext indexContext,
                                IndexComponentType type)
     {
         return indexContext.getView().getIndexes()

--- a/test/unit/org/apache/cassandra/index/sai/functional/VectorFormatDiskUsageTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/functional/VectorFormatDiskUsageTest.java
@@ -36,8 +36,7 @@ import static org.junit.Assert.*;
 
 /// Verifies on-disk vector index size behavior across SAI format versions,
 /// both preCompaction and postCompaction.
-public class VectorFormatDiskUsageTest extends VectorTester
-{
+public class VectorFormatDiskUsageTest extends VectorTester {
     private static final int DIMENSION = 128;
 
     /// Number of flushes before compaction. Each flush produces one SSTable. With only
@@ -55,14 +54,12 @@ public class VectorFormatDiskUsageTest extends VectorTester
     private static final long EXPECTED_TERMS_DATA_DELTA_PER_SEGMENT = 312L;
 
     @BeforeClass
-    public static void setUpClass()
-    {
+    public static void setUpClass() {
         VectorTester.setUpClass();
     }
 
     @After
-    public void resetVersion()
-    {
+    public void resetVersion() {
         SAIUtil.resetCurrentVersion();
     }
 
@@ -114,47 +111,46 @@ public class VectorFormatDiskUsageTest extends VectorTester
     /// `META` grows by exactly 8 bytes per segment (a `totalTermCount` long added in ED).
     /// All other components (`PQ`, `POSTING_LISTS`, `COLUMN_COMPLETION_MARKER`) are unchanged.
     @Test
-    public void testDiskUsageECvsFB()
-    {
-        DiskMeasurement ecPreCompaction  = measureDiskUsage(Version.EC, "EC-preCompaction",  false);
+    public void testDiskUsageECvsFB() {
+        DiskMeasurement ecPreCompaction = measureDiskUsage(Version.EC, "EC-preCompaction", false);
         DiskMeasurement ecPostCompaction = measureDiskUsage(Version.EC, "EC-postCompaction", true);
-        DiskMeasurement fbPreCompaction  = measureDiskUsage(Version.FB, "FB-preCompaction",  false);
+        DiskMeasurement fbPreCompaction = measureDiskUsage(Version.FB, "FB-preCompaction", false);
         DiskMeasurement fbPostCompaction = measureDiskUsage(Version.FB, "FB-postCompaction", true);
 
-        assertTrue("EC preCompaction index must have non-zero disk usage",  ecPreCompaction.totalBytes  > 0);
-        assertTrue("FB preCompaction index must have non-zero disk usage",  fbPreCompaction.totalBytes  > 0);
+        assertTrue("EC preCompaction index must have non-zero disk usage", ecPreCompaction.totalBytes > 0);
+        assertTrue("FB preCompaction index must have non-zero disk usage", fbPreCompaction.totalBytes > 0);
         assertTrue("EC postCompaction index must have non-zero disk usage", ecPostCompaction.totalBytes > 0);
         assertTrue("FB postCompaction index must have non-zero disk usage", fbPostCompaction.totalBytes > 0);
 
-        long preCompactionTermsDataDelta  = fbPreCompaction.termsDataBytes  - ecPreCompaction.termsDataBytes;
+        long preCompactionTermsDataDelta = fbPreCompaction.termsDataBytes - ecPreCompaction.termsDataBytes;
         long postCompactionTermsDataDelta = fbPostCompaction.termsDataBytes - ecPostCompaction.termsDataBytes;
 
-        double diskGrowthPercentPreCompaction  = 100.0 * (fbPreCompaction.totalBytes  - ecPreCompaction.totalBytes)  / ecPreCompaction.totalBytes;
+        double diskGrowthPercentPreCompaction = 100.0 * (fbPreCompaction.totalBytes - ecPreCompaction.totalBytes) / ecPreCompaction.totalBytes;
         double diskGrowthPercentPostCompaction = 100.0 * (fbPostCompaction.totalBytes - ecPostCompaction.totalBytes) / ecPostCompaction.totalBytes;
 
-        logger.debug("  EC preCompaction  diskUsage() : {} ({} segments)", ecPreCompaction.totalBytes,  ecPreCompaction.segmentCount);
-        logger.debug("  FB preCompaction  diskUsage() : {} ({} segments)", fbPreCompaction.totalBytes,  fbPreCompaction.segmentCount);
+        logger.debug("  EC preCompaction  diskUsage() : {} ({} segments)", ecPreCompaction.totalBytes, ecPreCompaction.segmentCount);
+        logger.debug("  FB preCompaction  diskUsage() : {} ({} segments)", fbPreCompaction.totalBytes, fbPreCompaction.segmentCount);
         logger.debug("  EC postCompaction diskUsage() : {} ({} segments)", ecPostCompaction.totalBytes, ecPostCompaction.segmentCount);
         logger.debug("  FB postCompaction diskUsage() : {} ({} segments)", fbPostCompaction.totalBytes, fbPostCompaction.segmentCount);
         logger.debug("  Total disk usage growth preCompaction  : +{} bytes ({} %)",
-                    fbPreCompaction.totalBytes  - ecPreCompaction.totalBytes,  String.format("%.4f", diskGrowthPercentPreCompaction));
+                fbPreCompaction.totalBytes - ecPreCompaction.totalBytes, String.format("%.4f", diskGrowthPercentPreCompaction));
         logger.debug("  Total disk usage growth postCompaction : +{} bytes ({} %)",
-                    fbPostCompaction.totalBytes - ecPostCompaction.totalBytes, String.format("%.4f", diskGrowthPercentPostCompaction));
+                fbPostCompaction.totalBytes - ecPostCompaction.totalBytes, String.format("%.4f", diskGrowthPercentPostCompaction));
         logger.debug("  TERMS_DATA delta preCompaction  : {} (expected {} × {} = {})",
-                    preCompactionTermsDataDelta,  NUM_FLUSHES, EXPECTED_TERMS_DATA_DELTA_PER_SEGMENT,
-                    NUM_FLUSHES * EXPECTED_TERMS_DATA_DELTA_PER_SEGMENT);
+                preCompactionTermsDataDelta, NUM_FLUSHES, EXPECTED_TERMS_DATA_DELTA_PER_SEGMENT,
+                NUM_FLUSHES * EXPECTED_TERMS_DATA_DELTA_PER_SEGMENT);
         logger.debug("  TERMS_DATA delta postCompaction : {} (expected {})",
-                    postCompactionTermsDataDelta, EXPECTED_TERMS_DATA_DELTA_PER_SEGMENT);
+                postCompactionTermsDataDelta, EXPECTED_TERMS_DATA_DELTA_PER_SEGMENT);
 
-        verifyComponentAccounting(ecPreCompaction,  fbPreCompaction,  "preCompaction");
+        verifyComponentAccounting(ecPreCompaction, fbPreCompaction, "preCompaction");
         verifyComponentAccounting(ecPostCompaction, fbPostCompaction, "postCompaction");
-        verifyTermsDataDelta(preCompactionTermsDataDelta,  ecPreCompaction.segmentCount,  "preCompaction");
+        verifyTermsDataDelta(preCompactionTermsDataDelta, ecPreCompaction.segmentCount, "preCompaction");
         verifyTermsDataDelta(postCompactionTermsDataDelta, ecPostCompaction.segmentCount, "postCompaction");
-        verifyUnchangedComponents(ecPreCompaction,  fbPreCompaction,  "preCompaction");
+        verifyUnchangedComponents(ecPreCompaction, fbPreCompaction, "preCompaction");
         verifyUnchangedComponents(ecPostCompaction, fbPostCompaction, "postCompaction");
-        verifyConservation(ecPreCompaction,  fbPreCompaction,  preCompactionTermsDataDelta,  "preCompaction");
+        verifyConservation(ecPreCompaction, fbPreCompaction, preCompactionTermsDataDelta, "preCompaction");
         verifyConservation(ecPostCompaction, fbPostCompaction, postCompactionTermsDataDelta, "postCompaction");
-        verifyTotalDiskGrowthUnder5Percent(diskGrowthPercentPreCompaction,  "preCompaction");
+        verifyTotalDiskGrowthUnder5Percent(diskGrowthPercentPreCompaction, "preCompaction");
         verifyTotalDiskGrowthUnder5Percent(diskGrowthPercentPostCompaction, "postCompaction");
     }
 
@@ -163,91 +159,84 @@ public class VectorFormatDiskUsageTest extends VectorTester
     /// 5% more disk than that older version. Catches accidental large regressions introduced
     /// by a new format version.
     @Test
-    public void testDiskGrowthAcrossVersions()
-    {
-        DiskMeasurement latestPreCompaction  = measureDiskUsage(Version.LATEST, Version.LATEST + "-preCompaction",  false);
+    public void testDiskGrowthAcrossVersions() {
+        DiskMeasurement latestPreCompaction = measureDiskUsage(Version.LATEST, Version.LATEST + "-preCompaction", false);
         DiskMeasurement latestPostCompaction = measureDiskUsage(Version.LATEST, Version.LATEST + "-postCompaction", true);
 
         Version.ALL.stream()
-                   .filter(v -> v.onOrAfter(Version.JVECTOR_EARLIEST) && !v.equals(Version.LATEST))
-                   .forEach(older ->
-        {
-            DiskMeasurement olderPreCompaction  = measureDiskUsage(older, older + "-preCompaction",  false);
-            DiskMeasurement olderPostCompaction = measureDiskUsage(older, older + "-postCompaction", true);
+                .filter(v -> v.onOrAfter(Version.JVECTOR_EARLIEST) && !v.equals(Version.LATEST))
+                .forEach(older ->
+                {
+                    DiskMeasurement olderPreCompaction = measureDiskUsage(older, older + "-preCompaction", false);
+                    DiskMeasurement olderPostCompaction = measureDiskUsage(older, older + "-postCompaction", true);
 
-            double diskGrowthPercentPreCompaction  = 100.0 * (latestPreCompaction.totalBytes  - olderPreCompaction.totalBytes)  / olderPreCompaction.totalBytes;
-            double diskGrowthPercentPostCompaction = 100.0 * (latestPostCompaction.totalBytes - olderPostCompaction.totalBytes) / olderPostCompaction.totalBytes;
+                    double diskGrowthPercentPreCompaction = 100.0 * (latestPreCompaction.totalBytes - olderPreCompaction.totalBytes) / olderPreCompaction.totalBytes;
+                    double diskGrowthPercentPostCompaction = 100.0 * (latestPostCompaction.totalBytes - olderPostCompaction.totalBytes) / olderPostCompaction.totalBytes;
 
-            logger.debug("  {} → {} preCompaction  : {} → {} bytes ({} %)",
-                         older, Version.LATEST, olderPreCompaction.totalBytes,  latestPreCompaction.totalBytes,
-                         String.format("%.4f", diskGrowthPercentPreCompaction));
-            logger.debug("  {} → {} postCompaction : {} → {} bytes ({} %)",
-                         older, Version.LATEST, olderPostCompaction.totalBytes, latestPostCompaction.totalBytes,
-                         String.format("%.4f", diskGrowthPercentPostCompaction));
+                    logger.debug("  {} → {} preCompaction  : {} → {} bytes ({} %)",
+                            older, Version.LATEST, olderPreCompaction.totalBytes, latestPreCompaction.totalBytes,
+                            String.format("%.4f", diskGrowthPercentPreCompaction));
+                    logger.debug("  {} → {} postCompaction : {} → {} bytes ({} %)",
+                            older, Version.LATEST, olderPostCompaction.totalBytes, latestPostCompaction.totalBytes,
+                            String.format("%.4f", diskGrowthPercentPostCompaction));
 
-            verifyTotalDiskGrowthUnder5Percent(diskGrowthPercentPreCompaction,  older + " → " + Version.LATEST + " preCompaction");
-            verifyTotalDiskGrowthUnder5Percent(diskGrowthPercentPostCompaction, older + " → " + Version.LATEST + " postCompaction");
-        });
+                    verifyTotalDiskGrowthUnder5Percent(diskGrowthPercentPreCompaction, older + " → " + Version.LATEST + " preCompaction");
+                    verifyTotalDiskGrowthUnder5Percent(diskGrowthPercentPostCompaction, older + " → " + Version.LATEST + " postCompaction");
+                });
     }
 
     /// Sanity: totalBytes must equal the sum of all five components (nothing missed or double-counted).
-    private static void verifyComponentAccounting(DiskMeasurement ec, DiskMeasurement fb, String phase)
-    {
+    private static void verifyComponentAccounting(DiskMeasurement ec, DiskMeasurement fb, String phase) {
         assertEquals("EC " + phase + ": totalBytes must equal sum of all per-index components",
-                     ec.totalBytes, ec.termsDataBytes + ec.pqBytes + ec.metaBytes + ec.postingListsBytes + ec.completionMarkerBytes);
+                ec.totalBytes, ec.termsDataBytes + ec.pqBytes + ec.metaBytes + ec.postingListsBytes + ec.completionMarkerBytes);
         assertEquals("FB " + phase + ": totalBytes must equal sum of all per-index components",
-                     fb.totalBytes, fb.termsDataBytes + fb.pqBytes + fb.metaBytes + fb.postingListsBytes + fb.completionMarkerBytes);
+                fb.totalBytes, fb.termsDataBytes + fb.pqBytes + fb.metaBytes + fb.postingListsBytes + fb.completionMarkerBytes);
     }
 
     /// The TERMS_DATA delta must equal exactly [#EXPECTED_TERMS_DATA_DELTA_PER_SEGMENT] × segmentCount.
     /// Each segment contributes one graph to the TERMS_DATA file, and each graph carries one header delta.
-    private static void verifyTermsDataDelta(long actualTermsDataDelta, int segmentCount, String phase)
-    {
+    private static void verifyTermsDataDelta(long actualTermsDataDelta, int segmentCount, String phase) {
         long expected = EXPECTED_TERMS_DATA_DELTA_PER_SEGMENT * segmentCount;
         assertEquals("TERMS_DATA delta " + phase + " must equal " + EXPECTED_TERMS_DATA_DELTA_PER_SEGMENT
-                     + " bytes × " + segmentCount + " segment(s) = " + expected
-                     + " (jvector format 4→6 header layout change only)",
-                     expected, actualTermsDataDelta);
+                        + " bytes × " + segmentCount + " segment(s) = " + expected
+                        + " (jvector format 4→6 header layout change only)",
+                expected, actualTermsDataDelta);
     }
 
-    private static void verifyUnchangedComponents(DiskMeasurement ec, DiskMeasurement fb, String phase)
-    {
+    private static void verifyUnchangedComponents(DiskMeasurement ec, DiskMeasurement fb, String phase) {
         assertEquals("PQ component size must be the same for EC and FB (" + phase + ')',
-                     ec.pqBytes, fb.pqBytes);
+                ec.pqBytes, fb.pqBytes);
         assertEquals("POSTING_LISTS must be the same size for EC and FB (" + phase + ')',
-                     ec.postingListsBytes, fb.postingListsBytes);
+                ec.postingListsBytes, fb.postingListsBytes);
         assertEquals("COLUMN_COMPLETION_MARKER must be the same size for EC and FB (" + phase + ')',
-                     ec.completionMarkerBytes, fb.completionMarkerBytes);
+                ec.completionMarkerBytes, fb.completionMarkerBytes);
     }
 
     /// META grows by exactly 8 bytes per segment EC → FB (a `totalTermCount` long added in ED).
     /// Because all other components except TERMS_DATA are identical, the net total delta equals
     /// the TERMS_DATA delta plus 8 × segmentCount bytes.
     private static void verifyConservation(DiskMeasurement ec, DiskMeasurement fb,
-                                           long actualTermsDataDelta, String phase)
-    {
+                                           long actualTermsDataDelta, String phase) {
         assertEquals("FB META must be exactly " + Long.BYTES + " bytes × " + ec.segmentCount
-                     + " segment(s) larger than EC META (" + phase + ')',
-                     ec.metaBytes + (long) Long.BYTES * ec.segmentCount, fb.metaBytes);
+                        + " segment(s) larger than EC META (" + phase + ')',
+                ec.metaBytes + (long) Long.BYTES * ec.segmentCount, fb.metaBytes);
         assertEquals("FB.totalBytes must equal ec.totalBytes + TERMS_DATA delta + 8 × segmentCount"
-                     + " (" + phase + ')',
-                     ec.totalBytes + actualTermsDataDelta + (long) Long.BYTES * ec.segmentCount,
-                     fb.totalBytes);
+                        + " (" + phase + ')',
+                ec.totalBytes + actualTermsDataDelta + (long) Long.BYTES * ec.segmentCount,
+                fb.totalBytes);
     }
 
     /// Total disk usage must grow by less than 5% between consecutive format versions.
     /// The fixed per-segment overhead (header delta + META) is negligible relative to
     /// the graph node data for any realistic dataset.
-    private static void verifyTotalDiskGrowthUnder5Percent(double diskGrowthPercent, String phase)
-    {
+    private static void verifyTotalDiskGrowthUnder5Percent(double diskGrowthPercent, String phase) {
         assertTrue(String.format("Total disk usage growth %s must be < 5%% but was %.4f%%",
-                                 phase, diskGrowthPercent),
-                   diskGrowthPercent < 5.0);
+                        phase, diskGrowthPercent),
+                diskGrowthPercent < 5.0);
     }
 
     /// Snapshot of per-component file sizes and segment count for one index build.
-    private static class DiskMeasurement
-    {
+    private static class DiskMeasurement {
         final long totalBytes;
         final long termsDataBytes;
         final long pqBytes;
@@ -256,8 +245,7 @@ public class VectorFormatDiskUsageTest extends VectorTester
         final long completionMarkerBytes;
         final int segmentCount; // total segments across all SSTables
 
-        private DiskMeasurement(Builder b)
-        {
+        private DiskMeasurement(Builder b) {
             this.totalBytes = b.totalBytes;
             this.termsDataBytes = b.termsDataBytes;
             this.pqBytes = b.pqBytes;
@@ -267,8 +255,7 @@ public class VectorFormatDiskUsageTest extends VectorTester
             this.segmentCount = b.segmentCount;
         }
 
-        static class Builder
-        {
+        static class Builder {
             long totalBytes;
             long termsDataBytes;
             long pqBytes;
@@ -277,50 +264,42 @@ public class VectorFormatDiskUsageTest extends VectorTester
             long completionMarkerBytes;
             int segmentCount;
 
-            Builder totalBytes(long v)
-            {
+            Builder totalBytes(long v) {
                 this.totalBytes = v;
                 return this;
             }
 
-            Builder termsDataBytes(long v)
-            {
+            Builder termsDataBytes(long v) {
                 this.termsDataBytes = v;
                 return this;
             }
 
-            Builder pqBytes(long v)
-            {
+            Builder pqBytes(long v) {
                 this.pqBytes = v;
                 return this;
             }
 
-            Builder metaBytes(long v)
-            {
+            Builder metaBytes(long v) {
                 this.metaBytes = v;
                 return this;
             }
 
-            Builder postingListsBytes(long v)
-            {
+            Builder postingListsBytes(long v) {
                 this.postingListsBytes = v;
                 return this;
             }
 
-            Builder completionMarkerBytes(long v)
-            {
+            Builder completionMarkerBytes(long v) {
                 this.completionMarkerBytes = v;
                 return this;
             }
 
-            Builder segmentCount(int v)
-            {
+            Builder segmentCount(int v) {
                 this.segmentCount = v;
                 return this;
             }
 
-            DiskMeasurement build()
-            {
+            DiskMeasurement build() {
                 return new DiskMeasurement(this);
             }
         }
@@ -333,15 +312,13 @@ public class VectorFormatDiskUsageTest extends VectorTester
     /// Each flush produces one SSTable with one segment (one graph in TERMS_DATA), so
     /// pre-compaction there are [#NUM_FLUSHES] segments across [#NUM_FLUSHES] SSTables;
     /// post-compaction there is exactly 1 segment in 1 SSTable.
-    private DiskMeasurement measureDiskUsage(Version version, String label, boolean compact)
-    {
+    private DiskMeasurement measureDiskUsage(Version version, String label, boolean compact) {
         SAIUtil.setCurrentVersion(version);
         createTable("CREATE TABLE %s (pk int, v vector<float, " + DIMENSION + ">, PRIMARY KEY(pk))");
         String indexName = createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
         disableCompaction();
 
-        for (int flush = 0; flush < NUM_FLUSHES; flush++)
-        {
+        for (int flush = 0; flush < NUM_FLUSHES; flush++) {
             for (int i = 0; i < CassandraOnHeapGraph.MIN_PQ_ROWS; i++)
                 execute("INSERT INTO %s (pk, v) VALUES (?, ?)",
                         flush * CassandraOnHeapGraph.MIN_PQ_ROWS + i, randomVectorBoxed(DIMENSION));
@@ -366,7 +343,7 @@ public class VectorFormatDiskUsageTest extends VectorTester
         int totalSegments = sstableIndexes.stream().mapToInt(s -> s.getSegments().size()).sum();
         int expectedSegments = compact ? 1 : NUM_FLUSHES;
         assertEquals("Expected " + expectedSegments + " segment(s) " + label,
-                     expectedSegments, totalSegments);
+                expectedSegments, totalSegments);
 
         logger.debug("[{}] diskUsage()                : {} ({} segment(s))", label, totalDiskBytes, totalSegments);
         logger.debug("[{}] TERMS_DATA component bytes : {}", label, graphComponentBytes);
@@ -376,25 +353,24 @@ public class VectorFormatDiskUsageTest extends VectorTester
         logger.debug("[{}] COMPLETION_MARKER bytes    : {}", label, completionMarkerBytes);
 
         return new DiskMeasurement.Builder()
-               .totalBytes(totalDiskBytes)
-               .termsDataBytes(graphComponentBytes)
-               .pqBytes(pqComponentBytes)
-               .metaBytes(metaComponentBytes)
-               .postingListsBytes(postingListsBytes)
-               .completionMarkerBytes(completionMarkerBytes)
-               .segmentCount(totalSegments)
-               .build();
+                .totalBytes(totalDiskBytes)
+                .termsDataBytes(graphComponentBytes)
+                .pqBytes(pqComponentBytes)
+                .metaBytes(metaComponentBytes)
+                .postingListsBytes(postingListsBytes)
+                .completionMarkerBytes(completionMarkerBytes)
+                .segmentCount(totalSegments)
+                .build();
     }
 
     private long componentSize(IndexContext indexContext,
-                               IndexComponentType type)
-    {
+                               IndexComponentType type) {
         return indexContext.getView().getIndexes()
-                           .stream()
-                           .mapToLong(idx -> {
-                               IndexComponents.ForRead perIndex = idx.usedPerIndexComponents();
-                               return perIndex.has(type) ? perIndex.get(type).file().length() : 0L;
-                           })
-                           .sum();
+                .stream()
+                .mapToLong(idx -> {
+                    IndexComponents.ForRead perIndex = idx.usedPerIndexComponents();
+                    return perIndex.has(type) ? perIndex.get(type).file().length() : 0L;
+                })
+                .sum();
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/functional/VectorFormatDiskUsageTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/functional/VectorFormatDiskUsageTest.java
@@ -220,8 +220,7 @@ public class VectorFormatDiskUsageTest extends VectorTester
         assertEquals("FB META must be exactly " + Long.BYTES + " bytes × " + ec.segmentCount
                         + " segment(s) larger than EC META (" + phase + ')',
                 ec.metaBytes + (long) Long.BYTES * ec.segmentCount, fb.metaBytes);
-        assertEquals("FB.totalBytes must equal ec.totalBytes + TERMS_DATA delta + 8 × segmentCount"
-                        + " (" + phase + ')',
+        assertEquals("FB.totalBytes must equal ec.totalBytes + TERMS_DATA delta + 8 × segmentCount(" + phase + ')',
                 ec.totalBytes + actualTermsDataDelta + (long) Long.BYTES * ec.segmentCount,
                 fb.totalBytes);
     }

--- a/test/unit/org/apache/cassandra/index/sai/functional/VectorFormatDiskUsageTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/functional/VectorFormatDiskUsageTest.java
@@ -1,0 +1,362 @@
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.functional;
+
+import java.util.List;
+
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.index.sai.SAIUtil;
+import org.apache.cassandra.index.sai.SSTableIndex;
+import org.apache.cassandra.index.sai.StorageAttachedIndex;
+import org.apache.cassandra.index.sai.cql.VectorTester;
+import org.apache.cassandra.index.sai.disk.format.IndexComponentType;
+import org.apache.cassandra.index.sai.disk.format.IndexComponents;
+import org.apache.cassandra.index.sai.disk.format.Version;
+import org.apache.cassandra.index.sai.disk.vector.CassandraOnHeapGraph;
+
+import static org.junit.Assert.*;
+
+/// Verifies on-disk vector index size behavior across SAI format versions,
+/// both preCompaction and postCompaction.
+public class VectorFormatDiskUsageTest extends VectorTester
+{
+    private static final int DIMENSION = 128;
+
+    /// Number of flushes before compaction. Each flush produces one SSTable. With only
+    /// [CassandraOnHeapGraph#MIN_PQ_ROWS] rows per flush the memory limit is not reached,
+    /// so each SSTable contains exactly one segment — asserted in [#measureDiskUsage].
+    private static final int NUM_FLUSHES = 2;
+
+    /// TERMS_DATA delta from EC (jvector format 4) to FB (jvector format 6) per segment:
+    /// one extra header copy + FOOTER_SIZE trailer. Independent of dimensions, number of vectors, etc.
+    ///
+    /// EC header  = (CommonHeader=288) + (feature bitmask int=4)                    = 292 bytes
+    /// FB header  = (CommonHeader=288) + (features.size() int=4) + (ordinal int=4)  = 296 bytes
+    /// FB writes: start-header + footer-header + FOOTER_SIZE(=Long+Int=12)          = 604 bytes
+    /// Δ = 604 − 292 = 312 bytes per segment
+    private static final long EXPECTED_TERMS_DATA_DELTA_PER_SEGMENT = 312L;
+
+    @BeforeClass
+    public static void setUpClass()
+    {
+        VectorTester.setUpClass();
+    }
+
+    @After
+    public void resetVersion()
+    {
+        SAIUtil.resetCurrentVersion();
+    }
+
+    /// Deep structural verification of the EC → FB format upgrade (jvector format 4 → 6,
+    /// no FusedPQ, no hierarchy). Asserts exact per-component byte deltas and that total
+    /// disk usage grows by less than 5%.
+    ///
+    /// A SAI vector index is stored as five on-disk component files per SSTable:
+    ///
+    /// | Component | Content |
+    /// |-----------|---------|
+    /// | `TERMS_DATA` | The graph: nodes, edges, and per-node inline vector data |
+    /// | `PQ` | Product Quantization codebook + per-vector PQ codes |
+    /// | `META` | Segment metadata: offsets, lengths, statistics |
+    /// | `POSTING_LISTS` | Mapping from row IDs to graph node ordinals |
+    /// | `COLUMN_COMPLETION_MARKER` | Fixed-size sentinel indicating the index is complete |
+    ///
+    /// FB (jvector format 6) writes the graph header twice (start + footer) plus a 12-byte trailer,
+    /// vs EC (jvector format 4) which writes it once.
+    ///
+    /// Header sizes are derived from {@code CommonHeader.size()} and {@code Header.size()} in jvector:
+    ///
+    /// ```
+    /// CommonHeader.size() (both formats):
+    ///   int size = 4;                         // size + dimension + entryNode + maxDegree  (always)
+    ///   if (version >= 3) size += 2;           // magic + version
+    ///   if (version >= 4) size += 2 + 2 * 32; // idUpperBound + numLayers + 32 LayerInfo pairs
+    ///   → (4 + 2 + 2 + 64) × 4 = 288 bytes
+    ///
+    /// Header.size() adds the feature section on top of CommonHeader:
+    ///   EC (format 4, version < 6): +Integer.BYTES for a single FeatureId bitmask int  → 288 + 4 = 292 bytes
+    ///   FB (format 6):              +Integer.BYTES (features count) + Integer.BYTES (feature ordinal) → 288 + 4 + 4 = 296 bytes
+    ///
+    /// The only feature present by default on FB is INLINE_VECTORS. With exactly [CassandraOnHeapGraph#MIN_PQ_ROWS]
+    /// rows, PQ training is met but FusedPQ is disabled, so no FusedPQ feature is written.
+    /// InlineVectors.headerSize() == 0 because dimension is already stored in CommonHeader.
+    ///
+    /// FOOTER_SIZE = FOOTER_MAGIC_SIZE(Integer.BYTES=4) + FOOTER_OFFSET_SIZE(Long.BYTES=8) = 12 bytes.
+    /// These constants and writeFooter() are in {@code AbstractGraphIndexWriter} in jvector.
+    /// writeFooter() writes: full header copy + 8-byte offset (pointing back to the header) + 4-byte magic.
+    /// Cassandra always passes useFooter=false to OnDiskGraphIndex.load(), so the footer is written
+    /// as part of the format but never read — see [CassandraDiskAnn] constructor.
+    ///
+    /// FB writes: start-header(296) + footer-header(296) + FOOTER_SIZE(Long+Int=12) = 604 bytes
+    /// EC writes: start-header(292)                                                  = 292 bytes
+    /// Δ = 604 − 292 = 312 bytes per segment
+    /// ```
+    ///
+    /// `META` grows by exactly 8 bytes per segment (a `totalTermCount` long added in ED).
+    /// All other components (`PQ`, `POSTING_LISTS`, `COLUMN_COMPLETION_MARKER`) are unchanged.
+    @Test
+    public void testDiskUsageECvsFB()
+    {
+        DiskMeasurement ecPreCompaction  = measureDiskUsage(Version.EC, "EC-preCompaction",  false);
+        DiskMeasurement ecPostCompaction = measureDiskUsage(Version.EC, "EC-postCompaction", true);
+        DiskMeasurement fbPreCompaction  = measureDiskUsage(Version.FB, "FB-preCompaction",  false);
+        DiskMeasurement fbPostCompaction = measureDiskUsage(Version.FB, "FB-postCompaction", true);
+
+        assertTrue("EC preCompaction index must have non-zero disk usage",  ecPreCompaction.totalBytes  > 0);
+        assertTrue("FB preCompaction index must have non-zero disk usage",  fbPreCompaction.totalBytes  > 0);
+        assertTrue("EC postCompaction index must have non-zero disk usage", ecPostCompaction.totalBytes > 0);
+        assertTrue("FB postCompaction index must have non-zero disk usage", fbPostCompaction.totalBytes > 0);
+
+        long preCompactionTermsDataDelta  = fbPreCompaction.termsDataBytes  - ecPreCompaction.termsDataBytes;
+        long postCompactionTermsDataDelta = fbPostCompaction.termsDataBytes - ecPostCompaction.termsDataBytes;
+
+        double diskGrowthPercentPreCompaction  = 100.0 * (fbPreCompaction.totalBytes  - ecPreCompaction.totalBytes)  / ecPreCompaction.totalBytes;
+        double diskGrowthPercentPostCompaction = 100.0 * (fbPostCompaction.totalBytes - ecPostCompaction.totalBytes) / ecPostCompaction.totalBytes;
+
+        logger.debug("  EC preCompaction  diskUsage() : {} ({} segments)", ecPreCompaction.totalBytes,  ecPreCompaction.segmentCount);
+        logger.debug("  FB preCompaction  diskUsage() : {} ({} segments)", fbPreCompaction.totalBytes,  fbPreCompaction.segmentCount);
+        logger.debug("  EC postCompaction diskUsage() : {} ({} segments)", ecPostCompaction.totalBytes, ecPostCompaction.segmentCount);
+        logger.debug("  FB postCompaction diskUsage() : {} ({} segments)", fbPostCompaction.totalBytes, fbPostCompaction.segmentCount);
+        logger.debug("  Total disk usage growth preCompaction  : +{} bytes ({} %)",
+                    fbPreCompaction.totalBytes  - ecPreCompaction.totalBytes,  String.format("%.4f", diskGrowthPercentPreCompaction));
+        logger.debug("  Total disk usage growth postCompaction : +{} bytes ({} %)",
+                    fbPostCompaction.totalBytes - ecPostCompaction.totalBytes, String.format("%.4f", diskGrowthPercentPostCompaction));
+        logger.debug("  TERMS_DATA delta preCompaction  : {} (expected {} × {} = {})",
+                    preCompactionTermsDataDelta,  NUM_FLUSHES, EXPECTED_TERMS_DATA_DELTA_PER_SEGMENT,
+                    NUM_FLUSHES * EXPECTED_TERMS_DATA_DELTA_PER_SEGMENT);
+        logger.debug("  TERMS_DATA delta postCompaction : {} (expected {})",
+                    postCompactionTermsDataDelta, EXPECTED_TERMS_DATA_DELTA_PER_SEGMENT);
+
+        verifyComponentAccounting(ecPreCompaction,  fbPreCompaction,  "preCompaction");
+        verifyComponentAccounting(ecPostCompaction, fbPostCompaction, "postCompaction");
+        verifyTermsDataDelta(preCompactionTermsDataDelta,  ecPreCompaction.segmentCount,  "preCompaction");
+        verifyTermsDataDelta(postCompactionTermsDataDelta, ecPostCompaction.segmentCount, "postCompaction");
+        verifyUnchangedComponents(ecPreCompaction,  fbPreCompaction,  "preCompaction");
+        verifyUnchangedComponents(ecPostCompaction, fbPostCompaction, "postCompaction");
+        verifyConservation(ecPreCompaction,  fbPreCompaction,  preCompactionTermsDataDelta,  "preCompaction");
+        verifyConservation(ecPostCompaction, fbPostCompaction, postCompactionTermsDataDelta, "postCompaction");
+        verifyTotalDiskGrowthUnder5Percent(diskGrowthPercentPreCompaction,  "preCompaction");
+        verifyTotalDiskGrowthUnder5Percent(diskGrowthPercentPostCompaction, "postCompaction");
+    }
+
+    /// Regression guard: for every vector-capable version from [Version#JVECTOR_EARLIEST] (CA)
+    /// up to but not including [Version#LATEST], asserts that [Version#LATEST] uses less than
+    /// 5% more disk than that older version. Catches accidental large regressions introduced
+    /// by a new format version.
+    @Test
+    public void testDiskGrowthAcrossVersions()
+    {
+        DiskMeasurement latestPreCompaction  = measureDiskUsage(Version.LATEST, Version.LATEST + "-preCompaction",  false);
+        DiskMeasurement latestPostCompaction = measureDiskUsage(Version.LATEST, Version.LATEST + "-postCompaction", true);
+
+        Version.ALL.stream()
+                   .filter(v -> v.onOrAfter(Version.JVECTOR_EARLIEST) && !v.equals(Version.LATEST))
+                   .forEach(older ->
+        {
+            DiskMeasurement olderPreCompaction  = measureDiskUsage(older, older + "-preCompaction",  false);
+            DiskMeasurement olderPostCompaction = measureDiskUsage(older, older + "-postCompaction", true);
+
+            double diskGrowthPercentPreCompaction  = 100.0 * (latestPreCompaction.totalBytes  - olderPreCompaction.totalBytes)  / olderPreCompaction.totalBytes;
+            double diskGrowthPercentPostCompaction = 100.0 * (latestPostCompaction.totalBytes - olderPostCompaction.totalBytes) / olderPostCompaction.totalBytes;
+
+            logger.debug("  {} → {} preCompaction  : {} → {} bytes ({} %)",
+                         older, Version.LATEST, olderPreCompaction.totalBytes,  latestPreCompaction.totalBytes,
+                         String.format("%.4f", diskGrowthPercentPreCompaction));
+            logger.debug("  {} → {} postCompaction : {} → {} bytes ({} %)",
+                         older, Version.LATEST, olderPostCompaction.totalBytes, latestPostCompaction.totalBytes,
+                         String.format("%.4f", diskGrowthPercentPostCompaction));
+
+            verifyTotalDiskGrowthUnder5Percent(diskGrowthPercentPreCompaction,  older + " → " + Version.LATEST + " preCompaction");
+            verifyTotalDiskGrowthUnder5Percent(diskGrowthPercentPostCompaction, older + " → " + Version.LATEST + " postCompaction");
+        });
+    }
+
+    /// Sanity: totalBytes must equal the sum of all five components (nothing missed or double-counted).
+    private static void verifyComponentAccounting(DiskMeasurement ec, DiskMeasurement fb, String phase)
+    {
+        assertEquals("EC " + phase + ": totalBytes must equal sum of all per-index components",
+                     ec.totalBytes, ec.termsDataBytes + ec.pqBytes + ec.metaBytes + ec.postingListsBytes + ec.completionMarkerBytes);
+        assertEquals("FB " + phase + ": totalBytes must equal sum of all per-index components",
+                     fb.totalBytes, fb.termsDataBytes + fb.pqBytes + fb.metaBytes + fb.postingListsBytes + fb.completionMarkerBytes);
+    }
+
+    /// The TERMS_DATA delta must equal exactly [#EXPECTED_TERMS_DATA_DELTA_PER_SEGMENT] × segmentCount.
+    /// Each segment contributes one graph to the TERMS_DATA file, and each graph carries one header delta.
+    private static void verifyTermsDataDelta(long actualTermsDataDelta, int segmentCount, String phase)
+    {
+        long expected = EXPECTED_TERMS_DATA_DELTA_PER_SEGMENT * segmentCount;
+        assertEquals("TERMS_DATA delta " + phase + " must equal " + EXPECTED_TERMS_DATA_DELTA_PER_SEGMENT
+                     + " bytes × " + segmentCount + " segment(s) = " + expected
+                     + " (jvector format 4→6 header layout change only)",
+                     expected, actualTermsDataDelta);
+    }
+
+    private static void verifyUnchangedComponents(DiskMeasurement ec, DiskMeasurement fb, String phase)
+    {
+        assertEquals("PQ component size must be the same for EC and FB (" + phase + ')',
+                     ec.pqBytes, fb.pqBytes);
+        assertEquals("POSTING_LISTS must be the same size for EC and FB (" + phase + ')',
+                     ec.postingListsBytes, fb.postingListsBytes);
+        assertEquals("COLUMN_COMPLETION_MARKER must be the same size for EC and FB (" + phase + ')',
+                     ec.completionMarkerBytes, fb.completionMarkerBytes);
+    }
+
+    /// META grows by exactly 8 bytes per segment EC → FB (a `totalTermCount` long added in ED).
+    /// Because all other components except TERMS_DATA are identical, the net total delta equals
+    /// the TERMS_DATA delta plus 8 × segmentCount bytes.
+    private static void verifyConservation(DiskMeasurement ec, DiskMeasurement fb,
+                                           long actualTermsDataDelta, String phase)
+    {
+        assertEquals("FB META must be exactly " + Long.BYTES + " bytes × " + ec.segmentCount
+                     + " segment(s) larger than EC META (" + phase + ')',
+                     ec.metaBytes + (long) Long.BYTES * ec.segmentCount, fb.metaBytes);
+        assertEquals("FB.totalBytes must equal ec.totalBytes + TERMS_DATA delta + 8 × segmentCount"
+                     + " (" + phase + ')',
+                     ec.totalBytes + actualTermsDataDelta + (long) Long.BYTES * ec.segmentCount,
+                     fb.totalBytes);
+    }
+
+    /// Total disk usage must grow by less than 5% between consecutive format versions.
+    /// The fixed per-segment overhead (header delta + META) is negligible relative to
+    /// the graph node data for any realistic dataset.
+    private static void verifyTotalDiskGrowthUnder5Percent(double diskGrowthPercent, String phase)
+    {
+        assertTrue(String.format("Total disk usage growth %s must be < 5%% but was %.4f%%",
+                                 phase, diskGrowthPercent),
+                   diskGrowthPercent < 5.0);
+    }
+
+    /// Snapshot of per-component file sizes and segment count for one index build.
+    private static class DiskMeasurement
+    {
+        final long totalBytes;
+        final long termsDataBytes;
+        final long pqBytes;
+        final long metaBytes;
+        final long postingListsBytes;
+        final long completionMarkerBytes;
+        final int  segmentCount; // total segments across all SSTables
+
+        private DiskMeasurement(Builder b)
+        {
+            this.totalBytes            = b.totalBytes;
+            this.termsDataBytes        = b.termsDataBytes;
+            this.pqBytes               = b.pqBytes;
+            this.metaBytes             = b.metaBytes;
+            this.postingListsBytes     = b.postingListsBytes;
+            this.completionMarkerBytes = b.completionMarkerBytes;
+            this.segmentCount          = b.segmentCount;
+        }
+
+        static class Builder
+        {
+            long totalBytes;
+            long termsDataBytes;
+            long pqBytes;
+            long metaBytes;
+            long postingListsBytes;
+            long completionMarkerBytes;
+            int  segmentCount;
+
+            Builder totalBytes(long v)            { this.totalBytes            = v; return this; }
+            Builder termsDataBytes(long v)        { this.termsDataBytes        = v; return this; }
+            Builder pqBytes(long v)               { this.pqBytes               = v; return this; }
+            Builder metaBytes(long v)             { this.metaBytes             = v; return this; }
+            Builder postingListsBytes(long v)     { this.postingListsBytes     = v; return this; }
+            Builder completionMarkerBytes(long v) { this.completionMarkerBytes = v; return this; }
+            Builder segmentCount(int v)           { this.segmentCount          = v; return this; }
+
+            DiskMeasurement build()               { return new DiskMeasurement(this); }
+        }
+    }
+
+    /// Builds a fresh table at `version`, writes [#NUM_FLUSHES] × [CassandraOnHeapGraph#MIN_PQ_ROWS]
+    /// vectors in separate flushes, then either returns the pre-compaction measurement
+    /// (`compact == false`) or runs major compaction first (`compact == true`).
+    ///
+    /// Each flush produces one SSTable with one segment (one graph in TERMS_DATA), so
+    /// pre-compaction there are [#NUM_FLUSHES] segments across [#NUM_FLUSHES] SSTables;
+    /// post-compaction there is exactly 1 segment in 1 SSTable.
+    private DiskMeasurement measureDiskUsage(Version version, String label, boolean compact)
+    {
+        SAIUtil.setCurrentVersion(version);
+        createTable("CREATE TABLE %s (pk int, v vector<float, " + DIMENSION + ">, PRIMARY KEY(pk))");
+        String indexName = createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
+        disableCompaction();
+
+        for (int flush = 0; flush < NUM_FLUSHES; flush++)
+        {
+            for (int i = 0; i < CassandraOnHeapGraph.MIN_PQ_ROWS; i++)
+                execute("INSERT INTO %s (pk, v) VALUES (?, ?)",
+                        flush * CassandraOnHeapGraph.MIN_PQ_ROWS + i, randomVectorBoxed(DIMENSION));
+            flush();
+        }
+
+        if (compact)
+            compact();
+
+        var sai = (StorageAttachedIndex) getCurrentColumnFamilyStore().indexManager.getIndexByName(indexName);
+        assertNotNull("Index not found: " + indexName, sai);
+        var indexContext = sai.getIndexContext();
+
+        long totalDiskBytes        = indexContext.diskUsage();
+        long graphComponentBytes   = componentSize(indexContext, IndexComponentType.TERMS_DATA);
+        long pqComponentBytes      = componentSize(indexContext, IndexComponentType.PQ);
+        long metaComponentBytes    = componentSize(indexContext, IndexComponentType.META);
+        long postingListsBytes     = componentSize(indexContext, IndexComponentType.POSTING_LISTS);
+        long completionMarkerBytes = componentSize(indexContext, IndexComponentType.COLUMN_COMPLETION_MARKER);
+
+        List<SSTableIndex> sstableIndexes = List.copyOf(indexContext.getView().getIndexes());
+        int totalSegments = sstableIndexes.stream().mapToInt(s -> s.getSegments().size()).sum();
+        int expectedSegments = compact ? 1 : NUM_FLUSHES;
+        assertEquals("Expected " + expectedSegments + " segment(s) " + label,
+                     expectedSegments, totalSegments);
+
+        logger.debug("[{}] diskUsage()                : {} ({} segment(s))", label, totalDiskBytes, totalSegments);
+        logger.debug("[{}] TERMS_DATA component bytes : {}", label, graphComponentBytes);
+        logger.debug("[{}] PQ component bytes         : {}", label, pqComponentBytes);
+        logger.debug("[{}] META component bytes       : {}", label, metaComponentBytes);
+        logger.debug("[{}] POSTING_LISTS bytes        : {}", label, postingListsBytes);
+        logger.debug("[{}] COMPLETION_MARKER bytes    : {}", label, completionMarkerBytes);
+
+        return new DiskMeasurement.Builder()
+               .totalBytes(totalDiskBytes)
+               .termsDataBytes(graphComponentBytes)
+               .pqBytes(pqComponentBytes)
+               .metaBytes(metaComponentBytes)
+               .postingListsBytes(postingListsBytes)
+               .completionMarkerBytes(completionMarkerBytes)
+               .segmentCount(totalSegments)
+               .build();
+    }
+
+    private long componentSize(org.apache.cassandra.index.sai.IndexContext indexContext,
+                               IndexComponentType type)
+    {
+        return indexContext.getView().getIndexes()
+                           .stream()
+                           .mapToLong(idx -> {
+                               IndexComponents.ForRead perIndex = idx.usedPerIndexComponents();
+                               return perIndex.has(type) ? perIndex.get(type).file().length() : 0L;
+                           })
+                           .sum();
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/functional/VectorFormatDiskUsageTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/functional/VectorFormatDiskUsageTest.java
@@ -36,7 +36,8 @@ import static org.junit.Assert.*;
 
 /// Verifies on-disk vector index size behavior across SAI format versions,
 /// both preCompaction and postCompaction.
-public class VectorFormatDiskUsageTest extends VectorTester {
+public class VectorFormatDiskUsageTest extends VectorTester
+{
     private static final int DIMENSION = 128;
 
     /// Number of flushes before compaction. Each flush produces one SSTable. With only
@@ -54,12 +55,14 @@ public class VectorFormatDiskUsageTest extends VectorTester {
     private static final long EXPECTED_TERMS_DATA_DELTA_PER_SEGMENT = 312L;
 
     @BeforeClass
-    public static void setUpClass() {
+    public static void setUpClass()
+    {
         VectorTester.setUpClass();
     }
 
     @After
-    public void resetVersion() {
+    public void resetVersion()
+    {
         SAIUtil.resetCurrentVersion();
     }
 
@@ -111,12 +114,14 @@ public class VectorFormatDiskUsageTest extends VectorTester {
     /// `META` grows by exactly 8 bytes per segment (a `totalTermCount` long added in ED).
     /// All other components (`PQ`, `POSTING_LISTS`, `COLUMN_COMPLETION_MARKER`) are unchanged.
     @Test
-    public void testDiskUsageECvsFB() {
+    public void testDiskUsageECvsFB()
+    {
         testDiskUsageECvsFB(false);
         testDiskUsageECvsFB(true);
     }
 
-    private void testDiskUsageECvsFB(boolean compact) {
+    private void testDiskUsageECvsFB(boolean compact)
+    {
         String phase = compact ? "postCompaction" : "preCompaction";
 
         DiskMeasurement ec = measureDiskUsage(Version.EC, "EC-" + phase, compact);
@@ -148,12 +153,14 @@ public class VectorFormatDiskUsageTest extends VectorTester {
     /// 5% more disk than that older version. Catches accidental large regressions introduced
     /// by a new format version.
     @Test
-    public void testDiskGrowthAcrossVersions() {
+    public void testDiskGrowthAcrossVersions()
+    {
         testDiskGrowthAcrossVersions(false);
         testDiskGrowthAcrossVersions(true);
     }
 
-    private void testDiskGrowthAcrossVersions(boolean compact) {
+    private void testDiskGrowthAcrossVersions(boolean compact)
+    {
         String name = compact ? "postCompaction" : "preCompaction";
         DiskMeasurement latest = measureDiskUsage(Version.LATEST, Version.LATEST + "-" + name, compact);
 
@@ -175,7 +182,8 @@ public class VectorFormatDiskUsageTest extends VectorTester {
     }
 
     /// Sanity: totalBytes must equal the sum of all five components (nothing missed or double-counted).
-    private static void verifyComponentAccounting(DiskMeasurement ec, DiskMeasurement fb, String phase) {
+    private static void verifyComponentAccounting(DiskMeasurement ec, DiskMeasurement fb, String phase)
+    {
         assertEquals("EC " + phase + ": totalBytes must equal sum of all per-index components",
                 ec.totalBytes, ec.termsDataBytes + ec.pqBytes + ec.metaBytes + ec.postingListsBytes + ec.completionMarkerBytes);
         assertEquals("FB " + phase + ": totalBytes must equal sum of all per-index components",
@@ -184,7 +192,8 @@ public class VectorFormatDiskUsageTest extends VectorTester {
 
     /// The TERMS_DATA delta must equal exactly [#EXPECTED_TERMS_DATA_DELTA_PER_SEGMENT] × segmentCount.
     /// Each segment contributes one graph to the TERMS_DATA file, and each graph carries one header delta.
-    private static void verifyTermsDataDelta(long actualTermsDataDelta, int segmentCount, String phase) {
+    private static void verifyTermsDataDelta(long actualTermsDataDelta, int segmentCount, String phase)
+    {
         long expected = EXPECTED_TERMS_DATA_DELTA_PER_SEGMENT * segmentCount;
         assertEquals("TERMS_DATA delta " + phase + " must equal " + EXPECTED_TERMS_DATA_DELTA_PER_SEGMENT
                         + " bytes × " + segmentCount + " segment(s) = " + expected
@@ -192,7 +201,8 @@ public class VectorFormatDiskUsageTest extends VectorTester {
                 expected, actualTermsDataDelta);
     }
 
-    private static void verifyUnchangedComponents(DiskMeasurement ec, DiskMeasurement fb, String phase) {
+    private static void verifyUnchangedComponents(DiskMeasurement ec, DiskMeasurement fb, String phase)
+    {
         assertEquals("PQ component size must be the same for EC and FB (" + phase + ')',
                 ec.pqBytes, fb.pqBytes);
         assertEquals("POSTING_LISTS must be the same size for EC and FB (" + phase + ')',
@@ -205,7 +215,8 @@ public class VectorFormatDiskUsageTest extends VectorTester {
     /// Because all other components except TERMS_DATA are identical, the net total delta equals
     /// the TERMS_DATA delta plus 8 × segmentCount bytes.
     private static void verifyConservation(DiskMeasurement ec, DiskMeasurement fb,
-                                           long actualTermsDataDelta, String phase) {
+                                           long actualTermsDataDelta, String phase)
+    {
         assertEquals("FB META must be exactly " + Long.BYTES + " bytes × " + ec.segmentCount
                         + " segment(s) larger than EC META (" + phase + ')',
                 ec.metaBytes + (long) Long.BYTES * ec.segmentCount, fb.metaBytes);
@@ -218,14 +229,16 @@ public class VectorFormatDiskUsageTest extends VectorTester {
     /// Total disk usage must grow by less than 5% between consecutive format versions.
     /// The fixed per-segment overhead (header delta + META) is negligible relative to
     /// the graph node data for any realistic dataset.
-    private static void verifyTotalDiskGrowthUnder5Percent(double diskGrowthPercent, String phase) {
+    private static void verifyTotalDiskGrowthUnder5Percent(double diskGrowthPercent, String phase)
+    {
         assertTrue(String.format("Total disk usage growth %s must be < 5%% but was %.4f%%",
                         phase, diskGrowthPercent),
                 diskGrowthPercent < 5.0);
     }
 
     /// Snapshot of per-component file sizes and segment count for one index build.
-    private static class DiskMeasurement {
+    private static class DiskMeasurement
+    {
         final long totalBytes;
         final long termsDataBytes;
         final long pqBytes;
@@ -234,7 +247,8 @@ public class VectorFormatDiskUsageTest extends VectorTester {
         final long completionMarkerBytes;
         final int segmentCount; // total segments across all SSTables
 
-        private DiskMeasurement(Builder b) {
+        private DiskMeasurement(Builder b)
+        {
             this.totalBytes = b.totalBytes;
             this.termsDataBytes = b.termsDataBytes;
             this.pqBytes = b.pqBytes;
@@ -244,7 +258,8 @@ public class VectorFormatDiskUsageTest extends VectorTester {
             this.segmentCount = b.segmentCount;
         }
 
-        static class Builder {
+        static class Builder
+        {
             long totalBytes;
             long termsDataBytes;
             long pqBytes;
@@ -253,42 +268,50 @@ public class VectorFormatDiskUsageTest extends VectorTester {
             long completionMarkerBytes;
             int segmentCount;
 
-            Builder totalBytes(long v) {
+            Builder totalBytes(long v)
+            {
                 this.totalBytes = v;
                 return this;
             }
 
-            Builder termsDataBytes(long v) {
+            Builder termsDataBytes(long v)
+            {
                 this.termsDataBytes = v;
                 return this;
             }
 
-            Builder pqBytes(long v) {
+            Builder pqBytes(long v)
+            {
                 this.pqBytes = v;
                 return this;
             }
 
-            Builder metaBytes(long v) {
+            Builder metaBytes(long v)
+            {
                 this.metaBytes = v;
                 return this;
             }
 
-            Builder postingListsBytes(long v) {
+            Builder postingListsBytes(long v)
+            {
                 this.postingListsBytes = v;
                 return this;
             }
 
-            Builder completionMarkerBytes(long v) {
+            Builder completionMarkerBytes(long v)
+            {
                 this.completionMarkerBytes = v;
                 return this;
             }
 
-            Builder segmentCount(int v) {
+            Builder segmentCount(int v)
+            {
                 this.segmentCount = v;
                 return this;
             }
 
-            DiskMeasurement build() {
+            DiskMeasurement build()
+            {
                 return new DiskMeasurement(this);
             }
         }
@@ -301,13 +324,15 @@ public class VectorFormatDiskUsageTest extends VectorTester {
     /// Each flush produces one SSTable with one segment (one graph in TERMS_DATA), so
     /// pre-compaction there are [#NUM_FLUSHES] segments across [#NUM_FLUSHES] SSTables;
     /// post-compaction there is exactly 1 segment in 1 SSTable.
-    private DiskMeasurement measureDiskUsage(Version version, String label, boolean compact) {
+    private DiskMeasurement measureDiskUsage(Version version, String label, boolean compact)
+    {
         SAIUtil.setCurrentVersion(version);
         createTable("CREATE TABLE %s (pk int, v vector<float, " + DIMENSION + ">, PRIMARY KEY(pk))");
         String indexName = createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
         disableCompaction();
 
-        for (int flush = 0; flush < NUM_FLUSHES; flush++) {
+        for (int flush = 0; flush < NUM_FLUSHES; flush++)
+        {
             for (int i = 0; i < CassandraOnHeapGraph.MIN_PQ_ROWS; i++)
                 execute("INSERT INTO %s (pk, v) VALUES (?, ?)",
                         flush * CassandraOnHeapGraph.MIN_PQ_ROWS + i, randomVectorBoxed(DIMENSION));
@@ -353,7 +378,8 @@ public class VectorFormatDiskUsageTest extends VectorTester {
     }
 
     private long componentSize(IndexContext indexContext,
-                               IndexComponentType type) {
+                               IndexComponentType type)
+    {
         return indexContext.getView().getIndexes()
                 .stream()
                 .mapToLong(idx -> {

--- a/test/unit/org/apache/cassandra/index/sai/functional/VectorFormatDiskUsageTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/functional/VectorFormatDiskUsageTest.java
@@ -112,46 +112,35 @@ public class VectorFormatDiskUsageTest extends VectorTester {
     /// All other components (`PQ`, `POSTING_LISTS`, `COLUMN_COMPLETION_MARKER`) are unchanged.
     @Test
     public void testDiskUsageECvsFB() {
-        DiskMeasurement ecPreCompaction = measureDiskUsage(Version.EC, "EC-preCompaction", false);
-        DiskMeasurement ecPostCompaction = measureDiskUsage(Version.EC, "EC-postCompaction", true);
-        DiskMeasurement fbPreCompaction = measureDiskUsage(Version.FB, "FB-preCompaction", false);
-        DiskMeasurement fbPostCompaction = measureDiskUsage(Version.FB, "FB-postCompaction", true);
+        testDiskUsageECvsFB(false);
+        testDiskUsageECvsFB(true);
+    }
 
-        assertTrue("EC preCompaction index must have non-zero disk usage", ecPreCompaction.totalBytes > 0);
-        assertTrue("FB preCompaction index must have non-zero disk usage", fbPreCompaction.totalBytes > 0);
-        assertTrue("EC postCompaction index must have non-zero disk usage", ecPostCompaction.totalBytes > 0);
-        assertTrue("FB postCompaction index must have non-zero disk usage", fbPostCompaction.totalBytes > 0);
+    private void testDiskUsageECvsFB(boolean compact) {
+        String phase = compact ? "postCompaction" : "preCompaction";
 
-        long preCompactionTermsDataDelta = fbPreCompaction.termsDataBytes - ecPreCompaction.termsDataBytes;
-        long postCompactionTermsDataDelta = fbPostCompaction.termsDataBytes - ecPostCompaction.termsDataBytes;
+        DiskMeasurement ec = measureDiskUsage(Version.EC, "EC-" + phase, compact);
+        DiskMeasurement fb = measureDiskUsage(Version.FB, "FB-" + phase, compact);
 
-        double diskGrowthPercentPreCompaction = 100.0 * (fbPreCompaction.totalBytes - ecPreCompaction.totalBytes) / ecPreCompaction.totalBytes;
-        double diskGrowthPercentPostCompaction = 100.0 * (fbPostCompaction.totalBytes - ecPostCompaction.totalBytes) / ecPostCompaction.totalBytes;
+        assertTrue("EC index must have non-zero disk usage", ec.totalBytes > 0);
+        assertTrue("FB index must have non-zero disk usage", fb.totalBytes > 0);
 
-        logger.debug("  EC preCompaction  diskUsage() : {} ({} segments)", ecPreCompaction.totalBytes, ecPreCompaction.segmentCount);
-        logger.debug("  FB preCompaction  diskUsage() : {} ({} segments)", fbPreCompaction.totalBytes, fbPreCompaction.segmentCount);
-        logger.debug("  EC postCompaction diskUsage() : {} ({} segments)", ecPostCompaction.totalBytes, ecPostCompaction.segmentCount);
-        logger.debug("  FB postCompaction diskUsage() : {} ({} segments)", fbPostCompaction.totalBytes, fbPostCompaction.segmentCount);
-        logger.debug("  Total disk usage growth preCompaction  : +{} bytes ({} %)",
-                fbPreCompaction.totalBytes - ecPreCompaction.totalBytes, String.format("%.4f", diskGrowthPercentPreCompaction));
-        logger.debug("  Total disk usage growth postCompaction : +{} bytes ({} %)",
-                fbPostCompaction.totalBytes - ecPostCompaction.totalBytes, String.format("%.4f", diskGrowthPercentPostCompaction));
-        logger.debug("  TERMS_DATA delta preCompaction  : {} (expected {} × {} = {})",
-                preCompactionTermsDataDelta, NUM_FLUSHES, EXPECTED_TERMS_DATA_DELTA_PER_SEGMENT,
+        long termsDataDelta = fb.termsDataBytes - ec.termsDataBytes;
+        double diskGrowthPercent = 100.0 * (fb.totalBytes - ec.totalBytes) / ec.totalBytes;
+
+        logger.debug("  EC {}  diskUsage() : {} ({} segments)", phase, ec.totalBytes, ec.segmentCount);
+        logger.debug("  FB {}  diskUsage() : {} ({} segments)", phase, fb.totalBytes, fb.segmentCount);
+        logger.debug("  Total disk usage growth {}  : +{} bytes ({} %)",
+                phase, fb.totalBytes - ec.totalBytes, String.format("%.4f", diskGrowthPercent));
+        logger.debug("  TERMS_DATA delta {}  : {} (expected {} × {} = {})",
+                phase, termsDataDelta, NUM_FLUSHES, EXPECTED_TERMS_DATA_DELTA_PER_SEGMENT,
                 NUM_FLUSHES * EXPECTED_TERMS_DATA_DELTA_PER_SEGMENT);
-        logger.debug("  TERMS_DATA delta postCompaction : {} (expected {})",
-                postCompactionTermsDataDelta, EXPECTED_TERMS_DATA_DELTA_PER_SEGMENT);
 
-        verifyComponentAccounting(ecPreCompaction, fbPreCompaction, "preCompaction");
-        verifyComponentAccounting(ecPostCompaction, fbPostCompaction, "postCompaction");
-        verifyTermsDataDelta(preCompactionTermsDataDelta, ecPreCompaction.segmentCount, "preCompaction");
-        verifyTermsDataDelta(postCompactionTermsDataDelta, ecPostCompaction.segmentCount, "postCompaction");
-        verifyUnchangedComponents(ecPreCompaction, fbPreCompaction, "preCompaction");
-        verifyUnchangedComponents(ecPostCompaction, fbPostCompaction, "postCompaction");
-        verifyConservation(ecPreCompaction, fbPreCompaction, preCompactionTermsDataDelta, "preCompaction");
-        verifyConservation(ecPostCompaction, fbPostCompaction, postCompactionTermsDataDelta, "postCompaction");
-        verifyTotalDiskGrowthUnder5Percent(diskGrowthPercentPreCompaction, "preCompaction");
-        verifyTotalDiskGrowthUnder5Percent(diskGrowthPercentPostCompaction, "postCompaction");
+        verifyComponentAccounting(ec, fb, phase);
+        verifyTermsDataDelta(termsDataDelta, ec.segmentCount, phase);
+        verifyUnchangedComponents(ec, fb, phase);
+        verifyConservation(ec, fb, termsDataDelta, phase);
+        verifyTotalDiskGrowthUnder5Percent(diskGrowthPercent, phase);
     }
 
     /// Regression guard: for every vector-capable version from [Version#JVECTOR_EARLIEST] (CA)
@@ -160,29 +149,29 @@ public class VectorFormatDiskUsageTest extends VectorTester {
     /// by a new format version.
     @Test
     public void testDiskGrowthAcrossVersions() {
-        DiskMeasurement latestPreCompaction = measureDiskUsage(Version.LATEST, Version.LATEST + "-preCompaction", false);
-        DiskMeasurement latestPostCompaction = measureDiskUsage(Version.LATEST, Version.LATEST + "-postCompaction", true);
+        testDiskGrowthAcrossVersions(false);
+        testDiskGrowthAcrossVersions(true);
+    }
 
-        Version.ALL.stream()
-                .filter(v -> v.onOrAfter(Version.JVECTOR_EARLIEST) && !v.equals(Version.LATEST))
-                .forEach(older ->
-                {
-                    DiskMeasurement olderPreCompaction = measureDiskUsage(older, older + "-preCompaction", false);
-                    DiskMeasurement olderPostCompaction = measureDiskUsage(older, older + "-postCompaction", true);
+    private void testDiskGrowthAcrossVersions(boolean compact) {
+        String name = compact ? "postCompaction" : "preCompaction";
+        DiskMeasurement latest = measureDiskUsage(Version.LATEST, Version.LATEST + "-" + name, compact);
 
-                    double diskGrowthPercentPreCompaction = 100.0 * (latestPreCompaction.totalBytes - olderPreCompaction.totalBytes) / olderPreCompaction.totalBytes;
-                    double diskGrowthPercentPostCompaction = 100.0 * (latestPostCompaction.totalBytes - olderPostCompaction.totalBytes) / olderPostCompaction.totalBytes;
+        for (Version version : Version.ALL)
+        {
+            if (version == Version.LATEST || !version.onOrAfter(Version.JVECTOR_EARLIEST))
+                continue;
 
-                    logger.debug("  {} → {} preCompaction  : {} → {} bytes ({} %)",
-                            older, Version.LATEST, olderPreCompaction.totalBytes, latestPreCompaction.totalBytes,
-                            String.format("%.4f", diskGrowthPercentPreCompaction));
-                    logger.debug("  {} → {} postCompaction : {} → {} bytes ({} %)",
-                            older, Version.LATEST, olderPostCompaction.totalBytes, latestPostCompaction.totalBytes,
-                            String.format("%.4f", diskGrowthPercentPostCompaction));
+            DiskMeasurement older = measureDiskUsage(version, version + "-" + name, compact);
 
-                    verifyTotalDiskGrowthUnder5Percent(diskGrowthPercentPreCompaction, older + " → " + Version.LATEST + " preCompaction");
-                    verifyTotalDiskGrowthUnder5Percent(diskGrowthPercentPostCompaction, older + " → " + Version.LATEST + " postCompaction");
-                });
+            double diskGrowthPercent = 100.0 * (latest.totalBytes - older.totalBytes) / older.totalBytes;
+
+            logger.debug("  {} → {} {}  : {} → {} bytes ({} %)",
+                         version, Version.LATEST, name, older.totalBytes, latest.totalBytes,
+                         String.format("%.4f", diskGrowthPercent));
+
+            verifyTotalDiskGrowthUnder5Percent(diskGrowthPercent, version + " → " + Version.LATEST + ' ' + name);
+        }
     }
 
     /// Sanity: totalBytes must equal the sum of all five components (nothing missed or double-counted).


### PR DESCRIPTION
### What is the issue
...
#18493
### What does this PR fix and why was it fixed
...
Introduce version FB (reusing V8OnDiskFormat/jvector format 6) as the
new default SAI format. Unlike FA where FusedPQ is always enabled,
FB makes FusedPQ opt-in via cassandra.sai.vector.enable_fused (default
false), restoring the pre-CNDB-17871 behaviour for new indexes.

FA retains its always-on FusedPQ semantics unchanged.