### PR TITLE
CNDB-18578 HCD-474: Add DecommissionHook so plugins can run work before a node finishes leaving

### DIFF
--- a/src/java/org/apache/cassandra/service/DecommissionHook.java
+++ b/src/java/org/apache/cassandra/service/DecommissionHook.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.service;
+
+/**
+ * Work that must run on a node that is being decommissioned, before that node finishes leaving.
+ *
+ * Register with {@link StorageService#registerDecommissionHook(DecommissionHook)}; several hooks
+ * may be registered, and they run one after another in registration order. A hook only ever runs
+ * on the node being decommissioned, and only for {@code nodetool decommission} -- not on a
+ * graceful shutdown, not on {@code nodetool removenode} (where this node is already gone), and
+ * not on the nodes that merely observe a peer leaving.
+ *
+ * <h2>Where this runs</h2>
+ *
+ * {@link StorageService#decommission(boolean)} invokes hooks after {@code unbootstrap()} has
+ * returned and before it tears any subsystem down. At that point:
+ *
+ * <ul>
+ *   <li>the batch log has completed its final replay, and hints have been transferred or dropped;</li>
+ *   <li>all ranges have been streamed to their new owners;</li>
+ *   <li>this node has left the ring -- {@code leaveRing()} removed it from {@code TokenMetadata},
+ *       announced LEFT and waited for the peers to notice, so coordinators no longer route
+ *       mutations here. Note this needs LEFT, not LEAVING: {@code addLeavingEndpoint} only records
+ *       the endpoint in a set that write routing never consults, so a LEAVING node stays a natural
+ *       write replica;</li>
+ *   <li>decommission has not yet stopped messaging, the native transport or the stages, so a hook
+ *       <b>may run CQL queries</b> and coordinate against the rest of the cluster.</li>
+ * </ul>
+ *
+ * <h2>Caveats a hook has to live with</h2>
+ *
+ * <ul>
+ *   <li>A late mutation can still <i>arrive</i>: a peer that has not yet processed LEFT may send
+ *       one, and this node applies it, because {@code reject_out_of_token_range_requests} defaults
+ *       to false. "No mutations" means none are routed here, not that none can land. Set that
+ *       option to true if a hook needs the stronger guarantee.</li>
+ *   <li>Hints do not help a hook's writes. {@code unbootstrap()} has already dealt with the hints
+ *       this node held: by default ({@code transfer_hints_on_decommission}) it streamed them to a
+ *       peer, otherwise it disabled hinted handoff and deleted them. Either way that happened
+ *       <i>before</i> the hooks, so a hint a hook's write creates now is never transferred, and is
+ *       lost when the process stops. A hook's write should meet its consistency level against live
+ *       replicas rather than rely on being completed later.</li>
+ *   <li>The native transport is only guaranteed not to have been shut down <i>by the decommission</i>;
+ *       it may still be off for unrelated reasons (never started, {@code nodetool disablebinary}).
+ *       A hook coordinating in-process via {@code QueryProcessor} does not depend on it.</li>
+ * </ul>
+ *
+ * <h2>Contract</h2>
+ *
+ * A hook may block for as long as it needs -- minutes or hours. Decommission does not proceed
+ * until every hook has returned, and {@code nodetool decommission} blocks for that whole time.
+ * Hooks run on the thread serving the decommission request, so they must not assume any particular
+ * executor.
+ *
+ * Within one process a hook runs at most once: hooks are only reached once {@code unbootstrap()}
+ * has succeeded, and from there the decommission always runs to completion, so a repeated
+ * {@code nodetool decommission} returns early rather than making a second pass. A decommission that
+ * fails <i>before</i> unbootstrap() completes never reaches the hooks at all, so a later retry runs
+ * them for the first time. That is not an across-restarts guarantee: {@code leaveRing()} persists
+ * NEEDS_BOOTSTRAP before the hooks run, so if the process is killed while a hook is still working,
+ * the node bootstraps back into the ring on restart and a later decommission runs every hook again.
+ * A hook that cannot tolerate that must make itself idempotent.
+ *
+ * If a hook fails, the remaining hooks still run and the decommission still completes -- by this
+ * point the data has streamed away and the node has left the ring, so there is nothing to roll back
+ * to, and refusing to finish would only strand the node (a retry is rejected because the node is no
+ * longer a ring member, and a restart would re-bootstrap it). The failure is logged, and
+ * {@code decommission} then throws naming the offending hooks, so a hook failure is never silent.
+ * Note what that means for tooling: a failure reported by {@code nodetool decommission} does not
+ * imply the decommission was not performed -- check the node's operation mode to tell the two apart.
+ *
+ * Anything a hook throws is reported this way, including an {@link Error}: escalating it to the JVM
+ * failure policy from here would strand the node in the window this design exists to avoid.
+ */
+public interface DecommissionHook
+{
+    /**
+     * Identifies this hook in the decommission log lines. Should be short and stable.
+     */
+    String name();
+
+    /**
+     * Runs the work. May block indefinitely; may run CQL queries. Throwing is reported and fails
+     * {@code nodetool decommission}, but does not stop the node from finishing its decommission.
+     */
+    void onDecommission() throws Exception;
+}

--- a/src/java/org/apache/cassandra/service/DecommissionHook.java
+++ b/src/java/org/apache/cassandra/service/DecommissionHook.java
@@ -109,8 +109,10 @@ package org.apache.cassandra.service;
  *       the usual idiom for a method that cannot throw -- returns normally and counts as success.
  *       The caller clears the flag (logging a warning) before invoking the next hook, so a restored
  *       interrupt never leaks into a later hook, into the shutdown sequence, or onto the pooled JMX
- *       handler thread that the decommission borrowed. The flag is cleared again after the last
- *       hook, so it can never outlive the chain.</li>
+ *       handler thread that the decommission borrowed. The same clearing happens when a hook
+ *       restores the flag and then throws something else, so the failure path leaks it no more than
+ *       the success path does, and the flag is cleared once more after the last hook, so it can
+ *       never outlive the chain.</li>
  * </ul>
  *
  * The practical consequences for a hook author: the interrupt flag is always clear on entry, so a

--- a/src/java/org/apache/cassandra/service/DecommissionHook.java
+++ b/src/java/org/apache/cassandra/service/DecommissionHook.java
@@ -85,6 +85,38 @@ package org.apache.cassandra.service;
  *
  * Anything a hook throws is reported this way, including an {@link Error}: escalating it to the JVM
  * failure policy from here would strand the node in the window this design exists to avoid.
+ *
+ * <h2>Interruption</h2>
+ *
+ * A hook is not interrupted by the decommission itself: nothing in {@code decommission()} cancels a
+ * running hook, and there is no timeout, so an interrupt can only come from whoever holds the
+ * decommission thread -- typically the JMX client disconnecting or a caller cancelling the JMX
+ * invocation. A hook that blocks should therefore treat interruption as "the operator gave up on
+ * this call", not as "the decommission was aborted": the node has already left the ring and the
+ * decommission will finish regardless.
+ *
+ * Both standard responses to interruption are handled, and neither is a no-op:
+ *
+ * <ul>
+ *   <li><b>Propagating {@link InterruptedException}</b> aborts the hook chain. The hook is recorded
+ *       as failed ({@code "<name> (interrupted)"}), every hook after it is recorded as not run, and
+ *       the decommission proceeds to its shutdown steps. The interrupt is <i>not</i> re-asserted:
+ *       throwing {@code InterruptedException} already cleared the flag, and restoring it would fail
+ *       the shutdown's blocking waits, so the remaining hooks are skipped rather than run against an
+ *       interrupted thread. A hook that wants the rest of the chain to run must not let an
+ *       {@code InterruptedException} escape.</li>
+ *   <li><b>Catching it and restoring the flag</b> -- {@code Thread.currentThread().interrupt()},
+ *       the usual idiom for a method that cannot throw -- returns normally and counts as success.
+ *       The caller clears the flag (logging a warning) before invoking the next hook, so a restored
+ *       interrupt never leaks into a later hook, into the shutdown sequence, or onto the pooled JMX
+ *       handler thread that the decommission borrowed. The flag is cleared again after the last
+ *       hook, so it can never outlive the chain.</li>
+ * </ul>
+ *
+ * The practical consequences for a hook author: the interrupt flag is always clear on entry, so a
+ * hook may block without first draining a stale interrupt; and setting the flag on the way out is
+ * harmless but pointless, because it is consumed immediately and cannot be used to signal anything
+ * to the decommission. A hook that wants to report a problem should throw instead.
  */
 public interface DecommissionHook
 {
@@ -96,6 +128,11 @@ public interface DecommissionHook
     /**
      * Runs the work. May block indefinitely; may run CQL queries. Throwing is reported and fails
      * {@code nodetool decommission}, but does not stop the node from finishing its decommission.
+     *
+     * The interrupt flag is clear on entry and is cleared again after this returns. Letting an
+     * {@link InterruptedException} escape marks this hook as interrupted and skips the hooks
+     * registered after it; catching it and restoring the flag counts as success and does not
+     * affect the hooks that follow. See the class javadoc.
      */
     void onDecommission() throws Exception;
 }

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -5454,13 +5454,6 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
             {
                 hook.onDecommission();
                 logger.info("Decommission hook {} completed in {} ms", name, elapsedMillis(startedAt));
-
-                // A hook that catches InterruptedException and restores the flag before returning
-                // -- the standard idiom -- hands us back an interrupted thread. Consume it: the
-                // decommission cannot be abandoned this late, and the shutdown below waits on
-                // futures that would fail instantly with the flag still set.
-                if (Thread.interrupted())
-                    logger.warn("Decommission hook {} returned with the interrupt flag set; clearing it", name);
             }
             catch (InterruptedException e)
             {
@@ -5483,6 +5476,18 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
                 // reported, not escalated into a JVM-stability event.
                 logger.error("Decommission hook {} failed after {} ms", name, elapsedMillis(startedAt), t);
                 failed.add(name);
+            }
+            finally
+            {
+                // A hook can hand us back an interrupted thread whichever way it leaves: by catching
+                // InterruptedException and restoring the flag before returning (the standard idiom),
+                // or by restoring it and then throwing something else. Consume it here, on every
+                // path, so it can never reach the next hook -- which is entitled to a clear flag and
+                // would otherwise fail the moment it blocked -- nor the shutdown below, which waits
+                // on futures that fail instantly with the flag set. The decommission cannot be
+                // abandoned this late, so there is nothing the flag could usefully signal.
+                if (Thread.interrupted())
+                    logger.warn("Decommission hook {} left the interrupt flag set; clearing it", name);
             }
         }
 

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -482,6 +482,9 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
 
     private final List<IEndpointLifecycleSubscriber> lifecycleSubscribers = new CopyOnWriteArrayList<>();
 
+    /** Hooks run by {@link #decommission(boolean)} once this node has left the ring; see {@link DecommissionHook}. */
+    private final List<DecommissionHook> decommissionHooks = new CopyOnWriteArrayList<>();
+
     private final String jmxObjectName;
 
     private Collection<Token> bootstrapTokens = null;
@@ -560,6 +563,24 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
     public void unregister(IEndpointLifecycleSubscriber subscriber)
     {
         lifecycleSubscribers.remove(subscriber);
+    }
+
+    /**
+     * Registers work to run on this node while it is being decommissioned, after it has left the
+     * ring and before anything is shut down. Hooks run in registration order; see
+     * {@link DecommissionHook} for the full contract.
+     */
+    public void registerDecommissionHook(DecommissionHook hook)
+    {
+        // Fail the caller now rather than during the decommission: CopyOnWriteArrayList accepts
+        // nulls, and by the time hooks run there is no safe way to fail.
+        decommissionHooks.add(Objects.requireNonNull(hook, "decommission hook must not be null"));
+    }
+
+    /** @return true if {@code hook} was registered. */
+    public boolean unregisterDecommissionHook(DecommissionHook hook)
+    {
+        return decommissionHooks.remove(hook);
     }
 
     // should only be called via JMX
@@ -5289,6 +5310,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         if (logger.isDebugEnabled())
             logger.debug("DECOMMISSIONING");
 
+        List<String> failedHooks = Collections.emptyList();
         try
         {
             PendingRangeCalculatorService.instance.blockUntilFinished();
@@ -5341,6 +5363,14 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
 
             unbootstrap();
 
+            // Hooks run here, in the window unbootstrap() opens and the shutdown below closes:
+            // this node has left the ring (so no coordinator routes mutations to it) and the batch
+            // log has finished its final replay, but messaging, the native transport and the stages
+            // are all still up, so a hook can still run queries. Hooks may block for hours; nothing
+            // below this line runs until they are all done. A failing hook is collected rather than
+            // thrown -- see the report after the finally block.
+            failedHooks = runDecommissionHooks();
+
             // shutdown cql, gossip, messaging, Stage and set state to DECOMMISSIONED
 
             shutdownClientServers();
@@ -5381,6 +5411,114 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         {
             isDecommissioning.set(false);
         }
+
+        // Reported only now that the node is DECOMMISSIONED, and deliberately not by failing the
+        // decommission: hooks run after unbootstrap(), so the data has already streamed away and
+        // leaveRing() has run. There is nothing to roll back to, and stopping at
+        // DECOMMISSION_FAILED here would strand the node -- a retry is rejected by the ring
+        // membership check above (leaveRing() removed us from TokenMetadata), and leaveRing() has
+        // persisted NEEDS_BOOTSTRAP, so a restart would bootstrap the node back into the ring.
+        // Finishing and then throwing still fails `nodetool decommission` loudly.
+        if (!failedHooks.isEmpty())
+            throw new RuntimeException("Node decommissioned, but decommission hook(s) failed: "
+                                       + String.join(", ", failedHooks) + "; see the log for details");
+    }
+
+    /**
+     * Runs the registered {@link DecommissionHook}s in registration order, on the decommission
+     * thread, blocking for as long as they take.
+     *
+     * Never throws. That is the whole point: this runs past leaveRing(), the one window where
+     * NEEDS_BOOTSTRAP is already persisted but DECOMMISSIONED is not, so anything escaping here
+     * strands the node (see the caller). Every hook runs even if an earlier one fails, so one
+     * broken hook cannot silently skip the rest.
+     *
+     * @return the names of the hooks that did not complete, in order; empty if all succeeded.
+     */
+    private List<String> runDecommissionHooks()
+    {
+        // Snapshot: a hook is free to unregister itself (or another) while we are iterating.
+        List<DecommissionHook> hooks = new ArrayList<>(decommissionHooks);
+        if (hooks.isEmpty())
+            return Collections.emptyList();
+
+        logger.info("Running {} decommission hook(s)", hooks.size());
+        List<String> failed = new ArrayList<>();
+        for (int i = 0; i < hooks.size(); i++)
+        {
+            DecommissionHook hook = hooks.get(i);
+            String name = hookName(hook);
+            setMode(Mode.LEAVING, "running decommission hook " + name, true);
+            long startedAt = nanoTime();
+            try
+            {
+                hook.onDecommission();
+                logger.info("Decommission hook {} completed in {} ms", name, elapsedMillis(startedAt));
+
+                // A hook that catches InterruptedException and restores the flag before returning
+                // -- the standard idiom -- hands us back an interrupted thread. Consume it: the
+                // decommission cannot be abandoned this late, and the shutdown below waits on
+                // futures that would fail instantly with the flag still set.
+                if (Thread.interrupted())
+                    logger.warn("Decommission hook {} returned with the interrupt flag set; clearing it", name);
+            }
+            catch (InterruptedException e)
+            {
+                // Report and stop, without re-asserting the interrupt (throwing InterruptedException
+                // already cleared it). Re-asserting would fail every remaining hook the moment it
+                // blocked, and this runs on a pooled JMX handler thread, so the flag would leak onto
+                // whatever that thread ran next.
+                logger.error("Decommission hook {} was interrupted after {} ms; skipping the remaining hook(s)",
+                             name, elapsedMillis(startedAt), e);
+                failed.add(name + " (interrupted)");
+                for (int j = i + 1; j < hooks.size(); j++)
+                    failed.add(hookName(hooks.get(j)) + " (not run)");
+                break;
+            }
+            catch (Throwable t)
+            {
+                // Deliberately no JVMStabilityInspector.inspectThrowable(t): it rethrows an
+                // OutOfMemoryError found anywhere in the cause chain, and acts on FSError, either of
+                // which would escape and strand the node here. A hook is plugin code; its failure is
+                // reported, not escalated into a JVM-stability event.
+                logger.error("Decommission hook {} failed after {} ms", name, elapsedMillis(startedAt), t);
+                failed.add(name);
+            }
+        }
+
+        // Logged here as well as reported by the caller: if the shutdown sequence after this point
+        // throws, the caller never gets to report, and a hook failure must not be silent.
+        if (!failed.isEmpty())
+            logger.error("{} of {} decommission hook(s) did not complete: {}",
+                         failed.size(), hooks.size(), String.join(", ", failed));
+
+        // The flag must not outlive this method: the shutdown below, and the JMX thread we borrow,
+        // both misbehave with an interrupted thread.
+        if (Thread.interrupted())
+            logger.warn("Decommission thread was left interrupted by the hooks; clearing the flag");
+
+        return failed;
+    }
+
+    /** A hook is third-party code: even name() may misbehave, and must not abort the run. */
+    private static String hookName(DecommissionHook hook)
+    {
+        if (hook == null)
+            return "null";
+        try
+        {
+            String name = hook.name();
+            return name == null ? hook.getClass().getName() : name;
+        }
+        catch (Throwable t)
+        {
+            return hook.getClass().getName();
+        }
+    }
+
+    private static long elapsedMillis(long startedAtNanos)
+    {
+        return TimeUnit.NANOSECONDS.toMillis(nanoTime() - startedAtNanos);
     }
 
     private void leaveRing()

--- a/test/distributed/org/apache/cassandra/distributed/test/DecommissionHookTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/DecommissionHookTest.java
@@ -65,13 +65,15 @@ public class DecommissionHookTest extends TestBaseImpl
     public static class Observed
     {
         static final List<String> order = Collections.synchronizedList(new ArrayList<>());
+        /** Names of the hooks that were entered with the interrupt flag already set. Must stay empty. */
+        static final List<String> enteredInterrupted = Collections.synchronizedList(new ArrayList<>());
         static volatile boolean stillRingMember = true;
         static volatile boolean nativeTransportRunning = false;
         static volatile int rowsReadByHook = -1;
         static volatile String queryError = null;
     }
 
-    /** Records that it ran, under its own name. */
+    /** Records that it ran, under its own name, and how it found the interrupt flag on entry. */
     public static class RecordingHook implements DecommissionHook
     {
         private final String name;
@@ -88,6 +90,10 @@ public class DecommissionHookTest extends TestBaseImpl
 
         public void onDecommission()
         {
+            // A hook is entitled to a clear flag: it may block, and a leaked interrupt would fail
+            // its very first blocking call. Checked without consuming, so a leak stays visible.
+            if (Thread.currentThread().isInterrupted())
+                Observed.enteredInterrupted.add(name);
             Observed.order.add(name);
         }
     }
@@ -141,6 +147,27 @@ public class DecommissionHookTest extends TestBaseImpl
         {
             Observed.order.add("interrupt-restoring");
             Thread.currentThread().interrupt();
+        }
+    }
+
+    /**
+     * Restores the interrupt flag and then throws something else -- the other way a hook can leave
+     * with the flag set, e.g. {@code catch (InterruptedException e) { Thread.currentThread()
+     * .interrupt(); throw new RuntimeException(e); }}. The flag has to be consumed on this path too,
+     * or it leaks into the next hook.
+     */
+    public static class InterruptRestoringExplodingHook implements DecommissionHook
+    {
+        public String name()
+        {
+            return "interrupt-restoring-exploding";
+        }
+
+        public void onDecommission()
+        {
+            Observed.order.add("interrupt-restoring-exploding");
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("simulated hook failure with the interrupt flag restored");
         }
     }
 
@@ -215,6 +242,7 @@ public class DecommissionHookTest extends TestBaseImpl
         {
             cluster.get(3).runOnInstance(() -> {
                 Observed.order.clear();
+                Observed.enteredInterrupted.clear();
                 StorageService.instance.registerDecommissionHook(new InterruptRestoringHook());
                 StorageService.instance.registerDecommissionHook(new RecordingHook("after-the-interrupt"));
 
@@ -229,6 +257,51 @@ public class DecommissionHookTest extends TestBaseImpl
 
                 assertEquals("a restored interrupt flag must not skip the hooks behind it",
                              Arrays.asList("interrupt-restoring", "after-the-interrupt"), Observed.order);
+                assertEquals("a restored interrupt flag must not leak into the next hook",
+                             Collections.emptyList(), Observed.enteredInterrupted);
+                assertEquals(DECOMMISSIONED.name(), StorageService.instance.getOperationMode());
+                assertFalse("the interrupt flag must not outlive the hook run",
+                            Thread.currentThread().isInterrupted());
+            });
+        }
+    }
+
+    /**
+     * The same, for a hook that restores the flag and then throws. The interrupt must be consumed on
+     * the failure path too: the next hook is entitled to a clear flag, and would otherwise fail on
+     * its first blocking call for a reason that has nothing to do with it.
+     */
+    @Test
+    public void testHookThrowingWithTheInterruptFlagSetDoesNotLeakItToTheNextHook() throws Throwable
+    {
+        try (Cluster cluster = init(Cluster.build(3)
+                                           .withConfig(config -> config.with(GOSSIP).with(NETWORK))
+                                           .start(), 2))
+        {
+            cluster.get(3).runOnInstance(() -> {
+                Observed.order.clear();
+                Observed.enteredInterrupted.clear();
+                StorageService.instance.registerDecommissionHook(new InterruptRestoringExplodingHook());
+                StorageService.instance.registerDecommissionHook(new RecordingHook("after-the-interrupting-explosion"));
+
+                Throwable thrown = null;
+                try
+                {
+                    StorageService.instance.decommission(true);
+                }
+                catch (Throwable t)
+                {
+                    thrown = t;
+                }
+                assertNotNull("a failing hook must be reported to the caller", thrown);
+                assertTrue("the failure must name the offending hook, was: " + thrown,
+                           String.valueOf(thrown.getMessage()).contains("interrupt-restoring-exploding"));
+
+                assertEquals("a hook that throws must not skip the hooks behind it",
+                             Arrays.asList("interrupt-restoring-exploding", "after-the-interrupting-explosion"),
+                             Observed.order);
+                assertEquals("an interrupt restored before throwing must not leak into the next hook",
+                             Collections.emptyList(), Observed.enteredInterrupted);
                 assertEquals(DECOMMISSIONED.name(), StorageService.instance.getOperationMode());
                 assertFalse("the interrupt flag must not outlive the hook run",
                             Thread.currentThread().isInterrupted());
@@ -278,6 +351,7 @@ public class DecommissionHookTest extends TestBaseImpl
         {
             cluster.get(3).runOnInstance(() -> {
                 Observed.order.clear();
+                Observed.enteredInterrupted.clear();
                 StorageService.instance.registerDecommissionHook(new ExplodingHook());
                 StorageService.instance.registerDecommissionHook(new RecordingHook("after-the-explosion"));
 

--- a/test/distributed/org/apache/cassandra/distributed/test/DecommissionHookTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/DecommissionHookTest.java
@@ -1,0 +1,325 @@
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+
+import org.apache.cassandra.cql3.QueryProcessor;
+import org.apache.cassandra.cql3.UntypedResultSet;
+import org.apache.cassandra.db.ConsistencyLevel;
+import org.apache.cassandra.db.SystemKeyspace.BootstrapState;
+import org.apache.cassandra.distributed.Cluster;
+import org.apache.cassandra.service.DecommissionHook;
+import org.apache.cassandra.service.StorageService;
+import org.apache.cassandra.utils.FBUtilities;
+
+import static org.apache.cassandra.distributed.api.Feature.GOSSIP;
+import static org.apache.cassandra.distributed.api.Feature.NATIVE_PROTOCOL;
+import static org.apache.cassandra.distributed.api.Feature.NETWORK;
+import static org.apache.cassandra.service.StorageService.Mode.DECOMMISSIONED;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * {@link DecommissionHook}: hooks run on a decommissioning node once it has left the ring, while
+ * it can still query the cluster.
+ *
+ * 3 nodes at RF=2, decommissioning node3, so the two survivors can still serve the hook's QUORUM
+ * read. The decommission is forceful because system_distributed is RF=3 on a 3-node cluster, which
+ * trips the RF-vs-live-nodes check whatever the test keyspace does -- the same reason
+ * {@link DecommissionTest} forces.
+ *
+ * Note the hooks below are static nested classes, not lambdas or anonymous classes: an anonymous
+ * class declared in a test method captures the test instance, which makes the enclosing
+ * runOnInstance closure unserializable.
+ */
+public class DecommissionHookTest extends TestBaseImpl
+{
+    /**
+     * What the hooks observed. Lives in the node's classloader: the hooks write it during the
+     * decommission, and the assertions read it back via a later runOnInstance on the same node.
+     */
+    public static class Observed
+    {
+        static final List<String> order = Collections.synchronizedList(new ArrayList<>());
+        static volatile boolean stillRingMember = true;
+        static volatile boolean nativeTransportRunning = false;
+        static volatile int rowsReadByHook = -1;
+        static volatile String queryError = null;
+    }
+
+    /** Records that it ran, under its own name. */
+    public static class RecordingHook implements DecommissionHook
+    {
+        private final String name;
+
+        RecordingHook(String name)
+        {
+            this.name = name;
+        }
+
+        public String name()
+        {
+            return name;
+        }
+
+        public void onDecommission()
+        {
+            Observed.order.add(name);
+        }
+    }
+
+    /** Records what the node looks like from inside a hook, and tries to query the cluster. */
+    public static class ProbingHook implements DecommissionHook
+    {
+        public String name()
+        {
+            return "probe";
+        }
+
+        public void onDecommission()
+        {
+            Observed.order.add("probe");
+            // unbootstrap() has run, so leaveRing() has removed us from the ring: no coordinator
+            // routes mutations here any more. This also transitively proves the batch log finished
+            // its final replay -- batchlogReplay.get() is sequenced before leaveRing() inside
+            // unbootstrap().
+            Observed.stillRingMember = StorageService.instance.getTokenMetadata()
+                                                              .isMember(FBUtilities.getBroadcastAddressAndPort());
+            // ...but nothing is shut down yet, so we can still coordinate queries.
+            Observed.nativeTransportRunning = StorageService.instance.isNativeTransportRunning();
+            try
+            {
+                UntypedResultSet rs = QueryProcessor.execute("SELECT * FROM " + KEYSPACE + ".tbl",
+                                                             ConsistencyLevel.QUORUM);
+                Observed.rowsReadByHook = rs.size();
+            }
+            catch (Throwable t)
+            {
+                Observed.queryError = t.toString();
+            }
+        }
+    }
+
+    /**
+     * Returns normally but leaves the thread interrupted -- the standard
+     * {@code catch (InterruptedException e) { Thread.currentThread().interrupt(); return; }} idiom
+     * minus the rethrow. runDecommissionHooks() has to consume that flag, or the shutdown steps
+     * after the hooks fail on it and strand the node.
+     */
+    public static class InterruptRestoringHook implements DecommissionHook
+    {
+        public String name()
+        {
+            return "interrupt-restoring";
+        }
+
+        public void onDecommission()
+        {
+            Observed.order.add("interrupt-restoring");
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    /** Fails, to show the hooks behind it still run and the decommission does not claim success. */
+    public static class ExplodingHook implements DecommissionHook
+    {
+        public String name()
+        {
+            return "exploding";
+        }
+
+        public void onDecommission()
+        {
+            Observed.order.add("exploding");
+            throw new RuntimeException("simulated hook failure");
+        }
+    }
+
+    @Test
+    public void testHooksRunInOrderAfterLeavingTheRingAndCanQuery() throws Throwable
+    {
+        // NATIVE_PROTOCOL so the "transport is still up" assertion below means something: without
+        // it the transport would never have been running and the assertion would be vacuous.
+        try (Cluster cluster = init(Cluster.build(3)
+                                           .withConfig(config -> config.with(GOSSIP).with(NETWORK).with(NATIVE_PROTOCOL))
+                                           .start(), 2))
+        {
+            cluster.schemaChange("CREATE TABLE " + KEYSPACE + ".tbl (k int PRIMARY KEY, v int)");
+            for (int i = 0; i < 10; i++)
+                cluster.coordinator(1).execute("INSERT INTO " + KEYSPACE + ".tbl (k, v) VALUES (?, ?)",
+                                               org.apache.cassandra.distributed.api.ConsistencyLevel.ALL, i, i);
+
+            cluster.get(3).runOnInstance(() -> {
+                StorageService.instance.registerDecommissionHook(new ProbingHook());
+                StorageService.instance.registerDecommissionHook(new RecordingHook("second"));
+
+                try
+                {
+                    StorageService.instance.decommission(true);
+                }
+                catch (Throwable t)
+                {
+                    fail("decommission should have succeeded, but failed on: " + t);
+                }
+            });
+
+            cluster.get(3).runOnInstance(() -> {
+                assertEquals("both hooks must run, in registration order",
+                             Arrays.asList("probe", "second"), Observed.order);
+                assertFalse("hooks must run after the node has left the ring, so no mutations arrive",
+                            Observed.stillRingMember);
+                assertTrue("the native transport must still be up so a hook can be queried through",
+                           Observed.nativeTransportRunning);
+                assertNull("the hook's coordinated read failed: " + Observed.queryError,
+                           Observed.queryError);
+                assertEquals("a hook must be able to read the cluster at QUORUM",
+                             10, Observed.rowsReadByHook);
+            });
+        }
+    }
+
+    /**
+     * A hook that hands back an interrupted thread must not derail the rest of the decommission:
+     * the shutdown after the hooks waits on futures that fail instantly if the flag is still set.
+     */
+    @Test
+    public void testHookLeavingTheThreadInterruptedStillCompletesTheDecommission() throws Throwable
+    {
+        try (Cluster cluster = init(Cluster.build(3)
+                                           .withConfig(config -> config.with(GOSSIP).with(NETWORK))
+                                           .start(), 2))
+        {
+            cluster.get(3).runOnInstance(() -> {
+                Observed.order.clear();
+                StorageService.instance.registerDecommissionHook(new InterruptRestoringHook());
+                StorageService.instance.registerDecommissionHook(new RecordingHook("after-the-interrupt"));
+
+                try
+                {
+                    StorageService.instance.decommission(true);
+                }
+                catch (Throwable t)
+                {
+                    fail("a hook returning with the interrupt flag set must not fail the decommission, got: " + t);
+                }
+
+                assertEquals("a restored interrupt flag must not skip the hooks behind it",
+                             Arrays.asList("interrupt-restoring", "after-the-interrupt"), Observed.order);
+                assertEquals(DECOMMISSIONED.name(), StorageService.instance.getOperationMode());
+                assertFalse("the interrupt flag must not outlive the hook run",
+                            Thread.currentThread().isInterrupted());
+            });
+        }
+    }
+
+    /** Registering a null hook must fail the caller, not the decommission. */
+    @Test
+    public void testNullHookIsRejectedAtRegistration() throws Throwable
+    {
+        try (Cluster cluster = init(Cluster.build(1)
+                                           .withConfig(config -> config.with(GOSSIP).with(NETWORK))
+                                           .start(), 1))
+        {
+            cluster.get(1).runOnInstance(() -> {
+                try
+                {
+                    StorageService.instance.registerDecommissionHook(null);
+                    fail("a null hook must be rejected at registration");
+                }
+                catch (NullPointerException expected)
+                {
+                    // A null reaching runDecommissionHooks() would have no safe way to fail.
+                }
+            });
+        }
+    }
+
+    /**
+     * A hook that throws must not silently skip the hooks behind it, must be reported, and must
+     * still leave the node fully decommissioned.
+     *
+     * The node state is the subtle part. Hooks run after unbootstrap(), so the data has already
+     * streamed away and leaveRing() has run. Stopping at DECOMMISSION_FAILED there would strand the
+     * node for good: a retry is rejected by decommission()'s ring-membership check (leaveRing()
+     * removed us from TokenMetadata), and leaveRing() persisted NEEDS_BOOTSTRAP, so a restart would
+     * bootstrap the node back into the ring instead. So the decommission finishes and the failure
+     * is reported afterwards.
+     */
+    @Test
+    public void testFailingHookIsReportedButStillCompletesTheDecommission() throws Throwable
+    {
+        try (Cluster cluster = init(Cluster.build(3)
+                                           .withConfig(config -> config.with(GOSSIP).with(NETWORK))
+                                           .start(), 2))
+        {
+            cluster.get(3).runOnInstance(() -> {
+                Observed.order.clear();
+                StorageService.instance.registerDecommissionHook(new ExplodingHook());
+                StorageService.instance.registerDecommissionHook(new RecordingHook("after-the-explosion"));
+
+                // Capture rather than assert inside the try: a fail() there would be caught by the
+                // catch below and re-reported under the wrong message.
+                Throwable thrown = null;
+                try
+                {
+                    StorageService.instance.decommission(true);
+                }
+                catch (Throwable t)
+                {
+                    thrown = t;
+                }
+                assertNotNull("a failing hook must be reported to the caller", thrown);
+                assertTrue("the failure must name the offending hook, was: " + thrown,
+                           String.valueOf(thrown.getMessage()).contains("exploding"));
+
+                assertEquals("a failing hook must not skip the hooks behind it",
+                             Arrays.asList("exploding", "after-the-explosion"), Observed.order);
+
+                // The decommission itself completed: the node is not stranded mid-leave.
+                assertEquals(DECOMMISSIONED.name(), StorageService.instance.getOperationMode());
+                assertEquals(BootstrapState.DECOMMISSIONED.name(), StorageService.instance.getBootstrapState());
+                assertFalse(StorageService.instance.isDecommissioning());
+
+                // ...so the operator is not stuck. Reaching DECOMMISSIONED is what makes the repeat
+                // call hit decommission()'s existing early return instead of the ring-membership
+                // check that would reject it forever -- which is the whole reason a hook failure
+                // must not stop the decommission short. Hooks do not run a second time.
+                Observed.order.clear();
+                try
+                {
+                    StorageService.instance.decommission(true);
+                }
+                catch (Throwable t)
+                {
+                    fail("decommissioning an already decommissioned node should be a no-op, got: " + t);
+                }
+                assertEquals("a repeat decommission must not re-run the hooks",
+                             Collections.emptyList(), Observed.order);
+            });
+        }
+    }
+}


### PR DESCRIPTION
### What is the issue

There was no way for a plugin to run work when an administrator decommissions a node. The extension points that come close do not fit: addPreShutdownHook fires on any graceful stop and cannot tell a decommission from a restart (and decommission never kills the JVM, so it does not fire then at all), and IEndpointLifecycleSubscriber.onLeaveCluster only reaches the leaving node at the very end of unbootstrap(), after everything has streamed away.


This implementation is required to ensure that all the mutations processed locally are sent to OpenSearch before decomissioning the node, see https://datastax.jira.com/browse/HCD-474

CNDB issue: https://github.com/riptano/cndb/issues/18578
CNDB PR: https://github.com/riptano/cndb/pull/18588
HCD PR: https://github.com/riptano/hcd/pull/259

### What does this PR fix and why was it fixed

Add a DecommissionHook interface plus StorageService.registerDecommissionHook / unregisterDecommissionHook. Several hooks may be registered and run in registration order.

Hooks run in decommission() between unbootstrap() and the shutdown that follows, which is the only window that satisfies all of:

 - the batch log has completed its final replay and hints are transferred or dropped, and all ranges have streamed to their new owners;
 - the node has left the ring, so coordinators no longer route mutations to it. This has to be after leaveRing(), not at LEAVING: addLeavingEndpoint only records the endpoint in a set that write routing never consults, so a LEAVING node stays a natural write replica and pending ranges merely add the new owners on top;
 - messaging, the native transport and the stages are all still up, so a hook can run CQL queries and coordinate against the rest of the cluster.

A hook may block indefinitely; decommission does not proceed until every hook returns.

That window is also the one place nothing may escape from. leaveRing() has persisted NEEDS_BOOTSTRAP but DECOMMISSIONED is not set yet, so a throw here strands the node for good: a retry is rejected by the ring-membership check at the top of decommission(), since the node is no longer in TokenMetadata, and a restart bootstraps it back into the ring. So runDecommissionHooks() reports rather than throws -- every hook runs, the node finishes its decommission, and decommission() then throws naming the hooks that failed, so `nodetool decommission` still surfaces the error. For the same reason a hook's throwable is not passed to JVMStabilityInspector.inspectThrowable, which would rethrow a wrapped OutOfMemoryError straight out of this window.

Interrupt state is consumed rather than propagated, both when a hook throws InterruptedException and when it restores the flag before returning: leaving it set would fail every remaining hook the moment it blocked, break the awaits in the shutdown below, and leak onto the pooled JMX handler thread.
