### PR TITLE
CNDB-17486: skip sonar.newCode.referenceBranch when analyzing main

### DIFF
--- a/.github/scripts/run_sonar_analysis.sh
+++ b/.github/scripts/run_sonar_analysis.sh
@@ -59,6 +59,12 @@ else
     -Dsonar.branch.name="$GIT_BRANCH"
     -Dsonar.links.scm="$GIT_REPO_URL/tree/$GIT_BRANCH"
   )
+
+  # Only set reference branch when analyzing a branch that is different from the base branch
+  # Sonar rejects setting the reference branch to the same branch being analyzed
+  if [[ "$GIT_BRANCH" != "$GIT_BASE_BRANCH" ]]; then
+    SONAR_ARGS+=(-Dsonar.newCode.referenceBranch="$GIT_BASE_BRANCH")
+  fi
 fi
 
 # Add debug flag if enabled


### PR DESCRIPTION
### What is the issue
Sonar rejects setting the reference branch to the same branch being analyzed. 

### What does this PR fix and why was it fixed
Only set sonar.newCode.referenceBranch when the current branch differs from the base branch.
