### PR TITLE
CNDB-18577 ignore Bob settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,8 @@ target/
 
 # AI agents
 .ai/
+.bob/
+AGENTS.md
 
 # General
 **/__pycache__


### PR DESCRIPTION

### What is the issue

Fixes https://github.com/riptano/cndb/issues/18577

As we are more actively working with customizing Bob for our development work, it can be useful to avoid sharing Bob settings unexpectedly.

### What does this PR fix and why was it fixed

Adds .bob and AGENTS.md to gitignore, so we don't override each other settings.
