### PR TITLE
CNDB-18663: Upgrade Netty to 4.1.136.Final (#2536)

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -172,7 +172,7 @@
     <property name="chronicle-threads.version" value="2.24ea14" />
     <property name="chronicle-map.version" value="3.24ea4" />
 
-    <property name="netty.version" value="4.1.133.Final" />
+    <property name="netty.version" value="4.1.136.Final" />
 
     <condition property="maven-ant-tasks.jar.exists">
       <available file="${build.dir}/maven-ant-tasks-${maven-ant-tasks.version}.jar" />


### PR DESCRIPTION
Note for reviewer: the commit message points to the original issue for the fix against `main` and `main-5.0`.
I will fix the commit message on merge.  This does not prevent us from review. 

### What is the issue
...
4.1.135.Final is affected by several CVEs, including [CVE-2026-56821](https://www.cve.org/CVERecord?id=CVE-2026-56821) and [CVE-2026-56822](https://www.cve.org/CVERecord?id=CVE-2026-56822).

### What does this PR fix and why was it fixed
...
Upgrades Netty to 4.1.136.Final.