### PR TITLE
HCD-468: Port interval tree improvements from OSS C*

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Future version (tbd)
+ * Add SSTableIntervalTree latency metric (CASSANDRA-20502)
  * Improve IntervalTree build throughput (CASSANDRA-19596)
  * Compact all SSTables of a level shard if their number reaches a limit (CNDB-14577)
  * Require only MODIFY permission on base when updating table with MV (STAR-564)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Future version (tbd)
+ * Improve IntervalTree build throughput (CASSANDRA-19596)
  * Compact all SSTables of a level shard if their number reaches a limit (CNDB-14577)
  * Require only MODIFY permission on base when updating table with MV (STAR-564)
 Merged from 5.0:

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Future version (tbd)
+ * Support for add and replace in IntervalTree (CASSANDRA-20513)
  * Add SSTableIntervalTree latency metric (CASSANDRA-20502)
  * Improve IntervalTree build throughput (CASSANDRA-19596)
  * Compact all SSTables of a level shard if their number reaches a limit (CNDB-14577)

--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -540,7 +540,9 @@ public enum CassandraRelevantProperties
      * Do not try to calculate optimal streaming candidates. This can take a lot of time in some configs specially
      * with vnodes.
      */
-    SKIP_OPTIMAL_STREAMING_CANDIDATES_CALCULATION("cassandra.skip_optimal_streaming_candidates_calculation", "false");
+    SKIP_OPTIMAL_STREAMING_CANDIDATES_CALCULATION("cassandra.skip_optimal_streaming_candidates_calculation", "false"),
+
+    TEST_INTERVAL_TREE_EXPENSIVE_CHECKS("cassandra.test.interval_tree_expensive_checks");
 
     CassandraRelevantProperties(String key, String defaultVal)
     {

--- a/src/java/org/apache/cassandra/db/SizeEstimatesRecorder.java
+++ b/src/java/org/apache/cassandra/db/SizeEstimatesRecorder.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import com.google.common.collect.ImmutableList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -135,7 +136,7 @@ public class SizeEstimatesRecorder implements SchemaChangeListener, Runnable
                     while (refs == null)
                     {
                         Iterable<SSTableReader> sstables = table.getTracker().getView().select(SSTableSet.CANONICAL);
-                        SSTableIntervalTree tree = SSTableIntervalTree.build(sstables);
+                        SSTableIntervalTree tree = SSTableIntervalTree.buildSSTableIntervalTree(ImmutableList.copyOf(sstables));
                         Range<PartitionPosition> r = Range.makeRowRange(unwrappedRange);
                         Iterable<SSTableReader> canonicalSSTables = View.sstablesInBounds(r.left, r.right, tree);
                         refs = Refs.tryRef(canonicalSSTables);

--- a/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
@@ -53,6 +53,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Predicates;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Collections2;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -129,6 +130,7 @@ import org.apache.cassandra.utils.WrappedRunnable;
 import org.apache.cassandra.utils.concurrent.Refs;
 
 import static java.util.Collections.singleton;
+import static org.apache.cassandra.db.lifecycle.SSTableIntervalTree.buildSSTableIntervalTree;
 import static org.apache.cassandra.service.ActiveRepairService.NO_PENDING_REPAIR;
 import static org.apache.cassandra.service.ActiveRepairService.UNREPAIRED_SSTABLE;
 
@@ -1034,8 +1036,7 @@ public class CompactionManager implements CompactionManagerMBean
     {
         final Set<SSTableReader> sstables = new HashSet<>();
         Iterable<SSTableReader> liveTables = cfs.getTracker().getView().select(SSTableSet.LIVE);
-        SSTableIntervalTree tree = SSTableIntervalTree.build(liveTables);
-
+        SSTableIntervalTree tree = buildSSTableIntervalTree(ImmutableList.copyOf(liveTables));
         for (Range<Token> tokenRange : tokenRangeCollection)
         {
             if (!AbstractBounds.strictlyWrapsAround(tokenRange.left, tokenRange.right))

--- a/src/java/org/apache/cassandra/db/lifecycle/LifecycleTransaction.java
+++ b/src/java/org/apache/cassandra/db/lifecycle/LifecycleTransaction.java
@@ -154,7 +154,7 @@ public class LifecycleTransaction extends Transactional.AbstractTransactional im
     /**
      * construct a Transaction for use in an offline operation
      */
-    public static LifecycleTransaction offline(OperationType operationType, TableMetadataRef metadata, Iterable<SSTableReader> readers)
+    public static LifecycleTransaction offline(OperationType operationType, TableMetadataRef metadata, Collection<SSTableReader> readers)
     {
         // if offline, for simplicity we just use a dummy tracker
         Tracker dummy = Tracker.newDummyTracker(metadata);

--- a/src/java/org/apache/cassandra/db/lifecycle/LifecycleTransaction.java
+++ b/src/java/org/apache/cassandra/db/lifecycle/LifecycleTransaction.java
@@ -28,6 +28,7 @@ import com.google.common.util.concurrent.Runnables;
 
 import org.apache.cassandra.concurrent.ScheduledExecutors;
 import org.apache.cassandra.io.util.File;
+import com.google.common.collect.Maps;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,6 +51,7 @@ import static com.google.common.collect.ImmutableSet.copyOf;
 import static com.google.common.collect.Iterables.*;
 import static java.util.Collections.singleton;
 import static org.apache.cassandra.db.lifecycle.Helpers.*;
+import static org.apache.cassandra.db.lifecycle.View.replaceSSTables;
 import static org.apache.cassandra.db.lifecycle.View.updateCompacting;
 import static org.apache.cassandra.db.lifecycle.View.updateLiveSet;
 import static org.apache.cassandra.utils.Throwables.maybeFail;
@@ -280,7 +282,15 @@ public class LifecycleTransaction extends Transactional.AbstractTransactional im
         // replace all updated readers with a version restored to its original state
         List<SSTableReader> restored = restoreUpdatedOriginals();
         List<SSTableReader> invalid = Lists.newArrayList(Iterables.concat(logged.update, logged.obsolete));
-        accumulate = tracker.apply(updateLiveSet(logged.update, restored, tracker.maybeGetSSTableIntervalTreeLatencyMetrics()), accumulate);
+
+        Map<SSTableReader, SSTableReader> replacementMap = Collections.emptyMap();
+        if (!isOffline())
+            replacementMap = getReplacementMap(logged.update, restored);
+        if (!replacementMap.isEmpty())
+            accumulate = tracker.apply(replaceSSTables(logged.update, restored, replacementMap, tracker.maybeGetSSTableIntervalTreeLatencyMetrics()), accumulate);
+        else
+            accumulate = tracker.apply(updateLiveSet(logged.update, restored, tracker.maybeGetSSTableIntervalTreeLatencyMetrics()), accumulate);
+
         accumulate = tracker.notifySSTablesChanged(invalid, restored, OperationType.COMPACTION, Optional.of(log.id()), accumulate);
         // setReplaced immediately preceding versions that have not been obsoleted
         accumulate = setReplaced(logged.update, accumulate);
@@ -368,8 +378,15 @@ public class LifecycleTransaction extends Transactional.AbstractTransactional im
         // ensure any new readers are in the compacting set, since we aren't done with them yet
         // and don't want anyone else messing with them
         // apply atomically along with updating the live set of readers
-        tracker.apply(compose(updateCompacting(emptySet(), fresh),
-                              updateLiveSet(toUpdate, staged.update, tracker.maybeGetSSTableIntervalTreeLatencyMetrics())));
+        Map<SSTableReader, SSTableReader> replacementMap = Collections.emptyMap();
+        if (!isOffline())
+            replacementMap = getReplacementMap(toUpdate, staged.update);
+        if (!replacementMap.isEmpty())
+            tracker.apply(compose(updateCompacting(emptySet(), fresh),
+                                  replaceSSTables(toUpdate, staged.update, replacementMap, tracker.maybeGetSSTableIntervalTreeLatencyMetrics())));
+        else
+            tracker.apply(compose(updateCompacting(emptySet(), fresh),
+                                  updateLiveSet(toUpdate, staged.update, tracker.maybeGetSSTableIntervalTreeLatencyMetrics())));
 
         // log the staged changes and our newly marked readers
         marked.addAll(fresh);
@@ -384,6 +401,38 @@ public class LifecycleTransaction extends Transactional.AbstractTransactional im
         return accumulate;
     }
 
+    // Match the SSTableReaders from the existing ones to the new one to be added (with same ranges)
+    // Returns the map of toRemove <-> toAdd. Return empty map if such 1-1 replacement doesn't exist
+    private static Map<SSTableReader, SSTableReader> getReplacementMap(final Set<SSTableReader> remove, final Collection<SSTableReader> add)
+    {
+        if (remove.size() != add.size())
+            return Collections.emptyMap();
+
+        List<SSTableReader> toAdds = new ArrayList<>(add);
+        List<SSTableReader> toRemoves = new ArrayList<>(remove);
+        // sort the SSTableReader list by (first, last, descriptor.id). The view is per cfs so id will be unique
+        Comparator<SSTableReader> comp = Comparator.comparing((SSTableReader s) -> s.getFirst())
+                                                   .thenComparing(s -> s.getLast())
+                                                   .thenComparing(SSTableReader.idComparator);
+        toRemoves.sort(comp);
+        toAdds.sort(comp);
+
+        Map<SSTableReader, SSTableReader> replacementMap = Maps.newHashMapWithExpectedSize(toAdds.size());
+        // toAdd and toRemove have the same size
+        for (int i = 0; i < toAdds.size(); i++)
+        {
+            SSTableReader toRemove = toRemoves.get(i);
+            SSTableReader toAdd = toAdds.get(i);
+            // optimization: here we don't check the descriptor. If we're able to match those to be removed with those
+            // to be added, we ensure that the pairs have the same (first, last) range
+            if (toRemove.getFirst().equals(toAdd.getFirst()) && toRemove.getLast().equals(toAdd.getLast()))
+                replacementMap.put(toRemove, toAdd);
+            else
+                // stop and return empty map if toAdd and toRemove can't match
+                return Collections.emptyMap();
+        }
+        return replacementMap;
+    }
 
     /**
      * update a reader: if !original, this is a reader that is being introduced by this transaction;

--- a/src/java/org/apache/cassandra/db/lifecycle/LifecycleTransaction.java
+++ b/src/java/org/apache/cassandra/db/lifecycle/LifecycleTransaction.java
@@ -280,7 +280,7 @@ public class LifecycleTransaction extends Transactional.AbstractTransactional im
         // replace all updated readers with a version restored to its original state
         List<SSTableReader> restored = restoreUpdatedOriginals();
         List<SSTableReader> invalid = Lists.newArrayList(Iterables.concat(logged.update, logged.obsolete));
-        accumulate = tracker.apply(updateLiveSet(logged.update, restored), accumulate);
+        accumulate = tracker.apply(updateLiveSet(logged.update, restored, tracker.maybeGetSSTableIntervalTreeLatencyMetrics()), accumulate);
         accumulate = tracker.notifySSTablesChanged(invalid, restored, OperationType.COMPACTION, Optional.of(log.id()), accumulate);
         // setReplaced immediately preceding versions that have not been obsoleted
         accumulate = setReplaced(logged.update, accumulate);
@@ -369,7 +369,7 @@ public class LifecycleTransaction extends Transactional.AbstractTransactional im
         // and don't want anyone else messing with them
         // apply atomically along with updating the live set of readers
         tracker.apply(compose(updateCompacting(emptySet(), fresh),
-                              updateLiveSet(toUpdate, staged.update)));
+                              updateLiveSet(toUpdate, staged.update, tracker.maybeGetSSTableIntervalTreeLatencyMetrics())));
 
         // log the staged changes and our newly marked readers
         marked.addAll(fresh);

--- a/src/java/org/apache/cassandra/db/lifecycle/SSTableIntervalTree.java
+++ b/src/java/org/apache/cassandra/db/lifecycle/SSTableIntervalTree.java
@@ -20,11 +20,10 @@
  */
 package org.apache.cassandra.db.lifecycle;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
-
-import com.google.common.collect.Iterables;
 
 import org.apache.cassandra.db.PartitionPosition;
 import org.apache.cassandra.db.compaction.CompactionSSTable;
@@ -41,21 +40,49 @@ public class SSTableIntervalTree extends IntervalTree<PartitionPosition, SSTable
         super(intervals);
     }
 
+    private SSTableIntervalTree(Interval<PartitionPosition, SSTableReader>[] minOrder, Interval<PartitionPosition, SSTableReader>[] maxOrder)
+    {
+        super(minOrder, maxOrder);
+    }
+
+    @Override
+    protected SSTableIntervalTree create(Interval<PartitionPosition, SSTableReader>[] minOrder, Interval<PartitionPosition, SSTableReader>[] maxOrder)
+    {
+        return new SSTableIntervalTree(minOrder, maxOrder);
+    }
+
     public static SSTableIntervalTree empty()
     {
         return EMPTY;
     }
 
-    public static SSTableIntervalTree build(Iterable<SSTableReader> sstables)
+    public static SSTableIntervalTree buildSSTableIntervalTree(Collection<SSTableReader> sstables)
     {
+        if (sstables.isEmpty())
+            return EMPTY;
         return new SSTableIntervalTree(buildIntervals(sstables));
     }
 
-    public static <S extends CompactionSSTable> List<Interval<PartitionPosition, S>> buildIntervals(Iterable<? extends S> sstables)
+    public static List<Interval<PartitionPosition, SSTableReader>> buildIntervals(Collection<SSTableReader> sstables)
     {
-        List<Interval<PartitionPosition, S>> intervals = new ArrayList<>(Iterables.size(sstables));
-        for (S sstable : sstables)
-            intervals.add(Interval.create(sstable.getFirst(), sstable.getLast(), sstable));
+        if (sstables == null || sstables.isEmpty())
+            return Collections.emptyList();
+        return Arrays.asList(buildIntervalsArray(sstables));
+    }
+
+    public static Interval<PartitionPosition, SSTableReader>[] buildIntervalsArray(Collection<SSTableReader> sstables)
+    {
+        if (sstables == null || sstables.isEmpty())
+            return IntervalTree.EMPTY_ARRAY;
+        Interval<PartitionPosition, SSTableReader>[] intervals = new Interval[sstables.size()];
+        int i = 0;
+        for (SSTableReader sstable : sstables)
+            intervals[i++] = sstable.getInterval();
         return intervals;
+    }
+
+    public static SSTableIntervalTree update(SSTableIntervalTree tree, Collection<SSTableReader> removals, Collection<SSTableReader> additions)
+    {
+        return (SSTableIntervalTree) tree.update(buildIntervalsArray(removals), buildIntervalsArray(additions));
     }
 }

--- a/src/java/org/apache/cassandra/db/lifecycle/SSTableIntervalTree.java
+++ b/src/java/org/apache/cassandra/db/lifecycle/SSTableIntervalTree.java
@@ -1,5 +1,4 @@
 /*
- *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -20,16 +19,20 @@
  */
 package org.apache.cassandra.db.lifecycle;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+
+import com.google.common.collect.Iterables;
 
 import org.apache.cassandra.db.PartitionPosition;
-import org.apache.cassandra.db.compaction.CompactionSSTable;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.utils.Interval;
 import org.apache.cassandra.utils.IntervalTree;
+import org.apache.cassandra.utils.Pair;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 public class SSTableIntervalTree extends IntervalTree<PartitionPosition, SSTableReader, Interval<PartitionPosition, SSTableReader>>
 {
@@ -38,6 +41,11 @@ public class SSTableIntervalTree extends IntervalTree<PartitionPosition, SSTable
     SSTableIntervalTree(Collection<Interval<PartitionPosition, SSTableReader>> intervals)
     {
         super(intervals);
+    }
+
+    SSTableIntervalTree(IntervalNode head, int modCount, Interval<PartitionPosition, SSTableReader>[] minOrder, Interval<PartitionPosition, SSTableReader>[] maxOrder)
+    {
+        super(head, modCount, minOrder, maxOrder);
     }
 
     private SSTableIntervalTree(Interval<PartitionPosition, SSTableReader>[] minOrder, Interval<PartitionPosition, SSTableReader>[] maxOrder)
@@ -49,6 +57,25 @@ public class SSTableIntervalTree extends IntervalTree<PartitionPosition, SSTable
     protected SSTableIntervalTree create(Interval<PartitionPosition, SSTableReader>[] minOrder, Interval<PartitionPosition, SSTableReader>[] maxOrder)
     {
         return new SSTableIntervalTree(minOrder, maxOrder);
+    }
+
+    @Override
+    protected SSTableIntervalTree create(IntervalNode head, int modCount, Interval<PartitionPosition, SSTableReader>[] minOrder, Interval<PartitionPosition, SSTableReader>[] maxOrder)
+    {
+        return new SSTableIntervalTree(head, modCount, minOrder, maxOrder);
+    }
+
+    @Override
+    protected SSTableIntervalTree create(Collection<Interval<PartitionPosition, SSTableReader>> intervals)
+    {
+        return new SSTableIntervalTree(intervals);
+    }
+
+        @Override
+    public SSTableIntervalTree replace(List<Pair<Interval<PartitionPosition, SSTableReader>, Interval<PartitionPosition, SSTableReader>>> replacements)
+    {
+        checkArgument(!replacements.isEmpty(), "Shouldn't call replace with no replacements");
+        return (SSTableIntervalTree) super.replace(replacements);
     }
 
     public static SSTableIntervalTree empty()
@@ -65,12 +92,14 @@ public class SSTableIntervalTree extends IntervalTree<PartitionPosition, SSTable
 
     public static List<Interval<PartitionPosition, SSTableReader>> buildIntervals(Collection<SSTableReader> sstables)
     {
-        if (sstables == null || sstables.isEmpty())
-            return Collections.emptyList();
-        return Arrays.asList(buildIntervalsArray(sstables));
+        List<Interval<PartitionPosition, SSTableReader>> intervals = new ArrayList<>(Iterables.size(sstables));
+        for (SSTableReader sstable : sstables)
+            intervals.add(Interval.create(sstable.getFirst(), sstable.getLast(), sstable));
+        return intervals;
     }
 
-    public static Interval<PartitionPosition, SSTableReader>[] buildIntervalsArray(Collection<SSTableReader> sstables)
+    @SuppressWarnings("unchecked")
+    static Interval<PartitionPosition, SSTableReader>[] buildIntervalsArray(Collection<SSTableReader> sstables)
     {
         if (sstables == null || sstables.isEmpty())
             return IntervalTree.EMPTY_ARRAY;
@@ -84,5 +113,37 @@ public class SSTableIntervalTree extends IntervalTree<PartitionPosition, SSTable
     public static SSTableIntervalTree update(SSTableIntervalTree tree, Collection<SSTableReader> removals, Collection<SSTableReader> additions)
     {
         return (SSTableIntervalTree) tree.update(buildIntervalsArray(removals), buildIntervalsArray(additions));
+    }
+
+    /**
+     * Creates a new SSTableIntervalTree where SSTableReaders within the replacementMap are updated from the map's
+     * key to its value. The new SSTableIntervalTree shares some {@code IntervalNode} instances with
+     * the original tree. Only the nodes along the paths to the replaced SSTableReaders are recreated, minimizing
+     * the extent of changes to the tree structure.
+     *
+     * Assumption: all SSTableReader keys of replacementMap are present within the current SSTableIntervalTree.
+     *
+     * @param replacementMap Map of SSTableReader(s) (toRemove, toAdd) that need to be replaced within the tree
+     * @return A new SSTableIntervalTree, partially sharing structure with the original tree, but with the specified
+     *         SSTableReaders replaced.
+     */
+    public static SSTableIntervalTree replace(SSTableIntervalTree tree, Map<SSTableReader, SSTableReader> replacementMap)
+    {
+        checkArgument(!replacementMap.isEmpty(), "Replacement map shouldn't be empty for SSTableIntervalTree.replace");
+        List<Pair<Interval<PartitionPosition, SSTableReader>, Interval<PartitionPosition, SSTableReader>>> replacementIntervalsMap = new ArrayList<>();
+        for (Map.Entry<SSTableReader, SSTableReader> entry : replacementMap.entrySet())
+        {
+            SSTableReader originalSSTable = entry.getKey();
+            SSTableReader replacementSSTable = entry.getValue();
+            Interval<PartitionPosition, SSTableReader> originalInterval = originalSSTable.getInterval();
+            Interval<PartitionPosition, SSTableReader> replacementInterval = replacementSSTable.getInterval();
+            replacementIntervalsMap.add(Pair.create(originalInterval, replacementInterval));
+        }
+        return tree.replace(replacementIntervalsMap);
+    }
+
+    public static SSTableIntervalTree addSSTables(SSTableIntervalTree tree, Collection<SSTableReader> additions)
+    {
+        return (SSTableIntervalTree) tree.add(buildIntervalsArray(additions));
     }
 }

--- a/src/java/org/apache/cassandra/db/lifecycle/Tracker.java
+++ b/src/java/org/apache/cassandra/db/lifecycle/Tracker.java
@@ -26,7 +26,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantLock;
 import javax.annotation.Nullable;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -96,7 +96,10 @@ public class Tracker
 
     public final ColumnFamilyStore cfstore;
     public final TableMetadataRef metadata;
-    final AtomicReference<View> view;
+
+    // Constructing views update can be quite slow so locking generates less CPU/garbage compared to CAS
+    final ReentrantLock viewUpdateLock = new ReentrantLock(true);
+    volatile View view = null;
     public final boolean loadsstables;
 
     /**
@@ -108,7 +111,6 @@ public class Tracker
     {
         this.cfstore = Objects.requireNonNull(columnFamilyStore);
         this.metadata = columnFamilyStore.metadata;
-        this.view = new AtomicReference<>();
         this.loadsstables = loadsstables;
         this.reset(memtable);
     }
@@ -122,7 +124,6 @@ public class Tracker
     {
         this.cfstore = null;
         this.metadata = Objects.requireNonNull(metadata);
-        this.view = new AtomicReference<>();
         this.loadsstables = loadsstables;
         this.reset(memtable);
     }
@@ -185,15 +186,22 @@ public class Tracker
      */
     Pair<View, View> apply(Predicate<View> permit, Function<View, View> function)
     {
-        while (true)
+        View updated;
+        View cur;
+        viewUpdateLock.lock();
+        try
         {
-            View cur = view.get();
+            cur = view;
             if (!permit.apply(cur))
                 return null;
-            View updated = function.apply(cur);
-            if (view.compareAndSet(cur, updated))
-                return Pair.create(cur, updated);
+            updated = function.apply(cur);
+            view = updated;
         }
+        finally
+        {
+            viewUpdateLock.unlock();
+        }
+        return Pair.create(cur, updated);
     }
 
     Throwable updateSizeTracking(Iterable<SSTableReader> oldSSTables, Iterable<SSTableReader> newSSTables, Throwable accumulate)
@@ -246,12 +254,12 @@ public class Tracker
 
     // SETUP / CLEANUP
 
-    public void addInitialSSTables(Iterable<SSTableReader> sstables)
+    public void addInitialSSTables(Collection<SSTableReader> sstables)
     {
         addSSTablesInternal(sstables, OperationType.INITIAL_LOAD, true, false, true);
     }
 
-    public void addInitialSSTablesWithoutUpdatingSize(Iterable<SSTableReader> sstables)
+    public void addInitialSSTablesWithoutUpdatingSize(Collection<SSTableReader> sstables)
     {
         addSSTablesInternal(sstables, OperationType.INITIAL_LOAD, true, false, false);
     }
@@ -261,12 +269,12 @@ public class Tracker
         maybeFail(updateSizeTracking(emptySet(), sstables, null));
     }
 
-    public void addSSTables(Iterable<SSTableReader> sstables, OperationType operationType)
+    public void addSSTables(Collection<SSTableReader> sstables, OperationType operationType)
     {
         addSSTablesInternal(sstables, operationType, false, true, true);
     }
 
-    private void addSSTablesInternal(Iterable<SSTableReader> sstables,
+    private void addSSTablesInternal(Collection<SSTableReader> sstables,
                                      OperationType operationType,
                                      boolean isInitialSSTables,
                                      boolean maybeIncrementallyBackup,
@@ -287,11 +295,19 @@ public class Tracker
     @VisibleForTesting
     public void reset(Memtable memtable)
     {
-        view.set(new View(memtable != null ? singletonList(memtable) : Collections.emptyList(),
-                          Collections.emptyList(),
-                          Collections.emptyMap(),
-                          Collections.emptyMap(),
-                          SSTableIntervalTree.empty()));
+        viewUpdateLock.lock();
+        try
+        {
+            view = new View(memtable != null ? singletonList(memtable) : Collections.emptyList(),
+                            Collections.emptyList(),
+                            Collections.emptyMap(),
+                            Collections.emptyMap(),
+                            SSTableIntervalTree.empty());
+        }
+        finally
+        {
+            viewUpdateLock.unlock();
+        }
     }
 
     public Throwable dropOrUnloadSSTablesIfInvalid(String message, @Nullable Throwable accumulate)
@@ -440,12 +456,13 @@ public class Tracker
         // there may be multiple memtables in the list that would 'accept' us, however we only ever choose
         // the oldest such memtable, as accepts() only prevents us falling behind (i.e. ensures we don't
         // assign operations to a memtable that was retired/queued before we started)
-        for (Memtable memtable : view.get().liveMemtables)
+        View view = this.view;
+        for (Memtable memtable : view.liveMemtables)
         {
             if (memtable.accepts(opGroup, commitLogPosition))
                 return memtable;
         }
-        throw new AssertionError(view.get().liveMemtables.toString());
+        throw new AssertionError(view.liveMemtables.toString());
     }
 
     /**
@@ -472,7 +489,7 @@ public class Tracker
         apply(View.markFlushing(memtable));
     }
 
-    public void replaceFlushed(Memtable memtable, Iterable<SSTableReader> sstables, Optional<UUID> operationId)
+    public void replaceFlushed(Memtable memtable, Collection<SSTableReader> sstables, Optional<UUID> operationId)
     {
         assert !isDummy();
         if (Iterables.isEmpty(sstables))
@@ -511,29 +528,29 @@ public class Tracker
 
     public Set<SSTableReader> getCompacting()
     {
-        return view.get().compacting;
+        return view.compacting;
     }
 
     public Iterable<SSTableReader> getNoncompacting()
     {
-        return view.get().select(SSTableSet.NONCOMPACTING);
+        return view.select(SSTableSet.NONCOMPACTING);
     }
 
     public <S extends CompactionSSTable> Iterable<S> getNoncompacting(Iterable<S> candidates)
     {
-        return view.get().getNoncompacting(candidates);
+        return view.getNoncompacting(candidates);
     }
 
     public Set<SSTableReader> getLiveSSTables()
     {
-        return view.get().liveSSTables();
+        return view.liveSSTables();
     }
 
     // used by CNDB
     @Nullable
     public SSTableReader getLiveSSTable(String filename)
     {
-        return view.get().getLiveSSTable(filename);
+        return view.getLiveSSTable(filename);
     }
 
     public void maybeIncrementallyBackup(final Iterable<SSTableReader> sstables)
@@ -688,7 +705,7 @@ public class Tracker
 
     public View getView()
     {
-        return view.get();
+        return view;
     }
 
     @VisibleForTesting

--- a/src/java/org/apache/cassandra/db/lifecycle/Tracker.java
+++ b/src/java/org/apache/cassandra/db/lifecycle/Tracker.java
@@ -48,7 +48,9 @@ import org.apache.cassandra.db.memtable.Memtable;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileUtils;
+import org.apache.cassandra.metrics.LatencyMetrics;
 import org.apache.cassandra.metrics.StorageMetrics;
+import org.apache.cassandra.metrics.TableMetrics;
 import org.apache.cassandra.notifications.INotification;
 import org.apache.cassandra.notifications.INotificationConsumer;
 import org.apache.cassandra.notifications.InitialSSTableAddedNotification;
@@ -283,7 +285,7 @@ public class Tracker
         notifyAdding(sstables, operationType);
         if (!isDummy())
             setupOnline(cfstore, sstables);
-        apply(updateLiveSet(emptySet(), sstables));
+        apply(updateLiveSet(emptySet(), sstables, maybeGetSSTableIntervalTreeLatencyMetrics()));
         if(updateSize)
             maybeFail(updateSizeTracking(emptySet(), sstables, null));
         if (maybeIncrementallyBackup)
@@ -353,7 +355,7 @@ public class Tracker
         {
             Pair<View, View> result = apply(view -> {
                 Set<SSTableReader> toremove = copyOf(filter(view.sstables, and(remove, notIn(view.compacting))));
-                return updateLiveSet(toremove, emptySet()).apply(view);
+                return updateLiveSet(toremove, emptySet(), maybeGetSSTableIntervalTreeLatencyMetrics()).apply(view);
             });
 
             Set<SSTableReader> removed = Sets.difference(result.left.sstables, result.right.sstables);
@@ -382,7 +384,7 @@ public class Tracker
                 if (err == null && cfstore != null && cfstore.isValid())
                 {
                     // if the obsoletions were cancelled and the table is still valid, i.e. not dropped, restore the sstables since they are valid, and for CNDB they are in etcd as well
-                    err = apply(updateLiveSet(emptySet(), removed), accumulate);
+                    err = apply(updateLiveSet(emptySet(), removed, maybeGetSSTableIntervalTreeLatencyMetrics()), accumulate);
                 }
                 else if (cfstore != null && !cfstore.isValid())
                 {
@@ -423,7 +425,7 @@ public class Tracker
     {
         Pair<View, View> result = apply(view -> {
             Set<SSTableReader> toUnload = copyOf(filter(view.sstables, notIn(view.compacting)));
-            return updateLiveSet(toUnload, emptySet()).apply(view);
+            return updateLiveSet(toUnload, emptySet(), maybeGetSSTableIntervalTreeLatencyMetrics()).apply(view);
         });
 
         // compacting sstables will be cleaned up by their transaction in {@link LifecycleTransaction#unmarkCompacting}
@@ -496,7 +498,7 @@ public class Tracker
         {
             // sstable may be null if we flushed batchlog and nothing needed to be retained
             // if it's null, we don't care what state the cfstore is in, we just replace it and continue
-            apply(View.replaceFlushed(memtable, null));
+            apply(View.replaceFlushed(memtable, null, maybeGetSSTableIntervalTreeLatencyMetrics()));
             return;
         }
 
@@ -504,10 +506,11 @@ public class Tracker
         // back up before creating a new Snapshot (which makes the new one eligible for compaction)
         maybeIncrementallyBackup(sstables);
 
+
         Throwable fail;
         fail = notifyAdding(sstables, memtable, null, OperationType.FLUSH, operationId);
 
-        apply(View.replaceFlushed(memtable, sstables));
+        apply(View.replaceFlushed(memtable, sstables, maybeGetSSTableIntervalTreeLatencyMetrics()));
 
         fail = updateSizeTracking(emptySet(), sstables, fail);
 
@@ -711,12 +714,19 @@ public class Tracker
     @VisibleForTesting
     public void removeUnsafe(Set<SSTableReader> toRemove)
     {
-        apply(view -> updateLiveSet(toRemove, emptySet()).apply(view));
+        Pair<View, View> result = apply(view -> updateLiveSet(toRemove, emptySet(), maybeGetSSTableIntervalTreeLatencyMetrics()).apply(view));
     }
 
     @VisibleForTesting
     public void removeCompactingUnsafe(Set<SSTableReader> toRemove)
     {
         apply(view -> updateCompacting(toRemove, emptySet()).apply(view));
+    }
+
+    public TableMetrics.TableLatencyMetrics maybeGetSSTableIntervalTreeLatencyMetrics()
+    {
+        if (cfstore == null)
+            return null;
+        return cfstore.metric != null ? cfstore.metric.viewSSTableIntervalTree : null;
     }
 }

--- a/src/java/org/apache/cassandra/db/lifecycle/View.java
+++ b/src/java/org/apache/cassandra/db/lifecycle/View.java
@@ -36,6 +36,8 @@ import org.apache.cassandra.db.memtable.Memtable;
 import org.apache.cassandra.db.PartitionPosition;
 import org.apache.cassandra.dht.AbstractBounds;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.metrics.LatencyMetrics;
+import org.apache.cassandra.metrics.TableMetrics;
 import org.apache.cassandra.utils.Interval;
 
 import static com.google.common.base.Predicates.equalTo;
@@ -313,7 +315,7 @@ public class View
     }
 
     // construct a function to change the liveset in a Snapshot
-    static Function<View, View> updateLiveSet(final Set<SSTableReader> remove, final Collection<SSTableReader> add)
+    static Function<View, View> updateLiveSet(final Set<SSTableReader> remove, final Collection<SSTableReader> add, @Nullable TableMetrics.TableLatencyMetrics sstableIntervalTreeLatency)
     {
         if (remove.isEmpty() && Iterables.isEmpty(add))
             return Functions.identity();
@@ -322,8 +324,11 @@ public class View
             public View apply(View view)
             {
                 Map<SSTableReader, SSTableReader> sstableMap = replace(view.sstablesMap, remove, add);
-                return new View(view.liveMemtables, view.flushingMemtables, sstableMap, view.compactingMap,
-                                SSTableIntervalTree.update(view.intervalTree, remove, add));
+                long treeBuildStart = System.nanoTime();
+                SSTableIntervalTree sstableIntervalTree = SSTableIntervalTree.update(view.intervalTree, remove, add);
+                if (sstableIntervalTreeLatency != null)
+                    sstableIntervalTreeLatency.addNano(System.nanoTime() - treeBuildStart);
+                return new View(view.liveMemtables, view.flushingMemtables, sstableMap, view.compactingMap, sstableIntervalTree);
             }
         };
     }
@@ -362,7 +367,7 @@ public class View
     }
 
     // called after flush: removes memtable from flushingMemtables, and inserts flushed into the live sstable set
-    static Function<View, View> replaceFlushed(final Memtable memtable, final Collection<SSTableReader> flushed)
+    static Function<View, View> replaceFlushed(final Memtable memtable, final Collection<SSTableReader> flushed, @Nullable TableMetrics.TableLatencyMetrics sstableIntervalTreeLatency)
     {
         return new Function<View, View>()
         {
@@ -376,8 +381,11 @@ public class View
                                     view.compactingMap, view.intervalTree);
 
                 Map<SSTableReader, SSTableReader> sstableMap = replace(view.sstablesMap, emptySet(), flushed);
-                return new View(view.liveMemtables, flushingMemtables, sstableMap, view.compactingMap,
-                                    SSTableIntervalTree.update(view.intervalTree, null, flushed));
+                long treeBuildStart = System.nanoTime();
+                SSTableIntervalTree sstableIntervalTree = SSTableIntervalTree.update(view.intervalTree, null, flushed);
+                if (sstableIntervalTreeLatency != null)
+                    sstableIntervalTreeLatency.addNano(System.nanoTime() - treeBuildStart);
+                return new View(view.liveMemtables, flushingMemtables, sstableMap, view.compactingMap, sstableIntervalTree);
             }
         };
     }

--- a/src/java/org/apache/cassandra/db/lifecycle/View.java
+++ b/src/java/org/apache/cassandra/db/lifecycle/View.java
@@ -333,6 +333,23 @@ public class View
         };
     }
 
+    // construct a function to replace the SSTable that have the same [first,last] intervals
+    static Function<View, View> replaceSSTables(final Set<SSTableReader> remove, final Iterable<SSTableReader> add, final Map<SSTableReader, SSTableReader> replacementMap, TableMetrics.TableLatencyMetrics sstableIntervalTreeLatency)
+    {
+        return new Function<View, View>()
+        {
+            public View apply(View view)
+            {
+                Map<SSTableReader, SSTableReader> sstableMap = replace(view.sstablesMap, remove, add);
+                long treeBuildStart = System.nanoTime();
+                SSTableIntervalTree sstableIntervalTree = SSTableIntervalTree.replace(view.intervalTree, replacementMap);
+                if (sstableIntervalTreeLatency != null)
+                    sstableIntervalTreeLatency.addNano(System.nanoTime() - treeBuildStart);
+                return new View(view.liveMemtables, view.flushingMemtables, sstableMap, view.compactingMap, sstableIntervalTree);
+            }
+        };
+    }
+
     // called prior to initiating flush: add newMemtable to liveMemtables, making it the latest memtable
     static Function<View, View> switchMemtable(final Memtable newMemtable)
     {
@@ -382,7 +399,7 @@ public class View
 
                 Map<SSTableReader, SSTableReader> sstableMap = replace(view.sstablesMap, emptySet(), flushed);
                 long treeBuildStart = System.nanoTime();
-                SSTableIntervalTree sstableIntervalTree = SSTableIntervalTree.update(view.intervalTree, null, flushed);
+                SSTableIntervalTree sstableIntervalTree = SSTableIntervalTree.addSSTables(view.intervalTree, flushed);
                 if (sstableIntervalTreeLatency != null)
                     sstableIntervalTreeLatency.addNano(System.nanoTime() - treeBuildStart);
                 return new View(view.liveMemtables, flushingMemtables, sstableMap, view.compactingMap, sstableIntervalTree);

--- a/src/java/org/apache/cassandra/db/lifecycle/View.java
+++ b/src/java/org/apache/cassandra/db/lifecycle/View.java
@@ -313,7 +313,7 @@ public class View
     }
 
     // construct a function to change the liveset in a Snapshot
-    static Function<View, View> updateLiveSet(final Set<SSTableReader> remove, final Iterable<SSTableReader> add)
+    static Function<View, View> updateLiveSet(final Set<SSTableReader> remove, final Collection<SSTableReader> add)
     {
         if (remove.isEmpty() && Iterables.isEmpty(add))
             return Functions.identity();
@@ -323,7 +323,7 @@ public class View
             {
                 Map<SSTableReader, SSTableReader> sstableMap = replace(view.sstablesMap, remove, add);
                 return new View(view.liveMemtables, view.flushingMemtables, sstableMap, view.compactingMap,
-                                SSTableIntervalTree.build(sstableMap.keySet()));
+                                SSTableIntervalTree.update(view.intervalTree, remove, add));
             }
         };
     }
@@ -362,7 +362,7 @@ public class View
     }
 
     // called after flush: removes memtable from flushingMemtables, and inserts flushed into the live sstable set
-    static Function<View, View> replaceFlushed(final Memtable memtable, final Iterable<SSTableReader> flushed)
+    static Function<View, View> replaceFlushed(final Memtable memtable, final Collection<SSTableReader> flushed)
     {
         return new Function<View, View>()
         {
@@ -377,7 +377,7 @@ public class View
 
                 Map<SSTableReader, SSTableReader> sstableMap = replace(view.sstablesMap, emptySet(), flushed);
                 return new View(view.liveMemtables, flushingMemtables, sstableMap, view.compactingMap,
-                                SSTableIntervalTree.build(sstableMap.keySet()));
+                                    SSTableIntervalTree.update(view.intervalTree, null, flushed));
             }
         };
     }

--- a/src/java/org/apache/cassandra/db/streaming/CassandraStreamManager.java
+++ b/src/java/org/apache/cassandra/db/streaming/CassandraStreamManager.java
@@ -18,10 +18,19 @@
 
 package org.apache.cassandra.db.streaming;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.PartitionPosition;
 import org.apache.cassandra.db.lifecycle.SSTableIntervalTree;
@@ -43,13 +52,8 @@ import org.apache.cassandra.streaming.TableStreamManager;
 import org.apache.cassandra.streaming.messages.StreamMessageHeader;
 import org.apache.cassandra.utils.concurrent.Ref;
 import org.apache.cassandra.utils.concurrent.Refs;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Set;
+import static org.apache.cassandra.db.lifecycle.SSTableIntervalTree.buildSSTableIntervalTree;
 import java.util.UUID;
 
 /**
@@ -94,7 +98,7 @@ public class CassandraStreamManager implements TableStreamManager
                 keyRanges.add(Range.makeRowRange(replica.range()));
             refs.addAll(cfs.selectAndReference(view -> {
                 Set<SSTableReader> sstables = Sets.newHashSet();
-                SSTableIntervalTree intervalTree = SSTableIntervalTree.build(view.select(SSTableSet.CANONICAL));
+                SSTableIntervalTree intervalTree = buildSSTableIntervalTree(ImmutableList.copyOf(view.select(SSTableSet.CANONICAL)));
                 Predicate<SSTableReader> predicate;
                 if (previewKind.isPreview())
                 {

--- a/src/java/org/apache/cassandra/index/sai/SSTableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/SSTableIndex.java
@@ -59,7 +59,7 @@ import org.apache.cassandra.utils.CloseableIterator;
 /**
  * SSTableIndex is created for each column index on individual sstable to track per-column indexer.
  */
-public class SSTableIndex
+public class SSTableIndex implements Comparable<SSTableIndex>
 {
     private static final Logger logger = LoggerFactory.getLogger(SSTableIndex.class);
 
@@ -349,5 +349,12 @@ public class SSTableIndex
     protected final KeyRangeIterator allSSTableKeys(AbstractBounds<PartitionPosition> keyRange) throws IOException
     {
         return PrimaryKeyMapIterator.create(sstableContext, keyRange);
+    }
+
+    @Override
+    public int compareTo(SSTableIndex index)
+    {
+        // SSTableReader is truly unique for comparison which is relied on in IntervalTree
+        return getSSTable().compareTo(index.getSSTable());
     }
 }

--- a/src/java/org/apache/cassandra/index/sasi/SSTableIndex.java
+++ b/src/java/org/apache/cassandra/index/sasi/SSTableIndex.java
@@ -40,7 +40,7 @@ import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.io.util.RandomAccessReader;
 import org.apache.cassandra.utils.concurrent.Ref;
 
-public class SSTableIndex
+public class SSTableIndex implements Comparable<SSTableIndex>
 {
     private final ColumnIndex columnIndex;
     private final Ref<? extends SSTableReader> sstableRef;
@@ -161,6 +161,13 @@ public class SSTableIndex
     public String toString()
     {
         return String.format("SSTableIndex(column: %s, SSTable: %s)", columnIndex.getColumnName(), sstable.descriptor);
+    }
+
+    @Override
+    public int compareTo(SSTableIndex o)
+    {
+        // Relied on in IntervalTree to be unique
+        return sstable.compareTo(o.sstable);
     }
 
     private static class DecoratedKeyFetcher implements Function<Long, DecoratedKey>

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
@@ -143,8 +143,10 @@ import org.apache.cassandra.utils.ExecutorUtils;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.FilterFactory;
 import org.apache.cassandra.utils.IFilter;
+import org.apache.cassandra.utils.Interval;
 import org.apache.cassandra.utils.JVMStabilityInspector;
 import org.apache.cassandra.utils.Throwables;
+import org.apache.cassandra.utils.TimeUUID;
 import org.apache.cassandra.utils.concurrent.OpOrder;
 import org.apache.cassandra.utils.concurrent.Ref;
 import org.apache.cassandra.utils.concurrent.RefCounted;
@@ -211,7 +213,7 @@ import static org.apache.cassandra.db.Directories.SECONDARY_INDEX_NAME_SEPARATOR
  *
  * TODO: fill in details about Tracker and lifecycle interactions for tools, and for compaction strategies
  */
-public abstract class SSTableReader extends SSTable implements SelfRefCounted<SSTableReader>, CompactionSSTable
+public abstract class SSTableReader extends SSTable implements SelfRefCounted<SSTableReader>, CompactionSSTable, Comparable<SSTableReader>
 {
     private static final Logger logger = LoggerFactory.getLogger(SSTableReader.class);
 
@@ -232,8 +234,25 @@ public abstract class SSTableReader extends SSTable implements SelfRefCounted<SS
 
     public abstract boolean hasIndex();
 
+    private static final TimeUUID.Generator.Factory<UniqueIdentifier> UNIQUE_IDENTIFIER_FACTORY = new TimeUUID.Generator.Factory<UniqueIdentifier>()
+    {
+        @Override
+        public UniqueIdentifier fromUUID(UUID timeUUID)
+        {
+            return new UniqueIdentifier(timeUUID);
+        }
+    };
+
     // it's just an object, which we use regular Object equality on; we introduce a special class just for easy recognition
-    public static final class UniqueIdentifier {}
+    // Also includes a TimeUUID to make these sortable
+    public static final class UniqueIdentifier extends TimeUUID
+    {
+        private UniqueIdentifier(UUID timeUUID)
+        {
+            super(msbToRawTimestamp(timeUUID.getMostSignificantBits()), timeUUID.getLeastSignificantBits());
+        }
+    }
+    public final UniqueIdentifier instanceId = TimeUUID.Generator.nextTimeUUID(UNIQUE_IDENTIFIER_FACTORY);
 
     /**
      * maxDataAge is a timestamp in local server time (e.g. System.currentTimeMilli) which represents an upper bound
@@ -258,7 +277,6 @@ public abstract class SSTableReader extends SSTable implements SelfRefCounted<SS
     }
 
     public final OpenReason openReason;
-    public final UniqueIdentifier instanceId = new UniqueIdentifier();
 
     // indexfile and datafile: might be null before a call to load()
     protected final FileHandle ifile;
@@ -307,6 +325,8 @@ public abstract class SSTableReader extends SSTable implements SelfRefCounted<SS
     private RestorableMeter readMeter;
 
     private volatile double crcCheckChance;
+
+    private volatile Interval<PartitionPosition, SSTableReader> interval;
 
     public static <T extends SSTableReader> Iterable<T> selectOnlyBigTableReaders(Iterable<T> readers)
     {
@@ -818,6 +838,13 @@ public abstract class SSTableReader extends SSTable implements SelfRefCounted<SS
      */
     public abstract ScrubPartitionIterator scrubPartitionsIterator() throws IOException;
 
+    public Interval<PartitionPosition, SSTableReader> getInterval()
+    {
+        if (interval == null)
+            interval = Interval.create(first, last, this); // races are benign
+        return interval;
+    }
+
     public boolean equals(Object that)
     {
         return that instanceof SSTableReader && ((SSTableReader) that).descriptor.equals(this.descriptor);
@@ -826,6 +853,13 @@ public abstract class SSTableReader extends SSTable implements SelfRefCounted<SS
     public int hashCode()
     {
         return this.descriptor.hashCode();
+    }
+
+    @Override
+    public int compareTo(SSTableReader other)
+    {
+        // Used in IntervalTree with the expecation that compareTo uniquely identifies an SSTableReader
+        return instanceId.compareTo(other.instanceId);
     }
 
     public String getFilename()

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
@@ -858,7 +858,7 @@ public abstract class SSTableReader extends SSTable implements SelfRefCounted<SS
     @Override
     public int compareTo(SSTableReader other)
     {
-        // Used in IntervalTree with the expecation that compareTo uniquely identifies an SSTableReader
+        // Used in IntervalTree with the expectation that compareTo uniquely identifies an SSTableReader
         return instanceId.compareTo(other.instanceId);
     }
 

--- a/src/java/org/apache/cassandra/metrics/KeyspaceMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/KeyspaceMetrics.java
@@ -178,6 +178,8 @@ public class KeyspaceMetrics
     public final Histogram repairedDataTrackingOverreadRows;
     public final Timer repairedDataTrackingOverreadTime;
 
+    public final LatencyMetrics viewSSTableIntervalTree;
+
     public final MetricNameFactory factory;
     private Keyspace keyspace;
 
@@ -276,6 +278,8 @@ public class KeyspaceMetrics
 
         repairedDataTrackingOverreadRows = createKeyspaceHistogram("RepairedDataTrackingOverreadRows", false);
         repairedDataTrackingOverreadTime = createKeyspaceTimer("RepairedDataTrackingOverreadTime");
+
+        viewSSTableIntervalTree = createLatencyMetrics("ViewSSTableIntervalTree");
     }
 
     /**

--- a/src/java/org/apache/cassandra/metrics/TableMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/TableMetrics.java
@@ -101,6 +101,9 @@ public class TableMetrics
 
     public static final String TABLE_EXTENSIONS_HISTOGRAMS_METRICS_KEY = "HISTOGRAM_METRICS";
 
+    @VisibleForTesting // Length of the caching period for estimated partition count. Changed by tests.
+    static long ESTIMATED_PARTITION_COUNT_CACHE_PERIOD_SECONDS = TimeUnit.MINUTES.toSeconds(5);
+
     public enum MetricsAggregation
     {
         AGGREGATED((byte) 0x00),
@@ -656,7 +659,9 @@ public class TableMetrics
                 return estimatedPartitions;
             }
         }, null);
-        estimatedPartitionCountInSSTablesCached = new CachedGauge<Long>(1, TimeUnit.SECONDS)
+        // This cached guage is used by compaction to calculate a size for single-partition sstables. It does not need
+        // to be up-to-date, only to give a rough indication of the number of partitions.
+        estimatedPartitionCountInSSTablesCached = new CachedGauge<Long>(ESTIMATED_PARTITION_COUNT_CACHE_PERIOD_SECONDS, TimeUnit.SECONDS)
         {
             public Long loadValue()
             {

--- a/src/java/org/apache/cassandra/metrics/TableMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/TableMetrics.java
@@ -400,6 +400,9 @@ public class TableMetrics
      * */
     public final MetricsAggregation metricsAggregation;
 
+    // Time spent building SSTableIntervalTree when constructing a new View under the Tracker lock
+    public final TableLatencyMetrics viewSSTableIntervalTree;
+
     private static Pair<Long, Long> totalNonSystemTablesSize(Predicate<SSTableReader> predicate)
     {
         long total = 0;
@@ -1133,6 +1136,8 @@ public class TableMetrics
             }
             return cnt;
         });
+
+        viewSSTableIntervalTree = createLatencyMetrics("ViewSSTableIntervalTree", cfs.getKeyspaceMetrics().viewSSTableIntervalTree, Optional.empty());
     }
 
     public MovingAverage flushSizeOnDisk()

--- a/src/java/org/apache/cassandra/utils/Interval.java
+++ b/src/java/org/apache/cassandra/utils/Interval.java
@@ -65,35 +65,49 @@ public class Interval<C, D>
         return Objects.equal(min, that.min) && Objects.equal(max, that.max) && Objects.equal(data, that.data);
     }
 
-    private static final AsymmetricOrdering<Interval<Comparable, Object>, Comparable> minOrdering
-    = new AsymmetricOrdering<Interval<Comparable, Object>, Comparable>()
+    private static final AsymmetricOrdering<Interval<Comparable, Comparable>, Comparable> minOrdering
+    = new AsymmetricOrdering<Interval<Comparable, Comparable>, Comparable>()
     {
-        public int compareAsymmetric(Interval<Comparable, Object> left, Comparable right)
+        public int compareAsymmetric(Interval<Comparable, Comparable> left, Comparable right)
         {
             return left.min.compareTo(right);
         }
 
-        public int compare(Interval<Comparable, Object> i1, Interval<Comparable, Object> i2)
+        public int compare(Interval<Comparable, Comparable> i1, Interval<Comparable, Comparable> i2)
         {
-            return i1.min.compareTo(i2.min);
+            int cmpMin = i1.min.compareTo(i2.min);
+            if (cmpMin != 0)
+                return cmpMin;
+            int cmpMax = i1.max.compareTo(i2.max);
+            if (cmpMax != 0)
+                return cmpMax;
+            // Null is allowed if all data values are null otherwise NPE
+            return i1.data == i2.data ? 0 : i1.data.compareTo(i2.data);
         }
     };
 
-    private static final AsymmetricOrdering<Interval<Comparable, Object>, Comparable> maxOrdering
-    = new AsymmetricOrdering<Interval<Comparable, Object>, Comparable>()
+    private static final AsymmetricOrdering<Interval<Comparable, Comparable>, Comparable> maxOrdering
+    = new AsymmetricOrdering<Interval<Comparable, Comparable>, Comparable>()
     {
-        public int compareAsymmetric(Interval<Comparable, Object> left, Comparable right)
+        public int compareAsymmetric(Interval<Comparable, Comparable> left, Comparable right)
         {
             return left.max.compareTo(right);
         }
 
-        public int compare(Interval<Comparable, Object> i1, Interval<Comparable, Object> i2)
+        public int compare(Interval<Comparable, Comparable> i1, Interval<Comparable, Comparable> i2)
         {
-            return i1.max.compareTo(i2.max);
+            int cmpMax = i1.max.compareTo(i2.max);
+            if (cmpMax != 0)
+                return cmpMax;
+            int cmpMin = i1.min.compareTo(i2.min);
+            if (cmpMin != 0)
+                return cmpMin;
+            // Null is allowed if all data values are null otherwise NPE
+            return i1.data == i2.data ? 0 : i1.data.compareTo(i2.data);
         }
     };
 
-    private static final AsymmetricOrdering<Interval<Comparable, Object>, Comparable> reverseMaxOrdering = maxOrdering.reverse();
+    private static final AsymmetricOrdering<Interval<Comparable, Comparable>, Comparable> reverseMaxOrdering = maxOrdering.reverse();
 
     public static <C extends Comparable<? super C>, V> AsymmetricOrdering<Interval<C, V>, C> minOrdering()
     {

--- a/src/java/org/apache/cassandra/utils/IntervalTree.java
+++ b/src/java/org/apache/cassandra/utils/IntervalTree.java
@@ -17,62 +17,110 @@
  */
 package org.apache.cassandra.utils;
 
-import java.io.IOException;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
-import java.util.*;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.List;
 
 import com.google.common.base.Joiner;
-import org.apache.cassandra.utils.AbstractIterator;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.apache.cassandra.db.TypeSizes;
-import org.apache.cassandra.io.ISerializer;
-import org.apache.cassandra.io.IVersionedSerializer;
-import org.apache.cassandra.io.util.DataInputPlus;
-import org.apache.cassandra.io.util.DataOutputPlus;
+
 import org.apache.cassandra.utils.AsymmetricOrdering.Op;
 
-public class IntervalTree<C extends Comparable<? super C>, D, I extends Interval<C, D>> implements Iterable<I>
+import static com.google.common.base.Preconditions.checkState;
+import static org.apache.cassandra.config.CassandraRelevantProperties.TEST_INTERVAL_TREE_EXPENSIVE_CHECKS;
+
+public class IntervalTree<C extends Comparable<? super C>, D extends Comparable<? super D>, I extends Interval<C, D>> implements Iterable<I>
 {
+    public static final boolean EXPENSIVE_CHECKS = TEST_INTERVAL_TREE_EXPENSIVE_CHECKS.getBoolean();
+
     private static final Logger logger = LoggerFactory.getLogger(IntervalTree.class);
+
+    public static final Interval[] EMPTY_ARRAY = new Interval[0];
 
     @SuppressWarnings("unchecked")
     private static final IntervalTree EMPTY_TREE = new IntervalTree(null);
 
     private final IntervalNode head;
-    private final int count;
+    private final I[] intervalsByMinOrder;
+    private final I[] intervalsByMaxOrder;
 
     protected IntervalTree(Collection<I> intervals)
     {
-        this.head = intervals == null || intervals.isEmpty() ? null : new IntervalNode(intervals);
-        this.count = intervals == null ? 0 : intervals.size();
+        if (intervals == null || intervals.isEmpty())
+        {
+            this.head = null;
+            intervalsByMinOrder = intervalsByMaxOrder = (I[])EMPTY_ARRAY;
+        }
+        else if (intervals.size() == 1)
+        {
+            intervalsByMinOrder = intervalsByMaxOrder = (I[])new Interval[] { intervals.iterator().next() };
+            this.head = new IntervalNode(intervals);
+        }
+        else
+        {
+            intervalsByMinOrder = intervals.toArray((I[])EMPTY_ARRAY);
+            Arrays.sort(intervalsByMinOrder, Interval.minOrdering());
+            intervalsByMaxOrder = intervals.toArray((I[])EMPTY_ARRAY);
+            Arrays.sort(intervalsByMaxOrder, Interval.maxOrdering());
+            this.head = new IntervalNode(Arrays.asList(intervalsByMinOrder), Arrays.asList(intervalsByMaxOrder));
+        }
     }
 
-    public static <C extends Comparable<? super C>, D, I extends Interval<C, D>> IntervalTree<C, D, I> build(Collection<I> intervals)
+    /**
+     * This constructor will not modify minSortedIntervals and maxSortedIntervals, but it also won't
+     * make defensive copies and will keep the originals.
+     */
+    protected IntervalTree(I[] minSortedIntervals, I[] maxSortedIntervals)
+    {
+        if (minSortedIntervals == null || minSortedIntervals.length == 0)
+        {
+            this.head = null;
+            intervalsByMinOrder = intervalsByMaxOrder = (I[])EMPTY_ARRAY;
+        }
+        else if (minSortedIntervals.length == 1)
+        {
+            intervalsByMinOrder = intervalsByMaxOrder = minSortedIntervals;
+            List<I> intervals = Collections.singletonList(minSortedIntervals[0]);
+            this.head = new IntervalNode(intervals, intervals);
+        }
+        else
+        {
+            intervalsByMinOrder = minSortedIntervals;
+            intervalsByMaxOrder = maxSortedIntervals;
+            this.head = new IntervalNode(Arrays.asList(minSortedIntervals), Arrays.asList(maxSortedIntervals));
+        }
+    }
+
+    protected IntervalTree<C, D, I> create(I[] minOrder, I[] maxOrder)
+    {
+        return new IntervalTree(minOrder, maxOrder);
+    }
+
+    public static <C extends Comparable<? super C>, D extends Comparable<? super D>, I extends Interval<C, D>> IntervalTree<C, D, I> build(Collection<I> intervals)
     {
         if (intervals == null || intervals.isEmpty())
             return emptyTree();
 
-        return new IntervalTree<C, D, I>(intervals);
-    }
-
-    public static <C extends Comparable<? super C>, D, I extends Interval<C, D>> Serializer<C, D, I> serializer(ISerializer<C> pointSerializer, ISerializer<D> dataSerializer, Constructor<I> constructor)
-    {
-        return new Serializer<>(pointSerializer, dataSerializer, constructor);
+        return new IntervalTree<>(intervals);
     }
 
     @SuppressWarnings("unchecked")
-    public static <C extends Comparable<? super C>, D, I extends Interval<C, D>> IntervalTree<C, D, I> emptyTree()
+    public static <C extends Comparable<? super C>, D extends Comparable<? super D>, I extends Interval<C, D>> IntervalTree<C, D, I> emptyTree()
     {
         return EMPTY_TREE;
     }
 
     public int intervalCount()
     {
-        return count;
+        return intervalsByMinOrder.length;
     }
 
     public boolean isEmpty()
@@ -111,6 +159,123 @@ public class IntervalTree<C extends Comparable<? super C>, D, I extends Interval
         return search(Interval.<C, D>create(point, point, null));
     }
 
+    /**
+     * The input arrays aren't defensively copied and will be sorted. The update method doesn't allow duplicates or elements to be removed
+     * to be missing and this differs from the constructor which does not duplicate checking at all.
+     *
+     * It made more sense for update to be stricter because it is tracking removals and additions explicitly instead of building
+     * a list from scratch and in the targeted use case of a list of SSTables there are no duplicates. At a given point in time
+     * an sstable represents exactly one interval (although it may switch via removal and addition as in early open).
+     */
+    public IntervalTree<C, D, I> update(I[] removals, I[] additions)
+    {
+        if (removals == null)
+            removals = (I[])EMPTY_ARRAY;
+        if (additions == null)
+            additions = (I[])EMPTY_ARRAY;
+
+        if (removals.length == 0 && additions.length == 0)
+        {
+            return this;
+        }
+
+        Arrays.sort(removals, Interval.<C, D>minOrdering());
+        Arrays.sort(additions, Interval.<C, D>minOrdering());
+
+        for (int i = 1; i < additions.length; i++)
+            checkState( Interval.<C, D>minOrdering().compare(additions[i], additions[i-1]) != 0, "Duplicate interval in additions %s", additions[i]);
+
+        I[] newByMin = buildUpdatedArray(
+            intervalsByMinOrder,
+            removals,
+            additions,
+            Interval.<C, D>minOrdering()
+        );
+
+        Arrays.sort(removals, Interval.<C, D>maxOrdering());
+        Arrays.sort(additions, Interval.<C, D>maxOrdering());
+
+        I[] newByMax = buildUpdatedArray(
+            intervalsByMaxOrder,
+            removals,
+            additions,
+            Interval.<C, D>maxOrdering()
+        );
+
+        return create(newByMin, newByMax);
+    }
+
+    @SuppressWarnings("unchecked")
+    private I[] buildUpdatedArray(I[] existingSorted,
+                                  I[] removalsSorted,
+                                  I[] additionsSorted,
+                                  AsymmetricOrdering<Interval<C, D>, C> cmp)
+    {
+        int finalSize = existingSorted.length + additionsSorted.length - removalsSorted.length;
+        I[] result = (I[]) new Interval[finalSize];
+
+        int existingIndex  = 0;
+        int removalsIndex  = 0;
+        int additionsIndex = 0;
+        int resultIndex    = 0;
+
+        while (existingIndex < existingSorted.length)
+        {
+            I currentExisting = existingSorted[existingIndex];
+
+            int c;
+            while (removalsIndex < removalsSorted.length
+                   && (c = cmp.compare(removalsSorted[removalsIndex], currentExisting)) <= 0)
+            {
+                if (c < 0)
+                {
+                    throw new IllegalStateException("Removal interval not found in the existing tree: " + removalsSorted[removalsIndex]);
+                }
+                else
+                {
+                    existingIndex++;
+                    removalsIndex++;
+
+                    if (existingIndex >= existingSorted.length)
+                        break;
+                    currentExisting = existingSorted[existingIndex];
+                }
+            }
+
+            if (existingIndex >= existingSorted.length )
+                break;
+
+            while (additionsIndex < additionsSorted.length)
+            {
+                int additionCmp = cmp.compare(additionsSorted[additionsIndex], currentExisting);
+                if (additionCmp == 0)
+                    throw new IllegalStateException("Attempting to add duplicate interval: " + additionsSorted[additionsIndex]);
+                else if (additionCmp < 0)
+                    result[resultIndex++] = additionsSorted[additionsIndex++];
+                else
+                    break;
+            }
+
+            result[resultIndex++] = currentExisting;
+            existingIndex++;
+        }
+
+        if (removalsIndex < removalsSorted.length)
+            throw new IllegalStateException("Removal interval not found in the existing tree: " + removalsSorted[removalsIndex]);
+
+        while (additionsIndex < additionsSorted.length)
+            result[resultIndex++] = additionsSorted[additionsIndex++];
+
+        if (EXPENSIVE_CHECKS)
+        {
+            if (result.length > 1)
+                for (int i = 1; i < result.length; i++)
+                    checkState(cmp.compare(result[i - 1], result[i]) < 0, "%s and %s out of order", result[i-1], result[i]);
+        }
+
+        return result;
+    }
+
     public Iterator<I> iterator()
     {
         if (head == null)
@@ -122,7 +287,7 @@ public class IntervalTree<C extends Comparable<? super C>, D, I extends Interval
     @Override
     public String toString()
     {
-        return "<" + Joiner.on(", ").join(this) + ">";
+        return "<" + Joiner.on(", ").join(Iterables.limit(this, 100)) + ">";
     }
 
     @Override
@@ -143,7 +308,7 @@ public class IntervalTree<C extends Comparable<? super C>, D, I extends Interval
         return result;
     }
 
-    private class IntervalNode
+    protected class IntervalNode
     {
         final C center;
         final C low;
@@ -157,14 +322,28 @@ public class IntervalTree<C extends Comparable<? super C>, D, I extends Interval
 
         public IntervalNode(Collection<I> toBisect)
         {
-            assert !toBisect.isEmpty();
-            logger.trace("Creating IntervalNode from {}", toBisect);
+            assert toBisect.size() == 1;
+            I interval = toBisect.iterator().next();
+            low = interval.min;
+            center = interval.max;
+            high = interval.max;
+            List<I> l = Collections.singletonList(interval);
+            intersectsLeft = l;
+            intersectsRight = l;
+            left = null;
+            right = null;
+        }
+
+        public IntervalNode(List<I> minOrder, List<I> maxOrder)
+        {
+            assert !minOrder.isEmpty();
+            logger.trace("Creating IntervalNode from {}", minOrder);
 
             // Building IntervalTree with one interval will be a reasonably
             // common case for range tombstones, so it's worth optimizing
-            if (toBisect.size() == 1)
+            if (minOrder.size() == 1)
             {
-                I interval = toBisect.iterator().next();
+                I interval = minOrder.iterator().next();
                 low = interval.min;
                 center = interval.max;
                 high = interval.max;
@@ -173,50 +352,82 @@ public class IntervalTree<C extends Comparable<? super C>, D, I extends Interval
                 intersectsRight = l;
                 left = null;
                 right = null;
+                return;
             }
-            else
+
+            low = minOrder.get(0).min;
+            high = maxOrder.get(maxOrder.size() - 1).max;
+
+            int i = 0, j = 0, count = 0;
+            while (count < minOrder.size())
             {
-                // Find min, median and max
-                List<C> allEndpoints = new ArrayList<C>(toBisect.size() * 2);
-                for (I interval : toBisect)
+                if (i < minOrder.size() && (j >= maxOrder.size() || minOrder.get(i).min.compareTo(maxOrder.get(j).max) <= 0))
+                    i++;
+                else
+                    j++;
+                count++;
+            }
+
+            if (i < minOrder.size() && (j >= maxOrder.size() || minOrder.get(i).min.compareTo(maxOrder.get(j).max) < 0))
+                center = minOrder.get(i).min;
+            else
+                center = maxOrder.get(j).max;
+
+            if (EXPENSIVE_CHECKS)
+            {
+                List<C> allEndpoints = new ArrayList<C>(minOrder.size() * 2);
+                for (I interval : minOrder)
                 {
                     allEndpoints.add(interval.min);
                     allEndpoints.add(interval.max);
                 }
 
                 Collections.sort(allEndpoints);
-
-                low = allEndpoints.get(0);
-                center = allEndpoints.get(toBisect.size());
-                high = allEndpoints.get(allEndpoints.size() - 1);
-
-                // Separate interval in intersecting center, left of center and right of center
-                List<I> intersects = new ArrayList<I>();
-                List<I> leftSegment = new ArrayList<I>();
-                List<I> rightSegment = new ArrayList<I>();
-
-                for (I candidate : toBisect)
-                {
-                    if (candidate.max.compareTo(center) < 0)
-                        leftSegment.add(candidate);
-                    else if (candidate.min.compareTo(center) > 0)
-                        rightSegment.add(candidate);
-                    else
-                        intersects.add(candidate);
-                }
-
-                intersectsLeft = Interval.<C, D>minOrdering().sortedCopy(intersects);
-                intersectsRight = Interval.<C, D>maxOrdering().sortedCopy(intersects);
-                left = leftSegment.isEmpty() ? null : new IntervalNode(leftSegment);
-                right = rightSegment.isEmpty() ? null : new IntervalNode(rightSegment);
-
-                assert (intersects.size() + leftSegment.size() + rightSegment.size()) == toBisect.size() :
-                        "intersects (" + String.valueOf(intersects.size()) +
-                        ") + leftSegment (" + String.valueOf(leftSegment.size()) +
-                        ") + rightSegment (" + String.valueOf(rightSegment.size()) +
-                        ") != toBisect (" + String.valueOf(toBisect.size()) + ")";
+                C expectedCenter = allEndpoints.get(minOrder.size());
+                checkState(expectedCenter.equals(center));
             }
+
+            // Separate interval in intersecting center, left of center and right of center
+            int initialIntersectionSize = i - j + 1;
+            intersectsLeft = new ArrayList<I>(initialIntersectionSize);
+            intersectsRight = new ArrayList<I>(initialIntersectionSize);
+            int initialChildSize = Math.min(i, j);
+            List<I> leftSegmentMinOrder = new ArrayList<I>(initialChildSize);
+            List<I> leftSegmentMaxOrder = new ArrayList<>(initialChildSize);
+            List<I> rightSegmentMinOrder = new ArrayList<I>(initialChildSize);
+            List<I> rightSegmentMaxOrder = new ArrayList<>(initialChildSize);
+
+            for (I candidate : minOrder)
+            {
+                if (candidate.max.compareTo(center) < 0)
+                    leftSegmentMinOrder.add(candidate);
+                else if (candidate.min.compareTo(center) > 0)
+                    rightSegmentMinOrder.add(candidate);
+                else
+                    intersectsLeft.add(candidate);
+            }
+
+            for (I candidate : maxOrder)
+            {
+                if (candidate.max.compareTo(center) < 0)
+                    leftSegmentMaxOrder.add(candidate);
+                else if (candidate.min.compareTo(center) > 0)
+                    rightSegmentMaxOrder.add(candidate);
+                else
+                    intersectsRight.add(candidate);
+            }
+
+            left = leftSegmentMinOrder.isEmpty() ? null : new IntervalNode(leftSegmentMinOrder, leftSegmentMaxOrder);
+            right = rightSegmentMinOrder.isEmpty() ? null : new IntervalNode(rightSegmentMinOrder, rightSegmentMaxOrder);
+
+            assert (intersectsLeft.size() == intersectsRight.size());
+            assert (intersectsLeft.size() + leftSegmentMinOrder.size() + rightSegmentMinOrder.size()) == minOrder.size() :
+            "intersects (" + String.valueOf(intersectsLeft.size()) +
+            ") + leftSegment (" + String.valueOf(leftSegmentMinOrder.size()) +
+            ") + rightSegment (" + String.valueOf(rightSegmentMinOrder.size()) +
+            ") != toBisect (" + String.valueOf(minOrder.size()) + ")";
         }
+
 
         void searchInternal(Interval<C, D> searchInterval, List<D> results)
         {
@@ -297,75 +508,6 @@ public class IntervalTree<C extends Comparable<? super C>, D, I extends Interval
                 node = node.left;
             }
 
-        }
-    }
-
-    public static class Serializer<C extends Comparable<? super C>, D, I extends Interval<C, D>> implements IVersionedSerializer<IntervalTree<C, D, I>>
-    {
-        private final ISerializer<C> pointSerializer;
-        private final ISerializer<D> dataSerializer;
-        private final Constructor<I> constructor;
-
-        private Serializer(ISerializer<C> pointSerializer, ISerializer<D> dataSerializer, Constructor<I> constructor)
-        {
-            this.pointSerializer = pointSerializer;
-            this.dataSerializer = dataSerializer;
-            this.constructor = constructor;
-        }
-
-        public void serialize(IntervalTree<C, D, I> it, DataOutputPlus out, int version) throws IOException
-        {
-            out.writeInt(it.count);
-            for (Interval<C, D> interval : it)
-            {
-                pointSerializer.serialize(interval.min, out);
-                pointSerializer.serialize(interval.max, out);
-                dataSerializer.serialize(interval.data, out);
-            }
-        }
-
-        /**
-         * Deserialize an IntervalTree whose keys use the natural ordering.
-         * Use deserialize(DataInput, int, Comparator) instead if the interval
-         * tree is to use a custom comparator, as the comparator is *not*
-         * serialized.
-         */
-        public IntervalTree<C, D, I> deserialize(DataInputPlus in, int version) throws IOException
-        {
-            return deserialize(in, version, null);
-        }
-
-        public IntervalTree<C, D, I> deserialize(DataInputPlus in, int version, Comparator<C> comparator) throws IOException
-        {
-            try
-            {
-                int count = in.readInt();
-                List<I> intervals = new ArrayList<I>(count);
-                for (int i = 0; i < count; i++)
-                {
-                    C min = pointSerializer.deserialize(in);
-                    C max = pointSerializer.deserialize(in);
-                    D data = dataSerializer.deserialize(in);
-                    intervals.add(constructor.newInstance(min, max, data));
-                }
-                return new IntervalTree<C, D, I>(intervals);
-            }
-            catch (InstantiationException | InvocationTargetException | IllegalAccessException e)
-            {
-                throw new RuntimeException(e);
-            }
-        }
-
-        public long serializedSize(IntervalTree<C, D, I> it, int version)
-        {
-            long size = TypeSizes.sizeof(0);
-            for (Interval<C, D> interval : it)
-            {
-                size += pointSerializer.serializedSize(interval.min);
-                size += pointSerializer.serializedSize(interval.max);
-                size += dataSerializer.serializedSize(interval.data);
-            }
-            return size;
         }
     }
 }

--- a/src/java/org/apache/cassandra/utils/IntervalTree.java
+++ b/src/java/org/apache/cassandra/utils/IntervalTree.java
@@ -17,14 +17,16 @@
  */
 package org.apache.cassandra.utils;
 
-import java.util.ArrayDeque;
+import java.util.AbstractCollection;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Deque;
 import java.util.Iterator;
 import java.util.List;
+import java.util.function.BiPredicate;
+import java.util.function.Predicate;
+import javax.annotation.Nullable;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.Iterables;
@@ -34,26 +36,45 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.utils.AsymmetricOrdering.Op;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static org.apache.cassandra.config.CassandraRelevantProperties.TEST_INTERVAL_TREE_EXPENSIVE_CHECKS;
 
 public class IntervalTree<C extends Comparable<? super C>, D extends Comparable<? super D>, I extends Interval<C, D>> implements Iterable<I>
 {
     public static final boolean EXPENSIVE_CHECKS = TEST_INTERVAL_TREE_EXPENSIVE_CHECKS.getBoolean();
+    private static final int REBUILD_AT_MOD_COUNT = 20;
 
     private static final Logger logger = LoggerFactory.getLogger(IntervalTree.class);
 
+    @SuppressWarnings("rawtypes")
     public static final Interval[] EMPTY_ARRAY = new Interval[0];
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "rawtypes"})
     private static final IntervalTree EMPTY_TREE = new IntervalTree(null);
 
     private final IntervalNode head;
+
+    /**
+     * Add can potentially unbalance the interval tree each time so force a rebuild after a certain number
+     * of adds to bound how unbalanced the worst path in the tree can become.
+     *
+     * In practice it's likely the tree will have been rebuilt anyways long before it hits mod count, but it's not
+     * good to leave it unbounded.
+     *
+     * Napkin math is a 100k interval tree is a large tree and lg2(100k) is 16 (lg2(1million) is 20) so by bounding it at 20 then
+     * the worst possible imbalance is a bit more than double a balanced tree.
+     */
+    protected final int modCount;
+
     private final I[] intervalsByMinOrder;
     private final I[] intervalsByMaxOrder;
 
+    @SuppressWarnings("unchecked")
     protected IntervalTree(Collection<I> intervals)
     {
+        this.modCount = 0;
         if (intervals == null || intervals.isEmpty())
         {
             this.head = null;
@@ -72,14 +93,25 @@ public class IntervalTree<C extends Comparable<? super C>, D extends Comparable<
             Arrays.sort(intervalsByMaxOrder, Interval.maxOrdering());
             this.head = new IntervalNode(Arrays.asList(intervalsByMinOrder), Arrays.asList(intervalsByMaxOrder));
         }
+        if (EXPENSIVE_CHECKS)
+        {
+            if (intervalsByMinOrder.length > 1)
+                for (int i = 1; i < intervalsByMinOrder.length; i++)
+                    checkState(Interval.<C, D>minOrdering().compare(intervalsByMinOrder[i - 1], intervalsByMinOrder[i]) <= 0, "%s and %s out of order", intervalsByMinOrder[i-1], intervalsByMinOrder[i]);
+            if (intervalsByMaxOrder.length > 1)
+                for (int i = 1; i < intervalsByMaxOrder.length; i++)
+                    checkState(Interval.<C, D>maxOrdering().compare(intervalsByMaxOrder[i - 1], intervalsByMaxOrder[i]) <= 0, "%s and %s out of order", intervalsByMaxOrder[i-1], intervalsByMaxOrder[i]);
+        }
     }
 
     /**
      * This constructor will not modify minSortedIntervals and maxSortedIntervals, but it also won't
      * make defensive copies and will keep the originals.
      */
+    @SuppressWarnings("unchecked")
     protected IntervalTree(I[] minSortedIntervals, I[] maxSortedIntervals)
     {
+        this.modCount = 0;
         if (minSortedIntervals == null || minSortedIntervals.length == 0)
         {
             this.head = null;
@@ -97,11 +129,50 @@ public class IntervalTree<C extends Comparable<? super C>, D extends Comparable<
             intervalsByMaxOrder = maxSortedIntervals;
             this.head = new IntervalNode(Arrays.asList(minSortedIntervals), Arrays.asList(maxSortedIntervals));
         }
+
+        if (EXPENSIVE_CHECKS)
+        {
+            if (intervalsByMinOrder.length > 1)
+                for (int i = 1; i < intervalsByMinOrder.length; i++)
+                    checkState(Interval.<C, D>minOrdering().compare(intervalsByMinOrder[i - 1], intervalsByMinOrder[i]) < 0, "%s and %s out of order", intervalsByMinOrder[i-1], intervalsByMinOrder[i]);
+            if (intervalsByMaxOrder.length > 1)
+                for (int i = 1; i < intervalsByMaxOrder.length; i++)
+                    checkState(Interval.<C, D>maxOrdering().compare(intervalsByMaxOrder[i - 1], intervalsByMaxOrder[i]) < 0, "%s and %s out of order", intervalsByMaxOrder[i-1], intervalsByMaxOrder[i]);
+        }
+    }
+
+    protected IntervalTree(IntervalNode head, int modCount, I[] minSortedIntervals, I[] maxSortedIntervals)
+    {
+        checkNotNull(minSortedIntervals, "minSortedIntervals is null");
+        checkNotNull(maxSortedIntervals, "maxSortedIntervals is null");
+        this.head = head;
+        this.modCount = modCount;
+        this.intervalsByMinOrder = minSortedIntervals;
+        this.intervalsByMaxOrder = maxSortedIntervals;
+        if (EXPENSIVE_CHECKS)
+        {
+            if (intervalsByMinOrder.length > 1)
+                for (int i = 1; i < intervalsByMinOrder.length; i++)
+                    checkState(Interval.<C, D>minOrdering().compare(intervalsByMinOrder[i - 1], intervalsByMinOrder[i]) < 0, "%s and %s out of order", intervalsByMinOrder[i-1], intervalsByMinOrder[i]);
+            if (intervalsByMaxOrder.length > 1)
+                for (int i = 1; i < intervalsByMaxOrder.length; i++)
+                    checkState(Interval.<C, D>maxOrdering().compare(intervalsByMaxOrder[i - 1], intervalsByMaxOrder[i]) < 0, "%s and %s out of order", intervalsByMaxOrder[i-1], intervalsByMaxOrder[i]);
+        }
+    }
+
+    protected IntervalTree<C, D, I> create(IntervalNode head, int modCount, @Nullable I[] minSortedIntervals, @Nullable I[] maxSortedIntervals)
+    {
+        return new IntervalTree<>(head, modCount, minSortedIntervals, maxSortedIntervals);
     }
 
     protected IntervalTree<C, D, I> create(I[] minOrder, I[] maxOrder)
     {
-        return new IntervalTree(minOrder, maxOrder);
+        return new IntervalTree<>(minOrder, maxOrder);
+    }
+
+    protected IntervalTree<C, D, I> create(Collection<I> intervals)
+    {
+        return new IntervalTree<>(intervals);
     }
 
     public static <C extends Comparable<? super C>, D extends Comparable<? super D>, I extends Interval<C, D>> IntervalTree<C, D, I> build(Collection<I> intervals)
@@ -147,74 +218,35 @@ public class IntervalTree<C extends Comparable<? super C>, D extends Comparable<
     public List<D> search(Interval<C, D> searchInterval)
     {
         if (head == null)
-            return Collections.<D>emptyList();
+            return Collections.emptyList();
 
-        List<D> results = new ArrayList<D>();
+        List<D> results = new ArrayList<>();
         head.searchInternal(searchInterval, results);
         return results;
     }
 
     public List<D> search(C point)
     {
-        return search(Interval.<C, D>create(point, point, null));
-    }
-
-    /**
-     * The input arrays aren't defensively copied and will be sorted. The update method doesn't allow duplicates or elements to be removed
-     * to be missing and this differs from the constructor which does not duplicate checking at all.
-     *
-     * It made more sense for update to be stricter because it is tracking removals and additions explicitly instead of building
-     * a list from scratch and in the targeted use case of a list of SSTables there are no duplicates. At a given point in time
-     * an sstable represents exactly one interval (although it may switch via removal and addition as in early open).
-     */
-    public IntervalTree<C, D, I> update(I[] removals, I[] additions)
-    {
-        if (removals == null)
-            removals = (I[])EMPTY_ARRAY;
-        if (additions == null)
-            additions = (I[])EMPTY_ARRAY;
-
-        if (removals.length == 0 && additions.length == 0)
-        {
-            return this;
-        }
-
-        Arrays.sort(removals, Interval.<C, D>minOrdering());
-        Arrays.sort(additions, Interval.<C, D>minOrdering());
-
-        for (int i = 1; i < additions.length; i++)
-            checkState( Interval.<C, D>minOrdering().compare(additions[i], additions[i-1]) != 0, "Duplicate interval in additions %s", additions[i]);
-
-        I[] newByMin = buildUpdatedArray(
-            intervalsByMinOrder,
-            removals,
-            additions,
-            Interval.<C, D>minOrdering()
-        );
-
-        Arrays.sort(removals, Interval.<C, D>maxOrdering());
-        Arrays.sort(additions, Interval.<C, D>maxOrdering());
-
-        I[] newByMax = buildUpdatedArray(
-            intervalsByMaxOrder,
-            removals,
-            additions,
-            Interval.<C, D>maxOrdering()
-        );
-
-        return create(newByMin, newByMax);
+        return search(Interval.create(point, point, null));
     }
 
     @SuppressWarnings("unchecked")
-    private I[] buildUpdatedArray(I[] existingSorted,
-                                  I[] removalsSorted,
-                                  I[] additionsSorted,
-                                  AsymmetricOrdering<Interval<C, D>, C> cmp)
+    private I[] buildUpdatedArrayForUpdate(I[] existingSorted,
+                                           I[] removalsSorted,
+                                           I[] additionsSorted,
+                                           AsymmetricOrdering<Interval<C, D>, C> cmp)
     {
+        if (EXPENSIVE_CHECKS)
+        {
+            if (existingSorted.length > 1)
+                for (int i = 1; i < existingSorted.length; i++)
+                    checkState(cmp.compare(existingSorted[i - 1], existingSorted[i]) < 0, "%s and %s out of order", existingSorted[i-1], existingSorted[i]);
+        }
+
         int finalSize = existingSorted.length + additionsSorted.length - removalsSorted.length;
         I[] result = (I[]) new Interval[finalSize];
 
-        int existingIndex  = 0;
+        int existingIndex = 0;
         int removalsIndex  = 0;
         int additionsIndex = 0;
         int resultIndex    = 0;
@@ -233,6 +265,7 @@ public class IntervalTree<C extends Comparable<? super C>, D extends Comparable<
                 }
                 else
                 {
+                    checkState(removalsSorted[removalsIndex].data == currentExisting.data, "Comparator does not implement identity");
                     existingIndex++;
                     removalsIndex++;
 
@@ -242,7 +275,7 @@ public class IntervalTree<C extends Comparable<? super C>, D extends Comparable<
                 }
             }
 
-            if (existingIndex >= existingSorted.length )
+            if (existingIndex >= existingSorted.length)
                 break;
 
             while (additionsIndex < additionsSorted.length)
@@ -276,26 +309,156 @@ public class IntervalTree<C extends Comparable<? super C>, D extends Comparable<
         return result;
     }
 
+    /**
+     * The input arrays aren't defensively copied and will be sorted. This update method doesn't allow duplicates or elements to be removed
+     * to be missing and this differs from creating the tree from scratch using {@link #build(Collection) build(Collection&lt;I&gt;)} method which allows duplicates.
+     *
+     * There is also the requirement that D will implement Comparable&lt;D&gt; and that comparator will implement identity
+     * which is not part of the normal contract of Comparable&lt;D&gt;. That means that if a.compareTo(b) == 0 then a == b;
+     *
+     * It made more sense for update to be stricter because it is tracking removals and additions explicitly instead of building
+     * a list from scratch and in the targeted use case of a list of SSTables there are no duplicates. At a given point in time
+     * an sstable represents exactly one interval (although it may switch via removal and addition as in early open).
+     */
+    @SuppressWarnings("unchecked")
+    public IntervalTree<C, D, I> update(I[] removals, I[] additions)
+    {
+        if ((removals == null || removals.length == 0) && (additions == null || additions.length == 0))
+            return this;
+
+        if (removals == null)
+            removals = (I[])EMPTY_ARRAY;
+        if (additions == null)
+            additions = (I[])EMPTY_ARRAY;
+
+        Arrays.sort(removals, Interval.minOrdering());
+        Arrays.sort(additions, Interval.minOrdering());
+
+        if (EXPENSIVE_CHECKS)
+        {
+            for (int i = 1; i < additions.length; i++)
+                checkState(Interval.<C, D>minOrdering().compare(additions[i], additions[i - 1]) != 0, "Duplicate interval in additions %s", additions[i]);
+        }
+
+        I[] newByMin = buildUpdatedArrayForUpdate(
+        intervalsByMinOrder,
+        removals,
+        additions,
+        Interval.minOrdering()
+        );
+
+        Arrays.sort(removals, Interval.maxOrdering());
+        Arrays.sort(additions, Interval.maxOrdering());
+
+        I[] newByMax = buildUpdatedArrayForUpdate(
+        intervalsByMaxOrder,
+        removals,
+        additions,
+        Interval.maxOrdering()
+        );
+
+        return create(newByMin, newByMax);
+    }
+
+    /**
+     * The in practice use case here is flush which only adds one interval so do binary search
+     */
+    @SuppressWarnings("unchecked")
+    private I[] buildUpdatedArrayForAdd(I[] addIntervals, I[] existingIntervals, AsymmetricOrdering<Interval<C, D>, C> ordering)
+    {
+        int newSize = existingIntervals.length + addIntervals.length;
+        Arrays.sort(addIntervals, ordering);
+        I[] newIntervals = (I[])new Interval[newSize];
+        int newIndex = 0;
+        int existingIndex = 0;
+
+        int i = 0;
+        for (; i < addIntervals.length; i++)
+        {
+            if (existingIndex >= existingIntervals.length)
+                break;
+            I addInterval = addIntervals[i];
+            int insertionPoint = Arrays.binarySearch(existingIntervals, addInterval, ordering);
+            checkState(insertionPoint < 0, "Interval being added should not already be present");
+            insertionPoint = -1 - insertionPoint;
+            if (insertionPoint > existingIndex)
+            {
+                int toCopy = insertionPoint - existingIndex;
+                System.arraycopy(existingIntervals, existingIndex, newIntervals, newIndex, toCopy);
+                newIndex += toCopy;
+                existingIndex += toCopy;
+            }
+            newIntervals[newIndex++] = addInterval;
+        }
+
+        if (i < addIntervals.length)
+            System.arraycopy(addIntervals, i, newIntervals, newIndex, addIntervals.length - i);
+
+        if (existingIndex < existingIntervals.length)
+            System.arraycopy(existingIntervals, existingIndex, newIntervals, newIndex, existingIntervals.length - existingIndex);
+
+        return newIntervals;
+    }
+
+    public IntervalTree<C, D, I> add(I[] intervals)
+    {
+        if (head == null)
+            return create(Arrays.asList(intervals));
+        if (intervals.length == 0)
+            return this;
+        if (modCount + 1 >= REBUILD_AT_MOD_COUNT)
+        {
+            return create(new AbstractCollection<>()
+            {
+                @Override
+                public Iterator<I> iterator()
+                {
+                    return Iterators.concat(IntervalTree.this.iterator(), Iterators.forArray(intervals));
+                }
+
+                @Override
+                public int size()
+                {
+                    return intervalsByMinOrder.length + intervals.length;
+                }
+            });
+        }
+
+        // Add does not preserve iteration order, not even by interval bounds, so it's necessary to compute the arrays that preserve the minOrder
+        // Or pay to sort and build them later
+        I[] sortableIntervals = Arrays.copyOf(intervals, intervals.length);
+        I[] newIntervalsByMinOrder = buildUpdatedArrayForAdd(sortableIntervals,
+                                                             intervalsByMinOrder,
+                                                             Interval.minOrdering());
+        I[] newIntervalsByMaxOrder = buildUpdatedArrayForAdd(sortableIntervals,
+                                                             intervalsByMaxOrder,
+                                                             Interval.maxOrdering());
+
+        return create(head.add(Arrays.asList(intervals)), modCount + 1, newIntervalsByMinOrder, newIntervalsByMaxOrder);
+    }
+
+    @Override
     public Iterator<I> iterator()
     {
         if (head == null)
             return Collections.emptyIterator();
 
-        return new TreeIterator(head);
+        return Iterators.forArray(intervalsByMinOrder);
     }
 
     @Override
     public String toString()
     {
-        return "<" + Joiner.on(", ").join(Iterables.limit(this, 100)) + ">";
+        return '<' + Joiner.on(", ").join(Iterables.limit(this, 100)) + '>';
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public boolean equals(Object o)
     {
         if(!(o instanceof IntervalTree))
             return false;
-        IntervalTree that = (IntervalTree)o;
+        IntervalTree<C, D, I> that = (IntervalTree<C, D, I>)o;
         return Iterators.elementsEqual(iterator(), that.iterator());
     }
 
@@ -306,6 +469,116 @@ public class IntervalTree<C extends Comparable<? super C>, D extends Comparable<
         for (Interval<C, D> interval : this)
             result = 31 * result + interval.hashCode();
         return result;
+    }
+
+    private I[] buildUpdatedArrayForReplace(I[] existingSorted,
+                                            List<Pair<I, I>> replacements,
+                                            AsymmetricOrdering<Interval<C, D>, C> cmp)
+    {
+        I[] replacementArray = Arrays.copyOf(existingSorted, existingSorted.length);
+        for (Pair<I, I> replacement : replacements)
+        {
+            I existingInterval = replacement.left;
+            I newInterval = replacement.right;
+
+            int removalIdx = Arrays.binarySearch(replacementArray, existingInterval, cmp);
+            if (removalIdx < 0)
+                throw new IllegalStateException("Interval to replace not found in the existing tree: " + existingInterval);
+            checkState(existingInterval.data == replacementArray[removalIdx].data, "Comparator does not implement identity");
+
+            int insertionIdx = Arrays.binarySearch(replacementArray, newInterval, cmp);
+            checkState(insertionIdx < 0, "Value to be inserted already exists");
+            insertionIdx = -1 - insertionIdx;
+
+            if (insertionIdx > removalIdx)
+            {
+                // Shift everything from insertionIdx and left down to removalIdx
+                System.arraycopy(replacementArray, removalIdx + 1, replacementArray, removalIdx, insertionIdx - removalIdx - 1);
+                replacementArray[insertionIdx - 1] = newInterval;
+            }
+            else if (insertionIdx < removalIdx)
+            {
+                // Shift everything from insertionIdx and onward right to removalIdx
+                System.arraycopy(replacementArray, insertionIdx, replacementArray, insertionIdx + 1, removalIdx - insertionIdx);
+                replacementArray[Math.min(replacementArray.length, insertionIdx)] = newInterval;
+            }
+            else
+            {
+                replacementArray[insertionIdx] = newInterval;
+            }
+        }
+
+        if (EXPENSIVE_CHECKS)
+        {
+            if (replacementArray.length > 1)
+                for (int i = 1; i < replacementArray.length; i++)
+                    checkState(cmp.compare(replacementArray[i - 1], replacementArray[i]) < 0, "%s and %s out of order", replacementArray[i-1], replacementArray[i]);
+        }
+
+        return replacementArray;
+    }
+
+    /**
+     * This replace method doesn't work correctly with duplicates. If the tree already has duplicates each replacement (or duplicate replacement)
+     * will replace one instance in the tree.
+     *
+     * There is also the requirement that D will implement Comparable&lt;D&gt; and that comparator will implement identity
+     * which is not part of the normal contract of Comparable&lt;D&gt;. That means that if a.compareTo(b) == 0 then a == b;
+     */
+    public IntervalTree<C, D, I> replace(List<Pair<I, I>> replacements)
+    {
+        if (head == null)
+        {
+            checkArgument(replacements.isEmpty(), "Can't replace intervals in an empty tree");
+            return this;
+        }
+
+        if (replacements.isEmpty())
+            return this;
+
+        List<Pair<I, I>> sortableReplacements = new ArrayList<>(replacements);
+        I[] newIntervalsByMinOrder = buildUpdatedArrayForReplace(intervalsByMinOrder, sortableReplacements, Interval.minOrdering());
+        I[] newIntervalsByMaxOrder = buildUpdatedArrayForReplace(intervalsByMaxOrder, sortableReplacements, Interval.maxOrdering());
+
+        checkState(newIntervalsByMinOrder.length == newIntervalsByMaxOrder.length);
+        if (EXPENSIVE_CHECKS)
+        {
+            boolean[] foundMinOrderReplacement = new boolean[replacements.size()];
+            boolean[] foundMaxOrderReplacement = new boolean[replacements.size()];
+            for (int i = 0; i < newIntervalsByMinOrder.length; i++)
+            {
+                for (int j = 0; j < replacements.size(); j++)
+                {
+                    Pair<I, I> replacement = replacements.get(j);
+                    if (newIntervalsByMinOrder[i].min.equals(replacement.left.min) && newIntervalsByMinOrder[i].max.equals(replacement.right.max))
+                    {
+                        checkState(newIntervalsByMinOrder[i].data != replacement.left.data);
+                        if (newIntervalsByMinOrder[i].data == replacement.right.data)
+                        {
+                            checkState(!foundMinOrderReplacement[j], "Replacement value appears more than once");
+                            foundMinOrderReplacement[j] = true;
+                        }
+                    }
+
+                    if (newIntervalsByMaxOrder[i].min.equals(replacement.left.min) && newIntervalsByMaxOrder[i].max.equals(replacement.right.max))
+                    {
+                        checkState(newIntervalsByMaxOrder[i].data != replacement.left.data);
+                        if (newIntervalsByMaxOrder[i].data == replacement.right.data)
+                        {
+                            checkState(!foundMaxOrderReplacement[j], "Replacement value appears more than once");
+                            foundMaxOrderReplacement[j] = true;
+                        }
+                    }
+                }
+            }
+            for (int i = 0; i < foundMaxOrderReplacement.length; i++)
+                checkState(foundMinOrderReplacement[i] && foundMaxOrderReplacement[i], "Didn't find replacement value that should be present");
+        }
+
+        return create(head.replace(head, replacements),
+                      modCount,
+                      newIntervalsByMinOrder,
+                      newIntervalsByMaxOrder);
     }
 
     protected class IntervalNode
@@ -375,7 +648,7 @@ public class IntervalTree<C extends Comparable<? super C>, D extends Comparable<
 
             if (EXPENSIVE_CHECKS)
             {
-                List<C> allEndpoints = new ArrayList<C>(minOrder.size() * 2);
+                List<C> allEndpoints = new ArrayList<>(minOrder.size() * 2);
                 for (I interval : minOrder)
                 {
                     allEndpoints.add(interval.min);
@@ -389,12 +662,12 @@ public class IntervalTree<C extends Comparable<? super C>, D extends Comparable<
 
             // Separate interval in intersecting center, left of center and right of center
             int initialIntersectionSize = i - j + 1;
-            intersectsLeft = new ArrayList<I>(initialIntersectionSize);
-            intersectsRight = new ArrayList<I>(initialIntersectionSize);
+            intersectsLeft = new ArrayList<>(initialIntersectionSize);
+            intersectsRight = new ArrayList<>(initialIntersectionSize);
             int initialChildSize = Math.min(i, j);
-            List<I> leftSegmentMinOrder = new ArrayList<I>(initialChildSize);
+            List<I> leftSegmentMinOrder = new ArrayList<>(initialChildSize);
             List<I> leftSegmentMaxOrder = new ArrayList<>(initialChildSize);
-            List<I> rightSegmentMinOrder = new ArrayList<I>(initialChildSize);
+            List<I> rightSegmentMinOrder = new ArrayList<>(initialChildSize);
             List<I> rightSegmentMaxOrder = new ArrayList<>(initialChildSize);
 
             for (I candidate : minOrder)
@@ -422,12 +695,22 @@ public class IntervalTree<C extends Comparable<? super C>, D extends Comparable<
 
             assert (intersectsLeft.size() == intersectsRight.size());
             assert (intersectsLeft.size() + leftSegmentMinOrder.size() + rightSegmentMinOrder.size()) == minOrder.size() :
-            "intersects (" + String.valueOf(intersectsLeft.size()) +
-            ") + leftSegment (" + String.valueOf(leftSegmentMinOrder.size()) +
-            ") + rightSegment (" + String.valueOf(rightSegmentMinOrder.size()) +
-            ") != toBisect (" + String.valueOf(minOrder.size()) + ")";
+            "intersects (" + intersectsLeft.size() +
+            ") + leftSegment (" + leftSegmentMinOrder.size() +
+            ") + rightSegment (" + rightSegmentMinOrder.size() +
+            ") != toBisect (" + minOrder.size() + ')';
         }
 
+        public IntervalNode(C center, C low, C high, List<I> intersectsLeft, List<I> intersectsRight, IntervalNode left, IntervalNode right)
+        {
+            this.center = center;
+            this.low = low;
+            this.high = high;
+            this.intersectsLeft = intersectsLeft;
+            this.intersectsRight = intersectsRight;
+            this.left = left;
+            this.right = right;
+        }
 
         void searchInternal(Interval<C, D> searchInterval, List<D> results)
         {
@@ -468,46 +751,185 @@ public class IntervalTree<C extends Comparable<? super C>, D extends Comparable<
                     right.searchInternal(searchInterval, results);
             }
         }
+
+
+        private IntervalNode replace(IntervalNode node, List<Pair<I, I>> replacements)
+        {
+            if (node == null || replacements.isEmpty())
+                return node;
+
+            List<Pair<I, I>> leftSegment = new ArrayList<>();
+            List<Pair<I, I>> rightSegment = new ArrayList<>();
+            List<I> newIntersectsLeft = null;
+            List<I> newIntersectsRight = null;
+            int updated = 0;
+
+            for (Pair<I, I> entry : replacements)
+            {
+                I intervalToRemove = entry.left;
+                I intervalToAdd = entry.right;
+                if (node.center.compareTo(intervalToRemove.min) < 0)
+                {
+                    rightSegment.add(entry);
+                }
+                else if (node.center.compareTo(intervalToRemove.max) > 0)
+                {
+                    leftSegment.add(entry);
+                }
+                else
+                {
+                    // only init once if any interval resides in current node
+                    if (newIntersectsLeft == null)
+                    {
+                        newIntersectsLeft = new ArrayList<>(node.intersectsLeft);
+                        newIntersectsRight = new ArrayList<>(node.intersectsRight);
+                    }
+                    boolean leftUpdated = false;
+                    boolean rightUpdated = false;
+
+                    int i = Interval.<C, D>minOrdering().binarySearchAsymmetric(node.intersectsLeft, intervalToRemove.min, Op.CEIL);
+                    while (i < node.intersectsLeft.size())
+                    {
+                        if (node.intersectsLeft.get(i).equals(intervalToRemove))
+                        {
+                            newIntersectsLeft.set(i, intervalToAdd);
+                            leftUpdated = true;
+                            break;
+                        }
+                        i++;
+                    }
+
+                    int j = Interval.<C, D>maxOrdering().binarySearchAsymmetric(node.intersectsRight, intervalToRemove.max, Op.CEIL);
+                    while (j < node.intersectsRight.size())
+                    {
+                        if (node.intersectsRight.get(j).equals(intervalToRemove))
+                        {
+                            newIntersectsRight.set(j, intervalToAdd);
+                            rightUpdated = true;
+                            break;
+                        }
+                        j++;
+                    }
+                    assert leftUpdated && rightUpdated : "leftupdated = " + leftUpdated + ", rightupdated = " + rightUpdated;
+                    updated++;
+                }
+            }
+
+            assert leftSegment.size() + rightSegment.size() + updated == replacements.size() :
+            "leftSegment size (" + leftSegment.size() + ") + rightSegment size (" + rightSegment.size() +
+            ") + updated (" + updated + ") != replacementMap size (" + replacements.size() + ')';
+            return new IntervalNode(node.center,
+                                    node.low,
+                                    node.high,
+                                    newIntersectsLeft != null ? newIntersectsLeft : node.intersectsLeft,
+                                    newIntersectsRight != null ? newIntersectsRight : node.intersectsRight,
+                                    replace(node.left, leftSegment),
+                                    replace(node.right, rightSegment));
+        }
+
+        private IntervalNode add(Collection<I> intervals)
+        {
+            return add(this, intervals);
+        }
+
+        private IntervalNode add(IntervalNode root, Collection<I> intervals)
+        {
+            if (intervals.isEmpty())
+                return root;
+
+            if (root == null)
+            {
+                List<I> minSortedIntervals = new ArrayList<>(intervals);
+                Collections.sort(minSortedIntervals, Interval.minOrdering());
+                List<I> maxSortedIntervals = new ArrayList<>(intervals);
+                Collections.sort(maxSortedIntervals, Interval.maxOrdering());
+                return new IntervalNode(minSortedIntervals, maxSortedIntervals);
+            }
+
+            List<I> leftSegment = new ArrayList<>();
+            List<I> rightSegment = new ArrayList<>();
+            C newLow = root.low;
+            C newHigh = root.high;
+            List<I> newIntersectsLeft = null;
+            List<I> newIntersectsRight = null;
+            for (I i : intervals)
+            {
+                newLow = newLow.compareTo(i.min) < 0 ? newLow : i.min;
+                newHigh = newHigh.compareTo(i.max) > 0 ? newHigh : i.max;
+                if (i.max.compareTo(root.center) < 0)
+                {
+                    leftSegment.add(i);
+                }
+                else if (i.min.compareTo(root.center) > 0)
+                {
+                    rightSegment.add(i);
+                }
+                else
+                {
+                    if (newIntersectsLeft == null)
+                    {
+                        newIntersectsLeft = new ArrayList<>(root.intersectsLeft);
+                        newIntersectsRight = new ArrayList<>(root.intersectsRight);
+                    }
+                    int leftIdx = Collections.binarySearch(newIntersectsLeft, i, Interval.minOrdering());
+                    checkState(leftIdx < 0, "Should not add the same interval twice");
+                    leftIdx = -1 - leftIdx;
+                    newIntersectsLeft.add(leftIdx, i);
+
+                    int rightIdx = Collections.binarySearch(newIntersectsRight, i, Interval.maxOrdering());
+                    checkState(rightIdx < 0, "Should not add the same interval twice");
+                    rightIdx = -1 - rightIdx;
+                    newIntersectsRight.add(rightIdx, i);
+                }
+            }
+
+            return new IntervalNode(root.center,
+                                    newLow,
+                                    newHigh,
+                                    newIntersectsLeft != null ? newIntersectsLeft : root.intersectsLeft,
+                                    newIntersectsRight != null ? newIntersectsRight : root.intersectsRight,
+                                    add(root.left, leftSegment),
+                                    add(root.right, rightSegment));
+        }
     }
 
-    private class TreeIterator extends AbstractIterator<I>
+    public static class Builder<C extends Comparable<? super C>, D extends Comparable<? super D>, I extends Interval<C, D>>
     {
-        private final Deque<IntervalNode> stack = new ArrayDeque<IntervalNode>();
-        private Iterator<I> current;
+        private final List<I> intervals = new ArrayList<>();
 
-        TreeIterator(IntervalNode node)
+        public Builder<C, D, I> addAll(IntervalTree<C, D, I> other)
         {
-            super();
-            gotoMinOf(node);
+            other.forEach(intervals::add);
+            return this;
         }
 
-        protected I computeNext()
+        public Builder<C, D, I> add(I interval)
         {
-            while (true)
-            {
-                if (current != null && current.hasNext())
-                    return current.next();
-
-                IntervalNode node = stack.pollFirst();
-                if (node == null)
-                    return endOfData();
-
-                current = node.intersectsLeft.iterator();
-
-                // We know this is the smaller not returned yet, but before doing
-                // its parent, we must do everyone on it's right.
-                gotoMinOf(node.right);
-            }
+            intervals.add(interval);
+            return this;
         }
 
-        private void gotoMinOf(IntervalNode node)
+        public Builder<C, D, I> removeIf(BiPredicate<C, C> predicate)
         {
-            while (node != null)
-            {
-                stack.offerFirst(node);
-                node = node.left;
-            }
+            intervals.removeIf(i -> predicate.test(i.min, i.max));
+            return this;
+        }
 
+        public Builder<C, D, I> removeIf(Predicate<D> predicate)
+        {
+            intervals.removeIf(i -> predicate.test(i.data));
+            return this;
+        }
+
+        public IntervalTree<C, D, I> build()
+        {
+            return IntervalTree.build(intervals);
+        }
+
+        @Override
+        public String toString()
+        {
+            return intervals.toString();
         }
     }
 }

--- a/src/java/org/apache/cassandra/utils/TimeUUID.java
+++ b/src/java/org/apache/cassandra/utils/TimeUUID.java
@@ -141,6 +141,16 @@ public class TimeUUID implements Comparable<TimeUUID>
 
     public static class Generator
     {
+        public interface Factory<T extends TimeUUID>
+        {
+            T fromUUID(UUID timeUUID);
+        }
+
+        public static <T extends TimeUUID> T nextTimeUUID(Factory<T> factory)
+        {
+            return factory.fromUUID(UUIDGen.getTimeUUID());
+        }
+
         public static TimeUUID nextTimeUUID()
         {
             return TimeUUID.fromUuid(UUIDGen.getTimeUUID());

--- a/test/unit/org/apache/cassandra/db/compaction/BaseCompactionStrategyTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/BaseCompactionStrategyTest.java
@@ -27,6 +27,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
+import com.google.common.collect.ImmutableList;
 import org.apache.commons.math3.random.JDKRandomGenerator;
 import org.junit.Ignore;
 
@@ -49,6 +50,7 @@ import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.schema.TableMetadataRef;
 import org.apache.cassandra.utils.FBUtilities;
+import org.apache.cassandra.utils.Interval;
 import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -177,7 +179,7 @@ public class BaseCompactionStrategyTest
      */
     void addSSTablesToStrategy(AbstractCompactionStrategy strategy, Iterable<SSTableReader> sstables)
     {
-        dataTracker.addInitialSSTables(sstables);
+        dataTracker.addInitialSSTables(ImmutableList.copyOf(sstables));
 
         if (strategy instanceof LegacyAbstractCompactionStrategy)
         {
@@ -242,6 +244,8 @@ public class BaseCompactionStrategyTest
         when(ret.getLast()).thenReturn(last);
         when(ret.isMarkedSuspect()).thenReturn(false);
         when(ret.isRepaired()).thenReturn(repaired);
+        when(ret.getInterval()).thenReturn(new Interval<>(first, last, ret));
+        when(ret.compareTo(any())).thenAnswer(invocationOnMock -> Integer.compare(ret.hashCode(), invocationOnMock.getArgument(0).hashCode()));
         when(ret.getRepairedAt()).thenReturn(repairedAt);
         when(ret.getPendingRepair()).thenReturn(pendingRepair);
         when(ret.isPendingRepair()).thenReturn(pendingRepair != null);

--- a/test/unit/org/apache/cassandra/db/compaction/LeveledCompactionStrategyTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/LeveledCompactionStrategyTest.java
@@ -34,6 +34,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.Collections2;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import org.junit.After;
@@ -876,7 +877,7 @@ public class LeveledCompactionStrategyTest
         List<SSTableReader> l0sstables = new ArrayList<>();
         for (int i = 10; i < 20; i++)
             l0sstables.add(MockSchema.sstable(i, (i + 1) * 1024 * 1024, cfs));
-        try (LifecycleTransaction txn = LifecycleTransaction.offline(OperationType.COMPACTION, cfs.metadata, Iterables.concat(l0sstables, l1sstables)))
+        try (LifecycleTransaction txn = LifecycleTransaction.offline(OperationType.COMPACTION, cfs.metadata, ImmutableList.copyOf(Iterables.concat(l0sstables, l1sstables))))
         {
             Set<SSTableReader> nonExpired = new HashSet<>(Sets.difference(txn.originals(), Collections.emptySet()));
             CompactionTask task = new LeveledCompactionTask(cfs, txn, 1, 0, 1024*1024, false, null);

--- a/test/unit/org/apache/cassandra/db/lifecycle/TrackerTest.java
+++ b/test/unit/org/apache/cassandra/db/lifecycle/TrackerTest.java
@@ -26,10 +26,9 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-import javax.annotation.Nullable;
 
-import com.google.common.base.Function;
 import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import org.junit.Assert;
@@ -116,27 +115,7 @@ public class TrackerTest
         final Tracker tracker = Tracker.newDummyTracker(cfs.metadata);
         final View resultView = ViewTest.fakeView(0, 0, cfs);
         final AtomicInteger count = new AtomicInteger();
-        tracker.apply(new Predicate<View>()
-        {
-            public boolean apply(View view)
-            {
-                // confound the CAS by swapping the view, and check we retry
-                if (count.incrementAndGet() < 3)
-                    tracker.view.set(ViewTest.fakeView(0, 0, cfs));
-                return true;
-            }
-        }, new Function<View, View>()
-        {
-            @Nullable
-            public View apply(View view)
-            {
-                return resultView;
-            }
-        });
-        Assert.assertEquals(3, count.get());
-        Assert.assertEquals(resultView, tracker.getView());
-
-        count.set(0);
+        tracker.apply(Predicates.alwaysTrue(), view -> resultView);
         // check that if the predicate returns false, we stop immediately and return null
         Assert.assertNull(tracker.apply(new Predicate<View>()
         {
@@ -162,7 +141,7 @@ public class TrackerTest
                                                        MockSchema.sstable(2, 9, cfs));
         tracker.addInitialSSTables(copyOf(readers));
 
-        Assert.assertEquals(3, tracker.view.get().sstables.size());
+        Assert.assertEquals(3, tracker.view.sstables.size());
         Assert.assertEquals(2, listener.senders.size()); // one sender sent two notifications
         Assert.assertEquals(listener.senders.get(0), listener.senders.get(1));
         Assert.assertEquals(2, listener.received.size());
@@ -189,7 +168,7 @@ public class TrackerTest
                                                        MockSchema.sstable(2, 9, cfs));
         tracker.addSSTables(copyOf(readers), OperationType.UNKNOWN);
 
-        Assert.assertEquals(3, tracker.view.get().sstables.size());
+        Assert.assertEquals(3, tracker.view.sstables.size());
 
         for (SSTableReader reader : readers)
             Assert.assertTrue(reader.isKeyCacheEnabled());

--- a/test/unit/org/apache/cassandra/db/lifecycle/ViewTest.java
+++ b/test/unit/org/apache/cassandra/db/lifecycle/ViewTest.java
@@ -28,10 +28,10 @@ import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import org.junit.Assert;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.PartitionPosition;
@@ -46,6 +46,7 @@ import static com.google.common.collect.ImmutableSet.of;
 import static com.google.common.collect.Iterables.concat;
 import static java.util.Collections.singleton;
 import static org.apache.cassandra.db.lifecycle.Helpers.emptySet;
+import static org.apache.cassandra.db.lifecycle.SSTableIntervalTree.buildSSTableIntervalTree;
 
 public class ViewTest
 {
@@ -225,6 +226,6 @@ public class ViewTest
         for (int i = 0 ; i < sstableCount ; i++)
             sstables.add(MockSchema.sstable(i, keepRef, cfs));
         return new View(ImmutableList.copyOf(memtables), Collections.<Memtable>emptyList(), Helpers.identityMap(sstables),
-                        Collections.<SSTableReader, SSTableReader>emptyMap(), SSTableIntervalTree.build(sstables));
+                        Collections.<SSTableReader, SSTableReader>emptyMap(), buildSSTableIntervalTree(sstables));
     }
 }

--- a/test/unit/org/apache/cassandra/db/lifecycle/ViewTest.java
+++ b/test/unit/org/apache/cassandra/db/lifecycle/ViewTest.java
@@ -120,7 +120,7 @@ public class ViewTest
         testFailure(View.updateCompacting(emptySet(), of(r2)), cur);
         // update one compacting, one non-compacting, of the liveset to another instance of the same readers;
         // confirm liveset changes but compacting does not
-        cur = View.updateLiveSet(copyOf(readers.subList(1, 3)), of(r1, r2)).apply(cur);
+        cur = View.updateLiveSet(copyOf(readers.subList(1, 3)), of(r1, r2), cfs.metric.viewSSTableIntervalTree).apply(cur);
         Assert.assertSame(readers.get(0), cur.sstablesMap.get(r0));
         Assert.assertSame(r1, cur.sstablesMap.get(r1));
         Assert.assertSame(r2, cur.sstablesMap.get(r2));
@@ -180,7 +180,7 @@ public class ViewTest
         Assert.assertEquals(memtable2, cur.liveMemtables.get(1));
         Assert.assertEquals(memtable3, cur.getCurrentMemtable());
 
-        testFailure(View.replaceFlushed(memtable2, null), cur);
+        testFailure(View.replaceFlushed(memtable2, null, cfs.metric.viewSSTableIntervalTree), cur);
 
         cur = View.markFlushing(memtable2).apply(cur);
         Assert.assertTrue(cur.flushingMemtables.contains(memtable2));
@@ -197,14 +197,14 @@ public class ViewTest
         Assert.assertEquals(memtable2, cur.flushingMemtables.get(1));
         Assert.assertEquals(memtable3, cur.getCurrentMemtable());
 
-        cur = View.replaceFlushed(memtable2, null).apply(cur);
+        cur = View.replaceFlushed(memtable2, null, cfs.metric.viewSSTableIntervalTree).apply(cur);
         Assert.assertEquals(1, cur.liveMemtables.size());
         Assert.assertEquals(1, cur.flushingMemtables.size());
         Assert.assertEquals(memtable1, cur.flushingMemtables.get(0));
         Assert.assertEquals(memtable3, cur.getCurrentMemtable());
 
         SSTableReader sstable = MockSchema.sstable(1, cfs);
-        cur = View.replaceFlushed(memtable1, singleton(sstable)).apply(cur);
+        cur = View.replaceFlushed(memtable1, singleton(sstable), cfs.metric.viewSSTableIntervalTree).apply(cur);
         Assert.assertEquals(0, cur.flushingMemtables.size());
         Assert.assertEquals(1, cur.liveMemtables.size());
         Assert.assertEquals(memtable3, cur.getCurrentMemtable());

--- a/test/unit/org/apache/cassandra/metrics/TableMetricsTest.java
+++ b/test/unit/org/apache/cassandra/metrics/TableMetricsTest.java
@@ -368,6 +368,20 @@ public class TableMetricsTest
     @Test
     public void testEstimatedPartitionCount() throws InterruptedException
     {
+        long prevPeriod = TableMetrics.ESTIMATED_PARTITION_COUNT_CACHE_PERIOD_SECONDS;
+        try
+        {
+            TableMetrics.ESTIMATED_PARTITION_COUNT_CACHE_PERIOD_SECONDS = 1;
+            doTestEstimatedPartitionCount();
+        }
+        finally
+        {
+            TableMetrics.ESTIMATED_PARTITION_COUNT_CACHE_PERIOD_SECONDS = prevPeriod;
+        }
+    }
+
+    private void doTestEstimatedPartitionCount()
+    {
         ColumnFamilyStore cfs = recreateTable();
         assertEquals(0L, cfs.metric.estimatedPartitionCount.getValue().longValue());
         assertEquals(0L, cfs.metric.estimatedPartitionCountInSSTablesCached.getValue().longValue());

--- a/test/unit/org/apache/cassandra/utils/IntervalTreeTest.java
+++ b/test/unit/org/apache/cassandra/utils/IntervalTreeTest.java
@@ -28,15 +28,17 @@ import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.quicktheories.WithQuickTheories;
 import org.quicktheories.core.Gen;
 import org.quicktheories.generators.SourceDSL;
 
+import static com.google.common.base.Predicates.not;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static java.util.function.Predicate.not;
 import static org.apache.cassandra.config.CassandraRelevantProperties.TEST_INTERVAL_TREE_EXPENSIVE_CHECKS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -46,13 +48,24 @@ import static org.junit.Assert.fail;
 
 public class IntervalTreeTest implements WithQuickTheories
 {
+    static final int TESTING_SECONDS = 15;
+
+    private final AtomicInteger id = new AtomicInteger();
+
     @BeforeClass
-    public static void enableExpensiveRangeChecks()
+    public static void beforeClass()
     {
         assertFalse(TEST_INTERVAL_TREE_EXPENSIVE_CHECKS.getBoolean()); // Expect off by default
+        DatabaseDescriptor.daemonInitialization();
         TEST_INTERVAL_TREE_EXPENSIVE_CHECKS.setBoolean(true);
         assertTrue(TEST_INTERVAL_TREE_EXPENSIVE_CHECKS.getBoolean());
         assertTrue(IntervalTree.EXPENSIVE_CHECKS);
+    }
+
+    @Before
+    public void setUp()
+    {
+        id.set(0);
     }
 
     @Test
@@ -314,17 +327,20 @@ public class IntervalTreeTest implements WithQuickTheories
                      resultPoint, resultInterval);
     }
 
+    private String intervalData(int lo, int hi)
+    {
+        return "(" + lo + "," + hi + "," + id.getAndIncrement() + ")";
+    }
+
     private Gen<Interval<Integer, String>> intervalGen()
     {
-        AtomicInteger id = new AtomicInteger();
         return SourceDSL.integers().between(-5, 5)
                         .flatMap(start ->
                                  SourceDSL.integers().between(-5, 5)
                                           .map(end -> {
                                               int lo = Math.min(start, end);
                                               int hi = Math.max(start, end);
-                                              String data = "(" + lo + "," + hi + "," + id.getAndIncrement() + ")";
-                                              return Interval.create(lo, hi, data);
+                                              return Interval.create(lo, hi, intervalData(lo, hi));
                                           }));
     }
 
@@ -369,7 +385,7 @@ public class IntervalTreeTest implements WithQuickTheories
     @Test
     public void qtIntervalTreeTest()
     {
-        qt().forAll(intervalsListGen(), queryGen())
+        qt().withExamples(-1).withTestingTime(TESTING_SECONDS, SECONDS).forAll(intervalsListGen(), queryGen())
             .check((intervals, query) -> {
                 IntervalTree<Integer, String, Interval<Integer, String>> tree = IntervalTree.build(intervals);
 
@@ -403,12 +419,12 @@ public class IntervalTreeTest implements WithQuickTheories
     }
 
     @Test
-    public void qtUpdateFunctionTest()
+    public void qtUpdateTest()
     {
-        qt().withExamples(-1).withTestingTime(30, SECONDS).forAll(intervalsListGen(),
-                                                                  intervalsListGen(),
-                                                                  SourceDSL.lists().of(queryGen()).ofSizeBetween(1, 4),
-                                                                  SourceDSL.integers().all())
+        qt().withExamples(-1).withTestingTime(TESTING_SECONDS, SECONDS).forAll(intervalsListGen(),
+                                                                               intervalsListGen(),
+                                                                               SourceDSL.lists().of(queryGen()).ofSizeBetween(1, 4),
+                                                                               SourceDSL.integers().all())
             .check((original, toAdd, queries, seed) -> {
                 IntervalTree<Integer, String, Interval<Integer, String>> originalTree = IntervalTree.build(original);
 
@@ -423,27 +439,19 @@ public class IntervalTreeTest implements WithQuickTheories
 
                 toAdd.removeAll(original.stream().filter(not(removals::contains)).collect(Collectors.toList()));
 
+                Set<Interval<Integer, String>> expectedFinal = new HashSet<>(original);
+                expectedFinal.removeAll(removals);
+                expectedFinal.addAll(toAdd);
+
                 IntervalTree<Integer, String, Interval<Integer, String>> updatedTree = originalTree.update(removals.toArray(new Interval[0]), toAdd.toArray(new Interval[0]));
 
-                Set<Interval<Integer, String>> naiveFinal = new HashSet<>(original);
-                naiveFinal.removeAll(removals);
-                naiveFinal.addAll(toAdd);
-
                 Set<Interval<Integer, String>> iteratedTree = ImmutableSet.copyOf(updatedTree);
-                if (!naiveFinal.equals(iteratedTree))
-                    originalTree.update(removals.toArray(new Interval[0]), toAdd.toArray(new Interval[0]));
-                assertEquals(naiveFinal, iteratedTree);
+                assertEquals(expectedFinal, iteratedTree);
 
                 for (Interval<Integer, String> query : queries)
                 {
                     Set<String> actualResults = ImmutableSet.copyOf(updatedTree.search(query));
-                    Set<String> expectedResults = ImmutableSet.copyOf(search(naiveFinal, query));
-
-                    if (!expectedResults.equals(actualResults))
-                    {
-                        originalTree.update(removals.toArray(new Interval[0]), toAdd.toArray(new Interval[0]));
-                        updatedTree.search(query);
-                    }
+                    Set<String> expectedResults = ImmutableSet.copyOf(search(expectedFinal, query));
 
                     assertEquals(expectedResults, actualResults);
 
@@ -454,6 +462,145 @@ public class IntervalTreeTest implements WithQuickTheories
                     }
                 }
 
+                return true;
+            });
+    }
+
+    @Test
+    public void qtReplaceFunctionTest()
+    {
+        qt().withExamples(-1).withTestingTime(TESTING_SECONDS, SECONDS)
+            .forAll(intervalsListGen(),     // Our random list of intervals
+                    SourceDSL.lists().of(queryGen()).ofSizeBetween(1, 4),
+                    SourceDSL.integers().all())
+            .check((original, queries, seed) -> {
+
+                IntervalTree<Integer, String, Interval<Integer, String>> originalTree = IntervalTree.build(original);
+                java.util.Random rng = new java.util.Random(seed);
+                List<Interval<Integer, String>> expectedFinal = new ArrayList<>(original);
+
+                int numReplacements = rng.nextInt(original.size() + 1);
+                List<Interval<Integer, String>> replacements = new ArrayList<>(original);
+                for (int i = 0; i < original.size() - numReplacements; i++)
+                    replacements.remove(rng.nextInt(replacements.size()));
+
+                List<Pair<Interval<Integer, String>, Interval<Integer, String>>> toReplace = new ArrayList<>();
+                for (int i = 0; i < replacements.size(); i++)
+                {
+                    Interval<Integer, String> oldInterval = replacements.get(i);
+
+                    Interval<Integer, String> newInterval = Interval.create(
+                    oldInterval.min,
+                    oldInterval.max,
+                    intervalData(oldInterval.min, oldInterval.max)
+                    );
+                    toReplace.add(Pair.create(oldInterval, newInterval));
+                }
+
+                for (Pair<Interval<Integer, String>, Interval<Integer, String>> entry : toReplace)
+                {
+                    expectedFinal.remove(entry.left);
+                    expectedFinal.add(entry.right);
+                }
+
+                IntervalTree<Integer, String, Interval<Integer, String>> replacedTree = originalTree.replace(toReplace);
+
+                Set<Interval<Integer, String>> iteratedReplaced = ImmutableSet.copyOf(replacedTree);
+                assertEquals("Iterated intervals should match expected set after replace",
+                             ImmutableSet.copyOf(expectedFinal), iteratedReplaced);
+
+                for (Interval<Integer, String> query : queries)
+                {
+                    List<String> replacedResults = replacedTree.search(query);
+                    List<String> expectedResults    = search(expectedFinal, query);
+
+                    Set<String> replacedSet = new HashSet<>(replacedResults);
+                    Set<String> expectedSet    = new HashSet<>(expectedResults);
+                    assertEquals("Search results mismatch after replace for query " + query,
+                                 expectedSet, replacedSet);
+
+                    // Also check point-search if min==max
+                    if (query.min.equals(query.max))
+                    {
+                        List<String> replacedPoint = replacedTree.search(query.min);
+                        assertEquals("Point-search mismatch after replace for point " + query.min,
+                                     replacedSet, new HashSet<>(replacedPoint));
+                    }
+                }
+
+                return true;
+            });
+    }
+
+    @Test
+    public void testAddIntervals()
+    {
+        List<Interval<Integer, Integer>> intervals = new ArrayList<>();
+
+        intervals.add(Interval.create(-300, -200));
+        intervals.add(Interval.create(-3, -2));
+        intervals.add(Interval.create(1, 2));
+        intervals.add(Interval.create(3, 6));
+        intervals.add(Interval.create(2, 4));
+        intervals.add(Interval.create(5, 7));
+        intervals.add(Interval.create(4, 6));
+        intervals.add(Interval.create(15, 20));
+        intervals.add(Interval.create(49, 60));
+
+
+        IntervalTree<Integer, Integer, Interval<Integer, Integer>> it = IntervalTree.build(intervals);
+
+        List<Interval<Integer, Integer>> intervalsToAdd = new ArrayList<>();
+        intervalsToAdd.add(Interval.create(1, 3));
+        intervalsToAdd.add(Interval.create(8, 9));
+        intervalsToAdd.add(Interval.create(40, 50));
+        intervals.addAll(intervalsToAdd);
+
+        it = it.add(intervalsToAdd.toArray(IntervalTree.EMPTY_ARRAY));
+
+        assertEquals(3, it.search(Interval.create(4, 4)).size());
+        assertEquals(4, it.search(Interval.create(4, 5)).size());
+        assertEquals(7, it.search(Interval.create(-1, 10)).size());
+        assertEquals(0, it.search(Interval.create(-1, -1)).size());
+        assertEquals(5, it.search(Interval.create(1, 4)).size());
+        assertEquals(2, it.search(Interval.create(0, 1)).size());
+        assertEquals(0, it.search(Interval.create(10, 12)).size());
+    }
+
+    @Test
+    public void qtAddTest()
+    {
+        qt().withExamples(-1).withTestingTime(TESTING_SECONDS, SECONDS)
+            .forAll(intervalsListGen(), queryGen())
+            .check((intervals, query) -> {
+                Set<Interval<Integer, String>> intervalsSet = ImmutableSet.copyOf(intervals);
+                IntervalTree<Integer, String, Interval<Integer, String>> tree = IntervalTree.build(ImmutableList.of());
+                List<Interval<Integer, String>> allIntervals = new ArrayList<>();
+                for (Interval<Integer, String> interval : intervals)
+                {
+                    allIntervals.add(interval);
+                    tree = tree.add(new Interval[] {interval});
+                }
+
+                List<String> expected = search(intervals, query);
+                List<String> actual = tree.search(query);
+
+                Set<String> setExpected = new HashSet<>(expected);
+                Set<String> setActual = new HashSet<>(actual);
+
+                assertEquals(setExpected, setActual);
+
+                if (query.min.equals(query.max))
+                {
+                    List<String> actualPoint = tree.search(query.min);
+                    assertEquals(setExpected, new HashSet<>(actualPoint));
+                }
+
+                List<Interval<Integer, String>> sortedByMin = new ArrayList<>(intervals);
+                sortedByMin.sort(Interval.minOrdering());
+
+                Set<Interval<Integer, String>> fromTree = ImmutableSet.copyOf(tree);
+                assertEquals(intervalsSet, fromTree);
                 return true;
             });
     }

--- a/test/unit/org/apache/cassandra/utils/IntervalTreeTest.java
+++ b/test/unit/org/apache/cassandra/utils/IntervalTreeTest.java
@@ -1,6 +1,4 @@
-package org.apache.cassandra.utils;
 /*
- *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -9,190 +7,454 @@ package org.apache.cassandra.utils;
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+package org.apache.cassandra.utils;
 
-
-import java.io.IOException;
-import java.lang.reflect.Constructor;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.junit.BeforeClass;
 import org.junit.Test;
-import org.apache.cassandra.io.ISerializer;
-import org.apache.cassandra.io.IVersionedSerializer;
-import org.apache.cassandra.io.util.DataInputBuffer;
-import org.apache.cassandra.io.util.DataInputPlus;
-import org.apache.cassandra.io.util.DataOutputBuffer;
-import org.apache.cassandra.io.util.DataOutputPlus;
 
+import org.quicktheories.WithQuickTheories;
+import org.quicktheories.core.Gen;
+import org.quicktheories.generators.SourceDSL;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.function.Predicate.not;
+import static org.apache.cassandra.config.CassandraRelevantProperties.TEST_INTERVAL_TREE_EXPENSIVE_CHECKS;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
-public class IntervalTreeTest
+public class IntervalTreeTest implements WithQuickTheories
 {
-    @Test
-    public void testSearch() throws Exception
+    @BeforeClass
+    public static void enableExpensiveRangeChecks()
     {
-        List<Interval<Integer, Void>> intervals = new ArrayList<Interval<Integer, Void>>();
+        assertFalse(TEST_INTERVAL_TREE_EXPENSIVE_CHECKS.getBoolean()); // Expect off by default
+        TEST_INTERVAL_TREE_EXPENSIVE_CHECKS.setBoolean(true);
+        assertTrue(TEST_INTERVAL_TREE_EXPENSIVE_CHECKS.getBoolean());
+        assertTrue(IntervalTree.EXPENSIVE_CHECKS);
+    }
 
-        intervals.add(Interval.<Integer, Void>create(-300, -200));
-        intervals.add(Interval.<Integer, Void>create(-3, -2));
-        intervals.add(Interval.<Integer, Void>create(1, 2));
-        intervals.add(Interval.<Integer, Void>create(3, 6));
-        intervals.add(Interval.<Integer, Void>create(2, 4));
-        intervals.add(Interval.<Integer, Void>create(5, 7));
-        intervals.add(Interval.<Integer, Void>create(1, 3));
-        intervals.add(Interval.<Integer, Void>create(4, 6));
-        intervals.add(Interval.<Integer, Void>create(8, 9));
-        intervals.add(Interval.<Integer, Void>create(15, 20));
-        intervals.add(Interval.<Integer, Void>create(40, 50));
-        intervals.add(Interval.<Integer, Void>create(49, 60));
+    @Test
+    public void testSearch()
+    {
+        List<Interval<Integer, Integer>> intervals = new ArrayList<>();
 
+        intervals.add(Interval.create(-300, -200));
+        intervals.add(Interval.create(-3, -2));
+        intervals.add(Interval.create(1, 2));
+        intervals.add(Interval.create(3, 6));
+        intervals.add(Interval.create(2, 4));
+        intervals.add(Interval.create(5, 7));
+        intervals.add(Interval.create(1, 3));
+        intervals.add(Interval.create(4, 6));
+        intervals.add(Interval.create(8, 9));
+        intervals.add(Interval.create(15, 20));
+        intervals.add(Interval.create(40, 50));
+        intervals.add(Interval.create(49, 60));
 
-        IntervalTree<Integer, Void, Interval<Integer, Void>> it = IntervalTree.build(intervals);
+        IntervalTree<Integer, Integer, Interval<Integer, Integer>> it = IntervalTree.build(intervals);
 
-        assertEquals(3, it.search(Interval.<Integer, Void>create(4, 4)).size());
-        assertEquals(4, it.search(Interval.<Integer, Void>create(4, 5)).size());
-        assertEquals(7, it.search(Interval.<Integer, Void>create(-1, 10)).size());
-        assertEquals(0, it.search(Interval.<Integer, Void>create(-1, -1)).size());
-        assertEquals(5, it.search(Interval.<Integer, Void>create(1, 4)).size());
-        assertEquals(2, it.search(Interval.<Integer, Void>create(0, 1)).size());
-        assertEquals(0, it.search(Interval.<Integer, Void>create(10, 12)).size());
+        assertEquals(3, it.search(Interval.create(4, 4)).size());
+        assertEquals(4, it.search(Interval.create(4, 5)).size());
+        assertEquals(7, it.search(Interval.create(-1, 10)).size());
+        assertEquals(0, it.search(Interval.create(-1, -1)).size());
+        assertEquals(5, it.search(Interval.create(1, 4)).size());
+        assertEquals(2, it.search(Interval.create(0, 1)).size());
+        assertEquals(0, it.search(Interval.create(10, 12)).size());
 
-        List<Interval<Integer, Void>> intervals2 = new ArrayList<Interval<Integer, Void>>();
+        List<Interval<Integer, Integer>> intervals2 = new ArrayList<>();
 
         //stravinsky 1880-1971
-        intervals2.add(Interval.<Integer, Void>create(1880, 1971));
+        intervals2.add(Interval.create(1880, 1971));
         //Schoenberg
-        intervals2.add(Interval.<Integer, Void>create(1874, 1951));
+        intervals2.add(Interval.create(1874, 1951));
         //Grieg
-        intervals2.add(Interval.<Integer, Void>create(1843, 1907));
+        intervals2.add(Interval.create(1843, 1907));
         //Schubert
-        intervals2.add(Interval.<Integer, Void>create(1779, 1828));
+        intervals2.add(Interval.create(1779, 1828));
         //Mozart
-        intervals2.add(Interval.<Integer, Void>create(1756, 1828));
+        intervals2.add(Interval.create(1756, 1828));
         //Schuetz
-        intervals2.add(Interval.<Integer, Void>create(1585, 1672));
+        intervals2.add(Interval.create(1585, 1672));
 
-        IntervalTree<Integer, Void, Interval<Integer, Void>> it2 = IntervalTree.build(intervals2);
+        IntervalTree<Integer, Integer, Interval<Integer, Integer>> it2 = IntervalTree.build(intervals2);
 
-        assertEquals(0, it2.search(Interval.<Integer, Void>create(1829, 1842)).size());
+        assertEquals(0, it2.search(Interval.create(1829, 1842)).size());
 
-        List<Void> intersection1 = it2.search(Interval.<Integer, Void>create(1907, 1907));
+        List<Integer> intersection1 = it2.search(Interval.create(1907, 1907));
         assertEquals(3, intersection1.size());
 
-        intersection1 = it2.search(Interval.<Integer, Void>create(1780, 1790));
+        intersection1 = it2.search(Interval.create(1780, 1790));
         assertEquals(2, intersection1.size());
-
     }
 
     @Test
     public void testIteration()
     {
-        List<Interval<Integer, Void>> intervals = new ArrayList<Interval<Integer, Void>>();
+        List<Interval<Integer, Integer>> intervals = new ArrayList<>();
 
-        intervals.add(Interval.<Integer, Void>create(-300, -200));
-        intervals.add(Interval.<Integer, Void>create(-3, -2));
-        intervals.add(Interval.<Integer, Void>create(1, 2));
-        intervals.add(Interval.<Integer, Void>create(3, 6));
-        intervals.add(Interval.<Integer, Void>create(2, 4));
-        intervals.add(Interval.<Integer, Void>create(5, 7));
-        intervals.add(Interval.<Integer, Void>create(1, 3));
-        intervals.add(Interval.<Integer, Void>create(4, 6));
-        intervals.add(Interval.<Integer, Void>create(8, 9));
-        intervals.add(Interval.<Integer, Void>create(15, 20));
-        intervals.add(Interval.<Integer, Void>create(40, 50));
-        intervals.add(Interval.<Integer, Void>create(49, 60));
+        intervals.add(Interval.create(-300, -200));
+        intervals.add(Interval.create(-3, -2));
+        intervals.add(Interval.create(1, 2));
+        intervals.add(Interval.create(3, 6));
+        intervals.add(Interval.create(2, 4));
+        intervals.add(Interval.create(5, 7));
+        intervals.add(Interval.create(1, 3));
+        intervals.add(Interval.create(4, 6));
+        intervals.add(Interval.create(8, 9));
+        intervals.add(Interval.create(15, 20));
+        intervals.add(Interval.create(40, 50));
+        intervals.add(Interval.create(49, 60));
 
-        IntervalTree<Integer, Void, Interval<Integer, Void>> it = IntervalTree.build(intervals);
+        IntervalTree<Integer, Integer, Interval<Integer, Integer>> it = IntervalTree.build(intervals);
 
-        Collections.sort(intervals, Interval.<Integer, Void>minOrdering());
+        Collections.sort(intervals, Interval.minOrdering());
 
-        List<Interval<Integer, Void>> l = new ArrayList<Interval<Integer, Void>>();
-        for (Interval<Integer, Void> i : it)
-            l.add(i);
+        List<Interval<Integer, Integer>> l = ImmutableList.copyOf(it);
 
         assertEquals(intervals, l);
     }
 
     @Test
-    public void testSerialization() throws Exception
+    public void testEmptyTree()
     {
-        List<Interval<Integer, String>> intervals = new ArrayList<Interval<Integer, String>>();
+        IntervalTree<Integer, String, Interval<Integer, String>> emptyTree = IntervalTree.emptyTree();
 
-        intervals.add(Interval.<Integer, String>create(-300, -200, "a"));
-        intervals.add(Interval.<Integer, String>create(-3, -2, "b"));
-        intervals.add(Interval.<Integer, String>create(1, 2, "c"));
-        intervals.add(Interval.<Integer, String>create(1, 3, "d"));
-        intervals.add(Interval.<Integer, String>create(2, 4, "e"));
-        intervals.add(Interval.<Integer, String>create(3, 6, "f"));
-        intervals.add(Interval.<Integer, String>create(4, 6, "g"));
-        intervals.add(Interval.<Integer, String>create(5, 7, "h"));
-        intervals.add(Interval.<Integer, String>create(8, 9, "i"));
-        intervals.add(Interval.<Integer, String>create(15, 20, "j"));
-        intervals.add(Interval.<Integer, String>create(40, 50, "k"));
-        intervals.add(Interval.<Integer, String>create(49, 60, "l"));
+        assertTrue("Tree should be empty", emptyTree.isEmpty());
+        assertEquals("Interval count should be 0", 0, emptyTree.intervalCount());
 
-        IntervalTree<Integer, String, Interval<Integer, String>> it = IntervalTree.build(intervals);
+        try
+        {
+            emptyTree.min();
+            fail("Expected IllegalStateException when calling min() on empty tree");
+        }
+        catch (IllegalStateException e) { /* expected */ }
 
-        IVersionedSerializer<IntervalTree<Integer, String, Interval<Integer, String>>> serializer = IntervalTree.serializer(
-                new ISerializer<Integer>()
+        try
+        {
+            emptyTree.max();
+            fail("Expected IllegalStateException when calling max() on empty tree");
+        }
+        catch (IllegalStateException e) { /* expected */ }
+
+        assertTrue("Search should yield empty list for empty tree",
+                   emptyTree.search(Interval.create(1, 5, "data")).isEmpty());
+        assertTrue("Search by point should yield empty list for empty tree",
+                   emptyTree.search(5).isEmpty());
+
+        assertFalse("Iterator should have no elements", emptyTree.iterator().hasNext());
+    }
+
+    @Test
+    public void testSingleInterval()
+    {
+        Interval<Integer, String> interval = Interval.create(10, 20, "single");
+        List<Interval<Integer, String>> list = new ArrayList<>();
+        list.add(interval);
+
+        IntervalTree<Integer, String, Interval<Integer, String>> tree = IntervalTree.build(list);
+
+        assertFalse("Tree should not be empty", tree.isEmpty());
+        assertEquals("Interval count should be 1", 1, tree.intervalCount());
+        assertEquals("min() should match the only interval's min", Integer.valueOf(10), tree.min());
+        assertEquals("max() should match the only interval's max", Integer.valueOf(20), tree.max());
+
+        List<String> result = tree.search(Interval.create(10, 20));
+        assertEquals("Should find exactly 1 match", 1, result.size());
+        assertEquals("Data should match 'single'", "single", result.get(0));
+
+        result = tree.search(Interval.create(15, 25));
+        assertEquals("Should find overlap", 1, result.size());
+
+        result = tree.search(Interval.create(1, 9));
+        assertTrue("Should find no intervals that do not overlap", result.isEmpty());
+
+        List<Interval<Integer, String>> iterationList = ImmutableList.copyOf(tree);
+
+        assertEquals("Iteration should produce exactly our single interval",
+                     list, iterationList);
+    }
+
+    @Test
+    public void testMultipleIntervals()
+    {
+        List<Interval<Integer, String>> intervals = new ArrayList<>();
+        intervals.add(Interval.create(1, 3, "A"));
+        intervals.add(Interval.create(2, 4, "B"));
+        intervals.add(Interval.create(5, 7, "C"));
+        intervals.add(Interval.create(6, 6, "D"));   // single-point overlap within (5,7)
+        intervals.add(Interval.create(8, 10, "E"));
+        intervals.add(Interval.create(10, 12, "F")); // boundary adjacency with (8,10)
+
+        IntervalTree<Integer, String, Interval<Integer, String>> tree = IntervalTree.build(intervals);
+
+        assertFalse("Tree should not be empty", tree.isEmpty());
+        assertEquals("Interval count", intervals.size(), tree.intervalCount());
+
+        assertEquals("min()", Integer.valueOf(1), tree.min());
+        assertEquals("max()", Integer.valueOf(12), tree.max());
+
+        List<String> result = tree.search(Interval.create(2, 2)); // point in [1,3] and also in [2,4]
+        assertTrue(result.contains("A"));
+        assertTrue(result.contains("B"));
+        assertEquals("Should find 2 intervals for point=2", 2, result.size());
+
+        result = tree.search(Interval.create(4, 6));
+        assertTrue(result.contains("B"));
+        assertTrue(result.contains("C"));
+        assertTrue(result.contains("D"));
+        assertEquals("Should have 3 overlaps for [4,6]", 3, result.size());
+
+        result = tree.search(Interval.create(13, 14));
+        assertTrue("Should be no matches for [13,14]", result.isEmpty());
+
+        result = tree.search(Interval.create(10, 10));
+        assertTrue(result.contains("E"));
+        assertTrue(result.contains("F"));
+        assertEquals("Should find 2 intervals at boundary=10", 2, result.size());
+
+        Collections.sort(intervals, Interval.minOrdering());
+        List<Interval<Integer, String>> iterated = ImmutableList.copyOf(tree);
+        assertEquals("Iterated intervals should be in ascending min-order", intervals, iterated);
+    }
+
+    @Test
+    public void testDuplicateAndSameBoundaryIntervals()
+    {
+        List<Interval<Integer, String>> intervals = new ArrayList<>();
+        intervals.add(Interval.create(5, 5, "X"));  // single point
+        intervals.add(Interval.create(5, 5, "Y"));  // same single point, different data
+        intervals.add(Interval.create(5, 5, "X"));  // same data and boundary as first
+        intervals.add(Interval.create(5, 6, "Z"));  // partial overlap
+        intervals.add(Interval.create(4, 5, "W"));  // partial overlap at boundary
+
+        IntervalTree<Integer, String, Interval<Integer, String>> tree = IntervalTree.build(intervals);
+
+        assertEquals("min()", Integer.valueOf(4), tree.min());
+        assertEquals("max()", Integer.valueOf(6), tree.max());
+
+        List<String> result = tree.search(5);
+        assertEquals("Should have 5 matching intervals that contain point=5", 5, result.size());
+
+        result = tree.search(Interval.create(5, 5));
+        assertEquals("Should have 5 matching intervals that contain [5,5]", 5, result.size());
+
+        result = tree.search(Interval.create(6, 6));
+        assertEquals("Should match only [5,6] for point=6", 1, result.size());
+        assertTrue(result.contains("Z"));
+
+        result = tree.search(7);
+        assertTrue("No intervals should contain point=7", result.isEmpty());
+    }
+
+    @Test
+    public void testEqualsAndHashCode()
+    {
+        List<Interval<Integer, String>> intervals1 = new ArrayList<>();
+        intervals1.add(Interval.create(1, 2, "A"));
+        intervals1.add(Interval.create(3, 5, "B"));
+        intervals1.add(Interval.create(4, 6, "C"));
+
+        List<Interval<Integer, String>> intervals2 = new ArrayList<>();
+        // same intervals but in different order
+        intervals2.add(Interval.create(4, 6, "C"));
+        intervals2.add(Interval.create(1, 2, "A"));
+        intervals2.add(Interval.create(3, 5, "B"));
+
+        IntervalTree<Integer, String, Interval<Integer, String>> tree1 = IntervalTree.build(intervals1);
+        IntervalTree<Integer, String, Interval<Integer, String>> tree2 = IntervalTree.build(intervals2);
+
+        assertTrue("tree1 should be equal to tree2 despite different input order", tree1.equals(tree2));
+        assertEquals("tree1.hashCode() should match tree2.hashCode()", tree1.hashCode(), tree2.hashCode());
+
+        // Create a slightly different set
+        List<Interval<Integer, String>> intervals3 = new ArrayList<>(intervals1);
+        intervals3.add(Interval.create(10, 11, "X")); // extra interval
+
+        IntervalTree<Integer, String, Interval<Integer, String>> tree3 = IntervalTree.build(intervals3);
+        assertFalse("tree1 should not equal tree3 which has an extra interval", tree1.equals(tree3));
+        assertNotEquals("hashCode should differ if intervals differ", tree1.hashCode(), tree3.hashCode());
+    }
+
+    @Test
+    public void testPointSearchEquivalence()
+    {
+        List<Interval<Integer, String>> intervals = new ArrayList<>();
+        intervals.add(Interval.create(1, 3, "A"));
+        intervals.add(Interval.create(2, 5, "B"));
+        intervals.add(Interval.create(10, 20, "C"));
+
+        IntervalTree<Integer, String, Interval<Integer, String>> tree = IntervalTree.build(intervals);
+
+        List<String> resultPoint = tree.search(2);
+        List<String> resultInterval = tree.search(Interval.create(2, 2));
+
+        assertEquals("Results of point search and interval-based search should match",
+                     resultPoint, resultInterval);
+    }
+
+    private Gen<Interval<Integer, String>> intervalGen()
+    {
+        AtomicInteger id = new AtomicInteger();
+        return SourceDSL.integers().between(-5, 5)
+                        .flatMap(start ->
+                                 SourceDSL.integers().between(-5, 5)
+                                          .map(end -> {
+                                              int lo = Math.min(start, end);
+                                              int hi = Math.max(start, end);
+                                              String data = "(" + lo + "," + hi + "," + id.getAndIncrement() + ")";
+                                              return Interval.create(lo, hi, data);
+                                          }));
+    }
+
+    private Gen<List<Interval<Integer, String>>> intervalsListGen()
+    {
+        return lists().of(intervalGen())
+                      .ofSizeBetween(0, 7);
+    }
+
+    private Gen<Interval<Integer, String>> queryGen()
+    {
+        return SourceDSL.booleans().all()
+                        .flatMap(isPoint -> {
+                            if (isPoint)
+                            {
+                                return SourceDSL.integers().between(-5, 5)
+                                                .map(x -> Interval.create(x, x, "queryPoint(" + x + ")"));
+                            }
+                            else
+                            {
+                                return intervalGen().map(i -> Interval.create(i.min, i.max, "query[" + i.min + "," + i.max + "]"));
+                            }
+                        });
+    }
+
+    private boolean overlaps(Interval<Integer, ?> a, Interval<Integer, ?> b)
+    {
+        return a.min <= b.max && a.max >= b.min;
+    }
+
+    private <D> List<D> search(Collection<Interval<Integer, D>> intervals, Interval<Integer, ?> query)
+    {
+        List<D> results = new ArrayList<>();
+        for (Interval<Integer, D> candidate : intervals)
+        {
+            if (overlaps(candidate, query))
+                results.add(candidate.data);
+        }
+        return results;
+    }
+
+    @Test
+    public void qtIntervalTreeTest()
+    {
+        qt().forAll(intervalsListGen(), queryGen())
+            .check((intervals, query) -> {
+                IntervalTree<Integer, String, Interval<Integer, String>> tree = IntervalTree.build(intervals);
+
+                List<String> expected = search(intervals, query);
+                List<String> actual = tree.search(query);
+
+                Set<String> setExpected = new HashSet<>(expected);
+                Set<String> setActual = new HashSet<>(actual);
+
+                assertEquals(setExpected, setActual);
+
+                if (query.min.equals(query.max))
                 {
-                    public void serialize(Integer i, DataOutputPlus out) throws IOException
-                    {
-                        out.writeInt(i);
-                    }
+                    List<String> actualPoint = tree.search(query.min);
+                    assertEquals(setExpected, new HashSet<>(actualPoint));
+                }
 
-                    public Integer deserialize(DataInputPlus in) throws IOException
-                    {
-                        return in.readInt();
-                    }
+                Set<Interval<Integer, String>> fromTree = ImmutableSet.copyOf(tree);
 
-                    public long serializedSize(Integer i)
-                    {
-                        return 4;
-                    }
-                },
-                new ISerializer<String>()
+                assertEquals(intervals.size(), fromTree.size());
+                Set<Interval<Integer, String>> original = ImmutableSet.copyOf(intervals);
+
+                assertEquals(original, fromTree);
+
+                IntervalTree<Integer, String, Interval<Integer, String>> tree2 = IntervalTree.build(intervals);
+                assertEquals(tree, tree2);
+                assertEquals(tree.hashCode(), tree2.hashCode());
+
+                return true;
+            });
+    }
+
+    @Test
+    public void qtUpdateFunctionTest()
+    {
+        qt().withExamples(-1).withTestingTime(30, SECONDS).forAll(intervalsListGen(),
+                                                                  intervalsListGen(),
+                                                                  SourceDSL.lists().of(queryGen()).ofSizeBetween(1, 4),
+                                                                  SourceDSL.integers().all())
+            .check((original, toAdd, queries, seed) -> {
+                IntervalTree<Integer, String, Interval<Integer, String>> originalTree = IntervalTree.build(original);
+
+                java.util.Random rng = new java.util.Random(seed);
+
+                List<Interval<Integer, String>> removals = new ArrayList<>();
+                for (Interval<Integer, String> candidate : original)
                 {
-                    public void serialize(String v, DataOutputPlus out) throws IOException
+                    if (rng.nextBoolean())
+                        removals.add(candidate);
+                }
+
+                toAdd.removeAll(original.stream().filter(not(removals::contains)).collect(Collectors.toList()));
+
+                IntervalTree<Integer, String, Interval<Integer, String>> updatedTree = originalTree.update(removals.toArray(new Interval[0]), toAdd.toArray(new Interval[0]));
+
+                Set<Interval<Integer, String>> naiveFinal = new HashSet<>(original);
+                naiveFinal.removeAll(removals);
+                naiveFinal.addAll(toAdd);
+
+                Set<Interval<Integer, String>> iteratedTree = ImmutableSet.copyOf(updatedTree);
+                if (!naiveFinal.equals(iteratedTree))
+                    originalTree.update(removals.toArray(new Interval[0]), toAdd.toArray(new Interval[0]));
+                assertEquals(naiveFinal, iteratedTree);
+
+                for (Interval<Integer, String> query : queries)
+                {
+                    Set<String> actualResults = ImmutableSet.copyOf(updatedTree.search(query));
+                    Set<String> expectedResults = ImmutableSet.copyOf(search(naiveFinal, query));
+
+                    if (!expectedResults.equals(actualResults))
                     {
-                        out.writeUTF(v);
+                        originalTree.update(removals.toArray(new Interval[0]), toAdd.toArray(new Interval[0]));
+                        updatedTree.search(query);
                     }
 
-                    public String deserialize(DataInputPlus in) throws IOException
+                    assertEquals(expectedResults, actualResults);
+
+                    if (query.min.equals(query.max))
                     {
-                        return in.readUTF();
+                        List<String> pointResults = updatedTree.search(query.min);
+                        assertEquals(new HashSet<>(expectedResults), new HashSet<>(pointResults));
                     }
+                }
 
-                    public long serializedSize(String v)
-                    {
-                        return v.length();
-                    }
-                },
-                (Constructor<Interval<Integer, String>>) (Object) Interval.class.getConstructor(Object.class, Object.class, Object.class)
-        );
-
-        DataOutputBuffer out = new DataOutputBuffer();
-
-        serializer.serialize(it, out, 0);
-
-        DataInputPlus in = new DataInputBuffer(out.toByteArray());
-
-        IntervalTree<Integer, String, Interval<Integer, String>> it2 = serializer.deserialize(in, 0);
-        List<Interval<Integer, String>> intervals2 = new ArrayList<Interval<Integer, String>>();
-        for (Interval<Integer, String> i : it2)
-            intervals2.add(i);
-
-        assertEquals(intervals, intervals2);
+                return true;
+            });
     }
 }

--- a/test/unit/org/apache/cassandra/utils/OverlapIteratorTest.java
+++ b/test/unit/org/apache/cassandra/utils/OverlapIteratorTest.java
@@ -76,7 +76,7 @@ public class OverlapIteratorTest
         compare(randomIntervals(range, increment, count), random(range, increment, count), 3);
     }
 
-    private <I extends Comparable<I>, V> void compare(List<Interval<I, V>> intervals, List<I> points, int initCount)
+    private <I extends Comparable<I>, V extends Comparable<V>> void compare(List<Interval<I, V>> intervals, List<I> points, int initCount)
     {
         Collections.sort(points);
         IntervalTree<I, V, Interval<I, V>> tree = IntervalTree.build(intervals);
@@ -98,5 +98,4 @@ public class OverlapIteratorTest
             assertTrue(missing.isEmpty());
         }
     }
-
 }


### PR DESCRIPTION
### What is the issue
[HCD-468](https://datastax.jira.com/browse/HCD-468)

Significant CPU pressure from interval tree construction during sstable set updates when the number of sstables is high.

### What does this PR fix and why was it fixed
The ported patches change the view to be updated by locking instead of compare-and-set, which avoids having to do the interval tree construction multiple times for an update, improve the performance of updates, and add a metric measuring the time spent managing the interval trees.

This patch also increases the caching time of the estimated partition count metric, which can also cause CPU pressure in the presence of many single-partition sstables (usually from repair).


[HCD-468]: https://datastax.jira.com/browse/HCD-468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ