### PR TITLE
CNDB-18538: reuse IndexDescriptor from SAI builder to register index components into TOC

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/SSTableContextManager.java
+++ b/src/java/org/apache/cassandra/index/sai/SSTableContextManager.java
@@ -236,6 +236,12 @@ public class SSTableContextManager
         });
     }
 
+    @VisibleForTesting
+    public int getDescriptorCount()
+    {
+        return sstableDescriptors.size();
+    }
+
     private static Set<IndexContext> contexts(Set<StorageAttachedIndex> indices)
     {
         Set<IndexContext> contexts = Sets.newHashSetWithExpectedSize(indices.size());

--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndexBuilder.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndexBuilder.java
@@ -21,7 +21,6 @@
 
 package org.apache.cassandra.index.sai;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
@@ -48,7 +47,6 @@ import org.apache.cassandra.index.sai.disk.StorageAttachedIndexWriter;
 import org.apache.cassandra.index.sai.disk.format.ComponentsBuildId;
 import org.apache.cassandra.index.sai.disk.format.IndexComponents;
 import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
-import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.io.sstable.Component;
 import org.apache.cassandra.io.sstable.Descriptor;
 import org.apache.cassandra.io.sstable.SSTableIdentityIterator;
@@ -225,7 +223,7 @@ public class StorageAttachedIndexBuilder extends SecondaryIndexBuilder
                     previousKeyPosition = dataPosition;
                 }
 
-                completeSSTable(txn, indexWriter, sstable, indexes, perSSTableFileLock, replacedComponents);
+                completeSSTable(txn, indexWriter, indexDescriptor, sstable, indexes, perSSTableFileLock, replacedComponents);
             }
             long timeTaken = ApproximateTime.nanoTime() - startTimeNanos;
             group.table().metric.updateStorageAttachedIndexBuildTime(timeTaken);
@@ -329,12 +327,23 @@ public class StorageAttachedIndexBuilder extends SecondaryIndexBuilder
             components.forWrite().forceDeleteAllComponents();
     }
 
+    /**
+     * Completes the index build for an SSTable and registers the built components in its TOC.
+     *
+     * <p>The supplied {@code indexDescriptor} must be the descriptor used to create {@code indexWriter}. Looking up the
+     * descriptor through the group at this point is unsafe because concurrent unloading can evict the cached descriptor;
+     * rebuilding it from the SSTable TOC would skip the components produced by this build.</p>
+     *
+     * <p>If {@code latch} is non-null, this builder owns the per-SSTable component build and releases waiting builders.
+     * Otherwise, this builder waits for an owner, if any, before publishing its per-index components.</p>
+     */
     private void completeSSTable(LifecycleTransaction txn,
                                  StorageAttachedIndexWriter indexWriter,
+                                 IndexDescriptor indexDescriptor,
                                  SSTableReader sstable,
                                  Set<StorageAttachedIndex> indexes,
                                  CountDownLatch latch,
-                                 Set<Component> replacedComponents) throws InterruptedException, IOException
+                                 Set<Component> replacedComponents) throws InterruptedException
     {
         indexWriter.complete(sstable);
 
@@ -361,8 +370,9 @@ public class StorageAttachedIndexBuilder extends SecondaryIndexBuilder
             return;
         }
 
-        // register custom index components into existing sstables
-        sstable.registerComponents(group.activeComponents(sstable), tracker);
+        // Register components from the descriptor that owns the writers. The context cache may have been
+        // evicted before this point, and a reader lookup would reconstruct a descriptor from the pre-build TOC.
+        sstable.registerComponents(group.activeComponents(indexDescriptor), tracker);
         if (!replacedComponents.isEmpty())
             sstable.unregisterComponents(replacedComponents, tracker);
 

--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndexGroup.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndexGroup.java
@@ -296,7 +296,14 @@ public class StorageAttachedIndexGroup implements Index.Group, INotificationCons
     @Override
     public Set<Component> activeComponents(SSTableReader sstable)
     {
-        IndexDescriptor indexDescriptor = descriptorFor(sstable);
+        return activeComponents(descriptorFor(sstable));
+    }
+
+    /**
+     * Returns the active components tracked by the supplied descriptor.
+     */
+    Set<Component> activeComponents(IndexDescriptor indexDescriptor)
+    {
         Set<Component> components = indexDescriptor
                                     .perSSTableComponents()
                                     .all()

--- a/test/unit/org/apache/cassandra/index/sai/StorageAttachedIndexBuilderTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/StorageAttachedIndexBuilderTest.java
@@ -76,19 +76,13 @@ public class StorageAttachedIndexBuilderTest extends SAITester
 
             // there is one descriptor populated by index build and it has all built index components
             assertThat(group.sstableContextManager().getDescriptorCount()).isEqualTo(1);
-            IndexDescriptor builtDescriptor = group.descriptorFor(sstable);
-            assertThat(builtDescriptor.perSSTableComponents().isComplete()).isTrue();
-            for (StorageAttachedIndex index : group.getIndexes())
-                assertThat(builtDescriptor.perIndexComponents(index.getIndexContext()).isComplete()).isTrue();
+            assertCompleteComponents(group, sstable);
 
             // now clear the cached descriptor and reload from TOC
             group.sstableContextManager().clear();
             assertThat(group.sstableContextManager().getDescriptorCount()).isEqualTo(0);
 
-            IndexDescriptor reloadedDescriptor = group.descriptorFor(sstable);
-            assertThat(reloadedDescriptor.perSSTableComponents().isComplete()).isTrue();
-            for (StorageAttachedIndex index : group.getIndexes())
-                assertThat(reloadedDescriptor.perIndexComponents(index.getIndexContext()).isComplete()).isTrue();
+            assertCompleteComponents(group, sstable);
         }
         finally
         {
@@ -97,6 +91,7 @@ public class StorageAttachedIndexBuilderTest extends SAITester
     }
 
     // called by byteman
+    @SuppressWarnings("unused")
     public static void evictDescriptorCache()
     {
         StorageAttachedIndexGroup group = StorageAttachedIndexGroup.getIndexGroup(columnFamilyStore);
@@ -105,5 +100,13 @@ public class StorageAttachedIndexBuilderTest extends SAITester
 
         group.sstableContextManager().clear();
         descriptorCacheEvicted = true;
+    }
+
+    private void assertCompleteComponents(StorageAttachedIndexGroup group, SSTableReader sstable)
+    {
+        IndexDescriptor descriptor = group.descriptorFor(sstable);
+        assertThat(descriptor.perSSTableComponents().isComplete()).isTrue();
+        for (StorageAttachedIndex index : group.getIndexes())
+            assertThat(descriptor.perIndexComponents(index.getIndexContext()).isComplete()).isTrue();
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/StorageAttachedIndexBuilderTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/StorageAttachedIndexBuilderTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai;
+
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+import com.google.common.collect.Iterables;
+import org.awaitility.Awaitility;
+import org.junit.Test;
+
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.index.sai.disk.StorageAttachedIndexWriter;
+import org.apache.cassandra.index.sai.disk.format.IndexDescriptor;
+import org.apache.cassandra.inject.ActionBuilder;
+import org.apache.cassandra.inject.Expression;
+import org.apache.cassandra.inject.Injection;
+import org.apache.cassandra.inject.Injections;
+import org.apache.cassandra.inject.InvokePointBuilder;
+import org.apache.cassandra.io.sstable.format.SSTableReader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StorageAttachedIndexBuilderTest extends SAITester
+{
+    private static volatile ColumnFamilyStore columnFamilyStore;
+    private static volatile boolean descriptorCacheEvicted;
+
+    @Test
+    public void testRegisterComponentsFromBuildDescriptorAfterCacheEviction() throws Throwable
+    {
+        createTable("CREATE TABLE %s (id text PRIMARY KEY, value int)");
+        execute("INSERT INTO %s (id, value) VALUES ('k1', 1)");
+        flush();
+
+        columnFamilyStore = getCurrentColumnFamilyStore();
+        descriptorCacheEvicted = false;
+
+        Injection evictDescriptorCache = Injections.newCustom("evict_descriptor_cache_after_sai_build")
+                                                    .add(InvokePointBuilder.newInvokePoint()
+                                                                           .onClass(StorageAttachedIndexBuilder.class)
+                                                                           .onMethod("completeSSTable")
+                                                                           .after("INVOKE " + StorageAttachedIndexWriter.class.getName() + ".complete"))
+                                                    .add(ActionBuilder.newActionBuilder()
+                                                                      .actions()
+                                                                      .doAction(Expression.expr(StorageAttachedIndexBuilderTest.class.getName())
+                                                                                          .method("evictDescriptorCache")
+                                                                                          .args()))
+                                                    .build();
+
+        try
+        {
+            Injections.inject(evictDescriptorCache);
+
+            createIndex(String.format(CREATE_INDEX_TEMPLATE, "value"));
+            Awaitility.await("Byteman called to clear SSTableContextManager")
+                    .atMost(10, TimeUnit.SECONDS)
+                    .untilAsserted(() -> assertThat(descriptorCacheEvicted).isTrue());
+
+            StorageAttachedIndexGroup group = Objects.requireNonNull(StorageAttachedIndexGroup.getIndexGroup(columnFamilyStore));
+            SSTableReader sstable = Iterables.getOnlyElement(columnFamilyStore.getLiveSSTables());
+
+            // there is one descriptor populated by index build and it has all built index components
+            assertThat(group.sstableContextManager().getDescriptorCount()).isEqualTo(1);
+            IndexDescriptor builtDescriptor = group.descriptorFor(sstable);
+            assertThat(builtDescriptor.perSSTableComponents().isComplete()).isTrue();
+            for (StorageAttachedIndex index : group.getIndexes())
+                assertThat(builtDescriptor.perIndexComponents(index.getIndexContext()).isComplete()).isTrue();
+
+            // now clear the cached descriptor and reload from TOC
+            group.sstableContextManager().clear();
+            assertThat(group.sstableContextManager().getDescriptorCount()).isEqualTo(0);
+
+            IndexDescriptor reloadedDescriptor = group.descriptorFor(sstable);
+            assertThat(reloadedDescriptor.perSSTableComponents().isComplete()).isTrue();
+            for (StorageAttachedIndex index : group.getIndexes())
+                assertThat(reloadedDescriptor.perIndexComponents(index.getIndexContext()).isComplete()).isTrue();
+        }
+        finally
+        {
+            columnFamilyStore = null;
+        }
+    }
+
+    // called by byteman
+    public static void evictDescriptorCache()
+    {
+        StorageAttachedIndexGroup group = StorageAttachedIndexGroup.getIndexGroup(columnFamilyStore);
+        if (group == null)
+            throw new IllegalStateException("Storage-attached index group is not registered");
+
+        group.sstableContextManager().clear();
+        descriptorCacheEvicted = true;
+    }
+}


### PR DESCRIPTION
, instead of using cached IndexDescriptor which can be removed by concurrent unloading

### What is the issue
[#18538](https://github.com/riptano/cndb/issues/18538)

### What does this PR fix and why was it fixed
reuse IndexDescriptor from SAI builder to register index components into TOC, instead of using cached IndexDescriptor which can be removed by concurrent unloading
