### PR TITLE
CNDB-18634: Upgrade Netty to 4.1.136.Final

### DIFF
--- a/.build/parent-pom-template.xml
+++ b/.build/parent-pom-template.xml
@@ -760,7 +760,7 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-all</artifactId>
-        <version>4.1.135.Final</version>
+        <version>4.1.136.Final</version>
         <exclusions>
           <exclusion>
             <groupId>io.netty</groupId>
@@ -850,18 +850,18 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-epoll</artifactId>
-        <version>4.1.135.Final</version>
+        <version>4.1.136.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-epoll</artifactId>
-        <version>4.1.135.Final</version>
+        <version>4.1.136.Final</version>
         <classifier>linux-x86_64</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-epoll</artifactId>
-        <version>4.1.135.Final</version>
+        <version>4.1.136.Final</version>
         <classifier>linux-aarch_64</classifier>
       </dependency>
 


### PR DESCRIPTION
### What is the issue
4.1.135.Final is affected by several CVEs, including [CVE-2026-56821](https://www.cve.org/CVERecord?id=CVE-2026-56821) and [CVE-2026-56822](https://www.cve.org/CVERecord?id=CVE-2026-56822).

### What does this PR fix and why was it fixed
Upgrades Netty to 4.1.136.Final.
