### PR TITLE
DSP-25176: Encryption and early-open fixes for CC 5

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,10 +1,13 @@
+Future version (tbd)
+ * Fix range queries on early-open BTI files (CASSANDRA-20976)
+
 5.0.7
  * Clear BTree.FastBuilder saved overflow state on reset to prevent cross-table column contamination after schema disagreement (CASSANDRA-21216, CASSANDRA-21260)
  * Refactor SAI ANN query execution to use score ordered iterators for correctness and speed (CASSANDRA-20086)
  * Disallow binding an identity to a superuser when the user is a regular user (CASSANDRA-21219)
  * Fix ConcurrentModificationException in compaction garbagecollect (CASSANDRA-21065)
  * Dynamically skip sharding L0 when SAI Vector index present (CASSANDRA-19661)
- * Optionally force IndexStatusManager to use the optimized index status format (CASSANDRA-21132) 
+ * Optionally force IndexStatusManager to use the optimized index status format (CASSANDRA-21132)
  * No need to evict already prepared statements, as it creates a race condition between multiple threads (CASSANDRA-17401)
  * Upgrade logback version to 1.5.18 and slf4j dependencies to 2.0.17 (CASSANDRA-21137)
  * Automatically disable zero-copy streaming for legacy sstables with old bloom filter format (CASSANDRA-21092)

--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -683,7 +683,8 @@ commitlog_segment_size: 32MiB
 commitlog_disk_access_mode: legacy
 
 # Compression to apply to SSTables as they flush for compressed tables.
-# Note that tables without compression enabled do not respect this flag.
+# Note that tables without compression enabled, or whose compression includes
+# an encryption component do not respect this flag.
 #
 # As high ratio compressors like LZ4HC, Zstd, and Deflate can potentially
 # block flushes for too long, the default is to flush with a known fast

--- a/src/java/org/apache/cassandra/cache/ChunkCache.java
+++ b/src/java/org/apache/cassandra/cache/ChunkCache.java
@@ -701,6 +701,12 @@ public class ChunkCache
         }
 
         @Override
+        public long positionForSkip(long currentPosition, int bytesToSkip)
+        {
+            return source.positionForSkip(currentPosition, bytesToSkip);
+        }
+
+        @Override
         public void close()
         {
             source.close();

--- a/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
@@ -1846,6 +1846,8 @@ public class CompactionManager implements CompactionManagerMBean, ICompactionMan
             public Throwable commit(Throwable accumulate) { return accumulate; }
             public void prepareToCommit() {}
             public void checkpoint() {}
+            @Override
+            public Throwable abortCheckpoint(Throwable accumulate) { return accumulate; }
             public void obsoleteOriginals() {}
             public void close() {}
         }

--- a/src/java/org/apache/cassandra/db/lifecycle/ILifecycleTransaction.java
+++ b/src/java/org/apache/cassandra/db/lifecycle/ILifecycleTransaction.java
@@ -31,6 +31,7 @@ import org.apache.cassandra.utils.concurrent.Transactional;
 public interface ILifecycleTransaction extends Transactional, LifecycleNewTracker
 {
     void checkpoint();
+    Throwable abortCheckpoint(Throwable accumulate);
     void update(SSTableReader reader, boolean original);
     void update(Collection<SSTableReader> readers, boolean original);
     SSTableReader current(SSTableReader reader);

--- a/src/java/org/apache/cassandra/db/lifecycle/LifecycleTransaction.java
+++ b/src/java/org/apache/cassandra/db/lifecycle/LifecycleTransaction.java
@@ -413,6 +413,19 @@ public class LifecycleTransaction extends Transactional.AbstractTransactional im
         return accumulate;
     }
 
+    /**
+     * Rolls back a prepared checkpoint by clearing the staged state.
+     */
+    public Throwable abortCheckpoint(Throwable accumulate)
+    {
+        // Release the references of newly-prepared SSTableReaders that will not be used.
+        accumulate = release(selfRefs(staged.update), accumulate);
+
+        staged.clear();
+        // We may have added some sstable states in the identities list, which we aren't removing. This is fine, the
+        // next time we try to checkpoint we will use different readers.
+        return accumulate;
+    }
 
     /**
      * update a reader: if !original, this is a reader that is being introduced by this transaction;

--- a/src/java/org/apache/cassandra/db/lifecycle/PartialLifecycleTransaction.java
+++ b/src/java/org/apache/cassandra/db/lifecycle/PartialLifecycleTransaction.java
@@ -54,6 +54,12 @@ public class PartialLifecycleTransaction implements ILifecycleTransaction
         // don't do anything, composite will checkpoint at end
     }
 
+    public Throwable abortCheckpoint(Throwable accumulate)
+    {
+        // treat like checkpoint above
+        return accumulate;
+    }
+
     private RuntimeException earlyOpenUnsupported()
     {
         throw new UnsupportedOperationException("PartialLifecycleTransaction does not support early opening of SSTables");

--- a/src/java/org/apache/cassandra/db/lifecycle/WrappedLifecycleTransaction.java
+++ b/src/java/org/apache/cassandra/db/lifecycle/WrappedLifecycleTransaction.java
@@ -40,6 +40,12 @@ public class WrappedLifecycleTransaction implements ILifecycleTransaction
         delegate.checkpoint();
     }
 
+    @Override
+    public Throwable abortCheckpoint(Throwable accumulate)
+    {
+        return delegate.abortCheckpoint(accumulate);
+    }
+
     public void update(SSTableReader reader, boolean original)
     {
         delegate.update(reader, original);

--- a/src/java/org/apache/cassandra/io/compress/CompressionMetadata.java
+++ b/src/java/org/apache/cassandra/io/compress/CompressionMetadata.java
@@ -97,12 +97,6 @@ public class CompressionMetadata extends WrappedSharedCloseable
      * Length of the compressed file in bytes. This refers to the partial file length if zero copy metadata is present.
      */
     public final long compressedFileLength;
-    
-    /**
-     * If true, the actual file size should be used instead of compressedFileLength when reading.
-     * This is used for encryption-only files where the final size isn't known at write time.
-     */
-    public final boolean useActualFileSize;
 
     /**
      * Offsets of consecutive chunks in the (compressed) data file. The length of this array is equal to the number of
@@ -137,34 +131,16 @@ public class CompressionMetadata extends WrappedSharedCloseable
      */
     public static CompressionMetadata encryptedOnly(CompressionParams compressionParams)
     {
-        // For encryption-only files, we create a CompressionMetadata that doesn't limit the file size
-        // We'll create dummy chunk offsets that allow the reader to work with large files
-        int maxChunks = 1000; // Support files up to ~4MB
-        ChunkOffsetMemory offsets = new ChunkOffsetMemory(maxChunks + 1);
-        
-        // Set chunk offsets - each chunk is CHUNK_SIZE + 4 bytes apart
-        long offset = 0;
-        for (int i = 0; i <= maxChunks; i++) {
-            offsets.set(i, offset);
-            offset += EncryptedSequentialWriter.CHUNK_SIZE + 4;
-        }
-        
         int chunkLength = EncryptedSequentialWriter.CHUNK_SIZE;
         int chunkLengthBits = Integer.numberOfTrailingZeros(chunkLength);
-        
-        // Set large values for data and compressed lengths to avoid limiting the reader
-        long dataLength = (long) maxChunks * chunkLength;
-        // Use a reasonable default compressed length (will be ignored due to useActualFileSize flag)
-        long compressedLength = dataLength;
-        
+
         return new CompressionMetadata(null, // chunksIndexFile
                 compressionParams,
-                offsets,
-                dataLength,
-                compressedLength,
+                null,
+                -1,
+                -1,
                 chunkLengthBits,
-                0, // startChunkIndex
-                true); // useActualFileSize = true for encryption-only files
+                0);
     }
 
     @VisibleForTesting
@@ -199,6 +175,12 @@ public class CompressionMetadata extends WrappedSharedCloseable
             catch (ConfigurationException e)
             {
                 throw new RuntimeException("Cannot create CompressionParams for stored parameters", e);
+            }
+
+            if (compressedLength < 0)
+            {
+                // This is a request to only read the encryption configuration. Do not read the chunk offsets.
+                return encryptedOnly(parameters);
             }
 
             assert Integer.bitCount(chunkLength) == 1;
@@ -241,20 +223,7 @@ public class CompressionMetadata extends WrappedSharedCloseable
                                int chunkLengthBits,
                                int startChunkIndex)
     {
-        this(chunksIndexFile, parameters, chunkOffsets, dataLength, compressedFileLength, chunkLengthBits, startChunkIndex, false);
-    }
-    
-    // Constructor with explicit useActualFileSize flag
-    private CompressionMetadata(File chunksIndexFile,
-                                CompressionParams parameters,
-                                ChunkOffsetMemory chunkOffsets,
-                                long dataLength,
-                                long compressedFileLength,
-                                int chunkLengthBits,
-                                int startChunkIndex,
-                                boolean useActualFileSize)
-    {
-        super(chunkOffsets);
+        super(chunkOffsets != null ? new AutoCloseable[] {chunkOffsets} : new AutoCloseable[] {});
         this.chunksIndexFile = chunksIndexFile;
         this.parameters = parameters;
         this.dataLength = dataLength;
@@ -262,7 +231,6 @@ public class CompressionMetadata extends WrappedSharedCloseable
         this.chunkOffsets = chunkOffsets;
         this.chunkLengthBits = chunkLengthBits;
         this.startChunkIndex = startChunkIndex;
-        this.useActualFileSize = useActualFileSize;
     }
 
     private CompressionMetadata(CompressionMetadata copy)
@@ -275,7 +243,6 @@ public class CompressionMetadata extends WrappedSharedCloseable
         this.chunkOffsets = copy.chunkOffsets;
         this.chunkLengthBits = copy.chunkLengthBits;
         this.startChunkIndex = copy.startChunkIndex;
-        this.useActualFileSize = copy.useActualFileSize;
     }
 
     public static long nativeMemoryAllocated()
@@ -304,14 +271,20 @@ public class CompressionMetadata extends WrappedSharedCloseable
      */
     public long offHeapSize()
     {
-        return chunkOffsets.memory.size();
+        return hasOffsets() ? chunkOffsets.memory.size() : 0;
+    }
+
+    public boolean hasOffsets()
+    {
+        return chunkOffsets != null;
     }
 
     @Override
     public void addTo(Ref.IdentityCollection identities)
     {
         super.addTo(identities);
-        identities.add(chunkOffsets.memory);
+        if (hasOffsets())
+            identities.add(chunkOffsets.memory);
     }
 
     @Override
@@ -441,6 +414,9 @@ public class CompressionMetadata extends WrappedSharedCloseable
      */
     public long getDataOffsetForChunkOffset(long chunkOffset)
     {
+        if (!hasOffsets())
+            return chunkOffset;
+
         long l = 0;
         long h = chunkOffsets.size() - 1;
         long idx, offset;
@@ -467,6 +443,8 @@ public class CompressionMetadata extends WrappedSharedCloseable
      */
     public long getTotalSizeForSections(Collection<SSTableReader.PartitionPositionBounds> sections)
     {
+        assert hasOffsets();
+
         long size = 0;
         int lastIncludedChunkIdx = -1;
         for (SSTableReader.PartitionPositionBounds section : sections)
@@ -493,6 +471,8 @@ public class CompressionMetadata extends WrappedSharedCloseable
      */
     public Chunk[] getChunksForSections(Collection<SSTableReader.PartitionPositionBounds> sections)
     {
+        assert hasOffsets();
+
         // use SortedSet to eliminate duplicates and sort by chunk offset
         SortedSet<Chunk> offsets = new TreeSet<>((o1, o2) -> Longs.compare(o1.offset, o2.offset));
 

--- a/src/java/org/apache/cassandra/io/compress/EncryptedSequentialWriter.java
+++ b/src/java/org/apache/cassandra/io/compress/EncryptedSequentialWriter.java
@@ -70,7 +70,6 @@ public class EncryptedSequentialWriter extends SequentialWriter
     // Having the size fixed to 4k also prevents fragmentation in the chunk cache, but may be wasteful if the
     // encryptor needs to store a lot of information each frame.
 
-
     private final ChecksumWriter crcMetadata;
 
     private final ICompressor encryptor;
@@ -288,6 +287,7 @@ public class EncryptedSequentialWriter extends SequentialWriter
         return bufferOffset + (buffer.position() == 0 ? 0 : CHUNK_SIZE);
     }
 
+    @Override
     public void establishEndAddressablePosition(int bytesNeeded) throws IOException
     {
         // Make sure the data does not span a page boundary (and the encryption data put there).

--- a/src/java/org/apache/cassandra/io/sstable/SSTableRewriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableRewriter.java
@@ -24,6 +24,9 @@ import java.util.function.Consumer;
 
 import com.google.common.annotations.VisibleForTesting;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.DeletionTime;
@@ -53,6 +56,8 @@ import org.apache.cassandra.utils.concurrent.Transactional;
  */
 public class SSTableRewriter extends Transactional.AbstractTransactional implements Transactional, SSTableDataSink
 {
+    private static final Logger logger = LoggerFactory.getLogger(SSTableRewriter.class);
+
     @VisibleForTesting
     public static boolean disableEarlyOpeningForTests = false;
 
@@ -195,9 +200,18 @@ public class SSTableRewriter extends Transactional.AbstractTransactional impleme
             {
                 writer.setMaxDataAge(maxAge);
                 writer.openEarly(reader -> {
-                    transaction.update(reader, false);
-                    currentlyOpenedEarlyAt = writer.getFilePointer();
-                    moveStarts(reader.getLast());
+                    try
+                    {
+                        transaction.update(reader, false);
+                        currentlyOpenedEarlyAt = writer.getFilePointer();
+                        moveStarts(reader.getLast());
+                    }
+                    catch (Throwable ex)
+                    {
+                        ex = transaction.abortCheckpoint(ex);
+                        logger.warn("Aborted early opening attempt due to error", ex);
+                        return;
+                    }
                     transaction.checkpoint();
                 });
             }

--- a/src/java/org/apache/cassandra/io/sstable/format/DataComponent.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/DataComponent.java
@@ -23,8 +23,6 @@ import java.util.Optional;
 import org.apache.cassandra.config.Config.FlushCompression;
 import org.apache.cassandra.db.compaction.OperationType;
 import org.apache.cassandra.io.compress.CompressedSequentialWriter;
-import org.apache.cassandra.io.compress.EncryptedSequentialWriter;
-import org.apache.cassandra.io.compress.Encryptor;
 import org.apache.cassandra.io.compress.ICompressor;
 import org.apache.cassandra.io.sstable.Descriptor;
 import org.apache.cassandra.io.sstable.format.SSTableFormat.Components;
@@ -47,24 +45,12 @@ public class DataComponent
         if (metadata.params.compression.isEnabled())
         {
             final CompressionParams compressionParams = buildCompressionParams(metadata, operationType, flushCompression);
-            final ICompressor compressor = compressionParams.getSstableCompressor();
-
-            // Check if this is encryption-only (no actual compression)
-            if (compressor instanceof Encryptor)
-            {
-                return new EncryptedSequentialWriter(descriptor.fileFor(Components.DATA),
-                                                     options,
-                                                     compressor);
-            }
-            else
-            {
-                return new CompressedSequentialWriter(descriptor.fileFor(Components.DATA),
-                                                      descriptor.fileFor(Components.COMPRESSION_INFO),
-                                                      descriptor.fileFor(Components.DIGEST),
-                                                      options,
-                                                      compressionParams,
-                                                      metadataCollector);
-            }
+            return new CompressedSequentialWriter(descriptor.fileFor(Components.DATA),
+                                                  descriptor.fileFor(Components.COMPRESSION_INFO),
+                                                  descriptor.fileFor(Components.DIGEST),
+                                                  options,
+                                                  compressionParams,
+                                                  metadataCollector);
         }
         else
         {
@@ -87,6 +73,9 @@ public class DataComponent
 
         if (null != compressor && operationType == OperationType.FLUSH)
         {
+            if (compressor.encryptionOnly() != null)
+                return compressionParams; // FlushCompression cannot disable encryption
+
             // When we are flushing out of the memtable throughput of the compressor is critical as flushes,
             // especially of large tables, can queue up and potentially block writes.
             // This optimization allows us to fall back to a faster compressor if a particular

--- a/src/java/org/apache/cassandra/io/sstable/format/SortedTableScrubber.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SortedTableScrubber.java
@@ -187,7 +187,9 @@ public abstract class SortedTableScrubber<R extends SSTableReaderWithFilter> imp
     {
         List<SSTableReader> finished = new ArrayList<>();
         outputHandler.output("Scrubbing %s (%s)", sstable, FBUtilities.prettyPrintMemory(dataFile.length()));
-        try (SSTableRewriter writer = SSTableRewriter.construct(realm, transaction, false, sstable.maxDataAge);
+        // Do not use early opening with scrub as it is unsafe (scrub may move rows to a different table that is not
+        // written until the whole operation completes).
+        try (SSTableRewriter writer = SSTableRewriter.constructWithoutEarlyOpening(transaction, false, sstable.maxDataAge);
              Refs<SSTableReader> refs = Refs.ref(Collections.singleton(sstable)))
         {
             StatsMetadata metadata = sstable.getSSTableMetadata();

--- a/src/java/org/apache/cassandra/io/sstable/format/bti/BtiTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/bti/BtiTableReader.java
@@ -52,6 +52,7 @@ import org.apache.cassandra.io.sstable.SSTableReadsListener.SelectionReason;
 import org.apache.cassandra.io.sstable.SSTableReadsListener.SkippingReason;
 import org.apache.cassandra.io.sstable.format.AbstractKeyFetcher;
 import org.apache.cassandra.io.sstable.format.SSTableReaderWithFilter;
+import org.apache.cassandra.io.util.DataInputPlus;
 import org.apache.cassandra.io.util.FileDataInput;
 import org.apache.cassandra.io.util.FileHandle;
 import org.apache.cassandra.io.util.RandomAccessReader;
@@ -242,6 +243,27 @@ public class BtiTableReader extends SSTableReaderWithFilter
     }
 
     /**
+     * In encrypted index files skipBytes may end up in a different but equivalent position when it's at the
+     * end of an encrypted chunk. More precisely, if the skipped sequence of bytes lands exactly at the end of the
+     * useable part of a chunk (just before the hole left for encryption metadata), a normal read would leave the file
+     * at that position; before reading the next byte it will silently advance to the start of the next chunk. A skip,
+     * on the other hand, will jump to the position that follows the data, which is correctly converted to the beginning
+     * of the next page in preparation for reading. As a result it will leave the file positioned at the start of the
+     * next page immediately. See {@link PartitionIndexEncryptedTest#testSkipAcrossHoles}.
+     *
+     * To avoid this, we skip one fewer byte and consume the last byte.
+     */
+    @VisibleForTesting
+    static void skipBytesWithCorrectPosition(DataInputPlus in, int skip) throws IOException
+    {
+        if (skip > 0)
+        {
+            in.skipBytesFully(skip - 1);
+            in.readByte();
+        }
+    }
+
+    /**
      * Called by {@link #getRowIndexEntry} above (via Reader.ceiling/floor) to check if the position satisfies the full
      * key constraint. This is called once if there is a prefix match (which can be in any relationship with the sought
      * key, thus assumeNoMatch: false), and if it returns null it is called again for the closest greater position
@@ -255,7 +277,10 @@ public class BtiTableReader extends SSTableReaderWithFilter
             try (FileDataInput in = rowIndexFile.createReader(pos))
             {
                 if (assumeNoMatch)
-                    ByteBufferUtil.skipShortLength(in);
+                {
+                    int skip = ByteBufferUtil.readShortLength(in);
+                    skipBytesWithCorrectPosition(in, skip);
+                }
                 else
                 {
                     ByteBuffer indexKey = ByteBufferUtil.readWithShortLength(in);

--- a/src/java/org/apache/cassandra/io/sstable/format/bti/BtiTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/bti/BtiTableReader.java
@@ -85,7 +85,7 @@ public class BtiTableReader extends SSTableReaderWithFilter
         this.approximateBloomFilterMemorySize = isBloomFilterLoaded() ? filter.offHeapSize() : computeExpectedBloomFilterMemorySize();
     }
 
-    protected final Builder unbuildTo(Builder builder, boolean sharedCopy)
+    public final Builder unbuildTo(Builder builder, boolean sharedCopy)
     {
         Builder b = super.unbuildTo(builder, sharedCopy);
         if (builder.getPartitionIndex() == null)
@@ -115,13 +115,16 @@ public class BtiTableReader extends SSTableReaderWithFilter
     }
 
     /**
-     * Whether to filter out data after {@link #last}. Early-open sstables may contain data beyond the switch point
-     * (because an early-opened sstable is not ready until buffers have been flushed), and leaving that data visible
-     * will give a redundant copy with all associated overheads.
+     * Whether to filter out data after {@link #last}. We only do this for zero-copy-streamed sstables where the index
+     * contains more keys than we have streamed.
+     *
+     * Early-open sstables may contain data beyond the switch point, but the partition index is created in a way that
+     * does not surface that data.
      */
-    protected boolean filterLast()
+    @VisibleForTesting
+    public boolean filterLast()
     {
-        return openReason == OpenReason.EARLY && partitionIndex instanceof PartitionIndexEarly || sstableMetadata.zeroCopyMetadata.exists();
+        return sstableMetadata.zeroCopyMetadata.exists();
     }
 
     public long estimatedKeys()

--- a/src/java/org/apache/cassandra/io/sstable/format/bti/BtiTableReaderLoadingBuilder.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/bti/BtiTableReaderLoadingBuilder.java
@@ -73,12 +73,12 @@ public class BtiTableReaderLoadingBuilder extends SortedTableReaderLoadingBuilde
     {
         checkNotNull(statsMetadata);
 
-        try (PartitionIndex index = PartitionIndex.load(partitionIndexFileBuilder(), tableMetadataRef.getLocal().partitioner, false, descriptor.version.getByteComparableVersion());
-             CompressionMetadata compressionMetadata = CompressionInfoComponent.maybeLoad(descriptor, components, statsMetadata.zeroCopyMetadata);
+        try (CompressionMetadata compressionMetadata = CompressionInfoComponent.maybeLoad(descriptor, components, statsMetadata.zeroCopyMetadata);
+             PartitionIndex index = PartitionIndex.load(partitionIndexFileBuilder(compressionMetadata), tableMetadataRef.getLocal().partitioner, false, descriptor.version.getByteComparableVersion());
              FileHandle dFile = dataFileBuilder(statsMetadata).withCompressionMetadata(compressionMetadata)
                                                               .withCrcCheckChance(() -> tableMetadataRef.getLocal().params.crcCheckChance)
                                                               .complete();
-             FileHandle riFile = rowIndexFileBuilder().complete())
+             FileHandle riFile = rowIndexFileBuilder(compressionMetadata).complete())
         {
             return PartitionIterator.create(index,
                                             tableMetadataRef.getLocal().partitioner,
@@ -126,24 +126,11 @@ public class BtiTableReaderLoadingBuilder extends SortedTableReaderLoadingBuilde
             if (builder.getFilter() == null)
                 builder.setFilter(FilterFactory.AlwaysPresent);
 
-            if (builder.getComponents().contains(Components.ROW_INDEX))
-                builder.setRowIndexFile(rowIndexFileBuilder().complete());
-
             if (descriptor.version.hasKeyRange() && builder.getStatsMetadata() != null)
             {
                 IPartitioner partitioner = tableMetadataRef.getLocal().partitioner;
                 builder.setFirst(partitioner.decorateKey(builder.getStatsMetadata().firstKey));
                 builder.setLast(partitioner.decorateKey(builder.getStatsMetadata().lastKey));
-            }
-
-            if (builder.getComponents().contains(Components.PARTITION_INDEX))
-            {
-                builder.setPartitionIndex(openPartitionIndex(!builder.getFilter().isInformative(), statsComponent.statsMetadata().zeroCopyMetadata));
-                if (builder.getFirst() == null || builder.getLast() == null)
-                {
-                    builder.setFirst(builder.getPartitionIndex().firstKey());
-                    builder.setLast(builder.getPartitionIndex().lastKey());
-                }
             }
 
             try (CompressionMetadata compressionMetadata = CompressionInfoComponent.maybeLoad(descriptor, components, statsComponent.statsMetadata().zeroCopyMetadata))
@@ -152,6 +139,19 @@ public class BtiTableReaderLoadingBuilder extends SortedTableReaderLoadingBuilde
                                     .withCompressionMetadata(compressionMetadata)
                                     .withCrcCheckChance(() -> tableMetadataRef.getLocal().params.crcCheckChance)
                                     .complete());
+
+                if (builder.getComponents().contains(Components.ROW_INDEX))
+                    builder.setRowIndexFile(rowIndexFileBuilder(compressionMetadata).complete());
+
+                if (builder.getComponents().contains(Components.PARTITION_INDEX))
+                {
+                    builder.setPartitionIndex(openPartitionIndex(compressionMetadata, !builder.getFilter().isInformative(), statsComponent.statsMetadata().zeroCopyMetadata));
+                    if (builder.getFirst() == null || builder.getLast() == null)
+                    {
+                        builder.setFirst(builder.getPartitionIndex().firstKey());
+                        builder.setLast(builder.getPartitionIndex().lastKey());
+                    }
+                }
             }
         }
         catch (IOException | RuntimeException | Error ex)
@@ -187,9 +187,9 @@ public class BtiTableReaderLoadingBuilder extends SortedTableReaderLoadingBuilde
         return bf;
     }
 
-    private PartitionIndex openPartitionIndex(boolean preload, ZeroCopyMetadata zeroCopyMetadata) throws IOException
+    private PartitionIndex openPartitionIndex(CompressionMetadata compressionMetadata, boolean preload, ZeroCopyMetadata zeroCopyMetadata) throws IOException
     {
-        try (FileHandle indexFile = partitionIndexFileBuilder().complete())
+        try (FileHandle indexFile = partitionIndexFileBuilder(compressionMetadata).complete())
         {
             return PartitionIndex.load(indexFile, tableMetadataRef.getLocal().partitioner, preload, zeroCopyMetadata, descriptor.version.getByteComparableVersion());
         }
@@ -200,7 +200,7 @@ public class BtiTableReaderLoadingBuilder extends SortedTableReaderLoadingBuilde
         }
     }
 
-    private FileHandle.Builder rowIndexFileBuilder()
+    private FileHandle.Builder rowIndexFileBuilder(CompressionMetadata compressionMetadata)
     {
         assert rowIndexFileBuilder == null || rowIndexFileBuilder.file.equals(descriptor.fileFor(Components.ROW_INDEX));
 
@@ -209,11 +209,13 @@ public class BtiTableReaderLoadingBuilder extends SortedTableReaderLoadingBuilde
 
         rowIndexFileBuilder.withChunkCache(chunkCache);
         rowIndexFileBuilder.mmapped(ioOptions.indexDiskAccessMode);
+        if (compressionMetadata != null && compressionMetadata.parameters.getSstableCompressor().encryptionOnly() != null)
+            rowIndexFileBuilder.withCompressionMetadata(compressionMetadata).encryptionOnly();
 
         return rowIndexFileBuilder;
     }
 
-    private FileHandle.Builder partitionIndexFileBuilder()
+    private FileHandle.Builder partitionIndexFileBuilder(CompressionMetadata compressionMetadata)
     {
         assert partitionIndexFileBuilder == null || partitionIndexFileBuilder.file.equals(descriptor.fileFor(Components.PARTITION_INDEX));
 
@@ -222,6 +224,8 @@ public class BtiTableReaderLoadingBuilder extends SortedTableReaderLoadingBuilde
 
         partitionIndexFileBuilder.withChunkCache(chunkCache);
         partitionIndexFileBuilder.mmapped(ioOptions.indexDiskAccessMode);
+        if (compressionMetadata != null && compressionMetadata.parameters.getSstableCompressor().encryptionOnly() != null)
+            partitionIndexFileBuilder.withCompressionMetadata(compressionMetadata).encryptionOnly();
 
         return partitionIndexFileBuilder;
     }

--- a/src/java/org/apache/cassandra/io/sstable/format/bti/BtiTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/bti/BtiTableWriter.java
@@ -293,7 +293,6 @@ public class BtiTableWriter extends SortedTableWriter<BtiFormatPartitionWriter, 
                                                {
                                                    rowIndexFHBuilder.withLengthOverride(rowIndexPosition);
                                                    callWhenReady.accept(partitionIndex);
-                                                   rowIndexFHBuilder.withLengthOverride(NO_LENGTH_OVERRIDE);
                                                },
                                                rowIndexPosition, dataPosition);
         }
@@ -319,12 +318,8 @@ public class BtiTableWriter extends SortedTableWriter<BtiFormatPartitionWriter, 
 
             // truncate index file
             rowIndexWriter.prepareToCommit();
-            
-            // For encrypted writers, we don't use getLastFlushOffset() as the length override
-            if (!(rowIndexWriter instanceof EncryptedSequentialWriter))
-            {
-                rowIndexFHBuilder.withLengthOverride(rowIndexWriter.getLastFlushOffset());
-            }
+
+            rowIndexWriter.updateFileHandle(rowIndexFHBuilder);
 
             complete();
         }
@@ -340,14 +335,8 @@ public class BtiTableWriter extends SortedTableWriter<BtiFormatPartitionWriter, 
                 partitionIndexCompleted = true;
                 
                 // Update FileHandle builders for encrypted writers
-                if (rowIndexWriter instanceof EncryptedSequentialWriter)
-                {
-                    ((EncryptedSequentialWriter) rowIndexWriter).updateFileHandle(rowIndexFHBuilder, rowIndexWriter.position());
-                }
-                if (partitionIndexWriter instanceof EncryptedSequentialWriter)
-                {
-                    ((EncryptedSequentialWriter) partitionIndexWriter).updateFileHandle(partitionIndexFHBuilder, partitionIndexWriter.position());
-                }
+                rowIndexWriter.updateFileHandle(rowIndexFHBuilder);
+                partitionIndexWriter.updateFileHandle(partitionIndexFHBuilder);
             }
             catch (IOException e)
             {
@@ -358,16 +347,6 @@ public class BtiTableWriter extends SortedTableWriter<BtiFormatPartitionWriter, 
         PartitionIndex completedPartitionIndex()
         {
             complete();
-            // For encrypted writers, the length override has been set by updateFileHandle()
-            // Don't reset it to NO_LENGTH_OVERRIDE
-            if (!(rowIndexWriter instanceof EncryptedSequentialWriter))
-            {
-                rowIndexFHBuilder.withLengthOverride(NO_LENGTH_OVERRIDE);
-            }
-            if (!(partitionIndexWriter instanceof EncryptedSequentialWriter))
-            {
-                partitionIndexFHBuilder.withLengthOverride(NO_LENGTH_OVERRIDE);
-            }
             try
             {
                 return PartitionIndex.load(partitionIndexFHBuilder, metadata.getLocal().partitioner, false, descriptor.version.getByteComparableVersion());

--- a/src/java/org/apache/cassandra/io/sstable/format/bti/BtiTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/bti/BtiTableWriter.java
@@ -217,7 +217,7 @@ public class BtiTableWriter extends SortedTableWriter<BtiFormatPartitionWriter, 
                 rowIndexFHBuilder = IndexComponent.fileBuilder(Components.ROW_INDEX, b, b.operationType)
                                                   .withMmappedRegionsCache(b.getMmappedRegionsCache())
                                                   .withCompressionMetadata(compressionMetadata)
-                                                  .maybeEncrypted(true);
+                                                  .encryptionOnly();
                 
                 partitionIndexWriter = new EncryptedSequentialWriter(descriptor.fileFor(Components.PARTITION_INDEX), 
                                                                     b.getIOOptions().writerOptions, 
@@ -225,7 +225,7 @@ public class BtiTableWriter extends SortedTableWriter<BtiFormatPartitionWriter, 
                 partitionIndexFHBuilder = IndexComponent.fileBuilder(Components.PARTITION_INDEX, b, b.operationType)
                                                         .withMmappedRegionsCache(b.getMmappedRegionsCache())
                                                         .withCompressionMetadata(compressionMetadata)
-                                                        .maybeEncrypted(true);
+                                                        .encryptionOnly();
             }
             else
             {

--- a/src/java/org/apache/cassandra/io/sstable/format/bti/BtiTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/bti/BtiTableWriter.java
@@ -200,27 +200,27 @@ public class BtiTableWriter extends SortedTableWriter<BtiFormatPartitionWriter, 
         IndexWriter(Builder b, SequentialWriter dataWriter)
         {
             super(b);
-            
+
             // Check if encryption is enabled (following trie-index pattern)
             boolean compression = b.getComponents().contains(SSTableFormat.Components.COMPRESSION_INFO);
             TableMetadata metadata = b.getTableMetadataRef().getLocal();
             CompressionParams params = metadata.params.compression;
             ICompressor encryptor = compression ? params.getSstableCompressor().encryptionOnly() : null;
-            
+
             if (encryptor != null)
             {
                 // Create encrypted writers and configure FileHandle builders for encryption
                 CompressionMetadata compressionMetadata = CompressionMetadata.encryptedOnly(params);
-                rowIndexWriter = new EncryptedSequentialWriter(descriptor.fileFor(Components.ROW_INDEX), 
-                                                               b.getIOOptions().writerOptions, 
+                rowIndexWriter = new EncryptedSequentialWriter(descriptor.fileFor(Components.ROW_INDEX),
+                                                               b.getIOOptions().writerOptions,
                                                                encryptor);
                 rowIndexFHBuilder = IndexComponent.fileBuilder(Components.ROW_INDEX, b, b.operationType)
                                                   .withMmappedRegionsCache(b.getMmappedRegionsCache())
                                                   .withCompressionMetadata(compressionMetadata)
                                                   .encryptionOnly();
-                
-                partitionIndexWriter = new EncryptedSequentialWriter(descriptor.fileFor(Components.PARTITION_INDEX), 
-                                                                    b.getIOOptions().writerOptions, 
+
+                partitionIndexWriter = new EncryptedSequentialWriter(descriptor.fileFor(Components.PARTITION_INDEX),
+                                                                    b.getIOOptions().writerOptions,
                                                                     encryptor);
                 partitionIndexFHBuilder = IndexComponent.fileBuilder(Components.PARTITION_INDEX, b, b.operationType)
                                                         .withMmappedRegionsCache(b.getMmappedRegionsCache())
@@ -333,7 +333,7 @@ public class BtiTableWriter extends SortedTableWriter<BtiFormatPartitionWriter, 
             {
                 partitionIndex.complete();
                 partitionIndexCompleted = true;
-                
+
                 // Update FileHandle builders for encrypted writers
                 rowIndexWriter.updateFileHandle(rowIndexFHBuilder);
                 partitionIndexWriter.updateFileHandle(partitionIndexFHBuilder);
@@ -347,6 +347,8 @@ public class BtiTableWriter extends SortedTableWriter<BtiFormatPartitionWriter, 
         PartitionIndex completedPartitionIndex()
         {
             complete();
+            rowIndexFHBuilder.withLengthOverride(NO_LENGTH_OVERRIDE);
+            partitionIndexFHBuilder.withLengthOverride(NO_LENGTH_OVERRIDE);
             try
             {
                 return PartitionIndex.load(partitionIndexFHBuilder, metadata.getLocal().partitioner, false, descriptor.version.getByteComparableVersion());

--- a/src/java/org/apache/cassandra/io/sstable/format/bti/PartitionIndexBuilder.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/bti/PartitionIndexBuilder.java
@@ -110,7 +110,8 @@ public class PartitionIndexBuilder implements AutoCloseable
         if (partitionIndexSyncPosition < partialIndexPartitionEnd)
             return;
 
-        try (FileHandle fh = fhBuilder.withLengthOverride(writer.getLastFlushOffset()).complete())
+        writer.updateFileHandle(fhBuilder);
+        try (FileHandle fh = fhBuilder.complete())
         {
             PartitionIndex pi = new PartitionIndexEarly(fh,
                                                         partialIndexTail.root(),
@@ -123,11 +124,6 @@ public class PartitionIndexBuilder implements AutoCloseable
             partialIndexConsumer.accept(pi);
             partialIndexConsumer = null;
         }
-        finally
-        {
-            fhBuilder.withLengthOverride(FileHandle.Builder.NO_LENGTH_OVERRIDE);
-        }
-
     }
 
     /**
@@ -181,12 +177,16 @@ public class PartitionIndexBuilder implements AutoCloseable
             writer.writeShort(0);
         }
 
+        // The next three longs are needed to be able to open the table and must be readable at a fixed offset from the
+        // end of the file. The call below ensures that for encrypted files which do not provide precise file length.
+        writer.establishEndAddressablePosition(PartitionIndex.FOOTER_LENGTH);
+
         writer.writeLong(firstKeyPos);
         writer.writeLong(count);
         writer.writeLong(root);
 
         writer.sync();
-        fhBuilder.withLengthOverride(writer.getLastFlushOffset());
+        writer.updateFileHandle(fhBuilder);
 
         return root;
     }

--- a/src/java/org/apache/cassandra/io/sstable/format/bti/PartitionIndexBuilder.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/bti/PartitionIndexBuilder.java
@@ -124,6 +124,11 @@ public class PartitionIndexBuilder implements AutoCloseable
             partialIndexConsumer.accept(pi);
             partialIndexConsumer = null;
         }
+        finally
+        {
+            fhBuilder.withLengthOverride(FileHandle.Builder.NO_LENGTH_OVERRIDE);
+        }
+
     }
 
     /**

--- a/src/java/org/apache/cassandra/io/sstable/metadata/MetadataSerializer.java
+++ b/src/java/org/apache/cassandra/io/sstable/metadata/MetadataSerializer.java
@@ -325,15 +325,15 @@ public class MetadataSerializer implements IMetadataSerializer
         rewriteSSTableMetadata(descriptor, currentComponents);
     }
 
+    // Package-private for testing
+    static CompressionParams testCompressionParams = null;
+
     /**
      * Read the compression info file pointed by the given descriptor and create the corresponding encryptor.
      *
      * Returns null if no encryption applies (version doesn't support it, compression is not applied, or the applicable
      * compression does not include encryption).
      */
-    // Package-private for testing
-    static CompressionParams testCompressionParams = null;
-    
     private ICompressor getEncryptor(Descriptor desc, boolean writeTime)
     {
         if (!desc.version.metadataIsEncrypted())
@@ -349,30 +349,29 @@ public class MetadataSerializer implements IMetadataSerializer
         }
         
         File compressionFile = desc.fileFor(Components.COMPRESSION_INFO);
+        if (!compressionFile.exists())
+            return null;
 
-        try
+        // Read the compression metadata from file
+        // We pass a negative compressedLength as we only need the parameters, not the actual chunk offsets
+        // CompressionMetadata is ref-counted and holds the chunk offsets in off-heap Memory, so it must be
+        // closed once the parameters have been extracted.
+        try (CompressionMetadata cm = CompressionMetadata.open(compressionFile, -1, false))
         {
-            // Read the compression metadata from file
-            // We pass a small compressedLength as we only need the parameters, not the actual chunk offsets.
-            // CompressionMetadata is ref-counted and holds the chunk offsets in off-heap Memory, so it must be
-            // closed once the parameters have been extracted.
-            try (CompressionMetadata cm = CompressionMetadata.open(compressionFile, 1024, false))
-            {
-                // Note: we use only the encryption component, without any compression. The reason for doing this is to
-                // avoid having to allocate (and save the size of) an additional buffer to hold the larger uncompressed
-                // serialization on reads.
-                ICompressor compressor = cm.parameters.getSstableCompressor();
-                if (compressor != null)
-                    return compressor.encryptionOnly();
-                return null;
-            }
+            // Note: we use only the encryption component, without any compression. The reason for doing this is to
+            // avoid having to allocate (and save the size of) an additional buffer to hold the larger uncompressed
+            // serialization on reads.
+            ICompressor compressor = cm.parameters.getSstableCompressor();
+            if (compressor != null)
+                return compressor.encryptionOnly();
+            return null;
         }
         catch (Throwable t)
         {
             // If we can't read the compression metadata, assume no encryption.
             // During flush, the compression file may not be accessible yet in some implementations
             // causing FSReadError. Catch Throwable to handle both Exception and Error.
-            logger.debug("Could not read compression metadata for {}: {}", desc, t.getMessage());
+            logger.debug("Could not read compression metadata for {}: {}", desc, t.getMessage(), t);
             return null;
         }
     }

--- a/src/java/org/apache/cassandra/io/util/AbstractReaderFileProxy.java
+++ b/src/java/org/apache/cassandra/io/util/AbstractReaderFileProxy.java
@@ -64,4 +64,10 @@ public abstract class AbstractReaderFileProxy implements ReaderFileProxy
     {
         return position;
     }
+
+    @Override
+    public long positionForSkip(long currentPosition, int bytesToSkip)
+    {
+        return currentPosition + bytesToSkip;
+    }
 }

--- a/src/java/org/apache/cassandra/io/util/BufferManagingRebufferer.java
+++ b/src/java/org/apache/cassandra/io/util/BufferManagingRebufferer.java
@@ -102,6 +102,12 @@ public abstract class BufferManagingRebufferer implements Rebufferer, Rebufferer
     }
 
     @Override
+    public long positionForSkip(long currentPosition, int bytesToSkip)
+    {
+        return source.positionForSkip(currentPosition, bytesToSkip);
+    }
+
+    @Override
     public String toString()
     {
         return "BufferManagingRebufferer." + getClass().getSimpleName() + ":" + source;

--- a/src/java/org/apache/cassandra/io/util/EmptyRebufferer.java
+++ b/src/java/org/apache/cassandra/io/util/EmptyRebufferer.java
@@ -58,6 +58,12 @@ public class EmptyRebufferer implements Rebufferer, RebuffererFactory
     }
 
     @Override
+    public long positionForSkip(long currentPosition, int bytesToSkip)
+    {
+        return currentPosition + bytesToSkip;
+    }
+
+    @Override
     public BufferHolder rebuffer(long position)
     {
         return EMPTY;

--- a/src/java/org/apache/cassandra/io/util/EncryptedChunkReader.java
+++ b/src/java/org/apache/cassandra/io/util/EncryptedChunkReader.java
@@ -162,18 +162,8 @@ public abstract class EncryptedChunkReader extends AbstractReaderFileProxy imple
 
         if (overrideLength <= 0)
         {
-            // For encrypted files, we need to calculate the logical data length
-            // Each chunk can hold maxBytesInPage of actual data
-            // Calculate how many complete chunks we have
-            long numChunks = fileLength / CHUNK_SIZE;
-            // Calculate the logical data that can be stored
-            overrideLength = numChunks * maxBytesInPage;
-            // If there's a partial last chunk, add its data
-            long lastChunkSize = fileLength % CHUNK_SIZE;
-            if (lastChunkSize > 0) {
-                // The last chunk might have less data
-                overrideLength += Math.max(0, lastChunkSize - (CHUNK_SIZE - maxBytesInPage));
-            }
+            // Use the position after the last useable byte to allow partition index readers to find their metadata
+            overrideLength = fileLength - (CHUNK_SIZE - maxBytesInPage);
         }
 
         return new Standard(channel, compressionParams, encryptor, overrideLength, maxBytesInPage);
@@ -190,18 +180,8 @@ public abstract class EncryptedChunkReader extends AbstractReaderFileProxy imple
 
         if (overrideLength <= 0)
         {
-            // For encrypted files, we need to calculate the logical data length
-            // Each chunk can hold maxBytesInPage of actual data
-            // Calculate how many complete chunks we have
-            long numChunks = fileLength / CHUNK_SIZE;
-            // Calculate the logical data that can be stored
-            overrideLength = numChunks * maxBytesInPage;
-            // If there's a partial last chunk, add its data
-            long lastChunkSize = fileLength % CHUNK_SIZE;
-            if (lastChunkSize > 0) {
-                // The last chunk might have less data
-                overrideLength += Math.max(0, lastChunkSize - (CHUNK_SIZE - maxBytesInPage));
-            }
+            // Use the position after the last useable byte to allow partition index readers to find their metadata
+            overrideLength = fileLength - (CHUNK_SIZE - maxBytesInPage);
         }
         return new Mmap(channel, regions, compressionParams, encryptor, overrideLength, maxBytesInPage);
     }

--- a/src/java/org/apache/cassandra/io/util/EncryptedChunkReader.java
+++ b/src/java/org/apache/cassandra/io/util/EncryptedChunkReader.java
@@ -79,6 +79,20 @@ public abstract class EncryptedChunkReader extends AbstractReaderFileProxy imple
         return position - maxBytesInPage + CHUNK_SIZE;
     }
 
+    @Override
+    public long positionForSkip(long currentPosition, int bytesToSkip)
+    {
+        long currentOffset = inChunkOffset(currentPosition);
+        while (currentOffset + bytesToSkip > maxBytesInPage)
+        {
+            long len = maxBytesInPage - currentOffset;
+            bytesToSkip -= len;
+            currentPosition += CHUNK_SIZE - maxBytesInPage + len;
+            currentOffset = 0;
+        }
+        return currentPosition + bytesToSkip;
+    }
+
     private static long inChunkOffset(long position)
     {
         return position & (CHUNK_SIZE - 1);

--- a/src/java/org/apache/cassandra/io/util/FileHandle.java
+++ b/src/java/org/apache/cassandra/io/util/FileHandle.java
@@ -301,6 +301,7 @@ public class FileHandle extends SharedCloseableImpl
         private MmappedRegionsCache mmappedRegionsCache;
         private SliceDescriptor sliceDescriptor = SliceDescriptor.NONE;
         private boolean adviseRandom = false;
+        private boolean encryptionOnly = false;
 
         public Builder(File file)
         {
@@ -424,10 +425,11 @@ public class FileHandle extends SharedCloseableImpl
             return this;
         }
 
-        public Builder maybeEncrypted(boolean encrypted)
+        public Builder encryptionOnly()
         {
             // For encrypted files, we need to ensure compressionMetadata is available
             // This is needed because encrypted files use the compression framework
+            this.encryptionOnly = true;
             return this;
         }
 
@@ -451,15 +453,10 @@ public class FileHandle extends SharedCloseableImpl
                 channel = channelProxyFactory.apply(file);
 
                 long fileLength;
-                if (compressionMetadata != null && compressionMetadata.useActualFileSize)
-                {
-                    // For encrypted-only files, we need to use the actual file size
-                    fileLength = channel.size();
-                }
+                if (compressionMetadata != null && !encryptionOnly)
+                    fileLength = compressionMetadata.compressedFileLength;
                 else
-                {
-                    fileLength = (compressionMetadata != null) ? compressionMetadata.compressedFileLength : channel.size();
-                }
+                    fileLength = channel.size();
                 long length = lengthOverride >= 0 ? lengthOverride : fileLength;
 
                 RebuffererFactory rebuffererFactory;
@@ -472,11 +469,11 @@ public class FileHandle extends SharedCloseableImpl
                     if (compressionMetadata != null)
                     {
                         // Check if this is encryption rather than compression
-                        if (compressionMetadata.compressor() instanceof Encryptor)
+                        if (encryptionOnly)
                         {
                             // For encrypted files, we need to map the actual file size, not logical data length
                             // MmappedRegions maps physical file regions, not logical data
-                            Encryptor encryptor = (Encryptor) compressionMetadata.compressor();
+                            Encryptor encryptor = (Encryptor) compressionMetadata.compressor().encryptionOnly();
                             
                             // Map the actual file size, with chunks aligned to CHUNK_SIZE
                             int chunkSize = EncryptedSequentialWriter.CHUNK_SIZE;
@@ -509,9 +506,9 @@ public class FileHandle extends SharedCloseableImpl
                     if (compressionMetadata != null)
                     {
                         // Check if this is encryption rather than compression
-                        if (compressionMetadata.compressor() instanceof Encryptor)
+                        if (encryptionOnly)
                         {
-                            Encryptor encryptor = (Encryptor) compressionMetadata.compressor();
+                            Encryptor encryptor = (Encryptor) compressionMetadata.compressor().encryptionOnly();
                             // For encrypted files without explicit length override, pass -1 to let EncryptedChunkReader calculate the logical length
                             long encryptedOverrideLength = (lengthOverride >= 0) ? length : -1;
                             rebuffererFactory = EncryptedChunkReader.createStandard(channel, encryptor, compressionMetadata.parameters, fileLength, encryptedOverrideLength);

--- a/src/java/org/apache/cassandra/io/util/PrefetchingRebufferer.java
+++ b/src/java/org/apache/cassandra/io/util/PrefetchingRebufferer.java
@@ -325,7 +325,13 @@ public class PrefetchingRebufferer implements Rebufferer
     @Override
     public long adjustPosition(long position)
     {
-        return position;
+        return source.adjustPosition(position);
+    }
+
+    @Override
+    public long positionForSkip(long currentPosition, int bytesToSkip)
+    {
+        return source.positionForSkip(currentPosition, bytesToSkip);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/io/util/RandomAccessReader.java
+++ b/src/java/org/apache/cassandra/io/util/RandomAccessReader.java
@@ -353,11 +353,17 @@ public class RandomAccessReader extends RebufferingInputStream implements FileDa
             return 0;
         if (buffer == null)
             throw new IOException("Attempted skipBytes() on a closed RAR");
-        long current = current();
-        long newPosition = Math.min(current + n, length());
-        n = (int)(newPosition - current);
-        seek(newPosition);
-        return n;
+        if (n <= buffer.remaining())
+        {
+            buffer.position(buffer.position() + n);
+            return n;
+        }
+
+        long current = getFilePointer();
+        long newPosition = rebufferer.positionForSkip(current, n);
+        long adjustedForSize = Math.min(newPosition, length());
+        seek(adjustedForSize);
+        return n + (int) (adjustedForSize - newPosition);
     }
 
     /**

--- a/src/java/org/apache/cassandra/io/util/ReaderFileProxy.java
+++ b/src/java/org/apache/cassandra/io/util/ReaderFileProxy.java
@@ -40,4 +40,13 @@ public interface ReaderFileProxy extends AutoCloseable
      * sequences of bytes (e.g. keys) that span over a hole.
      */
     long adjustPosition(long position);
+
+    /**
+     * Called to provide the position to be seeked to after skipping the given number of bytes.
+     * Default implementation in AbstractReaderFileProxy just adds the position and bytes.
+     * Overridden by EncryptedChunkReader to properly account for holes.
+     * Rebufferers (which often use a ChunkReader to do the work) must implement it to defer to
+     * their source.
+     */
+    long positionForSkip(long currentPosition, int bytesToSkip);
 }

--- a/src/java/org/apache/cassandra/io/util/WrappingRebufferer.java
+++ b/src/java/org/apache/cassandra/io/util/WrappingRebufferer.java
@@ -81,6 +81,12 @@ public abstract class WrappingRebufferer implements Rebufferer, Rebufferer.Buffe
     }
 
     @Override
+    public long positionForSkip(long currentPosition, int bytesToSkip)
+    {
+        return wrapped.positionForSkip(currentPosition, bytesToSkip);
+    }
+
+    @Override
     public void close()
     {
         assert buffer == null : "Rebufferer is attempted to be closed but the buffer holder has not been released";

--- a/src/java/org/apache/cassandra/schema/CompressionParams.java
+++ b/src/java/org/apache/cassandra/schema/CompressionParams.java
@@ -555,6 +555,12 @@ public final class CompressionParams
             .toHashCode();
     }
 
+    @Override
+    public String toString()
+    {
+        return asMap().toString();
+    }
+
     static class Serializer implements IVersionedSerializer<CompressionParams>
     {
         public void serialize(CompressionParams parameters, DataOutputPlus out, int version) throws IOException

--- a/test/distributed/org/apache/cassandra/distributed/test/SSTableEncryptionTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/SSTableEncryptionTest.java
@@ -34,6 +34,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.crypto.LocalSystemKey;
 import org.apache.cassandra.crypto.TDEConfigurationProvider;
 import org.apache.cassandra.db.Keyspace;
@@ -42,8 +43,9 @@ import org.apache.cassandra.distributed.api.ConsistencyLevel;
 import org.apache.cassandra.distributed.api.NodeToolResult;
 import org.apache.cassandra.io.sstable.Component;
 import org.apache.cassandra.io.sstable.format.SSTableFormat;
-import org.apache.cassandra.io.sstable.format.bti.BtiFormat;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.io.sstable.format.bti.BtiFormat;
+import org.apache.cassandra.io.util.PathUtils;
 import org.apache.cassandra.utils.ChecksumType;
 
 import static org.apache.cassandra.distributed.api.ConsistencyLevel.ALL;
@@ -78,9 +80,22 @@ public class SSTableEncryptionTest extends TestBaseImpl
     }
 
     @Test
+    public void shouldFlushToQueryableEncryptedSSTables() throws Throwable
+    {
+        // test reading sstables as set up by flush/compaction on the running node
+        testQueryableEncryptedSSTables(false);
+    }
+
+    @Test
     public void shouldCreateQueryableEncryptedSSTables() throws Throwable
     {
-        try (Cluster cluster = builder().withNodes(2)
+        // test reading sstables from disk without write-time set-up
+        testQueryableEncryptedSSTables(true);
+    }
+
+    public void testQueryableEncryptedSSTables(boolean restartNodes) throws Throwable
+    {
+        try (Cluster cluster = builder().withNodes(1)
                                         .withConfig(config -> config.with(GOSSIP).with(NETWORK))
                                         .start())
         {
@@ -101,6 +116,14 @@ public class SSTableEncryptionTest extends TestBaseImpl
             cluster.get(1).flush(keyspace);
 
             insertAndFlush(cluster, keyspace, table, numberOfRows);
+
+            if (restartNodes)
+            {
+                for (int i = 1; i <= cluster.size(); ++i)
+                {
+                    restartWithDeletedCommitLog(cluster, i);
+                }
+            }
 
             // when querying all
             Object[][] rows = cluster.coordinator(1).execute(String.format("SELECT * FROM %s.%s ", keyspace, table), ALL);
@@ -128,6 +151,16 @@ public class SSTableEncryptionTest extends TestBaseImpl
             assertThat(byIdRows[0][1]).isEqualTo(String.valueOf(2));
             assertThat(byIdRows[0][2]).isEqualTo(String.valueOf(2));
         }
+    }
+
+    private static void restartWithDeletedCommitLog(Cluster cluster, int i)
+    {
+        String commitlogpath = cluster.get(1).callOnInstance(() -> DatabaseDescriptor.getCommitLogLocation().path());
+        waitOn(cluster.get(i).shutdown());
+        // delete the commit log to make sure we are not recreating the data from it
+        PathUtils.deleteRecursive(Path.of(commitlogpath));
+        // start-up must now read the sstables
+        cluster.get(i).startup();
     }
 
     @Test
@@ -245,8 +278,7 @@ public class SSTableEncryptionTest extends TestBaseImpl
             assertEquals(secretKey, secretKey2);
 
             // restart to clear in memory secret key cache
-            waitOn(cluster.get(1).shutdown());
-            cluster.get(1).startup();
+            restartWithDeletedCommitLog(cluster, 1);
 
             // when
             Object[][] rows = cluster. get(1).executeInternal(String.format("SELECT * FROM %s.%s", keyspace, nonEncryptedTableName));

--- a/test/unit/org/apache/cassandra/cache/CachingRebuffererTest.java
+++ b/test/unit/org/apache/cassandra/cache/CachingRebuffererTest.java
@@ -132,6 +132,11 @@ public class CachingRebuffererTest
                 return position;
             }
 
+            public long positionForSkip(long currentPosition, int bytesToSkip)
+            {
+                return currentPosition + bytesToSkip;
+            }
+
             public void close()
             {
 

--- a/test/unit/org/apache/cassandra/cache/ChunkCacheInterceptingTest.java
+++ b/test/unit/org/apache/cassandra/cache/ChunkCacheInterceptingTest.java
@@ -117,6 +117,12 @@ public class ChunkCacheInterceptingTest
         }
 
         @Override
+        public long positionForSkip(long currentPosition, int bytesToSkip)
+        {
+            return wrapped.positionForSkip(currentPosition, bytesToSkip);
+        }
+
+        @Override
         public Rebufferer instantiateRebufferer(boolean isScan)
         {
             numInstantiations += 1;

--- a/test/unit/org/apache/cassandra/io/compress/EncryptedSequentialWriterTest.java
+++ b/test/unit/org/apache/cassandra/io/compress/EncryptedSequentialWriterTest.java
@@ -201,11 +201,12 @@ public class EncryptedSequentialWriterTest extends SequentialWriterTest
         }
 
         assert f.exists();
-        FileHandle.Builder builder = new FileHandle.Builder(f)
-                .withCompressionMetadata(CompressionMetadata.encryptedOnly(compressionParams))
-                .maybeEncrypted(true)
-                .mmapped(useMemmap);
-        try (FileHandle fh = builder.complete();
+        try (CompressionMetadata cm = CompressionMetadata.encryptedOnly(compressionParams);
+             FileHandle fh = new FileHandle.Builder(f)
+                                  .withCompressionMetadata(cm)
+                                  .encryptionOnly()
+                                  .mmapped(useMemmap)
+                                  .complete();
              RandomAccessReader reader = fh.createReader())
         {
             // No longer true: assertEquals(dataPre.length + rawPost.length, reader.length());
@@ -295,10 +296,11 @@ public class EncryptedSequentialWriterTest extends SequentialWriterTest
             writer.finish();
         }
 
-        FileHandle.Builder builder = new FileHandle.Builder(tempFile)
-                .withCompressionMetadata(CompressionMetadata.encryptedOnly(AESEncryptorParams))
-                .maybeEncrypted(true);
-        try (FileHandle fh = builder.complete();
+        try (CompressionMetadata cm = CompressionMetadata.encryptedOnly(AESEncryptorParams);
+             FileHandle fh = new FileHandle.Builder(tempFile)
+                                  .withCompressionMetadata(cm)
+                                  .encryptionOnly()
+                                  .complete();
              RandomAccessReader reader = fh.createReader())
         {
             assertTrue(reader.isEOF());

--- a/test/unit/org/apache/cassandra/io/sstable/EarlyOpenWithBytemanTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/EarlyOpenWithBytemanTest.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.io.sstable;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.apache.cassandra.SchemaLoader;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.db.compaction.CompactionManager;
+import org.apache.cassandra.db.marshal.UUIDType;
+import org.apache.cassandra.dht.ByteOrderedPartitioner;
+import org.apache.cassandra.exceptions.ConfigurationException;
+import org.apache.cassandra.schema.KeyspaceParams;
+import org.jboss.byteman.contrib.bmunit.BMRule;
+import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
+
+import static org.apache.cassandra.SchemaLoader.counterCFMD;
+import static org.apache.cassandra.SchemaLoader.createKeyspace;
+import static org.apache.cassandra.SchemaLoader.getCompressionParameters;
+import static org.apache.cassandra.SchemaLoader.loadSchema;
+import static org.apache.cassandra.SchemaLoader.standardCFMD;
+import static org.apache.cassandra.io.sstable.ScrubTest.CF;
+import static org.apache.cassandra.io.sstable.ScrubTest.CF_INDEX1;
+import static org.apache.cassandra.io.sstable.ScrubTest.CF_INDEX1_BYTEORDERED;
+import static org.apache.cassandra.io.sstable.ScrubTest.CF_INDEX2;
+import static org.apache.cassandra.io.sstable.ScrubTest.CF_INDEX2_BYTEORDERED;
+import static org.apache.cassandra.io.sstable.ScrubTest.CF_UUID;
+import static org.apache.cassandra.io.sstable.ScrubTest.COMPRESSION_CHUNK_LENGTH;
+import static org.apache.cassandra.io.sstable.ScrubTest.COUNTER_CF;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(BMUnitRunner.class)
+public class EarlyOpenWithBytemanTest
+{
+    public static AtomicInteger moveStartsCounter = new AtomicInteger(0);
+    public static AtomicInteger failedEarlyOpenCounter = new AtomicInteger(0);
+    public static AtomicBoolean canTriggerException = new AtomicBoolean(false);
+
+    static String KEYSPACE = "early_open_byteman_test";
+
+    @BeforeClass
+    public static void defineSchema() throws ConfigurationException
+    {
+        loadSchema();
+        createKeyspace(KEYSPACE,
+                KeyspaceParams.simple(1),
+                standardCFMD(KEYSPACE, CF),
+                counterCFMD(KEYSPACE, COUNTER_CF).compression(getCompressionParameters(COMPRESSION_CHUNK_LENGTH)),
+                standardCFMD(KEYSPACE, CF_UUID, 0, UUIDType.instance),
+                SchemaLoader.keysIndexCFMD(KEYSPACE, CF_INDEX1, true),
+                SchemaLoader.compositeIndexCFMD(KEYSPACE, CF_INDEX2, true),
+                SchemaLoader.keysIndexCFMD(KEYSPACE, CF_INDEX1_BYTEORDERED, true).partitioner(ByteOrderedPartitioner.instance),
+                SchemaLoader.compositeIndexCFMD(KEYSPACE, CF_INDEX2_BYTEORDERED, true).partitioner(ByteOrderedPartitioner.instance));
+    }
+
+
+    // DSP-25176
+    // Abort early-open attempts by blocking every second attempt to move an sstable's start (making sure some can
+    // succeed to test if created sstable references leak).
+    // Please check the output for "LEAK DETECTED" lines.
+    @Test
+    @BMRule(name="simulate_corruption",
+            targetClass = "org.apache.cassandra.io.sstable.SSTableRewriter",
+            targetMethod = "moveStarts",
+            targetLocation = "AT INVOKE org.apache.cassandra.io.sstable.format.SSTableReader.firstKeyBeyond",
+            condition = "org.apache.cassandra.io.sstable.EarlyOpenWithBytemanTest.canTriggerException.get() && " +
+                        "(org.apache.cassandra.io.sstable.EarlyOpenWithBytemanTest.moveStartsCounter.incrementAndGet() % 2 == 0)",
+            action = "org.apache.cassandra.io.sstable.EarlyOpenWithBytemanTest.failedEarlyOpenCounter.incrementAndGet();" +
+                     "throw new java.lang.RuntimeException(\"!!!Test simulated corruption!!!\");")
+    public void testExceptionsOnLifecycleBoundaries() throws Exception
+    {
+        boolean oldDisabledVal = SSTableRewriter.disableEarlyOpeningForTests;
+        int oldInterval = DatabaseDescriptor.getSSTablePreemptiveOpenIntervalInMiB();
+        int earlyOpenThresholdMB = 1;
+        int cfsRowsNum = 100_000;
+        try
+        {
+            // Ensure early opening is enabled
+            SSTableRewriter.disableEarlyOpeningForTests = false;
+            // Set a very low interval (e.g., 1MB) to trigger early opening quickly
+            DatabaseDescriptor.setSSTablePreemptiveOpenIntervalInMiB(earlyOpenThresholdMB);
+
+            CompactionManager.instance.disableAutoCompaction();
+            Keyspace keyspace = Keyspace.open(KEYSPACE);
+            ColumnFamilyStore cfs = keyspace.getColumnFamilyStore(CF);
+            cfs.clearUnsafe();
+
+            // Insert enough data to trigger early opening
+            ScrubTest.fillCF(cfs, cfsRowsNum);
+            // Do it again to have multiple source sstables
+            ScrubTest.fillCF(cfs, cfsRowsNum);
+            ScrubTest.assertOrderedAll(cfs, cfsRowsNum);
+
+
+            // This should trigger:
+            // 1. maybeReopenEarly() during normal writing
+            // 2. Corruption simulation
+            // 3. switchWriter() or other operation will try to update the transaction
+            failedEarlyOpenCounter.set(0);
+            canTriggerException.set(true);
+            cfs.forceMajorCompaction();
+            canTriggerException.set(false);
+            assertTrue("Corruption was not triggered " + failedEarlyOpenCounter.get(), failedEarlyOpenCounter.get() > 0);
+
+            // check data is still there
+            ScrubTest.assertOrderedAll(cfs, cfsRowsNum);
+        }
+        finally
+        {
+            SSTableRewriter.disableEarlyOpeningForTests = oldDisabledVal;
+            DatabaseDescriptor.setSSTablePreemptiveOpenIntervalInMiB(oldInterval);
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/io/sstable/SSTableScannerTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/SSTableScannerTest.java
@@ -22,17 +22,21 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import com.google.common.collect.Iterables;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.cassandra.SchemaLoader;
 import org.apache.cassandra.Util;
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.DataRange;
 import org.apache.cassandra.db.DecoratedKey;
@@ -50,10 +54,13 @@ import org.apache.cassandra.dht.ByteOrderedPartitioner;
 import org.apache.cassandra.dht.Range;
 import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.io.sstable.format.bti.BtiFormat;
+import org.apache.cassandra.io.sstable.format.bti.BtiTableReader;
 import org.apache.cassandra.schema.KeyspaceParams;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.hamcrest.Matchers;
+import org.mockito.Mockito;
 
 import static org.apache.cassandra.dht.AbstractBounds.isEmpty;
 import static org.junit.Assert.assertEquals;
@@ -186,11 +193,12 @@ public class SSTableScannerTest
 
     private static void assertScanMatches(SSTableReader sstable, int scanStart, int scanEnd, int ... boundaries)
     {
-        assertScanMatchesUsingScanner(sstable, scanStart, scanEnd, boundaries);
+        assertScanFromDataRangeMatches(sstable, scanStart, scanEnd, boundaries);
+        assertScanFromIteratorMatches(sstable, scanStart, scanEnd, boundaries);
         assertScanMatchesUsingSimple(sstable, scanStart, scanEnd, boundaries);
     }
 
-    private static void assertScanMatchesUsingScanner(SSTableReader sstable, int scanStart, int scanEnd, int ... boundaries)
+    private static void assertScanFromDataRangeMatches(SSTableReader sstable, int scanStart, int scanEnd, int ... boundaries)
     {
         assert boundaries.length % 2 == 0;
         for (DataRange range : dataRanges(sstable.metadata(), scanStart, scanEnd))
@@ -208,6 +216,33 @@ public class SSTableScannerTest
             {
                 throw new RuntimeException(e);
             }
+        }
+    }
+
+    private static void assertScanFromIteratorMatches(SSTableReader sstable, int scanStart, int scanEnd, int ... boundaries)
+    {
+        assert boundaries.length % 2 == 0;
+        Range<Token> range = rangeFor(scanStart, scanEnd);
+        List<Range<Token>> ranges = scanStart <= scanEnd ? List.of(range) : range.unwrap();
+        List<AbstractBounds<PartitionPosition>> pps =
+            ranges.stream()
+                  .sorted(Comparator.comparing(b -> b.left))
+                  .map(r -> new Range<PartitionPosition>(r.left.minKeyBound(), r.right.maxKeyBound()))
+                  .collect(Collectors.<AbstractBounds<PartitionPosition>>toList());
+
+        try(ISSTableScanner scanner = sstable.getScanner(pps.iterator()))
+        {
+            for (int b = 0; b < boundaries.length; b += 2)
+                for (int i = boundaries[b]; i <= boundaries[b + 1]; i++)
+                    assertEquals(toKey(i), new String(scanner.next().partitionKey().getKey().array()));
+            boolean hadNext = scanner.hasNext();
+            while (scanner.hasNext())
+                System.out.println("Got extra " + new String(scanner.next().partitionKey().getKey().array()));
+            assertFalse(hadNext);
+        }
+        catch (Exception e)
+        {
+            throw new RuntimeException(e);
         }
     }
 
@@ -241,6 +276,32 @@ public class SSTableScannerTest
     @Test
     public void testSingleDataRange() throws IOException
     {
+        testSingleDataRange(false, false);
+    }
+
+    @Test
+    public void testSingleDataRangeWithChangedStart() throws IOException
+    {
+        testSingleDataRange(true, false);
+    }
+
+    @Test
+    public void testSingleDataRangeWithChangedEnd() throws IOException
+    {
+
+        Assume.assumeTrue(DatabaseDescriptor.getSelectedSSTableFormat() == BtiFormat.getInstance());
+        testSingleDataRange(false, true);
+    }
+
+    @Test
+    public void testSingleDataRangeWithChangedBothEnds() throws IOException
+    {
+        Assume.assumeTrue(DatabaseDescriptor.getSelectedSSTableFormat() == BtiFormat.getInstance());
+        testSingleDataRange(true, true);
+    }
+
+    private void testSingleDataRange(boolean filterFirst, boolean filterLast)
+    {
         Keyspace keyspace = Keyspace.open(KEYSPACE);
         ColumnFamilyStore store = keyspace.getColumnFamilyStore(TABLE);
         store.clearUnsafe();
@@ -248,13 +309,35 @@ public class SSTableScannerTest
         // disable compaction while flushing
         store.disableAutoCompaction();
 
-        for (int i = 2; i < 10; i++)
+        for (int i = filterFirst ? 0 : 2; i <= (filterLast ? 12 : 9); i++)
             insertRowWithKey(store.metadata(), i);
-        Util.flush(store);
+        store.forceBlockingFlush(ColumnFamilyStore.FlushReason.UNIT_TESTS);
 
         assertEquals(1, store.getLiveSSTables().size());
         SSTableReader sstable = store.getLiveSSTables().iterator().next();
+        if (filterFirst)
+            sstable = sstable.cloneWithNewStart(dk(2));
+        if (filterLast)
+            sstable = cloneWithNewEndBound(sstable, dk(9));
+        testSingleDataRange(sstable);
+    }
 
+    private SSTableReader cloneWithNewEndBound(SSTableReader sstable, DecoratedKey last)
+    {
+        long fileEnd = sstable.getPosition(last, SSTableReader.Operator.GT);
+        // Change the end bound and make sure it is applied.
+        sstable = ((BtiTableReader) sstable).unbuildTo(new BtiTableReader.Builder(sstable.descriptor), true)
+                                            .setLast(last)
+                                            .build(sstable.owner().orElse(null), true, true);
+        BtiTableReader spied = Mockito.spy((BtiTableReader) sstable);
+        Mockito.when(spied.filterLast()).thenReturn(true);
+        // When it's given a position beyond the last key, the sstable will use uncompressedLength(). Mock that too.
+        Mockito.when(spied.uncompressedLength()).thenReturn(fileEnd);
+        return spied;
+    }
+
+    private void testSingleDataRange(SSTableReader sstable)
+    {
         // full range scan
         ISSTableScanner scanner = sstable.getScanner();
         for (int i = 2; i < 10; i++)
@@ -360,7 +443,7 @@ public class SSTableScannerTest
         // start of range edge conditions
         assertScanMatches(sstable, 3, 9, 4, 9);
         assertScanMatches(sstable, 4, 9, 4, 9);
-        assertScanMatches(sstable, 5, 9, 4, 9);
+        assertScanMatches(sstable, 5, 9, 5, 9);
 
         // end of range edge conditions
         assertScanMatches(sstable, 1, 8, 4, 8);

--- a/test/unit/org/apache/cassandra/io/sstable/format/bti/PartitionIndexEncryptedTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/format/bti/PartitionIndexEncryptedTest.java
@@ -1,0 +1,200 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.io.sstable.format.bti;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import javax.crypto.spec.DESKeySpec;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.apache.cassandra.cache.ChunkCache;
+import org.apache.cassandra.config.Config;
+import org.apache.cassandra.io.compress.CompressionMetadata;
+import org.apache.cassandra.io.compress.EncryptedSequentialWriter;
+import org.apache.cassandra.io.compress.EncryptionConfig;
+import org.apache.cassandra.io.compress.Encryptor;
+import org.apache.cassandra.io.compress.EncryptorTest;
+import org.apache.cassandra.io.sstable.metadata.ZeroCopyMetadata;
+import org.apache.cassandra.io.util.File;
+import org.apache.cassandra.io.util.FileHandle;
+import org.apache.cassandra.io.util.PageAware;
+import org.apache.cassandra.io.util.SequentialWriter;
+import org.apache.cassandra.io.util.SequentialWriterOption;
+import org.apache.cassandra.schema.CompressionParams;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable;
+
+@RunWith(Parameterized.class)
+public class PartitionIndexEncryptedTest extends PartitionIndexTest
+{
+    static final CompressionParams compressionParamsNormal;
+    static final CompressionParams compressionParamsOutOfPlace;
+    static final CompressionParams compressionParamsBlowfish;
+    static final CompressionParams compressionParamsDes;
+
+    static
+    {
+        Map<String, String> opts = new HashMap<>();
+
+        opts.put(EncryptionConfig.KEY_PROVIDER, EncryptorTest.KeyProviderFactoryStub.class.getName());
+
+        opts.put(EncryptionConfig.CIPHER_ALGORITHM, "AES/CBC/PKCS5Padding");
+        opts.put(EncryptionConfig.SECRET_KEY_STRENGTH, Integer.toString(128));
+        opts.put(CompressionParams.CLASS, Encryptor.class.getName());
+        compressionParamsNormal = CompressionParams.fromMap(opts);
+
+        opts.put(EncryptionConfig.CIPHER_ALGORITHM, "AES/ECB/PKCS5Padding");
+        opts.put(EncryptionConfig.SECRET_KEY_STRENGTH, Integer.toString(256));
+        opts.put(CompressionParams.CLASS, OutOfPlaceEncryptor.class.getName());
+        compressionParamsOutOfPlace = CompressionParams.fromMap(opts);
+
+        opts.put(EncryptionConfig.CIPHER_ALGORITHM, "Blowfish/CBC/PKCS5Padding");
+        opts.put(EncryptionConfig.SECRET_KEY_STRENGTH, Integer.toString(256));
+        opts.put(CompressionParams.CLASS, Encryptor.class.getName());
+        compressionParamsBlowfish = CompressionParams.fromMap(opts);
+
+        opts.put(EncryptionConfig.CIPHER_ALGORITHM, "DES/CBC/PKCS5Padding");
+        opts.put(EncryptionConfig.SECRET_KEY_STRENGTH, Integer.toString(DESKeySpec.DES_KEY_LEN * 8));
+        opts.put(CompressionParams.CLASS, Encryptor.class.getName());
+        compressionParamsDes = CompressionParams.fromMap(opts);
+    }
+
+    public static class OutOfPlaceEncryptor extends Encryptor
+    {
+        public static OutOfPlaceEncryptor create(Map<String, String> options)
+        {
+            EncryptionConfig encryptionConfig = EncryptionConfig.forClass(OutOfPlaceEncryptor.class).fromCompressionOptions(options).build();
+            return new OutOfPlaceEncryptor(encryptionConfig);
+        }
+
+        OutOfPlaceEncryptor(EncryptionConfig encryptionConfig)
+        {
+            super(encryptionConfig);
+        }
+
+        @Override
+        public boolean canDecompressInPlace()
+        {
+            return false;
+        }
+    }
+
+    @Parameterized.Parameters(name="accessMode {0} fromFile {1} compressionParams {2} BC version {3}")
+    public static Collection<Object[]> generateData()
+    {
+        return Arrays.asList(new Object[][]{
+                new Object[] {Config.DiskAccessMode.standard, false, compressionParamsNormal, ByteComparable.Version.LEGACY},
+                new Object[] {Config.DiskAccessMode.standard, false, compressionParamsNormal, ByteComparable.Version.OSS41},
+                new Object[] {Config.DiskAccessMode.standard, false, compressionParamsNormal, ByteComparable.Version.OSS50},
+                // fromFile and out-of-place have independent implementations, one run suffices to test both
+                new Object[] {Config.DiskAccessMode.standard, true, compressionParamsOutOfPlace, ByteComparable.Version.LEGACY},
+                new Object[] {Config.DiskAccessMode.standard, true, compressionParamsOutOfPlace, ByteComparable.Version.OSS41},
+                new Object[] {Config.DiskAccessMode.standard, true, compressionParamsOutOfPlace, ByteComparable.Version.OSS50},
+                new Object[] {Config.DiskAccessMode.mmap, false, compressionParamsBlowfish, ByteComparable.Version.LEGACY},
+                new Object[] {Config.DiskAccessMode.mmap, false, compressionParamsBlowfish, ByteComparable.Version.OSS41},
+                new Object[] {Config.DiskAccessMode.mmap, false, compressionParamsBlowfish, ByteComparable.Version.OSS50},
+                new Object[] {Config.DiskAccessMode.mmap, true, compressionParamsDes, ByteComparable.Version.LEGACY},
+                new Object[] {Config.DiskAccessMode.mmap, true, compressionParamsDes, ByteComparable.Version.OSS41},
+                new Object[] {Config.DiskAccessMode.mmap, true, compressionParamsDes, ByteComparable.Version.OSS50},
+        });
+    }
+
+    @Parameterized.Parameter(value = 1)
+    public static boolean fromFile = false;
+
+    @Parameterized.Parameter(value = 2)
+    public static CompressionParams compressionParams;
+
+    @Parameterized.Parameter(value = 3)
+    public static ByteComparable.Version version;
+
+    class JumpingEncryptedFile extends EncryptedSequentialWriter
+    {
+        long[] cutoffs;
+        long[] offsets;
+
+        JumpingEncryptedFile(File file, SequentialWriterOption option, long... cutoffsAndOffsets)
+        {
+            super(file, option, compressionParams.getSstableCompressor().encryptionOnly());
+            assert (cutoffsAndOffsets.length & 1) == 0;
+            cutoffs = new long[cutoffsAndOffsets.length / 2];
+            offsets = new long[cutoffs.length];
+            for (int i = 0; i < cutoffs.length; ++i)
+            {
+                cutoffs[i] = cutoffsAndOffsets[i * 2];
+                offsets[i] = cutoffsAndOffsets[i * 2 + 1];
+            }
+        }
+
+        @Override
+        public long position()
+        {
+            return jumped(super.position(), cutoffs, offsets);
+        }
+    }
+
+    protected SequentialWriter makeWriter(File file)
+    {
+
+        return new EncryptedSequentialWriter(file,
+                SequentialWriterOption
+                        .newBuilder()
+                        .finishOnClose(false)
+                        .build(),
+                compressionParams.getSstableCompressor().encryptionOnly());
+    }
+
+    @Override
+    public SequentialWriter makeJumpingWriter(File file, long[] cutoffsAndOffsets)
+    {
+        return new JumpingEncryptedFile(file, SequentialWriterOption.newBuilder().finishOnClose(true).build(), cutoffsAndOffsets);
+    }
+
+    @Override
+    protected FileHandle.Builder makeHandle(File file)
+    {
+        return new FileHandle.Builder(file)
+                .bufferSize(PageAware.PAGE_SIZE)
+                .mmapped(accessMode == Config.DiskAccessMode.mmap)
+                .withChunkCache(ChunkCache.instance)
+                .maybeEncrypted(true)
+                .withCompressionMetadata(CompressionMetadata.encryptedOnly(compressionParams));
+    }
+
+    @Override
+    protected PartitionIndex loadPartitionIndex(FileHandle.Builder fhBuilder, SequentialWriter writer) throws IOException
+    {
+        if (fromFile)
+        {
+            FileHandle.Builder fromFileBuilder = makeHandle(writer.getFile());
+            return PartitionIndex.load(fromFileBuilder, partitioner, false, ZeroCopyMetadata.EMPTY, version);
+        }
+        else
+            return PartitionIndex.load(fhBuilder, partitioner, false, ZeroCopyMetadata.EMPTY, version);
+    }
+
+    @Override
+    public void testDumpTrieToFile()
+    {
+        //FIXME: the tested trie dump method seems to be used only in tests, it should be revisited and fixed evnetually
+    }
+}

--- a/test/unit/org/apache/cassandra/io/sstable/format/bti/PartitionIndexEncryptedTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/format/bti/PartitionIndexEncryptedTest.java
@@ -17,6 +17,7 @@
  */
 package org.apache.cassandra.io.sstable.format.bti;
 
+import java.io.EOFException;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
@@ -25,7 +26,9 @@ import java.util.Map;
 import javax.crypto.spec.DESKeySpec;
 
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -40,6 +43,7 @@ import org.apache.cassandra.io.sstable.metadata.ZeroCopyMetadata;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileHandle;
 import org.apache.cassandra.io.util.PageAware;
+import org.apache.cassandra.io.util.RandomAccessReader;
 import org.apache.cassandra.io.util.SequentialWriter;
 import org.apache.cassandra.io.util.SequentialWriterOption;
 import org.apache.cassandra.schema.CompressionParams;
@@ -215,5 +219,77 @@ public class PartitionIndexEncryptedTest extends PartitionIndexTest
     public void testDumpTrieToFile()
     {
         //FIXME: the tested trie dump method seems to be used only in tests, it should be revisited and fixed evnetually
+    }
+
+    /**
+     * Verifies that seeking, reading and skipping over encryption-only files result in the same positions and read the
+     * same data. See DSP-25176.
+     */
+    @Test
+    public void testSkipAcrossHoles() throws IOException
+    {
+        int pageSize = PageAware.PAGE_SIZE;
+        File tempFile = new File(java.io.File.createTempFile(getClass().getName(), ".test"));
+        try (SequentialWriter writer = makeWriter(tempFile))
+        {
+            for (int i = 0; i < pageSize * 8; ++i)
+                writer.writeByte((byte) writer.position());
+            writer.finish();
+        }
+
+        FileHandle.Builder fhBuilder = makeHandle(tempFile);
+        try (FileHandle fh = fhBuilder.complete();
+             RandomAccessReader rdr = fh.createReader())
+        {
+            long len = rdr.length();
+            for (int readSize : new int[]{ 1, 7, 33, 45, 67, pageSize + 55, pageSize * 2, pageSize * 3 + 34 })
+            {
+                byte[] buf = new byte[readSize];
+                for (int seekPos = pageSize - 33; seekPos < len - 1; ++seekPos)
+                {
+                    rdr.seek(seekPos);
+                    int read = rdr.read(buf, 0, buf.length);
+                    long afterRead = rdr.getFilePointer();
+                    int nextByte = getNextByte(rdr);
+                    int expectedNextByte = (int) afterRead & 0xFF;
+
+                    rdr.seek(seekPos);
+                    BtiTableReader.skipBytesWithCorrectPosition(rdr, read);
+                    long afterSkip = rdr.getFilePointer();
+                    int nextByteAfterSkip = getNextByte(rdr);
+                    String context = String.format("(seek to %x, read %x bytes (of %x) to pos %x next %x; seek to %x corrected skip %x bytes to pos %x next %x)", seekPos, read, readSize, afterRead, nextByte, seekPos, read, afterSkip, nextByteAfterSkip);
+
+                    Assert.assertEquals("Position" + context, afterRead, afterSkip);
+                    Assert.assertEquals("Next byte" + context, nextByte, nextByteAfterSkip);
+
+                    rdr.seek(seekPos);
+                    rdr.skipBytes(read);
+                    afterSkip = rdr.getFilePointer();
+                    nextByteAfterSkip = getNextByte(rdr);
+                    context = String.format("(seek to %x, read %x bytes (of %x) to pos %x next %x; seek to %x plain skip %x bytes to pos %x next %x)", seekPos, read, readSize, afterRead, nextByte, seekPos, read, afterSkip, nextByteAfterSkip);
+
+                    if (afterRead != afterSkip)
+                        System.out.println("Different position after plain skip " + context); // this is expected and corrected for by BtiTableReader.skipBytesWithCorrectPosition
+                    Assert.assertEquals("Next byte" + context, nextByte, nextByteAfterSkip);
+
+                    if (nextByte != Integer.MAX_VALUE)
+                        Assert.assertEquals("Byte from write pos" + context, expectedNextByte, nextByte);
+                    else
+                        break; // because length() is imprecise, next seeks may hit beyond the end of the file
+                }
+            }
+        }
+    }
+
+    private static int getNextByte(RandomAccessReader rdr) throws IOException
+    {
+        try
+        {
+            return rdr.readByte() & 0xFF;
+        }
+        catch (EOFException e)
+        {
+            return Integer.MAX_VALUE;
+        }
     }
 }

--- a/test/unit/org/apache/cassandra/io/sstable/format/bti/PartitionIndexEncryptedTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/format/bti/PartitionIndexEncryptedTest.java
@@ -24,6 +24,8 @@ import java.util.HashMap;
 import java.util.Map;
 import javax.crypto.spec.DESKeySpec;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -76,6 +78,9 @@ public class PartitionIndexEncryptedTest extends PartitionIndexTest
         opts.put(EncryptionConfig.SECRET_KEY_STRENGTH, Integer.toString(DESKeySpec.DES_KEY_LEN * 8));
         opts.put(CompressionParams.CLASS, Encryptor.class.getName());
         compressionParamsDes = CompressionParams.fromMap(opts);
+
+        // TODO: Figure out why encrypted instance runs much slower
+        COUNT = 24525;
     }
 
     public static class OutOfPlaceEncryptor extends Encryptor
@@ -127,6 +132,20 @@ public class PartitionIndexEncryptedTest extends PartitionIndexTest
     @Parameterized.Parameter(value = 3)
     public static ByteComparable.Version version;
 
+    CompressionMetadata compressionMetadata;
+
+    @Before
+    public void setCompressionMetadata()
+    {
+        compressionMetadata = CompressionMetadata.encryptedOnly(compressionParams);
+    }
+
+    @After
+    public void releaseCompressionMetadata()
+    {
+        compressionMetadata.close();
+    }
+
     class JumpingEncryptedFile extends EncryptedSequentialWriter
     {
         long[] cutoffs;
@@ -176,8 +195,8 @@ public class PartitionIndexEncryptedTest extends PartitionIndexTest
                 .bufferSize(PageAware.PAGE_SIZE)
                 .mmapped(accessMode == Config.DiskAccessMode.mmap)
                 .withChunkCache(ChunkCache.instance)
-                .maybeEncrypted(true)
-                .withCompressionMetadata(CompressionMetadata.encryptedOnly(compressionParams));
+                .encryptionOnly()
+                .withCompressionMetadata(compressionMetadata);
     }
 
     @Override

--- a/test/unit/org/apache/cassandra/io/sstable/format/bti/PartitionIndexTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/format/bti/PartitionIndexTest.java
@@ -66,6 +66,7 @@ import org.apache.cassandra.io.util.SequentialWriterOption;
 import org.apache.cassandra.io.util.WrappingRebufferer;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.Pair;
+import org.apache.cassandra.utils.Throwables;
 import org.apache.cassandra.utils.bytecomparable.ByteComparable;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
@@ -93,7 +94,7 @@ public class PartitionIndexTest
 
     static final IPartitioner partitioner = Util.testPartitioner();
     //Lower the size of the indexes when running without the chunk cache, otherwise the test times out on Jenkins
-    static final int COUNT = ChunkCache.instance != null ? 245256 : 24525;
+    static int COUNT = ChunkCache.instance != null ? 245256 : 24525;
 
     @Parameterized.Parameters()
     public static Collection<Object[]> generateData()
@@ -149,7 +150,7 @@ public class PartitionIndexTest
             ch.write(generateRandomKey().getKey(), f.length() * 2 / 3);
         }
 
-        assertThatThrownBy(() -> testGetEq(data)).rootCause().isInstanceOfAny(AssertionError.class, IndexOutOfBoundsException.class, IllegalArgumentException.class, CorruptBlockException.class);
+        assertThatThrownBy(() -> testGetEq(data)).satisfies(t -> Throwables.assertAnyCause(t, AssertionError.class, IndexOutOfBoundsException.class, IllegalArgumentException.class, CorruptBlockException.class));
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/io/sstable/format/bti/PartitionIndexTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/format/bti/PartitionIndexTest.java
@@ -54,6 +54,7 @@ import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.dht.ByteOrderedPartitioner;
 import org.apache.cassandra.dht.IPartitioner;
 import org.apache.cassandra.dht.RandomPartitioner;
+import org.apache.cassandra.io.compress.CorruptBlockException;
 import org.apache.cassandra.io.tries.TrieNode;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileHandle;
@@ -148,7 +149,7 @@ public class PartitionIndexTest
             ch.write(generateRandomKey().getKey(), f.length() * 2 / 3);
         }
 
-        assertThatThrownBy(() -> testGetEq(data)).isInstanceOfAny(AssertionError.class, IndexOutOfBoundsException.class, IllegalArgumentException.class);
+        assertThatThrownBy(() -> testGetEq(data)).rootCause().isInstanceOfAny(AssertionError.class, IndexOutOfBoundsException.class, IllegalArgumentException.class, CorruptBlockException.class);
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/io/sstable/format/bti/RowIndexEncryptedTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/format/bti/RowIndexEncryptedTest.java
@@ -77,6 +77,7 @@ public class RowIndexEncryptedTest extends RowIndexTest
 
         FileHandle.Builder builder = new FileHandle.Builder(file)
                 .withCompressionMetadata(CompressionMetadata.encryptedOnly(compressionParams))
+                .encryptionOnly()
                 .mmapped(accessMode == Config.DiskAccessMode.mmap);
         
         fh = builder.complete();

--- a/test/unit/org/apache/cassandra/io/tries/AbstractTrieTestBase.java
+++ b/test/unit/org/apache/cassandra/io/tries/AbstractTrieTestBase.java
@@ -222,9 +222,16 @@ abstract public class AbstractTrieTestBase
             return 0;
         }
 
+        @Override
         public long adjustPosition(long position)
         {
             return position;
+        }
+
+        @Override
+        public long positionForSkip(long currentPosition, int bytesToSkip)
+        {
+            return currentPosition + bytesToSkip;
         }
 
         @Override

--- a/test/unit/org/apache/cassandra/io/util/WrappingRebuffererTest.java
+++ b/test/unit/org/apache/cassandra/io/util/WrappingRebuffererTest.java
@@ -143,6 +143,11 @@ public class WrappingRebuffererTest
             return position;
         }
 
+        public long positionForSkip(long currentPosition, int bytesToSkip)
+        {
+            return currentPosition + bytesToSkip;
+        }
+
         public void close()
         {
             // nothing


### PR DESCRIPTION
### What is the issue

[DSP-25176](https://datastax.jira.com/browse/DSP-25176) / [HCD-576](https://datastax.jira.com/browse/HCD-576)

Encrypted primary index files are written in a way that hides encryption metadata in holes in the file. Non-trie data like primary keys may span over these holes, which is handled correctly when we read these keys.
However, when we skip a key instead of reading it, we may end up in the wrong position if the key is longer than the metadata.

### What does this PR fix and why was it fixed

Sorts out multiple problems in sstable encryption setup to make sure it's compatible with CC 4 and survives restarts.
Implements skip position correction for encrypted primary index files.
Disables early opening for online scrub, which is unsafe because data may transiently disappear.
Makes sure that failed attempts to open a compaction result early are logged but do not stop the operation, by rolling back the prepared transaction checkpoint on error.
Ports over CASSANDRA-20976 to fix problems with early-open BTI files.
Adds tests.

CNDB PR: https://github.com/riptano/cndb/pull/19390

CC4 PR: https://github.com/datastax/cassandra/pull/2544
DSE PR: https://github.com/riptano/bdp/pull/21750


[DSP-25176]: https://datastax.jira.com/browse/DSP-25176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[HCD-576]: https://datastax.jira.com/browse/HCD-576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ