### PR TITLE
CNDB-18520: add Mutator#mutateCas for intercepting coordinator paxos write

### DIFF
--- a/src/java/org/apache/cassandra/service/Mutator.java
+++ b/src/java/org/apache/cassandra/service/Mutator.java
@@ -24,14 +24,17 @@ import javax.annotation.Nullable;
 
 import org.apache.cassandra.db.ConsistencyLevel;
 import org.apache.cassandra.db.CounterMutation;
+import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.IMutation;
 import org.apache.cassandra.db.Mutation;
 import org.apache.cassandra.db.WriteType;
+import org.apache.cassandra.db.rows.RowIterator;
 import org.apache.cassandra.exceptions.OverloadedException;
 import org.apache.cassandra.exceptions.UnavailableException;
 import org.apache.cassandra.exceptions.WriteTimeoutException;
 import org.apache.cassandra.locator.ReplicaPlan;
 import org.apache.cassandra.metrics.ClientRequestsMetrics;
+import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.service.paxos.Commit;
 
 /**
@@ -82,6 +85,13 @@ public interface Mutator
                                                            Runnable callback,
                                                            WriteType writeType,
                                                            long queryStartNanoTime);
+
+    /**
+     * Performs a CAS (LWT) operation coordinated on the local node and returns the result of its read.
+     */
+    RowIterator mutateCas(String keyspaceName, DecoratedKey key, CASRequest request, ConsistencyLevel consistencyForPaxos,
+                          ConsistencyLevel consistencyForCommit, QueryState state, int nowInSeconds, long queryStartNanoTime,
+                          QueryInfoTracker.LWTWriteTracker lwtTracker, ClientRequestsMetrics metrics, TableMetadata metadata);
 
     /**
      * Used for LWT mutation at the last (COMMIT) phase of Paxos.

--- a/src/java/org/apache/cassandra/service/Mutator.java
+++ b/src/java/org/apache/cassandra/service/Mutator.java
@@ -89,9 +89,9 @@ public interface Mutator
     /**
      * Performs a CAS (LWT) operation coordinated on the local node and returns the result of its read.
      */
-    RowIterator mutateCas(String keyspaceName, DecoratedKey key, CASRequest request, ConsistencyLevel consistencyForPaxos,
-                          ConsistencyLevel consistencyForCommit, QueryState state, int nowInSeconds, long queryStartNanoTime,
-                          QueryInfoTracker.LWTWriteTracker lwtTracker, ClientRequestsMetrics metrics, TableMetadata metadata);
+    RowIterator mutateCas(TableMetadata metadata, DecoratedKey key, QueryInfoTracker.LWTWriteTracker lwtTracker,
+                          ClientRequestsMetrics metrics, CASRequest request, ConsistencyLevel consistencyForPaxos,
+                          ConsistencyLevel consistencyForCommit, QueryState state, int nowInSeconds, long queryStartNanoTime);
 
     /**
      * Used for LWT mutation at the last (COMMIT) phase of Paxos.

--- a/src/java/org/apache/cassandra/service/StorageProxy.java
+++ b/src/java/org/apache/cassandra/service/StorageProxy.java
@@ -203,6 +203,12 @@ public class StorageProxy implements StorageProxyMBean
         }
 
         @Override
+        public RowIterator mutateCas(String keyspaceName, DecoratedKey key, CASRequest request, ConsistencyLevel consistencyForPaxos, ConsistencyLevel consistencyForCommit, QueryState state, int nowInSeconds, long queryStartNanoTime, QueryInfoTracker.LWTWriteTracker lwtTracker, ClientRequestsMetrics metrics, TableMetadata metadata)
+        {
+            return defaultCas(keyspaceName, key, request, consistencyForPaxos, consistencyForCommit, state, nowInSeconds, queryStartNanoTime, lwtTracker, metrics, metadata);
+        }
+
+        @Override
         public void mutateAtomically(Collection<Mutation> mutations, ConsistencyLevel consistencyLevel, boolean requireQuorumForRemove, long queryStartNanoTime, ClientRequestsMetrics metrics, ClientState clientState) throws UnavailableException, OverloadedException, WriteTimeoutException
         {
             Tracing.trace("Determining replicas for atomic batch");
@@ -506,72 +512,8 @@ public class StorageProxy implements StorageProxyMBean
         ExecutorLocals.set(locals);
         try
         {
-            consistencyForPaxos.validateForCas(keyspaceName, state);
-            consistencyForCommit.validateForCasCommit(Keyspace.open(keyspaceName).getReplicationStrategy(), keyspaceName, state);
 
-            Supplier<Pair<PartitionUpdate, RowIterator>> updateProposer = () ->
-            {
-                long startTimeNanos = System.nanoTime();
-                try
-                {
-                    // read the current values and check they validate the conditions
-                    Tracing.trace("Reading existing values for CAS precondition");
-                    SinglePartitionReadCommand readCommand = (SinglePartitionReadCommand) request.readCommand(nowInSeconds);
-                    ConsistencyLevel readConsistency = consistencyForPaxos == ConsistencyLevel.LOCAL_SERIAL ? ConsistencyLevel.LOCAL_QUORUM : ConsistencyLevel.QUORUM;
-
-                    FilteredPartition current;
-
-                    try (RowIterator rowIter = readOne(readCommand, readConsistency, queryStartNanoTime, lwtTracker))
-                    {
-                        current = FilteredPartition.create(rowIter);
-                    }
-
-                    if (!request.appliesTo(current))
-                    {
-                        Tracing.trace("CAS precondition does not match current values {}", current);
-                        lwtTracker.onNotApplied();
-                        lwtTracker.onDone();
-                        metrics.casWriteMetrics.conditionNotMet.inc();
-                        return Pair.create(PartitionUpdate.emptyUpdate(metadata, key), current.rowIterator());
-                    }
-
-                    // Create the desired updates
-                    PartitionUpdate updates = request.makeUpdates(current, state);
-                    lwtTracker.onApplied(updates);
-                    lwtTracker.onDone();
-
-                    long size = updates.dataSize();
-                    metrics.casWriteMetrics.mutationSize.update(size);
-                    metrics.writeMetricsForLevel(consistencyForPaxos).mutationSize.update(size);
-
-                    // Apply triggers to cas updates. A consideration here is that
-                    // triggers emit Mutations, and so a given trigger implementation
-                    // may generate mutations for partitions other than the one this
-                    // paxos round is scoped for. In this case, TriggerExecutor will
-                    // validate that the generated mutations are targetted at the same
-                    // partition as the initial updates and reject (via an
-                    // InvalidRequestException) any which aren't.
-                    updates = TriggerExecutor.instance.execute(updates);
-
-                    return Pair.create(updates, null);
-                }
-                finally
-                {
-                    metrics.casWriteMetrics.createProposalLatency.addNano(System.nanoTime() - startTimeNanos);
-                }
-            };
-
-            return doPaxos(metadata,
-                           key,
-                           consistencyForPaxos,
-                           consistencyForCommit,
-                           consistencyForCommit,
-                           state,
-                           queryStartNanoTime,
-                           metrics.casWriteMetrics,
-                           updateProposer,
-                           false);
-
+            return mutator.mutateCas(keyspaceName, key, request, consistencyForPaxos, consistencyForCommit, state, nowInSeconds, queryStartNanoTime, lwtTracker, metrics, metadata);
         }
         catch (CasWriteUnknownResultException e)
         {
@@ -617,6 +559,75 @@ public class StorageProxy implements StorageProxyMBean
             metrics.writeMetricsForLevel(consistencyForPaxos).serviceTimeMetrics.addNano(endTime - queryStartNanoTime);
             Keyspace.openAndGetStore(metadata).metric.coordinatorCasWriteLatency.update(latency, NANOSECONDS);
         }
+    }
+
+    private static RowIterator defaultCas(String keyspaceName, DecoratedKey key, CASRequest request, ConsistencyLevel consistencyForPaxos, ConsistencyLevel consistencyForCommit, QueryState state, int nowInSeconds, long queryStartNanoTime, QueryInfoTracker.LWTWriteTracker lwtTracker, ClientRequestsMetrics metrics, TableMetadata metadata)
+    {
+        consistencyForPaxos.validateForCas(keyspaceName, state);
+        consistencyForCommit.validateForCasCommit(Keyspace.open(keyspaceName).getReplicationStrategy(), keyspaceName, state);
+
+        Supplier<Pair<PartitionUpdate, RowIterator>> updateProposer = () ->
+        {
+            long startTimeNanos = System.nanoTime();
+            try
+            {
+                // read the current values and check they validate the conditions
+                Tracing.trace("Reading existing values for CAS precondition");
+                SinglePartitionReadCommand readCommand = (SinglePartitionReadCommand) request.readCommand(nowInSeconds);
+                ConsistencyLevel readConsistency = consistencyForPaxos == ConsistencyLevel.LOCAL_SERIAL ? ConsistencyLevel.LOCAL_QUORUM : ConsistencyLevel.QUORUM;
+
+                FilteredPartition current;
+
+                try (RowIterator rowIter = readOne(readCommand, readConsistency, queryStartNanoTime, lwtTracker))
+                {
+                    current = FilteredPartition.create(rowIter);
+                }
+
+                if (!request.appliesTo(current))
+                {
+                    Tracing.trace("CAS precondition does not match current values {}", current);
+                    lwtTracker.onNotApplied();
+                    lwtTracker.onDone();
+                    metrics.casWriteMetrics.conditionNotMet.inc();
+                    return Pair.create(PartitionUpdate.emptyUpdate(metadata, key), current.rowIterator());
+                }
+
+                // Create the desired updates
+                PartitionUpdate updates = request.makeUpdates(current, state);
+                lwtTracker.onApplied(updates);
+                lwtTracker.onDone();
+
+                long size = updates.dataSize();
+                metrics.casWriteMetrics.mutationSize.update(size);
+                metrics.writeMetricsForLevel(consistencyForPaxos).mutationSize.update(size);
+
+                // Apply triggers to cas updates. A consideration here is that
+                // triggers emit Mutations, and so a given trigger implementation
+                // may generate mutations for partitions other than the one this
+                // paxos round is scoped for. In this case, TriggerExecutor will
+                // validate that the generated mutations are targetted at the same
+                // partition as the initial updates and reject (via an
+                // InvalidRequestException) any which aren't.
+                updates = TriggerExecutor.instance.execute(updates);
+
+                return Pair.create(updates, null);
+            }
+            finally
+            {
+                metrics.casWriteMetrics.createProposalLatency.addNano(System.nanoTime() - startTimeNanos);
+            }
+        };
+
+        return doPaxos(metadata,
+                       key,
+                       consistencyForPaxos,
+                       consistencyForCommit,
+                       consistencyForCommit,
+                       state,
+                       queryStartNanoTime,
+                       metrics.casWriteMetrics,
+                       updateProposer,
+                       false);
     }
 
     private static void recordCasContention(TableMetadata table,

--- a/src/java/org/apache/cassandra/service/StorageProxy.java
+++ b/src/java/org/apache/cassandra/service/StorageProxy.java
@@ -203,9 +203,9 @@ public class StorageProxy implements StorageProxyMBean
         }
 
         @Override
-        public RowIterator mutateCas(String keyspaceName, DecoratedKey key, CASRequest request, ConsistencyLevel consistencyForPaxos, ConsistencyLevel consistencyForCommit, QueryState state, int nowInSeconds, long queryStartNanoTime, QueryInfoTracker.LWTWriteTracker lwtTracker, ClientRequestsMetrics metrics, TableMetadata metadata)
+        public RowIterator mutateCas(TableMetadata metadata, DecoratedKey key, QueryInfoTracker.LWTWriteTracker lwtTracker, ClientRequestsMetrics metrics, CASRequest request, ConsistencyLevel consistencyForPaxos, ConsistencyLevel consistencyForCommit, QueryState state, int nowInSeconds, long queryStartNanoTime)
         {
-            return defaultCas(keyspaceName, key, request, consistencyForPaxos, consistencyForCommit, state, nowInSeconds, queryStartNanoTime, lwtTracker, metrics, metadata);
+            return defaultCas(metadata, key, request, consistencyForPaxos, consistencyForCommit, state, nowInSeconds, queryStartNanoTime, lwtTracker, metrics);
         }
 
         @Override
@@ -513,7 +513,7 @@ public class StorageProxy implements StorageProxyMBean
         try
         {
 
-            return mutator.mutateCas(keyspaceName, key, request, consistencyForPaxos, consistencyForCommit, state, nowInSeconds, queryStartNanoTime, lwtTracker, metrics, metadata);
+            return mutator.mutateCas(metadata, key, lwtTracker, metrics, request, consistencyForPaxos, consistencyForCommit, state, nowInSeconds, queryStartNanoTime);
         }
         catch (CasWriteUnknownResultException e)
         {
@@ -561,10 +561,10 @@ public class StorageProxy implements StorageProxyMBean
         }
     }
 
-    private static RowIterator defaultCas(String keyspaceName, DecoratedKey key, CASRequest request, ConsistencyLevel consistencyForPaxos, ConsistencyLevel consistencyForCommit, QueryState state, int nowInSeconds, long queryStartNanoTime, QueryInfoTracker.LWTWriteTracker lwtTracker, ClientRequestsMetrics metrics, TableMetadata metadata)
+    private static RowIterator defaultCas(TableMetadata metadata, DecoratedKey key, CASRequest request, ConsistencyLevel consistencyForPaxos, ConsistencyLevel consistencyForCommit, QueryState state, int nowInSeconds, long queryStartNanoTime, QueryInfoTracker.LWTWriteTracker lwtTracker, ClientRequestsMetrics metrics)
     {
-        consistencyForPaxos.validateForCas(keyspaceName, state);
-        consistencyForCommit.validateForCasCommit(Keyspace.open(keyspaceName).getReplicationStrategy(), keyspaceName, state);
+        consistencyForPaxos.validateForCas(metadata.keyspace, state);
+        consistencyForCommit.validateForCasCommit(Keyspace.open(metadata.keyspace).getReplicationStrategy(), metadata.keyspace, state);
 
         Supplier<Pair<PartitionUpdate, RowIterator>> updateProposer = () ->
         {

--- a/test/unit/org/apache/cassandra/service/MutatorProviderTest.java
+++ b/test/unit/org/apache/cassandra/service/MutatorProviderTest.java
@@ -28,14 +28,17 @@ import junit.framework.TestCase;
 import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.db.ConsistencyLevel;
 import org.apache.cassandra.db.CounterMutation;
+import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.IMutation;
 import org.apache.cassandra.db.Mutation;
 import org.apache.cassandra.db.WriteType;
+import org.apache.cassandra.db.rows.RowIterator;
 import org.apache.cassandra.exceptions.OverloadedException;
 import org.apache.cassandra.exceptions.UnavailableException;
 import org.apache.cassandra.exceptions.WriteTimeoutException;
 import org.apache.cassandra.locator.ReplicaPlan;
 import org.apache.cassandra.metrics.ClientRequestsMetrics;
+import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.sensors.RequestSensors;
 import org.apache.cassandra.service.paxos.Commit;
 
@@ -61,6 +64,12 @@ public class MutatorProviderTest extends TestCase
 
         @Override
         public AbstractWriteResponseHandler<IMutation> mutateStandard(Mutation mutation, ConsistencyLevel consistencyLevel, String localDataCenter, StorageProxy.WritePerformer writePerformer, Runnable callback, WriteType writeType, long queryStartNanoTime)
+        {
+            return null;
+        }
+
+        @Override
+        public RowIterator mutateCas(String keyspaceName, DecoratedKey key, CASRequest request, ConsistencyLevel consistencyForPaxos, ConsistencyLevel consistencyForCommit, QueryState state, int nowInSeconds, long queryStartNanoTime, QueryInfoTracker.LWTWriteTracker lwtTracker, ClientRequestsMetrics metrics, TableMetadata metadata)
         {
             return null;
         }

--- a/test/unit/org/apache/cassandra/service/MutatorProviderTest.java
+++ b/test/unit/org/apache/cassandra/service/MutatorProviderTest.java
@@ -69,7 +69,7 @@ public class MutatorProviderTest extends TestCase
         }
 
         @Override
-        public RowIterator mutateCas(String keyspaceName, DecoratedKey key, CASRequest request, ConsistencyLevel consistencyForPaxos, ConsistencyLevel consistencyForCommit, QueryState state, int nowInSeconds, long queryStartNanoTime, QueryInfoTracker.LWTWriteTracker lwtTracker, ClientRequestsMetrics metrics, TableMetadata metadata)
+        public RowIterator mutateCas(TableMetadata metadata, DecoratedKey key, QueryInfoTracker.LWTWriteTracker lwtTracker, ClientRequestsMetrics metrics, CASRequest request, ConsistencyLevel consistencyForPaxos, ConsistencyLevel consistencyForCommit, QueryState state, int nowInSeconds, long queryStartNanoTime)
         {
             return null;
         }


### PR DESCRIPTION
### What is the issue
#18520

### What does this PR fix and why was it fixed
add `Mutator#mutateCas` for intercepting coordinator paxos write. Current `mutatePaxos` only intercepts on commit phase.
