### PR TITLE
[CC5] HCD-422 Separate memtable memory usage tracking from limit checking

### DIFF
--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -1725,9 +1725,18 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
     /**
      * Insert/Update the column family for this key.
      * Caller is responsible for acquiring Keyspace.switchLock
+     *
      * @param update to be applied
      * @param context write context for current update
-     * @param updateIndexes whether secondary indexes should be updated
+     * @param updateIndexes whether secondary indexes should be updated.
+     *                      When {@code false} this write is treated as a <em>nested</em> write: it skips the
+     *                      memtable pool's room-wait gate ({@link org.apache.cassandra.utils.memory.MemtableAllocator#awaitRoomToStart})
+     *                      and goes straight to {@link Memtable#putNested} instead of {@link Memtable#put}.
+     *                      Callers that pass {@code false} are already executing inside an enclosing mutation
+     *                      (e.g. a legacy 2i index write initiated from {@code indexer.onInserted()} under the
+     *                      base table's memtable-internal locks) and <strong>must not</strong> block for room,
+     *                      because doing so would deadlock the flush write-barrier (CASSANDRA-21019).
+     *                      As a consequence, a nested write may allocate slightly beyond the gated limit.
      */
     public void apply(PartitionUpdate update, CassandraWriteContext context, boolean updateIndexes)
 
@@ -1740,7 +1749,12 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
         {
             Memtable mt = data.getMemtableFor(opGroup, commitLogPosition);
             UpdateTransaction indexer = newUpdateTransaction(update, context, updateIndexes, mt);
-            long timeDelta = mt.put(update, indexer, opGroup);
+
+            // updateIndexes == false identifies the nested index-table write performed
+            // from within an enclosing mutation (CassandraTableWriteHandler.write via CassandraIndex)
+            long timeDelta = updateIndexes ? mt.put(update, indexer, opGroup)
+                                           : mt.putNested(update, indexer, opGroup);
+
             DecoratedKey key = update.partitionKey();
             invalidateCachedPartition(key);
             metric.topWritePartitionFrequency.addSample(key.getKey(), 1);

--- a/src/java/org/apache/cassandra/db/TableWriteHandler.java
+++ b/src/java/org/apache/cassandra/db/TableWriteHandler.java
@@ -22,5 +22,17 @@ import org.apache.cassandra.db.partitions.PartitionUpdate;
 
 public interface TableWriteHandler
 {
+    /**
+     * Apply {@code update} to the table's memtable.
+     *
+     * @param update       the partition update to write
+     * @param context      write context for the current mutation
+     * @param updateIndexes whether secondary indexes should be updated.
+     *                      When {@code false} this is a <em>nested</em> write (e.g. a legacy 2i index-table write
+     *                      issued from {@code indexer.onInserted()} under the base table's memtable-internal locks).
+     *                      Nested writes bypass the memtable pool's room-wait gate to avoid deadlocking the flush
+     *                      write-barrier; as a consequence they may allocate slightly beyond the gated limit
+     *                      (CASSANDRA-21019).
+     */
     void write(PartitionUpdate update, WriteContext context, boolean updateIndexes);
 }

--- a/src/java/org/apache/cassandra/db/memtable/AbstractAllocatorMemtable.java
+++ b/src/java/org/apache/cassandra/db/memtable/AbstractAllocatorMemtable.java
@@ -34,8 +34,10 @@ import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.DataRange;
 import org.apache.cassandra.db.commitlog.CommitLogPosition;
 import org.apache.cassandra.db.filter.ColumnFilter;
+import org.apache.cassandra.db.partitions.PartitionUpdate;
 import org.apache.cassandra.db.rows.Unfiltered;
 import org.apache.cassandra.db.rows.UnfilteredRowIterator;
+import org.apache.cassandra.index.transactions.UpdateTransaction;
 import org.apache.cassandra.schema.TableMetadataRef;
 import org.apache.cassandra.utils.Clock;
 import org.apache.cassandra.utils.FBUtilities;
@@ -164,6 +166,34 @@ public abstract class AbstractAllocatorMemtable extends AbstractMemtableWithComm
         return estimatedAverageRowSize.rowSize;
     }
     
+    /**
+     * CASSANDRA-21019: the memory limit is enforced once here, before a mutation starts
+     * and before any memtable-internal locks are taken; once started, a mutation runs to
+     * completion and individual allocations only track usage. Implemented here so every
+     * allocator-backed memtable (TrieMemtable, TrieMemtableStage1, SkipListMemtable, and
+     * future implementations) gets the gate; subclasses implement performPut().
+     */
+    @Override
+    public final long put(PartitionUpdate update, UpdateTransaction indexer, OpOrder.Group opGroup)
+    {
+        allocator.awaitRoomToStart(opGroup);
+        return performPut(update, indexer, opGroup);
+    }
+
+    /**
+     * CASSANDRA-21019: nested writes skip the room gate, as the enclosing mutation was
+     * gated when it started. (waiting for room here would run under the base table's
+     * memtable-internal locks where Barrier.markBlocking() cannot release a queued
+     * pre-barrier writer)
+     */
+    @Override
+    public final long putNested(PartitionUpdate update, UpdateTransaction indexer, OpOrder.Group opGroup)
+    {
+        return performPut(update, indexer, opGroup);
+    }
+
+    protected abstract long performPut(PartitionUpdate update, UpdateTransaction indexer, OpOrder.Group opGroup);
+
     @Override
     public boolean shouldSwitch(ColumnFamilyStore.FlushReason reason)
     {

--- a/src/java/org/apache/cassandra/db/memtable/Memtable.java
+++ b/src/java/org/apache/cassandra/db/memtable/Memtable.java
@@ -219,6 +219,23 @@ public interface Memtable extends Comparable<Memtable>, UnfilteredSource, CellSo
     long put(PartitionUpdate update, UpdateTransaction indexer, OpOrder.Group opGroup);
 
     /**
+     * Put variant for writes performed inside an already-started mutation on the same
+     * thread, e.g. legacy 2i applying to its index table's memtable from
+     * indexer.onInserted(), which runs under the base table's memtable-internal locks
+     * (CassandraIndex.insert -> CassandraTableWriteHandler.write, updateIndexes=false).
+     *
+     * Such writes must not wait for memtable pool room: parking there would hold the
+     * enclosing locks and deadlock the flush writeBarrier (CASSANDRA-21019). The memory
+     * limit was already enforced when the enclosing mutation started, we don't need to check again.
+     *
+     * Implementations without a room gate may keep this default.
+     */
+    default long putNested(PartitionUpdate update, UpdateTransaction indexer, OpOrder.Group opGroup)
+    {
+        return put(update, indexer, opGroup);
+    }
+
+    /**
      * Get the partition for the specified key. Returns null if no such partition is present.
      */
     Partition getPartition(DecoratedKey key);

--- a/src/java/org/apache/cassandra/db/memtable/PersistentMemoryMemtable.java
+++ b/src/java/org/apache/cassandra/db/memtable/PersistentMemoryMemtable.java
@@ -47,10 +47,11 @@ extends SkipListMemtable        // to test framework
         // We should possibly link the persistent data of this memtable
     }
 
-    public long put(PartitionUpdate update, UpdateTransaction indexer, OpOrder.Group opGroup)
+    @Override
+    protected long performPut(PartitionUpdate update, UpdateTransaction indexer, OpOrder.Group opGroup)
     {
         // TODO: implement
-        return super.put(update, indexer, opGroup);
+        return super.performPut(update, indexer, opGroup);
     }
 
     public MemtableUnfilteredPartitionIterator partitionIterator(ColumnFilter columnFilter, DataRange dataRange)

--- a/src/java/org/apache/cassandra/db/memtable/ShardedSkipListMemtable.java
+++ b/src/java/org/apache/cassandra/db/memtable/ShardedSkipListMemtable.java
@@ -123,7 +123,8 @@ public class ShardedSkipListMemtable extends AbstractShardedMemtable
      *
      * commitLogSegmentPosition should only be null if this is a secondary index, in which case it is *expected* to be null
      */
-    public long put(PartitionUpdate update, UpdateTransaction indexer, OpOrder.Group opGroup)
+    @Override
+    public long performPut(PartitionUpdate update, UpdateTransaction indexer, OpOrder.Group opGroup)
     {
         DecoratedKey key = update.partitionKey();
         MemtableShard shard = shards[boundaries.getShardForKey(key)];
@@ -550,7 +551,8 @@ public class ShardedSkipListMemtable extends AbstractShardedMemtable
          *
          * commitLogSegmentPosition should only be null if this is a secondary index, in which case it is *expected* to be null
          */
-        public long put(PartitionUpdate update, UpdateTransaction indexer, OpOrder.Group opGroup)
+        @Override
+        public long performPut(PartitionUpdate update, UpdateTransaction indexer, OpOrder.Group opGroup)
         {
             DecoratedKey key = update.partitionKey();
             MemtableShard shard = shards[boundaries.getShardForKey(key)];

--- a/src/java/org/apache/cassandra/db/memtable/SkipListMemtable.java
+++ b/src/java/org/apache/cassandra/db/memtable/SkipListMemtable.java
@@ -172,7 +172,7 @@ public class SkipListMemtable extends AbstractAllocatorMemtable
      * commitLogSegmentPosition should only be null if this is a secondary index, in which case it is *expected* to be null
      */
     @Override
-    public long put(PartitionUpdate update, UpdateTransaction indexer, OpOrder.Group opGroup)
+    protected long performPut(PartitionUpdate update, UpdateTransaction indexer, OpOrder.Group opGroup)
     {
         Cloner cloner = allocator.cloner(opGroup);
         AtomicBTreePartition previous = partitions.get(update.partitionKey());

--- a/src/java/org/apache/cassandra/db/memtable/TrieMemtable.java
+++ b/src/java/org/apache/cassandra/db/memtable/TrieMemtable.java
@@ -224,7 +224,7 @@ public class TrieMemtable extends AbstractShardedMemtable
      * commitLogSegmentPosition should only be null if this is a secondary index, in which case it is *expected* to be null
      */
     @Override
-    public long put(PartitionUpdate update, UpdateTransaction indexer, OpOrder.Group opGroup)
+    protected long performPut(PartitionUpdate update, UpdateTransaction indexer, OpOrder.Group opGroup)
     {
         DecoratedKey key = update.partitionKey();
         MemtableShard shard = shards[boundaries.getShardForKey(key)];

--- a/src/java/org/apache/cassandra/db/memtable/TrieMemtableStage1.java
+++ b/src/java/org/apache/cassandra/db/memtable/TrieMemtableStage1.java
@@ -220,7 +220,8 @@ public class TrieMemtableStage1 extends AbstractAllocatorMemtable
      *
      * commitLogSegmentPosition should only be null if this is a secondary index, in which case it is *expected* to be null
      */
-    public long put(PartitionUpdate update, UpdateTransaction indexer, OpOrder.Group opGroup)
+    @Override
+    protected long performPut(PartitionUpdate update, UpdateTransaction indexer, OpOrder.Group opGroup)
     {
         DecoratedKey key = update.partitionKey();
         MemtableShard shard = shards[boundaries.getShardForKey(key)];

--- a/src/java/org/apache/cassandra/utils/memory/MemtableAllocator.java
+++ b/src/java/org/apache/cassandra/utils/memory/MemtableAllocator.java
@@ -77,6 +77,18 @@ public abstract class MemtableAllocator
         return offHeap;
     }
 
+    /**
+     * Enforce the memtable memory limits once, before a mutation starts.
+     * 
+     * Called by AbstractAllocatorMemtable.put() before a mutation starts, prior to any
+     * memtable-internal locks; individual allocations no longer wait for room.
+     */
+    public void awaitRoomToStart(OpOrder.Group opGroup)
+    {
+        onHeap.awaitRoom(opGroup);
+        offHeap.awaitRoom(opGroup);
+    }
+
     public long unusedReservedOnHeapMemory()
     {
         return 0; // only slabbed allocators would have non-zero here
@@ -172,34 +184,54 @@ public abstract class MemtableAllocator
                 allocate(size, opGroup);
         }
 
-        // allocate memory in the tracker, and mark ourselves as owning it
+        // account memory in the tracker, and mark ourselves as owning it
         public void allocate(long size, OpOrder.Group opGroup)
         {
             assert size >= 0;
 
+            // CASSANDRA-21019: individual allocations only track usage (which still drives
+            // cleaner/flush triggering via maybeClean); the memory limit is enforced once,
+            // in awaitRoom(), before a mutation starts. Blocking here mid-mutation,
+            // potentially while holding memtable-internal locks such as TrieMemtable's
+            // shard write lock, can deadlock the flush writeBarrier: a pre-barrier
+            // writer queued behind such a lock cannot be released by Barrier.markBlocking(),
+            // which only reaches threads parked in this allocator. Letting a started
+            // mutation run to completion also retains less memory than parking it with a
+            // partial copy already written and locks held.
+            allocated(size);
+        }
+
+        /**
+         * Wait, if necessary, until the parent pool is below its limit, without reserving
+         * any memory.
+         * 
+         * This is the single point at which the memory limit
+         * pauses writes, memtables call it before starting to apply a mutation, before
+         * any internal locks are taken. Groups marked blocking by Barrier.markBlocking()
+         * skip or are released from this wait, exactly as they were from allocate(), so a
+         * flush can always drain the ops its barrier awaits.
+         */
+        public void awaitRoom(OpOrder.Group opGroup)
+        {
+            // A pool with no limit configured is never allocated from and never signalled
+            // (e.g. the off-heap pool under heap_buffers / unslabbed_heap_buffers, both
+            // created with an off-heap limit of 0)
+            if (parent.limit <= 0)
+                return;
+
             while (true)
             {
-                if (parent.tryAllocate(size))
-                {
-                    acquired(size);
+                if (parent.belowLimit() || opGroup.isBlocking())
                     return;
-                }
-                if (opGroup.isBlocking())
-                {
-                    allocated(size);
-                    return;
-                }
+
                 WaitQueue.Signal signal = parent.hasRoom().register(parent.markMemoryBlockedOnAllocating(), Timer.Context::stop);
                 opGroup.notifyIfBlocking(signal);
-                boolean allocated = parent.tryAllocate(size);
-                if (allocated)
+                if (parent.belowLimit() || opGroup.isBlocking())
                 {
                     signal.cancel();
-                    acquired(size);
                     return;
                 }
-                else
-                    signal.awaitThrowUncheckedOnInterrupt();
+                signal.awaitThrowUncheckedOnInterrupt();
             }
         }
 
@@ -211,24 +243,6 @@ public abstract class MemtableAllocator
         private void allocated(long size)
         {
             parent.allocated(size);
-            ownsUpdater.addAndGet(this, size);
-
-            if (state == LifeCycle.DISCARDING)
-            {
-                if (logger.isTraceEnabled())
-                    logger.trace("Allocated {} bytes whilst discarding", size);
-                updateReclaiming();
-            }
-        }
-
-        /**
-         * Retroactively mark an amount acquired in the tracker, and owned by us. If the state is discarding,
-         * then also update reclaiming since the flush operation is waiting at the barrier for in-flight writes,
-         * and it will flush this memory too.
-         */
-        private void acquired(long size)
-        {
-            parent.acquired();
             ownsUpdater.addAndGet(this, size);
 
             if (state == LifeCycle.DISCARDING)

--- a/src/java/org/apache/cassandra/utils/memory/MemtablePool.java
+++ b/src/java/org/apache/cassandra/utils/memory/MemtablePool.java
@@ -101,9 +101,9 @@ public abstract class MemtablePool
     }
 
     /**
-     * Note the difference between acquire() and allocate(); allocate() makes more resources available to all owners,
-     * and acquire() makes shared resources unavailable but still recorded. An Owner must always acquire resources,
-     * but only needs to allocate if there are none already available. This distinction is not always meaningful.
+     * Tracks memory attributed to this pool. Since CASSANDRA-21019 allocations only
+     * record usage (allocated/reclaiming) and drive cleaning; the limit is enforced
+     * before a mutation starts, via SubAllocator.awaitRoom() against belowLimit().
      */
     public class SubPool
     {
@@ -155,16 +155,10 @@ public abstract class MemtablePool
 
         /** Methods to allocate space **/
 
-        boolean tryAllocate(long size)
+        /** True if the pool is under its limit; reserves nothing. See SubAllocator.awaitRoom() */
+        boolean belowLimit()
         {
-            while (true)
-            {
-                long cur;
-                if ((cur = allocated) + size > limit)
-                    return false;
-                if (allocatedUpdater.compareAndSet(this, cur, cur + size))
-                    return true;
-            }
+            return allocated < limit;
         }
 
         /**
@@ -188,11 +182,6 @@ public abstract class MemtablePool
                 return;
 
             adjustAllocated(size);
-            maybeClean();
-        }
-
-        void acquired()
-        {
             maybeClean();
         }
 

--- a/test/unit/org/apache/cassandra/utils/memory/MemtableAllocatorAwaitRoomTest.java
+++ b/test/unit/org/apache/cassandra/utils/memory/MemtableAllocatorAwaitRoomTest.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.utils.memory;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.cassandra.utils.concurrent.ImmediateFuture;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.utils.concurrent.OpOrder;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * CASSANDRA-21019 review: heap_buffers and unslabbed_heap_buffers create their pool with
+ * an off-heap limit of 0 (SlabPool(heapLimit, 0, ...) / HeapPool -> super(max, 0, ...)).
+ * A zero-limit sub-pool is never allocated from and never signalled, so awaitRoom() must
+ * skip it -- without the guard, the first mutation on such a configuration hangs forever.
+ */
+public class MemtableAllocatorAwaitRoomTest
+{
+    @BeforeClass
+    public static void setup()
+    {
+        DatabaseDescriptor.daemonInitialization();
+    }
+
+    @Test(timeout = 30_000)
+    public void zeroLimitPoolDoesNotBlock() throws Exception
+    {
+        // heap_buffers shape: off-heap limit == 0
+        SlabPool pool = new SlabPool(1 << 20, 0, 1.0f, () -> ImmediateFuture.success(false));
+        try
+        {
+            MemtableAllocator allocator = pool.newAllocator("my_table");
+            OpOrder.Group g = new OpOrder().start();
+            Thread gate = run(() -> allocator.awaitRoomToStart(g));
+            gate.join(5_000);
+            assertFalse("awaitRoomToStart hung on the unused zero-limit off-heap pool", gate.isAlive());
+            g.close();
+        }
+        finally
+        {
+            pool.shutdownAndWait(1, TimeUnit.MINUTES);
+        }
+    }
+
+    @Test(timeout = 30_000)
+    public void configuredLimitStillGates() throws Exception
+    {
+        SlabPool pool = new SlabPool(1 << 20, 1 << 20, 1.0f, () -> ImmediateFuture.success(false));
+        try
+        {
+            MemtableAllocator allocator = pool.newAllocator("my_table");
+            OpOrder.Group g = new OpOrder().start();
+            pool.onHeap.allocated(pool.onHeap.limit);
+            Thread gate = run(() -> allocator.awaitRoomToStart(g));
+            gate.join(2_000);
+            assertTrue("gate did not wait while the on-heap pool was at its limit", gate.isAlive());
+            pool.onHeap.released(pool.onHeap.limit); // released() signals hasRoom
+            gate.join(10_000);
+            assertFalse("gate did not wake after room was released", gate.isAlive());
+            g.close();
+        }
+        finally
+        {
+            pool.shutdownAndWait(1, TimeUnit.MINUTES);
+        }
+    }
+
+    private static Thread run(Runnable r)
+    {
+        Thread t = new Thread(r, "await-room");
+        t.setDaemon(true);
+        t.start();
+        return t;
+    }
+}

--- a/test/unit/org/apache/cassandra/utils/memory/MemtableNestedPutSkipsRoomWaitTest.java
+++ b/test/unit/org/apache/cassandra/utils/memory/MemtableNestedPutSkipsRoomWaitTest.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.utils.memory;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.DeletionTime;
+import org.apache.cassandra.db.RangeTombstone;
+import org.apache.cassandra.db.commitlog.CommitLogPosition;
+import org.apache.cassandra.db.marshal.BytesType;
+import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.db.memtable.AbstractAllocatorMemtable;
+import org.apache.cassandra.db.memtable.Memtable;
+import org.apache.cassandra.db.memtable.ShardBoundaries;
+import org.apache.cassandra.db.memtable.TrieMemtableFactory;
+import org.apache.cassandra.db.partitions.PartitionUpdate;
+import org.apache.cassandra.db.rows.Row;
+import org.apache.cassandra.index.transactions.UpdateTransaction;
+import org.apache.cassandra.schema.TableMetadata;
+import org.apache.cassandra.schema.TableMetadataRef;
+import org.apache.cassandra.utils.concurrent.Future;
+import org.apache.cassandra.utils.concurrent.OpOrder;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * CASSANDRA-21019 review: legacy 2i applies to its index table's memtable from
+ * indexer.onInserted(), which runs under the base table's shard write lock
+ * (CassandraIndex.insert -> CassandraTableWriteHandler.write(updateIndexes=false) ->
+ * ColumnFamilyStore.apply -> Memtable.putNested, same thread). A nested write must never
+ * wait for pool room: parking there would hold the base shard lock and recreate the
+ * flush-writeBarrier deadlock one level down.
+ *
+ * Nesting is explicit in the API (put() gates; putNested() does not) and routed in
+ * ColumnFamilyStore.apply on the existing updateIndexes bit, so the write path carries
+ * no per-thread state. This test pins both halves of the contract at the exact
+ * production timing: nestedPutMustNotWaitForRoom exhausts the pool from inside
+ * onInserted (i.e. under the base shard lock) and asserts putNested completes;
+ * topLevelPutGatesAtLimit asserts put() still applies back-pressure.
+ */
+public class MemtableNestedPutSkipsRoomWaitTest
+{
+    private static final OpOrder READ_ORDER = new OpOrder();
+
+    private static final Memtable.Owner OWNER = new Memtable.Owner()
+    {
+        public Future<CommitLogPosition> signalFlushRequired(Memtable m, ColumnFamilyStore.FlushReason r) { return null; }
+        public Memtable getCurrentMemtable() { return null; }
+        public Iterable<Memtable> getIndexMemtables() { return java.util.Collections.emptyList(); }
+        public ShardBoundaries localRangeSplits(int shardCount) { return ShardBoundaries.NONE; }
+        public OpOrder readOrdering() { return READ_ORDER; }
+        public int getMemtableFlushPeriodInMs() { return 0; }
+    };
+
+    @BeforeClass
+    public static void setup()
+    {
+        DatabaseDescriptor.daemonInitialization();
+    }
+
+    @Test(timeout = 60_000)
+    public void nestedPutMustNotWaitForRoom() throws Exception
+    {
+        TableMetadata tmBase = metadata("base");
+        TableMetadata tmIndex = metadata("index");
+        Memtable.Factory factory = TrieMemtableFactory.INSTANCE;
+
+        Memtable base = factory.create(new AtomicReference<>(CommitLogPosition.NONE),
+                                       TableMetadataRef.forOfflineTools(tmBase), OWNER);
+
+        Memtable index = factory.create(new AtomicReference<>(CommitLogPosition.NONE),
+                                        TableMetadataRef.forOfflineTools(tmIndex), OWNER);
+
+        MemtablePool pool = AbstractAllocatorMemtable.MEMORY_POOL;
+        OpOrder.Group g = new OpOrder().start();
+        AtomicBoolean claimed = new AtomicBoolean();
+
+        // Mirrors the production seam: from onInserted (under the base shard writeLock),
+        // synchronously apply to another memtable with the same op group via putNested,
+        // as ColumnFamilyStore.apply does for updateIndexes == false. The pool is
+        // exhausted at exactly that point.
+        UpdateTransaction tx = new UpdateTransaction()
+        {
+            public void start() {}
+            public void onPartitionDeletion(DeletionTime deletionTime) {}
+            public void onRangeTombstone(RangeTombstone rangeTombstone) {}
+            public void onInserted(Row row)
+            {
+                pool.onHeap.allocated(pool.onHeap.limit);
+                pool.offHeap.allocated(pool.offHeap.limit);
+                claimed.set(true);
+                index.putNested(update(tmIndex), UpdateTransaction.NO_OP, g);
+            }
+            public void onUpdated(Row existing, Row updated) {}
+            public void commit() {}
+        };
+
+        Thread writer = new Thread(() -> { base.put(update(tmBase), tx, g); g.close(); }, "base-writer");
+        writer.setDaemon(true);
+        writer.start();
+        try
+        {
+            writer.join(10_000);
+            if (writer.isAlive())
+            {
+                StringBuilder sb = new StringBuilder("nested putNested() waited for room under the base shard lock:\n");
+                for (StackTraceElement f : writer.getStackTrace())
+                    sb.append("    at ").append(f).append('\n');
+                fail(sb.toString());
+            }
+        }
+        finally
+        {
+            if (claimed.get())
+            {
+                pool.onHeap.released(pool.onHeap.limit);
+                pool.offHeap.released(pool.offHeap.limit);
+            }
+        }
+    }
+
+    @Test(timeout = 60_000)
+    public void topLevelPutGatesAtLimit() throws Exception
+    {
+        TableMetadata tm = metadata("gated");
+        Memtable.Factory factory = TrieMemtableFactory.INSTANCE;
+
+        Memtable mt = factory.create(new AtomicReference<>(CommitLogPosition.NONE),
+                                     TableMetadataRef.forOfflineTools(tm), OWNER);
+
+        MemtablePool pool = AbstractAllocatorMemtable.MEMORY_POOL;
+        OpOrder.Group g = new OpOrder().start();
+        pool.onHeap.allocated(pool.onHeap.limit);
+        pool.offHeap.allocated(pool.offHeap.limit);
+        try
+        {
+            Thread writer = new Thread(() -> { mt.put(update(tm), UpdateTransaction.NO_OP, g); g.close(); }, "gated-writer");
+            writer.setDaemon(true);
+            writer.start();
+            writer.join(2_000);
+            assertTrue("top-level put() did not wait for room at the pool limit", writer.isAlive());
+        }
+        finally
+        {
+            pool.onHeap.released(pool.onHeap.limit);
+            pool.offHeap.released(pool.offHeap.limit);
+        }
+    }
+
+    private static TableMetadata metadata(String table)
+    {
+        return TableMetadata.builder("ks", table)
+                            .addPartitionKeyColumn("pk", Int32Type.instance)
+                            .addRegularColumn("v", BytesType.instance)
+                            .build();
+    }
+
+    private static PartitionUpdate update(TableMetadata tm)
+    {
+        PartitionUpdate.SimpleBuilder b = PartitionUpdate.simpleBuilder(tm, 42);
+        b.row().add("v", ByteBuffer.allocate(64));
+        return b.build();
+    }
+}

--- a/test/unit/org/apache/cassandra/utils/memory/NativeAllocatorTest.java
+++ b/test/unit/org/apache/cassandra/utils/memory/NativeAllocatorTest.java
@@ -141,10 +141,18 @@ public class NativeAllocatorTest
             allocator.allocate(50, group);
             verifyUsedReclaiming(80, 80);
 
-            // allocate above limit, check we block until "marked blocking"
-            exec.schedule(markBlocking, 10L, TimeUnit.MILLISECONDS);
+            // allocations above the limit dont block, they only track usage;
+            // the limit is enforced before a mutation starts, in awaitRoom()
             Assert.assertEquals(0, pool.blockedOnAllocatingCount.getCount());
             allocator.allocate(30, group);
+            Assert.assertNull(barrier.get());
+            Assert.assertEquals(0, pool.blockedOnAllocatingCount.getCount());
+            verifyUsedReclaiming(110, 110);
+
+            // the wait moved to awaitRoom(): above the limit it blocks until the pool has
+            // room or the group is "marked blocking", exactly as allocate() used to
+            exec.schedule(markBlocking, 10L, TimeUnit.MILLISECONDS);
+            allocator.offHeap().awaitRoom(group);
             Assert.assertNotNull(barrier.get());
             Assert.assertEquals(1, pool.blockedOnAllocatingCount.getCount());
             verifyUsedReclaiming(110, 110);

--- a/test/unit/org/apache/cassandra/utils/memory/TrieMemtableShardLockDeadlockTest.java
+++ b/test/unit/org/apache/cassandra/utils/memory/TrieMemtableShardLockDeadlockTest.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cassandra.utils.memory;
+
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.commitlog.CommitLogPosition;
+import org.apache.cassandra.db.marshal.BytesType;
+import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.db.memtable.AbstractAllocatorMemtable;
+import org.apache.cassandra.db.memtable.Memtable;
+import org.apache.cassandra.db.memtable.ShardBoundaries;
+import org.apache.cassandra.db.memtable.TrieMemtableFactory;
+import org.apache.cassandra.db.memtable.TrieMemtableStage1;
+import org.apache.cassandra.db.partitions.PartitionUpdate;
+import org.apache.cassandra.index.transactions.UpdateTransaction;
+import org.apache.cassandra.schema.TableMetadata;
+import org.apache.cassandra.schema.TableMetadataRef;
+import org.apache.cassandra.utils.concurrent.Future;
+import org.apache.cassandra.utils.concurrent.OpOrder;
+
+import static org.junit.Assert.fail;
+
+/**
+ * Regression test for the TrieMemtable shard-lock / flush-barrier deadlock (CASSANDRA-21019).
+ * On code where allocations wait for pool room mid-mutation (under the shard writeLock),
+ * this deadlocks and the test fails after ~15s, printing the three participating stacks.
+ * With the memory limit enforced once at put() entry (MemtableAllocator.awaitRoomToStart)
+ * and individual allocations tracking-only, the barrier drains and the test passes.
+ *
+ * Cycle reproduced: the barrier waits on pre-barrier op W1; W1 queues on the (single)
+ * MemtableShard writeLock; the lock is held by post-barrier op W2, parked in
+ * SubAllocator.allocate (isBlocking == false, correctly); memory is freed only by the
+ * flush; the flush waits on the barrier. markBlocking() releases only allocator waiters,
+ * never lock waiters, so the barrier cannot complete.
+ *
+ * The flush machinery is replaced by the three calls ColumnFamilyStore.Flush.run makes
+ * (issue, markBlocking, await); pool exhaustion is synthetic (claim the whole SubPool
+ * limit, restored in a finally so the shared pool is clean for other tests).
+ * The setup checkpoints tolerate a fixed build: if W1/W2 complete instead of wedging,
+ * the test proceeds to the barrier join and goes green.
+ */
+@RunWith(Parameterized.class)
+public class TrieMemtableShardLockDeadlockTest
+{
+    /**
+     * CASSANDRA-21019 review: parameterized over every allocator-backed memtable with a per-shard write lock
+     */
+    @Parameterized.Parameters(name = "{0}")
+    public static Object[][] factories()
+    {
+        DatabaseDescriptor.daemonInitialization();
+        Memtable.Factory trie = TrieMemtableFactory.INSTANCE;
+        Memtable.Factory stage1 = TrieMemtableStage1.FACTORY;
+        return new Object[][]{ { "TrieMemtable", trie }, { "TrieMemtableStage1", stage1 } };
+    }
+
+    @Parameterized.Parameter(0)
+    public String factoryName;
+    @Parameterized.Parameter(1)
+    public Memtable.Factory factory;
+
+    /** put() touches none of this beyond construction; single shard, no scheduled flush. */
+    private static final OpOrder READ_ORDER = new OpOrder();
+    private static final Memtable.Owner OWNER = new Memtable.Owner()
+    {
+        public Future<CommitLogPosition> signalFlushRequired(Memtable m, ColumnFamilyStore.FlushReason r) { return null; }
+        public Memtable getCurrentMemtable() { return null; }
+        public Iterable<Memtable> getIndexMemtables() { return Collections.emptyList(); }
+        public ShardBoundaries localRangeSplits(int shardCount) { return ShardBoundaries.NONE; }
+        public OpOrder readOrdering() { return READ_ORDER; }
+        public int getMemtableFlushPeriodInMs() { return 0; }
+    };
+
+    @Test(timeout = 60_000)
+    public void writeBarrierMustCompleteDespiteShardLockQueue() throws Exception
+    {
+        TableMetadata tm = TableMetadata.builder("ks", "t")
+                                        .addPartitionKeyColumn("pk", Int32Type.instance)
+                                        .addRegularColumn("v", BytesType.instance)
+                                        .build();
+
+        Memtable mt = TrieMemtableFactory.INSTANCE.create(new AtomicReference<>(CommitLogPosition.NONE),
+                                     TableMetadataRef.forOfflineTools(tm),
+                                     OWNER);
+
+        OpOrder order = new OpOrder(); // stands in for Keyspace.writeOrder
+        MemtablePool pool = AbstractAllocatorMemtable.MEMORY_POOL;
+
+        OpOrder.Group g1 = order.start();          // W1's op: PRE-barrier
+
+        OpOrder.Barrier barrier = order.newBarrier();
+        barrier.issue();
+        barrier.markBlocking();                    // exactly what ColumnFamilyStore.Flush.run does
+
+        pool.onHeap.allocated(pool.onHeap.limit);  // synthetic exhaustion: next allocate parks
+        pool.offHeap.allocated(pool.offHeap.limit);
+        try
+        {
+            OpOrder.Group g2 = order.start();      // W2's op: POST-barrier
+            Thread w2 = run("w2", () -> { mt.put(update(tm), UpdateTransaction.NO_OP, g2); g2.close(); });
+            waitUntilBlockedAtOrDone(w2, "SubAllocator"); // unpatched: lock holder parked in allocate(); patched: parked in awaitRoom() (AbstractAllocatorMemtable.put) before the lock
+
+            Thread w1 = run("w1", () -> { mt.put(update(tm), UpdateTransaction.NO_OP, g1); g1.close(); });
+            waitUntilBlockedAtOrDone(w1, "MemtableShard", "ReentrantLock");// queued on the same (only) lock
+
+            // A flush's writeBarrier.await() must complete: markBlocking() has run, and the
+            // design guarantees pre-barrier ops can always make progress. On current main
+            // it never returns -- W1 is on a lock, invisible to the valve.
+            Thread flush = run("flush", barrier::await);
+            flush.join(15_000);
+
+            if (flush.isAlive())
+                fail("DEADLOCK (CASSANDRA-21019 regression): writeBarrier.await() did not complete in 15s;\n"
+                     + "a pre-barrier write is queued on a shard lock held by a memory-blocked post-barrier write.\n"
+                     + dump(flush, w1, w2));
+        }
+        finally
+        {
+            pool.onHeap.released(pool.onHeap.limit);   // restore the shared pool for other tests;
+            pool.offHeap.released(pool.offHeap.limit); // also drains the wedged daemon threads
+        }
+    }
+
+    private static PartitionUpdate update(TableMetadata tm)
+    {
+        PartitionUpdate.SimpleBuilder b = PartitionUpdate.simpleBuilder(tm, 42);
+        b.row().add("v", ByteBuffer.allocate(64));
+        return b.build();
+    }
+
+    private static Thread run(String name, Runnable r)
+    {
+        Thread t = new Thread(r, name); t.setDaemon(true); t.start(); return t;
+    }
+
+    /** Wait until the thread's stack shows all substrings (wedged, the bug) or the thread ends (fixed build). */
+    private static void waitUntilBlockedAtOrDone(Thread t, String... frameSubstrings) throws InterruptedException
+    {
+        for (long deadline = System.nanoTime() + 30_000_000_000L; System.nanoTime() < deadline; Thread.sleep(50))
+        {
+            if (!t.isAlive())
+                return;
+
+            String stack = java.util.Arrays.toString(t.getStackTrace());
+            boolean all = true;
+
+            for (String s : frameSubstrings)
+                all &= stack.contains(s);
+
+            if (all)
+                return;
+        }
+        throw new AssertionError(t.getName() + " neither finished nor reached " + String.join("+", frameSubstrings));
+    }
+
+    /** Mini-jstack of the deadlock participants for the failure message. */
+    private static String dump(Thread... threads)
+    {
+        StringBuilder sb = new StringBuilder();
+        for (Thread t : threads)
+        {
+            sb.append('"').append(t.getName()).append("\" ").append(t.getState()).append('\n');
+            StackTraceElement[] stack = t.getStackTrace();
+
+            for (int i = 0; i < Math.min(stack.length, 12); i++)
+                sb.append("    at ").append(stack[i]).append('\n');
+        }
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
CC5 (`main-5.0`) forward 0f https://github.com/datastax/cassandra/pull/2520

https://datastax.jira.com/browse/HCD-442

### What is the issue


`TrieMemtable` (and `ShardedSkipListMemtable` with `serialize_writes: true`) performs **blocking memory allocations while holding a per-shard write lock**: the cloner allocates during `data.apply`, and `allocator.onHeap()/offHeap().adjust(..., opGroup)` runs before the lock is released. When the memtable pool is at its limit, this deadlocks flushes:

1. A **post-barrier** write takes a shard lock and parks in `SubAllocator.allocate()` waiting for pool room (`isBlocking == false`, since the flush barrier does not wait on it).
2. A **pre-barrier** write: one the flush's `writeBarrier` *does* wait on; queues behind that lock.
3. `Flush.run`'s `writeBarrier.markBlocking()` cannot help: it only releases threads parked **in the allocator**, never threads parked on a lock or monitor.
4. Pool memory is reclaimed only when the flush completes → the flush waits on the barrier → the barrier waits on the lock queue → the lock holder waits on the memory. **Permanent deadlock.**

Because `Keyspace.writeOrder` is node-global while memtable switching is per-CFS, pre- and post-barrier writes routinely share shard locks on every table *not* being flushed, no special interleaving is needed beyond memory pressure.

Observed in production as a total write stall requiring a node restart:

- all MutationStage threads parked in `SubAllocator.allocate` or on shard `ReentrantLock`s,
- `MemtableFlushWriter` at `OpOrder$Barrier.await`, `MemtablePostFlush` behind it.

Heap-dump analysis confirmed the cycle: the barrier group held N unfinished ops, **all** queued on shard locks, each lock owned by a post-barrier writer parked in the allocator.


### What does this PR fix and why was it fixed


Check the allocation limits **once, before a mutation starts**, and once started allow it to fully progress to completion:

- `SubAllocator.allocate()` now only tracks usage; it never consults the limit and never  blocks. Cleaner/flush triggering is unchanged. Its dead remnants  (`SubPool.tryAllocate`/`acquired`, `SubAllocator.acquired`) are removed and the stale `SubPool` javadoc rewritten.
- New `SubAllocator.awaitRoom()` waits, without reserving memory, until the pool is  below its limit. Groups marked by `Barrier.markBlocking()` skip or are released from  this wait, so a flush can always drain the ops its barrier awaits. Sub-pools with no
  limit configured are skipped — the off-heap pool under `heap_buffers` / `unslabbed_heap_buffers` is created with limit 0, is never allocated from and never  signalled, and waiting on it would hang the first write.
- The gate lives in `AbstractAllocatorMemtable`: a `final put()` calls  `awaitRoomToStart()` then delegates to a new abstract `performPut()` implemented by  `TrieMemtable`, `TrieMemtableStage1`, `SkipListMemtable` and  `PersistentMemoryMemtable`. Every allocator-backed memtable — current and future —  gets the gate by construction; `final` turns a forgotten override into a compile
  error rather than a silently ungated write path.
- Nested writes are **explicit, not detected**: `Memtable.putNested()` (default:  delegate to `put()`; gated implementations MUST override — `AbstractAllocatorMemtable`  does, `final`, bypassing the gate) and `ColumnFamilyStore.apply` routes on the
  existing `updateIndexes` bit, which already distinguishes top-level writes from the  2i index-table write. Nesting is statically known at the call sites, so the write  path carries **no per-thread state** — an earlier `ThreadLocal` depth guard was  rejected for hot-path cost, consistent with the project's removal of `ThreadLocal`  from hot paths.

The cost model is the ticket's: the limit may be breached by up to the in-flight mutations' allocations — effectively what already happens for operations permitted to complete against a memtable marked for flush.

Tests: a regression test reproducing the deadlock deterministically on the previous code, parameterized over `TrieMemtable` and `TrieMemtableStage1` (barrier never completes; fails printing the three participating stacks); a contract pair proving
`putNested()` completes with the pool exhausted from under the base shard lock while `put()` still applies back-pressure; and a test pinning the zero-limit-pool skip plus gate wake-up on `released()`.

