### PR TITLE
HCD-485: Add SelectStatement.executeWithReadQuery for externally-ordered paged reads

### DIFF
--- a/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
@@ -28,6 +28,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableSet;
+import java.util.Objects;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeMap;
@@ -472,6 +473,97 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
                            requestTime,
                            unmask);
         }
+        if (!SchemaConstants.isSystemKeyspace(table.keyspace))
+            ClientRequestSizeMetrics.recordReadResponseMetrics(rows, restrictions, selection);
+
+        return rows;
+    }
+
+    /**
+     * Executes this {@code SELECT} against a caller-supplied {@link ReadQuery} instead of the one this
+     * statement would build from its own {@code WHERE} restrictions, returning a single page of results.
+     * <p>
+     * This is the entry point for components that resolve <em>which</em> partitions to read (and in
+     * <em>what order</em>) out of band — for example a custom {@link org.apache.cassandra.cql3.QueryHandler}
+     * that obtains the matching primary keys from an external index and, in the desired order, assembles a
+     * {@link org.apache.cassandra.db.SinglePartitionReadCommand.Group}. Result order is entirely the query's:
+     * this method pages the supplied {@code query} through {@link #getPager(ReadQuery, QueryOptions)}, and a
+     * {@link org.apache.cassandra.service.pager.MultiPartitionPager} yields partitions in the order of the
+     * {@link org.apache.cassandra.db.SinglePartitionReadCommand.Group}'s commands — not token order — across
+     * page boundaries.
+     * <p>
+     * Apart from substituting {@code query} for {@link #getQuery(QueryOptions, ClientState, ColumnFilter, long, int, int, int, AggregationSpecification)},
+     * this is the same flow as {@link #execute(QueryState, QueryOptions, Dispatcher.RequestTime)}: consistency
+     * validation, guardrails ({@link #validateQueryOptions}, {@code pageSize.guard}), read-threshold tracking
+     * ({@link ReadQuery#trackWarnings()}), selection/projection, user {@code LIMIT}/{@code OFFSET}, aggregation,
+     * dynamic-data masking, the single-shot fast path when paging can be skipped, read metrics/sensors, and page
+     * continuation via {@link ResultSet.ResultMetadata#setHasMorePages}.
+     * <p>
+     * Caller contract:
+     * <ul>
+     *   <li>{@code query} must read partitions of this statement's {@link #table}; build it with this
+     *       statement's data limits and column filter (see {@link #getQuery(QueryOptions, long)}) so
+     *       storage-level and result-level limits agree. Passing a query over a different table, or one whose
+     *       shape disagrees with this statement's aggregation/selection, is undefined.</li>
+     *   <li>Top-K queries are not supported through this entry point.</li>
+     * </ul>
+     * This method holds no state across calls and reads only immutable statement fields, so — like
+     * {@link #execute(QueryState, QueryOptions, Dispatcher.RequestTime)} — it is safe to call concurrently on a
+     * single shared (prepared) {@code SelectStatement} instance, one {@code query} per call. It relies on the
+     * same request-scoped thread-locals as the normal read path ({@link ClientWarn},
+     * {@link org.apache.cassandra.sensors.RequestTracker}), so callers must invoke it on a request thread that
+     * has them set up (as the native-transport dispatch path does).
+     */
+    public ResultMessage.Rows executeWithReadQuery(QueryState state,
+                                                   QueryOptions options,
+                                                   ReadQuery query,
+                                                   Dispatcher.RequestTime requestTime)
+    {
+        Objects.requireNonNull(query, "query");
+        // Top-K needs the specific validation/CL-downgrade handling in getQuery, which this entry point bypasses.
+        checkFalse(query.isTopK(), "Top-K queries are not supported by executeWithReadQuery");
+
+        ConsistencyLevel cl = options.getConsistency();
+        checkNotNull(cl, "Invalid empty consistency level");
+        cl.validateForRead();
+        validateQueryOptions(state, options);
+
+        long nowInSec = options.getNowInSeconds(state);
+        int userLimit = getLimit(options);
+        int userOffset = getOffset(options);
+        PageSize pageSize = options.getPageSize();
+        boolean unmask = !table.hasMaskedColumns() || state.getClientState().hasTablePermission(table, Permission.UNMASK);
+
+        Selectors selectors = selection.newSelectors(options);
+        AggregationSpecification aggregationSpec = getAggregationSpec(options);
+
+        if (options.isReadThresholdsEnabled())
+            query.trackWarnings();
+
+        if (query.limits().isGroupByLimit() && pageSize != null && pageSize.isDefined() && pageSize.getUnit() == PageSize.PageUnit.BYTES)
+            throw new InvalidRequestException("Paging in bytes cannot be specified for aggregation queries");
+
+        ResultMessage.Rows rows;
+        if (aggregationSpec == null && canSkipPaging(query.limits(), pageSize, query.isTopK()))
+        {
+            rows = execute(query, options, state.getClientState(), selectors, nowInSec, userLimit, userOffset, null, requestTime, unmask);
+        }
+        else
+        {
+            QueryPager pager = getPager(query, options);
+            rows = execute(state,
+                           Pager.forDistributedQuery(pager, cl, state.getClientState()),
+                           options,
+                           selectors,
+                           pageSize,
+                           nowInSec,
+                           userLimit,
+                           userOffset,
+                           aggregationSpec,
+                           requestTime,
+                           unmask);
+        }
+
         if (!SchemaConstants.isSystemKeyspace(table.keyspace))
             ClientRequestSizeMetrics.recordReadResponseMetrics(rows, restrictions, selection);
 

--- a/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
@@ -494,7 +494,9 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
      * <p>
      * Apart from substituting {@code query} for {@link #getQuery(QueryOptions, ClientState, ColumnFilter, long, int, int, int, AggregationSpecification)},
      * this is the same flow as {@link #execute(QueryState, QueryOptions, Dispatcher.RequestTime)}: consistency
-     * validation, guardrails ({@link #validateQueryOptions}, {@code pageSize.guard}), read-threshold tracking
+     * validation, guardrails ({@link #validateQueryOptions}, {@code pageSize.guard}), the per-query validation
+     * {@code getQuery} applies to the query it builds ({@link ReadQuery#validateSelectOptions(SelectOptions, ClientState)},
+     * {@link ReadQuery#maybeValidateIndexes()}), read-threshold tracking
      * ({@link ReadQuery#trackWarnings()}), selection/projection, user {@code LIMIT}/{@code OFFSET}, aggregation,
      * dynamic-data masking, the single-shot fast path when paging can be skipped, read metrics/sensors, and page
      * continuation via {@link ResultSet.ResultMetadata#setHasMorePages}.
@@ -536,6 +538,10 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
 
         Selectors selectors = selection.newSelectors(options);
         AggregationSpecification aggregationSpec = getAggregationSpec(options);
+
+        // The validation getQuery(...) would have performed on the query it builds.
+        query.validateSelectOptions(selectOptions, state.getClientState());
+        query.maybeValidateIndexes();
 
         if (options.isReadThresholdsEnabled())
             query.trackWarnings();

--- a/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
@@ -35,6 +35,7 @@ import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -428,6 +429,22 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
     @Override
     public ResultMessage.Rows execute(QueryState state, QueryOptions options, Dispatcher.RequestTime requestTime)
     {
+        return execute(state, options, null, requestTime);
+    }
+
+    /**
+     * Common implementation of {@link #execute(QueryState, QueryOptions, Dispatcher.RequestTime)} and
+     * {@link #executeWithReadQuery(QueryState, QueryOptions, ReadQuery, Dispatcher.RequestTime)}: the two differ
+     * only in where the {@link ReadQuery} to read comes from.
+     *
+     * @param externalQuery the caller-supplied query to read, or {@code null} to build one from this statement's
+     *                      own restrictions with {@code getQuery(...)}
+     */
+    private ResultMessage.Rows execute(QueryState state,
+                                       QueryOptions options,
+                                       @Nullable ReadQuery externalQuery,
+                                       Dispatcher.RequestTime requestTime)
+    {
         ConsistencyLevel cl = options.getConsistency();
         checkNotNull(cl, "Invalid empty consistency level");
 
@@ -443,8 +460,19 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
 
         Selectors selectors = selection.newSelectors(options);
         AggregationSpecification aggregationSpec = getAggregationSpec(options);
-        ReadQuery query = getQuery(options, state.getClientState(), selectors.getColumnFilter(),
-                                   nowInSec, userLimit, userPerPartitionLimit, userOffset, aggregationSpec);
+        ReadQuery query;
+        if (externalQuery == null)
+        {
+            query = getQuery(options, state.getClientState(), selectors.getColumnFilter(),
+                             nowInSec, userLimit, userPerPartitionLimit, userOffset, aggregationSpec);
+        }
+        else
+        {
+            // getQuery(...) validates the query it builds before returning it; do the same for the supplied one.
+            query = externalQuery;
+            query.validateSelectOptions(selectOptions, state.getClientState());
+            query.maybeValidateIndexes();
+        }
 
         if (options.isReadThresholdsEnabled())
             query.trackWarnings();
@@ -493,7 +521,8 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
      * page boundaries.
      * <p>
      * Apart from substituting {@code query} for {@link #getQuery(QueryOptions, ClientState, ColumnFilter, long, int, int, int, AggregationSpecification)},
-     * this is the same flow as {@link #execute(QueryState, QueryOptions, Dispatcher.RequestTime)}: consistency
+     * this runs the very same code as {@link #execute(QueryState, QueryOptions, Dispatcher.RequestTime)} — both
+     * delegate to {@link #execute(QueryState, QueryOptions, ReadQuery, Dispatcher.RequestTime)}: consistency
      * validation, guardrails ({@link #validateQueryOptions}, {@code pageSize.guard}), the per-query validation
      * {@code getQuery} applies to the query it builds ({@link ReadQuery#validateSelectOptions(SelectOptions, ClientState)},
      * {@link ReadQuery#maybeValidateIndexes()}), read-threshold tracking
@@ -525,55 +554,7 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
         // Top-K needs the specific validation/CL-downgrade handling in getQuery, which this entry point bypasses.
         checkFalse(query.isTopK(), "Top-K queries are not supported by executeWithReadQuery");
 
-        ConsistencyLevel cl = options.getConsistency();
-        checkNotNull(cl, "Invalid empty consistency level");
-        cl.validateForRead();
-        validateQueryOptions(state, options);
-
-        long nowInSec = options.getNowInSeconds(state);
-        int userLimit = getLimit(options);
-        int userOffset = getOffset(options);
-        PageSize pageSize = options.getPageSize();
-        boolean unmask = !table.hasMaskedColumns() || state.getClientState().hasTablePermission(table, Permission.UNMASK);
-
-        Selectors selectors = selection.newSelectors(options);
-        AggregationSpecification aggregationSpec = getAggregationSpec(options);
-
-        // The validation getQuery(...) would have performed on the query it builds.
-        query.validateSelectOptions(selectOptions, state.getClientState());
-        query.maybeValidateIndexes();
-
-        if (options.isReadThresholdsEnabled())
-            query.trackWarnings();
-
-        if (query.limits().isGroupByLimit() && pageSize != null && pageSize.isDefined() && pageSize.getUnit() == PageSize.PageUnit.BYTES)
-            throw new InvalidRequestException("Paging in bytes cannot be specified for aggregation queries");
-
-        ResultMessage.Rows rows;
-        if (aggregationSpec == null && canSkipPaging(query.limits(), pageSize, query.isTopK()))
-        {
-            rows = execute(query, options, state.getClientState(), selectors, nowInSec, userLimit, userOffset, null, requestTime, unmask);
-        }
-        else
-        {
-            QueryPager pager = getPager(query, options);
-            rows = execute(state,
-                           Pager.forDistributedQuery(pager, cl, state.getClientState()),
-                           options,
-                           selectors,
-                           pageSize,
-                           nowInSec,
-                           userLimit,
-                           userOffset,
-                           aggregationSpec,
-                           requestTime,
-                           unmask);
-        }
-
-        if (!SchemaConstants.isSystemKeyspace(table.keyspace))
-            ClientRequestSizeMetrics.recordReadResponseMetrics(rows, restrictions, selection);
-
-        return rows;
+        return execute(state, options, query, requestTime);
     }
 
     public AggregationSpecification getAggregationSpec(QueryOptions options)

--- a/test/distributed/org/apache/cassandra/distributed/test/SelectStatementExecuteWithPagerDistributedTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/SelectStatementExecuteWithPagerDistributedTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+
+import org.apache.cassandra.cql3.QueryOptions;
+import org.apache.cassandra.cql3.PageSize;
+import org.apache.cassandra.cql3.statements.SelectStatement;
+import org.apache.cassandra.db.SinglePartitionReadCommand;
+import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.distributed.Cluster;
+import org.apache.cassandra.distributed.api.ConsistencyLevel;
+import org.apache.cassandra.service.ClientState;
+import org.apache.cassandra.service.QueryState;
+import org.apache.cassandra.service.pager.PagingState;
+import org.apache.cassandra.transport.Dispatcher;
+import org.apache.cassandra.transport.ProtocolVersion;
+import org.apache.cassandra.transport.messages.ResultMessage;
+import org.apache.cassandra.utils.FBUtilities;
+
+/**
+ * End-to-end integration coverage for {@link SelectStatement#executeWithReadQuery}: a real two-node cluster
+ * (RF=2), reads coordinated through {@link org.apache.cassandra.service.StorageProxy}, and the continuation
+ * {@link PagingState} round-tripped through its wire format between pages. Asserts that an externally-ordered
+ * multi-partition read is returned in the pager's command order — not token order — across page boundaries,
+ * with every row delivered exactly once.
+ */
+public class SelectStatementExecuteWithPagerDistributedTest extends TestBaseImpl
+{
+    @Test
+    public void pagesExternallyOrderedReadAcrossNodes() throws Exception
+    {
+        try (Cluster cluster = init(builder().withNodes(2).start()))
+        {
+            cluster.schemaChange(withKeyspace("CREATE TABLE %s.tbl (pk int PRIMARY KEY, v text)"));
+
+            final int rows = 12;
+            for (int pk = 0; pk < rows; pk++)
+                cluster.coordinator(1).execute(withKeyspace("INSERT INTO %s.tbl (pk, v) VALUES (?, ?)"),
+                                               ConsistencyLevel.ALL, pk, "v" + pk);
+
+            final String ks = KEYSPACE;
+
+            // All assertions run inside the instance; a thrown AssertionError propagates as a test failure.
+            cluster.get(1).runOnInstance(() -> {
+                SelectStatement select = (SelectStatement) org.apache.cassandra.cql3.QueryProcessor.parseStatement(
+                    "SELECT pk, v FROM " + ks + ".tbl WHERE pk IN (0,1,2,3,4,5,6,7,8,9,10,11)",
+                    ClientState.forInternalCalls());
+
+                long nowInSec = FBUtilities.nowInSeconds();
+                SinglePartitionReadCommand.Group base =
+                    (SinglePartitionReadCommand.Group) select.getQuery(probe(null), nowInSec);
+
+                // Reverse the (token-ordered) command list, so a token-ordered result would fail this test.
+                List<SinglePartitionReadCommand> reversed = new ArrayList<>(base.queries);
+                Collections.reverse(reversed);
+                SinglePartitionReadCommand.Group group =
+                    SinglePartitionReadCommand.Group.create(reversed, base.limits());
+
+                List<Integer> expected = new ArrayList<>();
+                for (SinglePartitionReadCommand c : reversed)
+                    expected.add(Int32Type.instance.compose(c.partitionKey().getKey()));
+
+                List<Integer> got = new ArrayList<>();
+                PagingState state = null;
+                int guard = 0;
+                do
+                {
+                    QueryOptions opts = probe(state);
+                    ResultMessage.Rows msg = select.executeWithReadQuery(QueryState.forInternalCalls(), opts, group,
+                                                                         Dispatcher.RequestTime.forImmediateExecution());
+                    if (msg.result.rows.size() > 5)
+                        throw new AssertionError("page exceeded requested size: " + msg.result.rows.size());
+                    for (List<ByteBuffer> row : msg.result.rows)
+                        got.add(Int32Type.instance.compose(row.get(0)));
+
+                    PagingState next = msg.result.metadata.getPagingState();
+                    state = next == null ? null
+                                         : PagingState.deserialize(next.serialize(ProtocolVersion.CURRENT), ProtocolVersion.CURRENT);
+                    if (++guard > 100)
+                        throw new AssertionError("paging did not terminate");
+                }
+                while (state != null);
+
+                if (!expected.equals(got))
+                    throw new AssertionError("expected pager order " + expected + " but got " + got);
+            });
+        }
+    }
+
+    /**
+     * A page-size-5 read at CL ALL (RF=2), resuming from {@code state} (null on the first page). CL ALL forces
+     * every partition to be read from both replicas, so the coordinator on node1 genuinely fans out to node2.
+     */
+    private static QueryOptions probe(PagingState state)
+    {
+        return QueryOptions.create(org.apache.cassandra.db.ConsistencyLevel.ALL,
+                                   Collections.emptyList(),
+                                   false,
+                                   PageSize.inRows(5),
+                                   state,
+                                   null,
+                                   ProtocolVersion.CURRENT,
+                                   null);
+    }
+}

--- a/test/unit/org/apache/cassandra/cql3/statements/SelectStatementExecuteWithPagerTest.java
+++ b/test/unit/org/apache/cassandra/cql3/statements/SelectStatementExecuteWithPagerTest.java
@@ -1,0 +1,369 @@
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3.statements;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.QueryOptions;
+import org.apache.cassandra.cql3.PageSize;
+import org.apache.cassandra.db.ConsistencyLevel;
+import org.apache.cassandra.db.SinglePartitionReadCommand;
+import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.db.marshal.LongType;
+import org.apache.cassandra.service.QueryState;
+import org.apache.cassandra.service.pager.PagingState;
+import org.apache.cassandra.transport.Dispatcher;
+import org.apache.cassandra.transport.ProtocolVersion;
+import org.apache.cassandra.transport.messages.ResultMessage;
+import org.apache.cassandra.utils.FBUtilities;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for {@link SelectStatement#executeWithReadQuery}: running a {@code SELECT} against a
+ * caller-supplied, externally-ordered {@link org.apache.cassandra.db.ReadQuery} and paging the result. The
+ * recurring theme is that the query's command order — <em>not</em> token order — is what the result follows,
+ * across page boundaries (including boundaries that fall inside a partition), while selection/limit/aggregation
+ * behave exactly as the normal read path.
+ */
+public class SelectStatementExecuteWithPagerTest extends CQLTester
+{
+    private static final Dispatcher.RequestTime NOW = Dispatcher.RequestTime.forImmediateExecution();
+
+    @BeforeClass
+    public static void setUp()
+    {
+        // executeWithReadQuery reads through the distributed path (StorageProxy), so the embedded node must be a
+        // live NORMAL replica. CQLTester's default in-process execute() uses the internal read path, which does
+        // not require this.
+        requireNetworkWithoutDriver();
+    }
+
+    private QueryOptions options(PageSize pageSize, PagingState pagingState)
+    {
+        return QueryOptions.create(ConsistencyLevel.ONE,
+                                   Collections.emptyList(),
+                                   false,
+                                   pageSize,
+                                   pagingState,
+                                   null,
+                                   ProtocolVersion.CURRENT,
+                                   null);
+    }
+
+    private SelectStatement parseSelect(String cql)
+    {
+        return (SelectStatement) parseStatement(cql);
+    }
+
+    private static int pkOf(SinglePartitionReadCommand cmd)
+    {
+        return Int32Type.instance.compose(cmd.partitionKey().getKey());
+    }
+
+    /** Rebuild a {@code Group} whose commands are in the exact partition order of {@code pkOrder}. */
+    private SinglePartitionReadCommand.Group reorderedGroup(SelectStatement select, long nowInSec, int... pkOrder)
+    {
+        SinglePartitionReadCommand.Group base =
+            (SinglePartitionReadCommand.Group) select.getQuery(options(PageSize.NONE, null), nowInSec);
+
+        Map<Integer, SinglePartitionReadCommand> byPk = new HashMap<>();
+        for (SinglePartitionReadCommand cmd : base.queries)
+            byPk.put(pkOf(cmd), cmd);
+
+        List<SinglePartitionReadCommand> ordered = new ArrayList<>(pkOrder.length);
+        for (int pk : pkOrder)
+        {
+            SinglePartitionReadCommand cmd = byPk.get(pk);
+            assertNotNull("no read command for pk=" + pk, cmd);
+            ordered.add(cmd);
+        }
+        return SinglePartitionReadCommand.Group.create(ordered, base.limits());
+    }
+
+    /** Round-trip a paging state through its wire format, as the native protocol would between pages. */
+    private PagingState roundTrip(PagingState state)
+    {
+        if (state == null)
+            return null;
+        return PagingState.deserialize(state.serialize(ProtocolVersion.CURRENT), ProtocolVersion.CURRENT);
+    }
+
+    private ResultMessage.Rows onePage(SelectStatement select, SinglePartitionReadCommand.Group group, QueryOptions opts)
+    {
+        return select.executeWithReadQuery(QueryState.forInternalCalls(), opts, group, NOW);
+    }
+
+    /**
+     * Page {@code group} fully, collecting every row (decoded by {@code decoder}) in the order returned and
+     * asserting each page holds at most {@code pageRows}. The continuation state is round-tripped through the
+     * wire format between pages and the group is rebuilt implicitly (same instance) each time.
+     */
+    private <T> List<T> pageAll(SelectStatement select, SinglePartitionReadCommand.Group group, int pageRows,
+                                java.util.function.Function<List<ByteBuffer>, T> decoder)
+    {
+        List<T> got = new ArrayList<>();
+        PagingState state = null;
+        int guard = 0;
+        do
+        {
+            ResultMessage.Rows msg = onePage(select, group, options(PageSize.inRows(pageRows), state));
+            assertTrue("page exceeded requested size", msg.result.rows.size() <= pageRows);
+            for (List<ByteBuffer> row : msg.result.rows)
+                got.add(decoder.apply(row));
+            state = roundTrip(msg.result.metadata.getPagingState());
+            assertTrue("paging did not terminate", ++guard < 1000);
+        }
+        while (state != null);
+        return got;
+    }
+
+    private static int intCol(List<ByteBuffer> row, int i)
+    {
+        return Int32Type.instance.compose(row.get(i));
+    }
+
+    @Test
+    public void pagerOrderIsPreservedAcrossPages() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int PRIMARY KEY, v text)");
+        for (int pk = 0; pk < 10; pk++)
+            execute("INSERT INTO %s (pk, v) VALUES (?, ?)", pk, "v" + pk);
+
+        SelectStatement select = parseSelect("SELECT pk, v FROM %s WHERE pk IN (0,1,2,3,4,5,6,7,8,9)");
+        long nowInSec = FBUtilities.nowInSeconds();
+
+        // A deliberately non-token order, so a token-ordered result would fail this test.
+        int[] order = { 7, 2, 9, 0, 5, 1, 8, 3, 6, 4 };
+        SinglePartitionReadCommand.Group group = reorderedGroup(select, nowInSec, order);
+
+        List<Integer> got = pageAll(select, group, 3, row -> intCol(row, 0));
+
+        List<Integer> expected = new ArrayList<>();
+        for (int pk : order) expected.add(pk);
+        assertEquals("rows must follow the query's command order across pages", expected, got);
+    }
+
+    @Test
+    public void singlePageWhenPageSizeExceedsResult() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int PRIMARY KEY, v text)");
+        for (int pk = 0; pk < 5; pk++)
+            execute("INSERT INTO %s (pk, v) VALUES (?, ?)", pk, "v" + pk);
+
+        SelectStatement select = parseSelect("SELECT pk, v FROM %s WHERE pk IN (0,1,2,3,4)");
+        long nowInSec = FBUtilities.nowInSeconds();
+        SinglePartitionReadCommand.Group group = reorderedGroup(select, nowInSec, 4, 3, 2, 1, 0);
+
+        // One big page: everything comes back at once and there is no continuation.
+        ResultMessage.Rows msg = onePage(select, group, options(PageSize.inRows(1000), null));
+        List<Integer> got = new ArrayList<>();
+        for (List<ByteBuffer> row : msg.result.rows) got.add(intCol(row, 0));
+
+        assertEquals(List.of(4, 3, 2, 1, 0), got);
+        assertNull("no continuation expected for a complete single page", msg.result.metadata.getPagingState());
+    }
+
+    @Test
+    public void userLimitIsApplied() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int PRIMARY KEY, v text)");
+        for (int pk = 0; pk < 10; pk++)
+            execute("INSERT INTO %s (pk, v) VALUES (?, ?)", pk, "v" + pk);
+
+        SelectStatement select = parseSelect("SELECT pk, v FROM %s WHERE pk IN (0,1,2,3,4,5,6,7,8,9) LIMIT 4");
+        long nowInSec = FBUtilities.nowInSeconds();
+        int[] order = { 7, 2, 9, 0, 5, 1, 8, 3, 6, 4 };
+        SinglePartitionReadCommand.Group group = reorderedGroup(select, nowInSec, order);
+
+        List<Integer> got = pageAll(select, group, 3, row -> intCol(row, 0));
+
+        // Exactly LIMIT rows, and they are the first LIMIT of the query's order.
+        assertEquals("LIMIT must cap the total across pages", List.of(7, 2, 9, 0), got);
+    }
+
+    @Test
+    public void offsetSkipsLeadingRowsInQueryOrder() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int PRIMARY KEY, v text)");
+        for (int pk = 0; pk < 10; pk++)
+            execute("INSERT INTO %s (pk, v) VALUES (?, ?)", pk, "v" + pk);
+
+        // OFFSET is applied at result build time in the query's order: skip 2, take 4.
+        SelectStatement select = parseSelect("SELECT pk, v FROM %s WHERE pk IN (0,1,2,3,4,5,6,7,8,9) LIMIT 4 OFFSET 2");
+        long nowInSec = FBUtilities.nowInSeconds();
+        int[] order = { 7, 2, 9, 0, 5, 1, 8, 3, 6, 4 };
+        SinglePartitionReadCommand.Group group = reorderedGroup(select, nowInSec, order);
+
+        // OFFSET disables user-facing paging (readAll), so the answer arrives in one response.
+        ResultMessage.Rows msg = onePage(select, group, options(PageSize.inRows(1000), null));
+        List<Integer> got = new ArrayList<>();
+        for (List<ByteBuffer> row : msg.result.rows) got.add(intCol(row, 0));
+
+        assertEquals(List.of(9, 0, 5, 1), got);
+    }
+
+    @Test
+    public void perPartitionLimitIsApplied() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck int, v text, PRIMARY KEY (pk, ck))");
+        for (int pk = 0; pk < 2; pk++)
+            for (int ck = 0; ck < 3; ck++)
+                execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", pk, ck, "v" + pk + "_" + ck);
+
+        SelectStatement select = parseSelect("SELECT pk, ck FROM %s WHERE pk IN (0,1) PER PARTITION LIMIT 2");
+        long nowInSec = FBUtilities.nowInSeconds();
+        SinglePartitionReadCommand.Group group = reorderedGroup(select, nowInSec, 1, 0);
+
+        List<int[]> got = pageAllPairs(select, group, 10);
+        assertPairs(new int[][]{ {1, 0}, {1, 1}, {0, 0}, {0, 1} }, got);
+    }
+
+    @Test
+    public void clusteringRowsFollowPartitionOrderThenClusteringOrder() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck int, v text, PRIMARY KEY (pk, ck))");
+        for (int pk = 0; pk < 3; pk++)
+            for (int ck = 0; ck < 2; ck++)
+                execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", pk, ck, "v" + pk + "_" + ck);
+
+        SelectStatement select = parseSelect("SELECT pk, ck, v FROM %s WHERE pk IN (0,1,2)");
+        long nowInSec = FBUtilities.nowInSeconds();
+        SinglePartitionReadCommand.Group group = reorderedGroup(select, nowInSec, 2, 0, 1);
+
+        // page size 2 == exactly one (two-row) partition per page here
+        List<int[]> got = pageAllPairs(select, group, 2);
+        assertPairs(new int[][]{ {2, 0}, {2, 1}, {0, 0}, {0, 1}, {1, 0}, {1, 1} }, got);
+    }
+
+    @Test
+    public void pageBoundaryFallingInsideAPartitionResumesMidPartition() throws Throwable
+    {
+        // Partitions are 3 rows wide but the page is 2 rows, so every partition is split across a page boundary
+        // and the round-tripped paging state must resume in the middle of a partition.
+        createTable("CREATE TABLE %s (pk int, ck int, v text, PRIMARY KEY (pk, ck))");
+        for (int pk = 0; pk < 2; pk++)
+            for (int ck = 0; ck < 3; ck++)
+                execute("INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", pk, ck, "v" + pk + "_" + ck);
+
+        SelectStatement select = parseSelect("SELECT pk, ck, v FROM %s WHERE pk IN (0,1)");
+        long nowInSec = FBUtilities.nowInSeconds();
+        SinglePartitionReadCommand.Group group = reorderedGroup(select, nowInSec, 1, 0);
+
+        List<int[]> got = pageAllPairs(select, group, 2);
+        assertPairs(new int[][]{ {1, 0}, {1, 1}, {1, 2}, {0, 0}, {0, 1}, {0, 2} }, got);
+    }
+
+    @Test
+    public void aggregationCountIsComputed() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int PRIMARY KEY, v text)");
+        for (int pk = 0; pk < 6; pk++)
+            execute("INSERT INTO %s (pk, v) VALUES (?, ?)", pk, "v" + pk);
+
+        SelectStatement select = parseSelect("SELECT count(*) FROM %s WHERE pk IN (0,1,2,3,4,5)");
+        long nowInSec = FBUtilities.nowInSeconds();
+        SinglePartitionReadCommand.Group group =
+            (SinglePartitionReadCommand.Group) select.getQuery(options(PageSize.NONE, null), nowInSec);
+
+        ResultMessage.Rows msg = onePage(select, group, options(PageSize.inRows(2), null));
+
+        assertEquals(1, msg.result.rows.size());
+        assertEquals(6L, (long) LongType.instance.compose(msg.result.rows.get(0).get(0)));
+    }
+
+    @Test
+    public void functionProjectionRoutesThroughSelection() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int PRIMARY KEY, v text)");
+        for (int pk = 0; pk < 4; pk++)
+            execute("INSERT INTO %s (pk, v) VALUES (?, ?)", pk, "v" + pk);
+
+        // writetime(v) is synthesised by the Selection layer; here it must just work.
+        SelectStatement select = parseSelect("SELECT pk, writetime(v) FROM %s WHERE pk IN (0,1,2,3)");
+        long nowInSec = FBUtilities.nowInSeconds();
+        SinglePartitionReadCommand.Group group = reorderedGroup(select, nowInSec, 3, 1, 2, 0);
+
+        ResultMessage.Rows msg = onePage(select, group, options(PageSize.inRows(10), null));
+
+        assertEquals(4, msg.result.rows.size());
+        List<Integer> pks = new ArrayList<>();
+        for (List<ByteBuffer> row : msg.result.rows)
+        {
+            pks.add(intCol(row, 0));
+            assertNotNull("writetime column must be present", row.get(1));
+        }
+        assertEquals(List.of(3, 1, 2, 0), pks);
+    }
+
+    @Test
+    public void emptyQueryYieldsNoRowsAndNoContinuation() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int PRIMARY KEY, v text)");
+        execute("INSERT INTO %s (pk, v) VALUES (?, ?)", 1, "v1");
+
+        // Keys that do not exist.
+        SelectStatement select = parseSelect("SELECT pk, v FROM %s WHERE pk IN (100,101,102)");
+        long nowInSec = FBUtilities.nowInSeconds();
+        SinglePartitionReadCommand.Group group = reorderedGroup(select, nowInSec, 100, 101, 102);
+
+        ResultMessage.Rows msg = onePage(select, group, options(PageSize.inRows(2), null));
+
+        assertTrue(msg.result.rows.isEmpty());
+        assertNull(msg.result.metadata.getPagingState());
+    }
+
+    @Test
+    public void nullReadQueryIsRejected() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int PRIMARY KEY, v text)");
+        SelectStatement select = parseSelect("SELECT pk, v FROM %s WHERE pk = 1");
+        QueryOptions opts = options(PageSize.inRows(2), null);
+        assertThrows(NullPointerException.class,
+                     () -> select.executeWithReadQuery(QueryState.forInternalCalls(), opts, null, NOW));
+    }
+
+    // --- (pk, ck) pair helpers -------------------------------------------------
+
+    private List<int[]> pageAllPairs(SelectStatement select, SinglePartitionReadCommand.Group group, int pageRows)
+    {
+        return pageAll(select, group, pageRows, row -> new int[]{ intCol(row, 0), intCol(row, 1) });
+    }
+
+    private static void assertPairs(int[][] expected, List<int[]> got)
+    {
+        assertEquals("row count", expected.length, got.size());
+        for (int i = 0; i < expected.length; i++)
+        {
+            assertEquals("pk at " + i, expected[i][0], got.get(i)[0]);
+            assertEquals("ck at " + i, expected[i][1], got.get(i)[1]);
+        }
+    }
+}


### PR DESCRIPTION
### What is the issue

Custom QueryHandlers cannot fully implement paging


HCD side implementation: https://github.com/riptano/hcd/pull/265   (custom QueryHandler that proxies OpenSearch + lookup in Cassandra and handle paging)

### What does this PR fix and why was it fixed
Expose a public entry point that runs a SELECT against a caller-supplied ReadQuery instead of the query derived from the statement's own restrictions, returning a single page. This lets a component that resolves which partitions to read (and in what order) out of band — e.g. a custom QueryHandler backed by an external index that assembles a SinglePartitionReadCommand.Group in the desired order — reuse the whole normal read flow: consistency validation, guardrails, read-threshold tracking, selection/projection, LIMIT/OFFSET, aggregation, dynamic-data masking, the single-shot fast path, read metrics, and page continuation via setHasMorePages. A MultiPartitionPager yields partitions in the Group's command order, so the caller controls result order across page boundaries.

The method mirrors the public execute(QueryState, QueryOptions, RequestTime) exactly, substituting the supplied ReadQuery for getQuery(...).

Adds unit coverage (order preservation across pages including boundaries that fall inside a partition, single page, LIMIT, OFFSET, PER PARTITION LIMIT, clustering order, aggregation, function projection, empty and null query) and a two-node distributed test that pages an externally-ordered read across nodes at CL ALL with the paging state round-tripped through its wire format.



