### PR TITLE
CNDB-18443: coordinatorReadSize metrics in KeyspaceMetrics/TableMetrics don't contain the last row selected

### DIFF
--- a/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
@@ -1034,10 +1034,11 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
             }
         }
 
+        ResultSet resultSet = result.build();
         ColumnFamilyStore store = cfs();
         if (store != null)
             updatedMetrics(store.metric, restrictions, result.readRowsSize());
-        return result.build();
+        return resultSet;
     }
 
     private void updatedMetrics(TableMetrics metrics, StatementRestrictions restrictions, long rowsSize)

--- a/test/unit/org/apache/cassandra/metrics/CoordinatorReadSizeMetricsTest.java
+++ b/test/unit/org/apache/cassandra/metrics/CoordinatorReadSizeMetricsTest.java
@@ -24,6 +24,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Session;
 import com.codahale.metrics.Histogram;
 import org.apache.cassandra.ServerTestUtils;
@@ -368,6 +369,28 @@ public class CoordinatorReadSizeMetricsTest
         assertCount(cfs.metric.coordinatorRangeReadSize, rangeNoIndex + rangeWithIndex);
         assertCount(cfs.metric.coordinatorRangeReadSizeWithoutIndex, rangeNoIndex);
         assertCount(cfs.metric.coordinatorRangeReadSizeWithIndex, rangeWithIndex);
+    }
+
+    @Test
+    public void testReadSizeMetricsForZeroOneAndMultipleRows()
+    {
+        ColumnFamilyStore cfs = cfs();
+
+        // 0 rows returned
+        session.execute(String.format("SELECT * FROM %s.%s WHERE pk = 999;", KEYSPACE, TABLE)).one();
+        long sizeForZeroRows = cfs.metric.coordinatorReadSize.tableOrKeyspaceHistogram().getSnapshot().getMax();
+        clearMetrics();
+
+        // 1 row returned
+        session.execute(String.format("SELECT * FROM %s.%s WHERE pk = 0;", KEYSPACE, TABLE)).one();
+        long sizeForOneRow = cfs.metric.coordinatorReadSize.tableOrKeyspaceHistogram().getSnapshot().getMax();
+        assertTrue("Expected coordinatorReadSize for 1 row (" + sizeForOneRow + " bytes) to be greater than 0 rows (" + sizeForZeroRows + " bytes)", sizeForOneRow > sizeForZeroRows);
+        clearMetrics();
+
+        // 5 rows returned (all rows in the table)
+        session.execute(String.format("SELECT * FROM %s.%s;", KEYSPACE, TABLE)).one();
+        long sizeForFiveRows = cfs.metric.coordinatorReadSize.tableOrKeyspaceHistogram().getSnapshot().getMax();
+        assertTrue("Expected coordinatorReadSize for 5 rows (" + sizeForFiveRows + " bytes) to be greater than 4x the size of 1 row (" + (sizeForOneRow * 4) + " bytes)", sizeForFiveRows > sizeForOneRow * 4);
     }
 
     private static ColumnFamilyStore cfs()


### PR DESCRIPTION
### What is the issue
The ResultSetBuilder has an internal readRowsSize metric. This is updated when adding a row. We "add" a row when the next new row is started or when we build the result set. The table metrics are updated in SelectStatement prior to building the result set. This means the size of the last row in the result set isn't reflected in the metrics, as it isn't added to the result set until after the histogram is updated.

### What does this PR fix and why was it fixed
Fix by calling result.build() first, capturing the ResultSet, then reading readRowsSize() for the metrics update before returning.
