### PR TITLE
CNDB-18013 link to SonarCloud to manually check coverage in 5.0 (#2526)

### DIFF
--- a/.github/workflows/checklist_comment_on_new_pr.yml
+++ b/.github/workflows/checklist_comment_on_new_pr.yml
@@ -10,8 +10,8 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Add comment
-        run:
-          gh pr comment $PRNUM --body-file .github/workflows/pr_checklist.md
+        run: |
+          sed "s/{{PR_NUMBER}}/$PRNUM/" .github/workflows/pr_checklist.md | gh pr comment $PRNUM --body-file -
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}

--- a/.github/workflows/pr_checklist.md
+++ b/.github/workflows/pr_checklist.md
@@ -3,7 +3,7 @@
 - [ ] Make sure there is a PR and ticket in the CNDB project updating the Converged Cassandra version
 - [ ] Use `NoSpamLogger` for log lines that may appear frequently in the logs
 - [ ] Verify test results on Butler
-- [ ] Test coverage for new/modified code is > 80%
+- [ ] Test coverage for new/modified code is > 80%, check manually at [SonarCloud page](https://sonarcloud.io/summary/new_code?id=cassandra-stargazer&pullRequest={{PR_NUMBER}})
 - [ ] Proper code formatting
 - [ ] Proper title for each commit staring with the project-issue number, like CNDB-1234
 - [ ] Each commit has a meaningful description


### PR DESCRIPTION
While SonarCloud report comment is not published in PRs, this is a workaround to simplify manually checking the SonarCloud report.

Workaround for https://github.com/riptano/cndb/issues/18013