### PR TITLE
DSP-25176

### DIFF
--- a/src/java/org/apache/cassandra/cache/ChunkCache.java
+++ b/src/java/org/apache/cassandra/cache/ChunkCache.java
@@ -697,6 +697,12 @@ public class ChunkCache
         }
 
         @Override
+        public long positionForSkip(long currentPosition, int bytesToSkip)
+        {
+            return source.positionForSkip(currentPosition, bytesToSkip);
+        }
+
+        @Override
         public void close()
         {
             source.close();

--- a/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
@@ -1698,6 +1698,8 @@ public class CompactionManager implements CompactionManagerMBean
             public Throwable commit(Throwable accumulate) { return accumulate; }
             public void prepareToCommit() {}
             public void checkpoint() {}
+            @Override
+            public Throwable abortCheckpoint(Throwable accumulate) { return accumulate; }
             public void obsoleteOriginals() {}
             public void close() {}
         }

--- a/src/java/org/apache/cassandra/db/compaction/Scrubber.java
+++ b/src/java/org/apache/cassandra/db/compaction/Scrubber.java
@@ -215,7 +215,9 @@ public class Scrubber implements Closeable
     {
         List<SSTableReader> finished = new ArrayList<>();
         outputHandler.output(String.format("Scrubbing %s (%s)", sstable, FBUtilities.prettyPrintMemory(dataFile.length())));
-        try (SSTableRewriter writer = SSTableRewriter.construct(realm, transaction, false, sstable.maxDataAge);
+        // Do not use early opening with scrub as it is unsafe (scrub may move rows to a different table that is not
+        // written until the whole operation completes).
+        try (SSTableRewriter writer = SSTableRewriter.constructWithoutEarlyOpening(transaction, false, sstable.maxDataAge);
              Refs<SSTableReader> refs = Refs.ref(Collections.singleton(sstable)))
         {
             assert !indexAvailable() || indexIterator.dataPosition() == sstable.getDataFileSliceDescriptor().dataStart : indexIterator.dataPosition();

--- a/src/java/org/apache/cassandra/db/lifecycle/ILifecycleTransaction.java
+++ b/src/java/org/apache/cassandra/db/lifecycle/ILifecycleTransaction.java
@@ -31,6 +31,7 @@ import org.apache.cassandra.utils.concurrent.Transactional;
 public interface ILifecycleTransaction extends Transactional, LifecycleNewTracker
 {
     void checkpoint();
+    Throwable abortCheckpoint(Throwable accumulate);
     void update(SSTableReader reader, boolean original);
     void update(Collection<SSTableReader> readers, boolean original);
     SSTableReader current(SSTableReader reader);

--- a/src/java/org/apache/cassandra/db/lifecycle/LifecycleTransaction.java
+++ b/src/java/org/apache/cassandra/db/lifecycle/LifecycleTransaction.java
@@ -442,6 +442,19 @@ public class LifecycleTransaction extends Transactional.AbstractTransactional im
         }
         return replacementMap;
     }
+    /**
+     * Rolls back a prepared checkpoint by clearing the staged state.
+     */
+    public Throwable abortCheckpoint(Throwable accumulate)
+    {
+        // Release the references of newly-prepared SSTableReaders that will not be used.
+        accumulate = release(selfRefs(staged.update), accumulate);
+
+        staged.clear();
+        // We may have added some sstable states in the identities list, which we aren't removing. This is fine, the
+        // next time we try to checkpoint we will use different readers.
+        return accumulate;
+    }
 
     /**
      * update a reader: if !original, this is a reader that is being introduced by this transaction;

--- a/src/java/org/apache/cassandra/db/lifecycle/PartialLifecycleTransaction.java
+++ b/src/java/org/apache/cassandra/db/lifecycle/PartialLifecycleTransaction.java
@@ -55,6 +55,12 @@ public class PartialLifecycleTransaction implements ILifecycleTransaction
         // don't do anything, composite will checkpoint at end
     }
 
+    public Throwable abortCheckpoint(Throwable accumulate)
+    {
+        // treat like checkpoint above
+        return accumulate;
+    }
+
     private RuntimeException earlyOpenUnsupported()
     {
         throw new UnsupportedOperationException("PartialLifecycleTransaction does not support early opening of SSTables");

--- a/src/java/org/apache/cassandra/db/lifecycle/WrappedLifecycleTransaction.java
+++ b/src/java/org/apache/cassandra/db/lifecycle/WrappedLifecycleTransaction.java
@@ -40,6 +40,12 @@ public class WrappedLifecycleTransaction implements ILifecycleTransaction
         delegate.checkpoint();
     }
 
+    @Override
+    public Throwable abortCheckpoint(Throwable accumulate)
+    {
+        return delegate.abortCheckpoint(accumulate);
+    }
+
     public void update(SSTableReader reader, boolean original)
     {
         delegate.update(reader, original);

--- a/src/java/org/apache/cassandra/io/sstable/SSTable.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTable.java
@@ -58,6 +58,7 @@ import org.apache.cassandra.io.util.FileOutputStreamPlus;
 import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.schema.TableMetadataRef;
+import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.Pair;
 import org.apache.cassandra.utils.memory.HeapCloner;
 
@@ -187,9 +188,9 @@ public abstract class SSTable
      */
     public static DecoratedKey getMinimalKey(DecoratedKey key)
     {
-        return key.getKey().position() > 0 || key.getKey().hasRemaining() || !key.getKey().hasArray()
-                                       ? new BufferDecoratedKey(key.getToken(), HeapCloner.instance.clone(key.getKey()))
-                                       : key;
+        return ByteBufferUtil.canMinimize(key.getKey())
+               ? new BufferDecoratedKey(key.getToken(), HeapCloner.instance.clone(key.getKey()))
+               : key;
     }
 
     public String getFilename()

--- a/src/java/org/apache/cassandra/io/sstable/SSTableRewriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableRewriter.java
@@ -24,6 +24,9 @@ import java.util.function.Consumer;
 
 import com.google.common.annotations.VisibleForTesting;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.DeletionTime;
@@ -54,6 +57,8 @@ import org.apache.cassandra.utils.concurrent.Transactional;
  */
 public class SSTableRewriter extends Transactional.AbstractTransactional implements Transactional
 {
+    private static final Logger logger = LoggerFactory.getLogger(SSTableRewriter.class);
+
     @VisibleForTesting
     public static boolean disableEarlyOpeningForTests = false;
 
@@ -192,9 +197,18 @@ public class SSTableRewriter extends Transactional.AbstractTransactional impleme
             else
             {
                 writer.setMaxDataAge(maxAge).openEarly(reader -> {
-                    transaction.update(reader, false);
-                    currentlyOpenedEarlyAt = writer.getFilePointer();
-                    moveStarts(reader, reader.last);
+                    try
+                    {
+                        transaction.update(reader, false);
+                        currentlyOpenedEarlyAt = writer.getFilePointer();
+                        moveStarts(reader, reader.last);
+                    }
+                    catch (Throwable ex)
+                    {
+                        ex = transaction.abortCheckpoint(ex);
+                        logger.warn("Aborted early opening attempt due to error", ex);
+                        return;
+                    }
                     transaction.checkpoint();
                 });
             }

--- a/src/java/org/apache/cassandra/io/sstable/format/SortedTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SortedTableWriter.java
@@ -340,21 +340,16 @@ public abstract class SortedTableWriter extends SSTableWriter
         FileHandle dfile = dbuilder.bufferSize(dataBufferSize).complete();
         invalidateCacheAtPreviousBoundary(dfile, Long.MAX_VALUE);
 
-        DecoratedKey firstMinimized = getMinimalKey(first);
-        DecoratedKey lastMinimized = getMinimalKey(last);
         try
         {
-            SSTableReader reader = openReader(reason, dfile, stats, Optional.of(compactionMetadata));
-            reader.first = firstMinimized;
-            reader.last = lastMinimized;
-            return reader;
+            return openReader(reason, dfile, stats, Optional.of(compactionMetadata));
         }
         catch (Throwable t)
         {
             Throwable err = Throwables.close(t, dfile);
 
             if (storageHandler != null)
-                return storageHandler.onOpeningWrittenSSTableFailure(reason, descriptor, components(), dfile.onDiskLength, dfile.dataLength(), stats, firstMinimized, lastMinimized, keyCount, err);
+                return storageHandler.onOpeningWrittenSSTableFailure(reason, descriptor, components(), dfile.onDiskLength, dfile.dataLength(), stats, getMinimalKey(first), getMinimalKey(last), keyCount, err);
 
             throw Throwables.unchecked(err);
         }

--- a/src/java/org/apache/cassandra/io/sstable/format/SortedTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SortedTableWriter.java
@@ -66,7 +66,6 @@ import org.apache.cassandra.schema.CompressionParams;
 import org.apache.cassandra.schema.SchemaConstants;
 import org.apache.cassandra.schema.TableMetadataRef;
 import org.apache.cassandra.utils.FBUtilities;
-import org.apache.cassandra.utils.IFilter;
 import org.apache.cassandra.utils.Throwables;
 
 public abstract class SortedTableWriter extends SSTableWriter

--- a/src/java/org/apache/cassandra/io/sstable/format/big/BigTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/BigTableWriter.java
@@ -245,18 +245,21 @@ public class BigTableWriter extends SortedTableWriter
         int indexBufferSize = optimizationStrategy.bufferSize(indexFileLength / indexSummary.size());
         iwriter.indexFile.updateFileHandle(iwriter.builder);
         FileHandle ifile = iwriter.builder.bufferSize(indexBufferSize).complete();
-        return SSTableReader.internalOpen(descriptor,
-                                          components(),
-                                          metadata,
-                                          ifile,
-                                          dataFileHandle,
-                                          indexSummary,
-                                          iwriter.bf.sharedCopy(),
-                                          maxDataAge,
-                                          stats,
-                                          compactionMetadata,
-                                          reason,
-                                          header);
+        SSTableReader reader =  SSTableReader.internalOpen(descriptor,
+                                                           components(),
+                                                           metadata,
+                                                           ifile,
+                                                           dataFileHandle,
+                                                           indexSummary,
+                                                           iwriter.bf.sharedCopy(),
+                                                           maxDataAge,
+                                                           stats,
+                                                           compactionMetadata,
+                                                           reason,
+                                                           header);
+        reader.first = getMinimalKey(first);
+        reader.last = getMinimalKey(last);
+        return reader;
     }
 
     protected SortedTableWriter.TransactionalProxy txnProxy()

--- a/src/java/org/apache/cassandra/io/sstable/format/big/BigTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/BigTableWriter.java
@@ -38,7 +38,6 @@ import org.apache.cassandra.db.compaction.OperationType;
 import org.apache.cassandra.db.lifecycle.LifecycleNewTracker;
 import org.apache.cassandra.db.rows.Unfiltered;
 import org.apache.cassandra.io.FSWriteError;
-import org.apache.cassandra.io.compress.CompressedSequentialWriter;
 import org.apache.cassandra.io.sstable.Component;
 import org.apache.cassandra.io.sstable.Descriptor;
 import org.apache.cassandra.io.sstable.Downsampling;

--- a/src/java/org/apache/cassandra/io/sstable/format/trieindex/TrieIndexSSTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/trieindex/TrieIndexSSTableReader.java
@@ -223,12 +223,12 @@ public class TrieIndexSSTableReader extends SSTableReader
         partitionIndex.addTo(identities);
     }
 
-    protected boolean filterFirst()
+    public boolean filterFirst()
     {
         return openReason == OpenReason.MOVED_START || sstableMetadata.zeroCopyMetadata.exists();
     }
 
-    protected boolean filterLast()
+    public boolean filterLast()
     {
         return sstableMetadata.zeroCopyMetadata.exists();
     }
@@ -526,16 +526,10 @@ public class TrieIndexSSTableReader extends SSTableReader
             assert !AbstractBounds.strictlyWrapsAround(bounds.left, bounds.right) : String.format("[%s,%s]", bounds.left, bounds.right);
 
             left = bounds.left;
-            inclusiveLeft = bounds.inclusiveLeft();
-            if (filterFirst() && first.compareTo(left) > 0)
-            {
-                left = first;
-                inclusiveLeft = true;
-            }
-
             right = bounds.right;
+            inclusiveLeft = bounds.inclusiveLeft();
             inclusiveRight = bounds.inclusiveRight();
-            if (filterLast() && last.compareTo(right) < 0)
+            if (right.isMinimum())
             {
                 right = last;
                 inclusiveRight = true;
@@ -550,21 +544,19 @@ public class TrieIndexSSTableReader extends SSTableReader
 
     public PartitionIterator coveredKeysIterator(PartitionPosition left, boolean inclusiveLeft, PartitionPosition right, boolean inclusiveRight) throws IOException
     {
-        AbstractBounds<PartitionPosition> cover = Bounds.bounds(left, inclusiveLeft, right, inclusiveRight);
-        boolean isLeftInSStableRange = !filterFirst() || first.compareTo(left) <= 0 && last.compareTo(left) >= 0;
-        boolean isRightInSStableRange = !filterLast() || first.compareTo(right) <= 0 && last.compareTo(right) >= 0;
-        if (isLeftInSStableRange || isRightInSStableRange || (cover.contains(first) && cover.contains(last)))
-        {
-            inclusiveLeft = isLeftInSStableRange ? inclusiveLeft : true;
-            inclusiveRight = isRightInSStableRange ? inclusiveRight : true;
-            return new PartitionIterator(partitionIndex,
-                                         metadata().partitioner,
-                                         rowIndexFile, dfile,
-                                         isLeftInSStableRange ? left : first, inclusiveLeft ? -1 : 0,
-                                         isRightInSStableRange ? right : last, inclusiveRight ? 0 : -1);
-        }
-        else
+        if (filterFirst() && first.compareTo(right) > 0 || filterLast() && last.compareTo(left) < 0)
             return PartitionIterator.empty(partitionIndex);
+
+        boolean isLeftInSStableRange = !filterFirst() || first.compareTo(left) <= 0;
+        boolean isRightInSStableRange = !filterLast() || last.compareTo(right) >= 0;
+
+        inclusiveLeft = isLeftInSStableRange ? inclusiveLeft : true;
+        inclusiveRight = isRightInSStableRange ? inclusiveRight : true;
+        return new PartitionIterator(partitionIndex,
+                                     metadata().partitioner,
+                                     rowIndexFile, dfile,
+                                     isLeftInSStableRange ? left : first, inclusiveLeft ? -1 : 0,
+                                     isRightInSStableRange ? right : last, inclusiveRight ? 0 : -1);
     }
 
     public PartitionIterator allKeysIterator() throws IOException

--- a/src/java/org/apache/cassandra/io/sstable/format/trieindex/TrieIndexSSTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/trieindex/TrieIndexSSTableReader.java
@@ -182,6 +182,10 @@ public class TrieIndexSSTableReader extends SSTableReader
         TrieIndexSSTableReader reader = new TrieIndexSSTableReader(desc, components, metadata, maxDataAge, sstableMetadata, compactionMetadata, openReason, header, dfile, rowIndexFile, partitionIndex, bf);
         reader.first = partitionIndex.firstKey();
         reader.last = partitionIndex.lastKey();
+        // Make sure index is not retaining keys that reference slab memory.
+        assert !ByteBufferUtil.canMinimize(reader.first.getKey());
+        assert !ByteBufferUtil.canMinimize(reader.last.getKey());
+
 
         return reader;
     }

--- a/src/java/org/apache/cassandra/io/sstable/format/trieindex/TrieIndexSSTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/trieindex/TrieIndexSSTableReader.java
@@ -78,6 +78,7 @@ import org.apache.cassandra.io.sstable.metadata.StatsMetadata;
 import org.apache.cassandra.io.sstable.metadata.ValidationMetadata;
 import org.apache.cassandra.io.util.BufferedDataOutputStreamPlus;
 import org.apache.cassandra.io.util.ChannelProxy;
+import org.apache.cassandra.io.util.DataInputPlus;
 import org.apache.cassandra.io.util.DataOutputStreamPlus;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileDataInput;
@@ -342,6 +343,27 @@ public class TrieIndexSSTableReader extends SSTableReader
     }
 
     /**
+     * In encrypted index files skipBytes may end up in a different but equivalent position when it's at the
+     * end of an encrypted chunk. More precisely, if the skipped sequence of bytes lands exactly at the end of the
+     * useable part of a chunk (just before the hole left for encryption metadata), a normal read would leave the file
+     * at that position; before reading the next byte it will silently advance to the start of the next chunk. A skip,
+     * on the other hand, will jump to the position that follows the data, which is correctly converted to the beginning
+     * of the next page in preparation for reading. As a result it will leave the file positioned at the start of the
+     * next page immediately. See PartitionIndexEncryptedTest#testSkipAcrossHoles.
+     *
+     * To avoid this, we skip one fewer byte and consume the last byte.
+     */
+    @VisibleForTesting
+    static void skipBytesWithCorrectPosition(DataInputPlus in, int skip) throws IOException
+    {
+        if (skip > 0)
+        {
+            in.skipBytesFully(skip - 1);
+            in.readByte();
+        }
+    }
+
+    /**
      * Called by getPosition above (via Reader.ceiling/floor) to check if the position satisfies the full key constraint.
      * This is called once if there is a prefix match (which can be in any relationship with the sought key, thus
      * assumeNoMatch: false), and if it returns null it is called again for the closest greater position
@@ -355,7 +377,10 @@ public class TrieIndexSSTableReader extends SSTableReader
             try (FileDataInput in = rowIndexFile.createReader(pos))
             {
                 if (assumeNoMatch)
-                    ByteBufferUtil.skipShortLength(in);
+                {
+                    int skip = ByteBufferUtil.readShortLength(in);
+                    skipBytesWithCorrectPosition(in, skip);
+                }
                 else
                 {
                     ByteBuffer indexKey = ByteBufferUtil.readWithShortLength(in);

--- a/src/java/org/apache/cassandra/io/sstable/format/trieindex/TrieIndexSSTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/trieindex/TrieIndexSSTableWriter.java
@@ -243,6 +243,7 @@ public class TrieIndexSSTableWriter extends SortedTableWriter
     protected SSTableReader openReader(SSTableReader.OpenReason reason, FileHandle dataFileHandle, StatsMetadata stats, Optional<CompactionMetadata> compactionMetadata)
     {
         PartitionIndex partitionIndex = iwriter.completedPartitionIndex();
+        iwriter.rowIndexFile.updateFileHandle(iwriter.rowIndexFHBuilder);
         FileHandle rowIndexFile = iwriter.rowIndexFHBuilder.complete();
         SSTableReader sstable = TrieIndexSSTableReader.internalOpen(descriptor,
                                                             components(),
@@ -397,7 +398,6 @@ public class TrieIndexSSTableWriter extends SortedTableWriter
 
         public boolean buildPartial(long dataPosition, Consumer<PartitionIndex> callWhenReady)
         {
-            rowIndexFile.updateFileHandle(rowIndexFHBuilder);
             return partitionIndex.buildPartial(callWhenReady, rowIndexFile.position(), dataPosition);
         }
 
@@ -450,8 +450,6 @@ public class TrieIndexSSTableWriter extends SortedTableWriter
 
             // truncate index file
             rowIndexFile.prepareToCommit();
-            rowIndexFHBuilder.withLength(rowIndexFile.getLastFlushOffset());
-            //TODO figure out whether the update should be done before or after the prepare to commit
             rowIndexFile.updateFileHandle(rowIndexFHBuilder);
 
             complete();

--- a/src/java/org/apache/cassandra/io/sstable/format/trieindex/TrieIndexSSTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/trieindex/TrieIndexSSTableWriter.java
@@ -218,8 +218,6 @@ public class TrieIndexSSTableWriter extends SortedTableWriter
                                                                         Optional.of(compactionMetadata),  // never null here
                                                                         SSTableReader.OpenReason.EARLY, header);
 
-            sstable.first = getMinimalKey(partitionIndex.firstKey());
-            sstable.last = getMinimalKey(partitionIndex.lastKey());
             sstable.setup(true);
             callWhenReady.accept(sstable);
         });
@@ -246,17 +244,17 @@ public class TrieIndexSSTableWriter extends SortedTableWriter
         iwriter.rowIndexFile.updateFileHandle(iwriter.rowIndexFHBuilder);
         FileHandle rowIndexFile = iwriter.rowIndexFHBuilder.complete();
         SSTableReader sstable = TrieIndexSSTableReader.internalOpen(descriptor,
-                                                            components(),
-                                                            this.metadata,
-                                                            rowIndexFile,
-                                                            dataFileHandle,
-                                                            partitionIndex,
-                                                            iwriter.bf.sharedCopy(),
-                                                            maxDataAge,
-                                                            stats,
-                                                            compactionMetadata,
-                                                            reason,
-                                                            header);
+                                                                    components(),
+                                                                    this.metadata,
+                                                                    rowIndexFile,
+                                                                    dataFileHandle,
+                                                                    partitionIndex,
+                                                                    iwriter.bf.sharedCopy(),
+                                                                    maxDataAge,
+                                                                    stats,
+                                                                    compactionMetadata,
+                                                                    reason,
+                                                                    header);
         sstable.setup(true);
         return sstable;
     }

--- a/src/java/org/apache/cassandra/io/util/BufferManagingRebufferer.java
+++ b/src/java/org/apache/cassandra/io/util/BufferManagingRebufferer.java
@@ -90,6 +90,12 @@ public abstract class BufferManagingRebufferer implements Rebufferer, Rebufferer
     }
 
     @Override
+    public long positionForSkip(long currentPosition, int bytesToSkip)
+    {
+        return source.positionForSkip(currentPosition, bytesToSkip);
+    }
+
+    @Override
     public BufferHolder rebuffer(long position)
     {
         offset = alignedPosition(position);

--- a/src/java/org/apache/cassandra/io/util/EncryptedChunkReader.java
+++ b/src/java/org/apache/cassandra/io/util/EncryptedChunkReader.java
@@ -80,6 +80,20 @@ public abstract class EncryptedChunkReader extends AbstractReaderFileProxy imple
         return position - maxBytesInPage + CHUNK_SIZE;
     }
 
+    @Override
+    public long positionForSkip(long currentPosition, int bytesToSkip)
+    {
+        long currentOffset = inChunkOffset(currentPosition);
+        while (currentOffset + bytesToSkip > maxBytesInPage)
+        {
+            long len = maxBytesInPage - currentOffset;
+            bytesToSkip -= len;
+            currentPosition += CHUNK_SIZE - maxBytesInPage + len;
+            currentOffset = 0;
+        }
+        return currentPosition + bytesToSkip;
+    }
+
     private static long inChunkOffset(long position)
     {
         return position & (CHUNK_SIZE - 1);

--- a/src/java/org/apache/cassandra/io/util/RandomAccessReader.java
+++ b/src/java/org/apache/cassandra/io/util/RandomAccessReader.java
@@ -353,11 +353,17 @@ public class RandomAccessReader extends RebufferingInputStream implements FileDa
             return 0;
         if (buffer == null)
             throw new IOException("Attempted skipBytes() on a closed RAR");
-        long current = current();
-        long newPosition = Math.min(current + n, length());
-        n = (int)(newPosition - current);
-        seek(newPosition);
-        return n;
+        if (n <= buffer.remaining())
+        {
+            buffer.position(buffer.position() + n);
+            return n;
+        }
+
+        long current = getFilePointer();
+        long newPosition = rebufferer.positionForSkip(current, n);
+        long adjustedForSize = Math.min(newPosition, length());
+        seek(adjustedForSize);
+        return n + (int) (adjustedForSize - newPosition);
     }
 
     /**

--- a/src/java/org/apache/cassandra/io/util/ReaderFileProxy.java
+++ b/src/java/org/apache/cassandra/io/util/ReaderFileProxy.java
@@ -37,6 +37,15 @@ public interface ReaderFileProxy extends AutoCloseable
     long adjustPosition(long position);
 
     /**
+     * Called to provide the position to be seeked to after skipping the given number of bytes.
+     * Overridden by EncryptedChunkReader to properly account for holes.
+     */
+    default long positionForSkip(long currentPosition, int bytesToSkip)
+    {
+        return currentPosition + bytesToSkip;
+    }
+
+    /**
      * Needed for tests. Returns the table's CRC check chance, which is only set for compressed tables.
      */
     double getCrcCheckChance();

--- a/src/java/org/apache/cassandra/io/util/WrappingRebufferer.java
+++ b/src/java/org/apache/cassandra/io/util/WrappingRebufferer.java
@@ -82,6 +82,12 @@ public abstract class WrappingRebufferer implements Rebufferer, Rebufferer.Buffe
     }
 
     @Override
+    public long positionForSkip(long currentPosition, int bytesToSkip)
+    {
+        return source.positionForSkip(currentPosition, bytesToSkip);
+    }
+
+    @Override
     public void close()
     {
         assert buffer == null : "Rebufferer is attempted to be closed but the buffer holder has not been released";

--- a/test/distributed/org/apache/cassandra/distributed/test/SSTableEncryptionTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/SSTableEncryptionTest.java
@@ -33,6 +33,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.crypto.LocalSystemKey;
 import org.apache.cassandra.crypto.TDEConfigurationProvider;
 import org.apache.cassandra.db.Keyspace;
@@ -41,6 +42,7 @@ import org.apache.cassandra.distributed.api.ConsistencyLevel;
 import org.apache.cassandra.distributed.api.NodeToolResult;
 import org.apache.cassandra.io.sstable.Component;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.io.util.PathUtils;
 import org.apache.cassandra.utils.ChecksumType;
 
 import static org.apache.cassandra.distributed.api.ConsistencyLevel.ALL;
@@ -75,9 +77,22 @@ public class SSTableEncryptionTest extends TestBaseImpl
     }
 
     @Test
+    public void shouldFlushToQueryableEncryptedSSTables() throws Throwable
+    {
+        // test reading sstables as set up by flush/compaction on the running node
+        testQueryableEncryptedSSTables(false);
+    }
+
+    @Test
     public void shouldCreateQueryableEncryptedSSTables() throws Throwable
     {
-        try (Cluster cluster = builder().withNodes(2)
+        // test reading sstables from disk without write-time set-up
+        testQueryableEncryptedSSTables(true);
+    }
+
+    public void testQueryableEncryptedSSTables(boolean restartNodes) throws Throwable
+    {
+        try (Cluster cluster = builder().withNodes(1)
                                         .withConfig(config -> config.with(GOSSIP).with(NETWORK))
                                         .start())
         {
@@ -98,6 +113,14 @@ public class SSTableEncryptionTest extends TestBaseImpl
             cluster.get(1).flush(keyspace);
 
             insertAndFlush(cluster, keyspace, table, numberOfRows);
+
+            if (restartNodes)
+            {
+                for (int i = 1; i <= cluster.size(); ++i)
+                {
+                    restartWithDeletedCommitLog(cluster, i);
+                }
+            }
 
             // when querying all
             Object[][] rows = cluster.coordinator(1).execute(String.format("SELECT * FROM %s.%s ", keyspace, table), ALL);
@@ -127,6 +150,16 @@ public class SSTableEncryptionTest extends TestBaseImpl
         }
     }
 
+    private static void restartWithDeletedCommitLog(Cluster cluster, int i)
+    {
+        String commitlogpath = cluster.get(1).callOnInstance(() -> DatabaseDescriptor.getCommitLogLocation().path());
+        waitOn(cluster.get(i).shutdown());
+        // delete the commit log to make sure we are not recreating the data from it
+        PathUtils.deleteRecursive(Path.of(commitlogpath));
+        // start-up must now read the sstables
+        cluster.get(i).startup();
+    }
+
     @Test
     public void shouldEncryptSensitiveData() throws Exception
     {
@@ -137,7 +170,7 @@ public class SSTableEncryptionTest extends TestBaseImpl
             // given tables with and without encryption
             String keyspace = createKeyspace(cluster);
             // force no compression because some compression algorithms likely won't preserve the sensitive key
-            TestTable nonEncryptedTable = createTableWithSampleData(cluster, keyspace, " WITH compression = {'class': 'NoopCompressor'}");
+            TestTable nonEncryptedTable = createTableWithSampleData(cluster, keyspace, "");
             Path secretKey = createLocalSecretKey(cluster);
             TestTable encryptedTable = createTableWithSampleData(cluster, keyspace, localSystemKeyEncryptionCompressionSuffix("Encryptor", secretKey.toAbsolutePath().toString()));
 
@@ -243,8 +276,7 @@ public class SSTableEncryptionTest extends TestBaseImpl
             assertEquals(secretKey, secretKey2);
 
             // restart to clear in memory secret key cache
-            waitOn(cluster.get(1).shutdown());
-            cluster.get(1).startup();
+            restartWithDeletedCommitLog(cluster, 1);
 
             // when
             Object[][] rows = cluster. get(1).executeInternal(String.format("SELECT * FROM %s.%s", keyspace, nonEncryptedTableName));

--- a/test/long/org/apache/cassandra/cql3/EarlyOpenCompactionTest.java
+++ b/test/long/org/apache/cassandra/cql3/EarlyOpenCompactionTest.java
@@ -1,0 +1,226 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.hamcrest.Matchers;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+
+public class EarlyOpenCompactionTest extends CQLTester
+{
+    private static final int NUM_PARTITIONS = 1000;
+    private static final int NUM_ROWS_PER_PARTITION = 100;
+    private static final int VALUE_SIZE = 1000; // ~1KB per row
+    private static final int VERIFICATION_THREADS = 4;
+
+    private final AtomicBoolean stopVerification = new AtomicBoolean(false);
+    private final AtomicInteger verificationErrors = new AtomicInteger(0);
+    private final Random random = new Random();
+    private ExecutorService executor;
+
+    @After
+    public void cleanupAfter() throws Throwable
+    {
+        stopVerification.set(true);
+        if (executor != null)
+        {
+            executor.shutdownNow();
+            executor.awaitTermination(1, TimeUnit.MINUTES);
+        }
+        DatabaseDescriptor.setSSTablePreemptiveOpenIntervalInMB(50);
+    }
+
+    @Test
+    public void testEarlyOpenDuringCompaction() throws Throwable
+    {
+        // Create a table with a simple schema
+        createTable("CREATE TABLE %s (" +
+            "pk int, " +
+            "ck int, " +
+            "data text, " +
+            "PRIMARY KEY (pk, ck)" +
+            ")");
+
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        disableCompaction();
+
+        // Insert data to create multiple SSTables
+        System.out.println("Inserting test data...");
+        for (int i = 0; i < NUM_PARTITIONS; i++)
+        {
+            for (int j = 0; j < NUM_ROWS_PER_PARTITION; j++)
+            {
+                String value = randomString(VALUE_SIZE);
+                execute("INSERT INTO %s (pk, ck, data) VALUES (?, ?, ?)", i, j, value);
+            }
+
+            // Flush from time to time to get 10 sstables
+            if (i > 0 && i % Math.max(1, NUM_PARTITIONS / 10) == 0)
+            {
+                flush();
+            }
+        }
+
+        // Final flush to ensure all data is written
+        flush();
+
+        // Verify we have multiple SSTables
+        int sstableCount = cfs.getLiveSSTables().size();
+        assertTrue("Expected multiple SSTables, got: " + sstableCount, sstableCount > 1);
+
+        // Start verification threads
+        System.out.println("Starting verification threads...");
+        executor = Executors.newFixedThreadPool(VERIFICATION_THREADS);
+        List<Future<?>> futures = new ArrayList<>();
+
+        for (int i = 0; i < VERIFICATION_THREADS; i++)
+        {
+            futures.add(executor.submit(new VerificationTask()));
+        }
+
+        // Wait a bit to ensure verification is running
+        Thread.sleep(1000);
+
+        // Set early open interval to 1MiB to trigger early open during compaction
+        System.out.println("Setting early open interval to 1MiB...");
+        DatabaseDescriptor.setSSTablePreemptiveOpenIntervalInMB(1);
+        // Slow down compaction to give the verifier time to fail.
+        DatabaseDescriptor.setCompactionThroughputMbPerSec(10);
+
+        // Trigger compaction and await its completion
+        System.out.println("Starting compaction...");
+        cfs.enableAutoCompaction(true);
+
+        // Let verification run for a while during and after compaction
+        System.out.println("Verifying data during and after compaction...");
+        Thread.sleep(1000);
+
+        // Stop verification
+        stopVerification.set(true);
+
+        // Wait for verification to complete
+        for (Future<?> future : futures)
+        {
+            try
+            {
+                future.get(10, TimeUnit.SECONDS);
+            }
+            catch (Exception e)
+            {
+                System.err.println("Verification task failed: " + e);
+                e.printStackTrace();
+            }
+        }
+
+        // Verify no errors occurred during verification
+        int errors = verificationErrors.get();
+        assertEquals("Found " + errors + " verification errors. Check logs for details.", 0, errors);
+
+        System.out.println("Test completed successfully");
+    }
+
+    private class VerificationTask implements Runnable
+    {
+        @Override
+        public void run()
+        {
+            try
+            {
+                Random localRandom = new Random(Thread.currentThread().getId());
+
+                while (!stopVerification.get() && !Thread.currentThread().isInterrupted())
+                {
+                    // Randomly choose between point query and partition range query
+                    if (localRandom.nextBoolean())
+                    {
+                        // Point query
+                        int pk = localRandom.nextInt(NUM_PARTITIONS * 110 / 100); // 10% chance outside
+                        int ck = localRandom.nextInt(NUM_ROWS_PER_PARTITION * 110 / 100); // 10% chance outside
+
+                        try
+                        {
+                            Assert.assertEquals(pk < NUM_PARTITIONS && ck < NUM_ROWS_PER_PARTITION ? 1 : 0,
+                                execute("SELECT data FROM %s WHERE pk = ? AND ck = ?", pk, ck).size());
+                        }
+                        catch (Throwable t)
+                        {
+                            verificationErrors.incrementAndGet();
+                            System.err.println("Point query failed for pk=" + pk + ", ck=" + ck + ": " + t);
+                            t.printStackTrace();
+                        }
+                    }
+                    else
+                    {
+                        // Partition range query
+                        int pk = localRandom.nextInt(NUM_PARTITIONS);
+
+                        try
+                        {
+                            Assert.assertThat(execute("SELECT data FROM %s WHERE token(pk) <= token(?) AND token(pk) >= token(?)", pk, pk).size(),
+                                Matchers.greaterThanOrEqualTo(NUM_ROWS_PER_PARTITION));
+                        }
+                        catch (Throwable t)
+                        {
+                            verificationErrors.incrementAndGet();
+                            System.err.println("Range query failed for pk in (" + pk + ", " + (pk + 1) + ", " + (pk + 2) + "): " + t);
+                            t.printStackTrace();
+                        }
+                    }
+
+                    // Add a small delay to prevent overwhelming the system
+                    Thread.yield();
+                }
+            }
+            catch (Throwable t)
+            {
+                verificationErrors.incrementAndGet();
+                System.err.println("Verification task failed: " + t);
+                t.printStackTrace();
+            }
+        }
+    }
+
+    private String randomString(int length)
+    {
+        StringBuilder sb = new StringBuilder(length);
+        for (int i = 0; i < length; i++)
+        {
+            sb.append((char)('a' + random.nextInt(26)));
+        }
+        return sb.toString();
+    }
+}

--- a/test/unit/org/apache/cassandra/db/EarlyOpenWithBytemanTest.java
+++ b/test/unit/org/apache/cassandra/db/EarlyOpenWithBytemanTest.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cassandra.db;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.apache.cassandra.SchemaLoader;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.db.compaction.CompactionManager;
+import org.apache.cassandra.db.marshal.UUIDType;
+import org.apache.cassandra.dht.ByteOrderedPartitioner;
+import org.apache.cassandra.exceptions.ConfigurationException;
+import org.apache.cassandra.io.sstable.SSTableRewriter;
+import org.apache.cassandra.schema.KeyspaceParams;
+import org.jboss.byteman.contrib.bmunit.BMRule;
+import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
+
+import static org.apache.cassandra.SchemaLoader.counterCFMD;
+import static org.apache.cassandra.SchemaLoader.createKeyspace;
+import static org.apache.cassandra.SchemaLoader.getCompressionParameters;
+import static org.apache.cassandra.SchemaLoader.loadSchema;
+import static org.apache.cassandra.SchemaLoader.standardCFMD;
+import static org.apache.cassandra.db.ScrubTest.CF;
+import static org.apache.cassandra.db.ScrubTest.CF_INDEX1;
+import static org.apache.cassandra.db.ScrubTest.CF_INDEX1_BYTEORDERED;
+import static org.apache.cassandra.db.ScrubTest.CF_INDEX2;
+import static org.apache.cassandra.db.ScrubTest.CF_INDEX2_BYTEORDERED;
+import static org.apache.cassandra.db.ScrubTest.CF_UUID;
+import static org.apache.cassandra.db.ScrubTest.COMPRESSION_CHUNK_LENGTH;
+import static org.apache.cassandra.db.ScrubTest.COUNTER_CF;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(BMUnitRunner.class)
+public class EarlyOpenWithBytemanTest
+{
+    public static AtomicInteger moveStartsCounter = new AtomicInteger(0);
+    public static AtomicInteger failedEarlyOpenCounter = new AtomicInteger(0);
+    public static AtomicBoolean canTriggerException = new AtomicBoolean(false);
+
+    static String KEYSPACE = "early_open_byteman_test";
+
+    @BeforeClass
+    public static void defineSchema() throws ConfigurationException
+    {
+        loadSchema();
+        createKeyspace(KEYSPACE,
+                KeyspaceParams.simple(1),
+                standardCFMD(KEYSPACE, CF),
+                counterCFMD(KEYSPACE, COUNTER_CF).compression(getCompressionParameters(COMPRESSION_CHUNK_LENGTH)),
+                standardCFMD(KEYSPACE, CF_UUID, 0, UUIDType.instance),
+                SchemaLoader.keysIndexCFMD(KEYSPACE, CF_INDEX1, true),
+                SchemaLoader.compositeIndexCFMD(KEYSPACE, CF_INDEX2, true),
+                SchemaLoader.keysIndexCFMD(KEYSPACE, CF_INDEX1_BYTEORDERED, true).partitioner(ByteOrderedPartitioner.instance),
+                SchemaLoader.compositeIndexCFMD(KEYSPACE, CF_INDEX2_BYTEORDERED, true).partitioner(ByteOrderedPartitioner.instance));
+    }
+
+
+    // DSP-25176
+    // Abort early-open attempts by blocking every second attempt to move an sstable's start (making sure some can
+    // succeed to test if created sstable references leak).
+    // Please check the output for "LEAK DETECTED" lines.
+    @Test
+    @BMRule(name="simulate_corruption",
+            targetClass = "org.apache.cassandra.io.sstable.SSTableRewriter",
+            targetMethod = "moveStarts",
+            targetLocation = "AT INVOKE org.apache.cassandra.io.sstable.format.SSTableReader.firstKeyBeyond",
+            condition = "org.apache.cassandra.db.EarlyOpenWithBytemanTest.canTriggerException.get() && " +
+                        "(org.apache.cassandra.db.EarlyOpenWithBytemanTest.moveStartsCounter.incrementAndGet() % 2 == 0)",
+            action = "org.apache.cassandra.db.EarlyOpenWithBytemanTest.failedEarlyOpenCounter.incrementAndGet();" +
+                     "throw new java.lang.RuntimeException(\"!!!Test simulated corruption!!!\");")
+    public void testExceptionsOnLifecycleBoundaries() throws Exception
+    {
+        boolean oldDisabledVal = SSTableRewriter.disableEarlyOpeningForTests;
+        int oldInterval = DatabaseDescriptor.getSSTablePreemptiveOpenIntervalInMB();
+        int earlyOpenThresholdMB = 1;
+        int cfsRowsNum = 100_000;
+        try
+        {
+            // Ensure early opening is enabled
+            SSTableRewriter.disableEarlyOpeningForTests = false;
+            // Set a very low interval (e.g., 1MB) to trigger early opening quickly
+            DatabaseDescriptor.setSSTablePreemptiveOpenIntervalInMB(earlyOpenThresholdMB);
+
+            CompactionManager.instance.disableAutoCompaction();
+            Keyspace keyspace = Keyspace.open(KEYSPACE);
+            ColumnFamilyStore cfs = keyspace.getColumnFamilyStore(CF);
+            cfs.clearUnsafe();
+
+            // Insert enough data to trigger early opening
+            ScrubTest.fillCF(cfs, cfsRowsNum);
+            // Do it again to have multiple source sstables
+            ScrubTest.fillCF(cfs, cfsRowsNum);
+            ScrubTest.assertOrderedAll(cfs, cfsRowsNum);
+
+
+            // This should trigger:
+            // 1. maybeReopenEarly() during normal writing
+            // 2. Corruption simulation
+            // 3. switchWriter() or other operation will try to update the transaction
+            failedEarlyOpenCounter.set(0);
+            canTriggerException.set(true);
+            cfs.forceMajorCompaction();
+            canTriggerException.set(false);
+            assertTrue("Corruption was not triggered " + failedEarlyOpenCounter.get(), failedEarlyOpenCounter.get() > 0);
+
+            // check data is still there
+            ScrubTest.assertOrderedAll(cfs, cfsRowsNum);
+        }
+        finally
+        {
+            SSTableRewriter.disableEarlyOpeningForTests = oldDisabledVal;
+            DatabaseDescriptor.setSSTablePreemptiveOpenIntervalInMB(oldInterval);
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/io/sstable/SSTableReaderTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/SSTableReaderTest.java
@@ -109,6 +109,7 @@ import org.apache.cassandra.service.CacheService;
 import org.apache.cassandra.utils.BloomCalculations;
 import org.apache.cassandra.utils.BloomFilter;
 import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.FastByteOperations;
 import org.apache.cassandra.utils.FilterFactory;
 import org.apache.cassandra.utils.IFilter;
 import org.apache.cassandra.utils.PageAware;
@@ -127,7 +128,9 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -1719,5 +1722,41 @@ public class SSTableReaderTest
         T ref = refSupplier.get();
         refsToRelease.add(ref.selfRef());
         return ref;
+    }
+
+    @Test
+    public void testGetMinimalKey()
+    {
+        partitioner = DatabaseDescriptor.getPartitioner();
+        DecoratedKey key = k(1);
+        ByteBuffer keyBuffer = key.getKey();
+        assertSame(key, SSTable.getMinimalKey(key));
+        ByteBuffer slab = ByteBuffer.allocate(100);
+        ByteBuffer partial = slab.position(20).limit(20 + key.getKeyLength()).slice();
+        FastByteOperations.copy(keyBuffer, keyBuffer.position(), partial, partial.position(), keyBuffer.remaining());
+        DecoratedKey k2 = new BufferDecoratedKey(key.getToken(), partial);
+        assertEquals(key, k2);
+        checkMinimization(k2);
+
+        partial = slab.position(20).limit(20 + key.getKeyLength());
+        FastByteOperations.copy(keyBuffer, keyBuffer.position(), partial, partial.position(), keyBuffer.remaining());
+        k2 = new BufferDecoratedKey(key.getToken(), partial);
+        assertEquals(key, k2);
+        checkMinimization(k2);
+
+        ByteBuffer direct = ByteBuffer.allocateDirect(key.getKeyLength());
+        FastByteOperations.copy(keyBuffer, keyBuffer.position(), direct, direct.position(), keyBuffer.remaining());
+        DecoratedKey k3 = new BufferDecoratedKey(key.getToken(), direct);
+        assertEquals(key, k3);
+        checkMinimization(k3);
+    }
+
+    private static void checkMinimization(DecoratedKey k2)
+    {
+        DecoratedKey minimal = SSTable.getMinimalKey(k2);
+        assertEquals(k2, minimal);
+        assertNotSame(k2, minimal);
+        assertFalse(ByteBufferUtil.canMinimize(minimal.getKey()));
+        assertSame(minimal, SSTable.getMinimalKey(minimal));
     }
 }

--- a/test/unit/org/apache/cassandra/io/sstable/SSTableScannerTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/SSTableScannerTest.java
@@ -22,18 +22,22 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import com.google.common.collect.Iterables;
 import com.google.common.util.concurrent.Runnables;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.cassandra.SchemaLoader;
 import org.apache.cassandra.Util;
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.DataRange;
 import org.apache.cassandra.db.DecoratedKey;
@@ -50,12 +54,15 @@ import org.apache.cassandra.dht.AbstractBounds;
 import org.apache.cassandra.dht.ByteOrderedPartitioner;
 import org.apache.cassandra.dht.Range;
 import org.apache.cassandra.dht.Token;
+import org.apache.cassandra.io.sstable.format.SSTableFormat;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.sstable.format.SSTableReadsListener;
+import org.apache.cassandra.io.sstable.format.trieindex.TrieIndexSSTableReader;
 import org.apache.cassandra.schema.KeyspaceParams;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.hamcrest.Matchers;
+import org.mockito.Mockito;
 
 import static org.apache.cassandra.dht.AbstractBounds.isEmpty;
 import static org.junit.Assert.assertEquals;
@@ -188,18 +195,19 @@ public class SSTableScannerTest
 
     private static void assertScanMatches(SSTableReader sstable, int scanStart, int scanEnd, int ... boundaries)
     {
-        assertScanMatchesUsingScanner(sstable, scanStart, scanEnd, boundaries);
+        assertScanFromDataRangeMatches(sstable, scanStart, scanEnd, boundaries);
+        assertScanFromIteratorMatches(sstable, scanStart, scanEnd, boundaries);
         assertScanMatchesUsingSimple(sstable, scanStart, scanEnd, boundaries);
     }
 
-    private static void assertScanMatchesUsingScanner(SSTableReader sstable, int scanStart, int scanEnd, int ... boundaries)
+    private static void assertScanFromDataRangeMatches(SSTableReader sstable, int scanStart, int scanEnd, int ... boundaries)
     {
         assert boundaries.length % 2 == 0;
         for (DataRange range : dataRanges(sstable.metadata(), scanStart, scanEnd))
         {
-            try(UnfilteredPartitionIterator scanner = sstable.getScanner(ColumnFilter.all(sstable.metadata()),
-                                                                         range,
-                                                                         SSTableReadsListener.NOOP_LISTENER))
+            try(ISSTableScanner scanner = sstable.getScanner(ColumnFilter.all(sstable.metadata()),
+                                                             range,
+                                                             SSTableReadsListener.NOOP_LISTENER))
             {
                 for (int b = 0; b < boundaries.length; b += 2)
                     for (int i = boundaries[b]; i <= boundaries[b + 1]; i++)
@@ -210,6 +218,33 @@ public class SSTableScannerTest
             {
                 throw new RuntimeException(e);
             }
+        }
+    }
+
+    private static void assertScanFromIteratorMatches(SSTableReader sstable, int scanStart, int scanEnd, int ... boundaries)
+    {
+        assert boundaries.length % 2 == 0;
+        Range<Token> range = rangeFor(scanStart, scanEnd);
+        List<Range<Token>> ranges = scanStart <= scanEnd ? List.of(range) : range.unwrap();
+        List<AbstractBounds<PartitionPosition>> pps =
+            ranges.stream()
+                  .sorted(Comparator.comparing(b -> b.left))
+                  .map(r -> new Range<PartitionPosition>(r.left.minKeyBound(), r.right.maxKeyBound()))
+                  .collect(Collectors.<AbstractBounds<PartitionPosition>>toList());
+
+        try(ISSTableScanner scanner = sstable.getScanner(pps.iterator()))
+        {
+            for (int b = 0; b < boundaries.length; b += 2)
+                for (int i = boundaries[b]; i <= boundaries[b + 1]; i++)
+                    assertEquals(toKey(i), new String(scanner.next().partitionKey().getKey().array()));
+            boolean hadNext = scanner.hasNext();
+            while (scanner.hasNext())
+                System.out.println("Got extra " + new String(scanner.next().partitionKey().getKey().array()));
+            assertFalse(hadNext);
+        }
+        catch (Exception e)
+        {
+            throw new RuntimeException(e);
         }
     }
 
@@ -243,6 +278,32 @@ public class SSTableScannerTest
     @Test
     public void testSingleDataRange() throws IOException
     {
+        testSingleDataRange(false, false);
+    }
+
+    @Test
+    public void testSingleDataRangeWithChangedStart() throws IOException
+    {
+        testSingleDataRange(true, false);
+    }
+
+    @Test
+    public void testSingleDataRangeWithChangedEnd() throws IOException
+    {
+
+        Assume.assumeTrue(SSTableFormat.Type.current() == SSTableFormat.Type.BTI);
+        testSingleDataRange(false, true);
+    }
+
+    @Test
+    public void testSingleDataRangeWithChangedBothEnds() throws IOException
+    {
+        Assume.assumeTrue(SSTableFormat.Type.current() == SSTableFormat.Type.BTI);
+        testSingleDataRange(true, true);
+    }
+
+    private void testSingleDataRange(boolean filterFirst, boolean filterLast)
+    {
         Keyspace keyspace = Keyspace.open(KEYSPACE);
         ColumnFamilyStore store = keyspace.getColumnFamilyStore(TABLE);
         store.clearUnsafe();
@@ -250,13 +311,33 @@ public class SSTableScannerTest
         // disable compaction while flushing
         store.disableAutoCompaction();
 
-        for (int i = 2; i < 10; i++)
+        for (int i = filterFirst ? 0 : 2; i <= (filterLast ? 12 : 9); i++)
             insertRowWithKey(store.metadata(), i);
-        Util.flush(store);
+        store.forceBlockingFlush(ColumnFamilyStore.FlushReason.UNIT_TESTS);
 
         assertEquals(1, store.getLiveSSTables().size());
         SSTableReader sstable = store.getLiveSSTables().iterator().next();
+        if (filterFirst)
+            sstable = sstable.cloneWithNewStart(dk(2), Runnables.doNothing());
+        if (filterLast)
+            sstable = cloneWithNewEndBound(sstable, dk(9));
+        testSingleDataRange(sstable);
+    }
 
+    private SSTableReader cloneWithNewEndBound(SSTableReader sstable, DecoratedKey last)
+    {
+        long fileEnd = sstable.getPosition(last, SSTableReader.Operator.GT).position;
+        TrieIndexSSTableReader spied = Mockito.spy((TrieIndexSSTableReader) sstable);
+        // Change the end bound and make sure it is applied.
+        spied.last = last;
+        Mockito.when(spied.filterLast()).thenReturn(true);
+        // When it's given a position beyond the last key, the sstable will use uncompressedLength(). Mock that too.
+        Mockito.when(spied.uncompressedLength()).thenReturn(fileEnd);
+        return spied;
+    }
+
+    private void testSingleDataRange(SSTableReader sstable)
+    {
         // full range scan
         ISSTableScanner scanner = sstable.getScanner();
         for (int i = 2; i < 10; i++)
@@ -357,7 +438,7 @@ public class SSTableScannerTest
         // start of range edge conditions
         assertScanMatches(sstable, 3, 9, 4, 9);
         assertScanMatches(sstable, 4, 9, 4, 9);
-        assertScanMatches(sstable, 5, 9, 4, 9);
+        assertScanMatches(sstable, 5, 9, 5, 9);
 
         // end of range edge conditions
         assertScanMatches(sstable, 1, 8, 4, 8);

--- a/test/unit/org/apache/cassandra/io/sstable/format/trieindex/PartitionIndexEncryptedTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/format/trieindex/PartitionIndexEncryptedTest.java
@@ -15,6 +15,7 @@
  */
 package org.apache.cassandra.io.sstable.format.trieindex;
 
+import java.io.EOFException;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
@@ -22,6 +23,8 @@ import java.util.HashMap;
 import java.util.Map;
 import javax.crypto.spec.DESKeySpec;
 
+import org.junit.Assert;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -35,6 +38,7 @@ import org.apache.cassandra.io.compress.EncryptorTest;
 import org.apache.cassandra.io.sstable.metadata.ZeroCopyMetadata;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileHandle;
+import org.apache.cassandra.io.util.RandomAccessReader;
 import org.apache.cassandra.io.util.SequentialWriter;
 import org.apache.cassandra.io.util.SequentialWriterOption;
 import org.apache.cassandra.schema.CompressionParams;
@@ -194,5 +198,77 @@ public class PartitionIndexEncryptedTest extends PartitionIndexTest
     public void testDumpTrieToFile()
     {
         //FIXME: the tested trie dump method seems to be used only in tests, it should be revisited and fixed evnetually
+    }
+
+    /**
+     * Verifies that seeking, reading and skipping over encryption-only files result in the same positions and read the
+     * same data. See DSP-25176.
+     */
+    @Test
+    public void testSkipAcrossHoles() throws IOException
+    {
+        int pageSize = PageAware.PAGE_SIZE;
+        File tempFile = new File(java.io.File.createTempFile(getClass().getName(), ".test"));
+        try (SequentialWriter writer = makeWriter(tempFile))
+        {
+            for (int i = 0; i < pageSize * 8; ++i)
+                writer.writeByte((byte) writer.position());
+            writer.finish();
+        }
+
+        try (FileHandle.Builder fhBuilder = makeHandle(tempFile);
+             FileHandle fh = fhBuilder.complete();
+             RandomAccessReader rdr = fh.createReader())
+        {
+            long len = rdr.length();
+            for (int readSize : new int[]{ 1, 7, 33, 45, 67, pageSize + 55, pageSize * 2, pageSize * 3 + 34 })
+            {
+                byte[] buf = new byte[readSize];
+                for (int seekPos = pageSize - 33; seekPos < len - 1; ++seekPos)
+                {
+                    rdr.seek(seekPos);
+                    int read = rdr.read(buf, 0, buf.length);
+                    long afterRead = rdr.getFilePointer();
+                    int nextByte = getNextByte(rdr);
+                    int expectedNextByte = (int) afterRead & 0xFF;
+
+                    rdr.seek(seekPos);
+                    TrieIndexSSTableReader.skipBytesWithCorrectPosition(rdr, read);
+                    long afterSkip = rdr.getFilePointer();
+                    int nextByteAfterSkip = getNextByte(rdr);
+                    String context = String.format("(seek to %x, read %x bytes (of %x) to pos %x next %x; seek to %x corrected skip %x bytes to pos %x next %x)", seekPos, read, readSize, afterRead, nextByte, seekPos, read, afterSkip, nextByteAfterSkip);
+
+                    Assert.assertEquals("Position" + context, afterRead, afterSkip);
+                    Assert.assertEquals("Next byte" + context, nextByte, nextByteAfterSkip);
+
+                    rdr.seek(seekPos);
+                    rdr.skipBytes(read);
+                    afterSkip = rdr.getFilePointer();
+                    nextByteAfterSkip = getNextByte(rdr);
+                    context = String.format("(seek to %x, read %x bytes (of %x) to pos %x next %x; seek to %x plain skip %x bytes to pos %x next %x)", seekPos, read, readSize, afterRead, nextByte, seekPos, read, afterSkip, nextByteAfterSkip);
+
+                    if (afterRead != afterSkip)
+                        System.out.println("Different position after plain skip " + context); // this is expected and corrected for by TrieIndexSSTableReader.skipBytesWithCorrectPosition
+                    Assert.assertEquals("Next byte" + context, nextByte, nextByteAfterSkip);
+
+                    if (nextByte != Integer.MAX_VALUE)
+                        Assert.assertEquals("Byte from write pos" + context, expectedNextByte, nextByte);
+                    else
+                        break; // because length() is imprecise, next seeks may hit beyond the end of the file
+                }
+            }
+        }
+    }
+
+    private static int getNextByte(RandomAccessReader rdr) throws IOException
+    {
+        try
+        {
+            return rdr.readByte() & 0xFF;
+        }
+        catch (EOFException e)
+        {
+            return Integer.MAX_VALUE;
+        }
     }
 }


### PR DESCRIPTION
### What is the issue
[DSP-25176](https://datastax.jira.com/browse/DSP-25176) / [HCD-576](https://datastax.jira.com/browse/HCD-576)

Encrypted primary index files are written in a way that hides encryption metadata in holes in the file. Non-trie data like primary keys may span over these holes, which is handled correctly when we read these keys.
However, when we skip a key instead of reading it, we may end up in the wrong position if the key is longer than the metadata.


### What does this PR fix and why was it fixed
Implements skip position correction for encrypted primary index files.
Also corrects problems listing partitions when the boundaries of an sstable have been reduced due to zero-copy streaming metadata.
Adds tests for both problems.
Disables early opening for online scrub, which is unsafe because data may transiently disappear.
Makes sure that failed attempts to open a compaction result early are logged but do not stop the operation, by rolling back the prepared transaction checkpoint on error.
Fixes incorrect row index length in openFinalEarly.
Fixes incorrect DecoratedKey minimization.

CNDB PR: https://github.com/riptano/cndb/pull/19391

CC5 PR: https://github.com/datastax/cassandra/pull/2547
DSE PR: https://github.com/riptano/bdp/pull/21750


[DSP-25176]: https://datastax.jira.com/browse/DSP-25176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[HCD-576]: https://datastax.jira.com/browse/HCD-576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ