### PR TITLE
HCD-468: Shard level max sstables limit

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Future version (tbd)
+ * Compact all SSTables of a level shard if their number reaches a limit (CNDB-14577)
  * Require only MODIFY permission on base when updating table with MV (STAR-564)
 Merged from 5.0:
  * Disable chronicle analytics (CASSANDRA-19656)

--- a/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.java
+++ b/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.java
@@ -948,7 +948,7 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
 
             for (Level level : entry.getValue())
             {
-                Collection<CompactionAggregate.UnifiedAggregate> aggregates = level.getCompactionAggregates(arena, controller, spaceAvailable);
+                Collection<CompactionAggregate.UnifiedAggregate> aggregates = level.getCompactionAggregates(arena, controller, getShardManager(), spaceAvailable);
                 // Note: We allow empty aggregates into the list of pending compactions. The pending compactions list
                 // is for progress tracking only, and it is helpful to see empty levels there.
                 pending.addAll(aggregates);
@@ -1265,6 +1265,24 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
         return realm.metadata();
     }
 
+    CompactionPick createPick(UUID id, long parent, Collection<? extends CompactionSSTable> sstables)
+    {
+        return createPick(controller, id, parent, sstables);
+    }
+
+    static CompactionPick createPick(Controller controller, UUID id, long parent, Collection<? extends CompactionSSTable> sstables)
+    {
+        long totalDataSize = CompactionAggregate.getTotSizeBytes(sstables);
+        return CompactionPick.create(id,
+                                     parent,
+                                     sstables,
+                                     Collections.emptyList(),
+                                     0,
+                                     totalDataSize / Math.max(sstables.size(), 1),
+                                     totalDataSize);
+    }
+
+
     /// A compaction arena contains the list of sstables that belong to this arena as well as the arena
     /// selector used for comparison.
     public static class Arena implements Comparable<Arena>
@@ -1370,6 +1388,79 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
             this.avg += (size - avg) / sstables.size();
         }
 
+        private List<CompactionAggregate.UnifiedAggregate> getOversizeShardsAggregates(Arena arena,
+                                                                                       Controller controller,
+                                                                                       ShardManager shardManager)
+        {
+            List<CompactionAggregate.UnifiedAggregate> aggregates = new ArrayList<>();
+            double shardThreshold = fanout * controller.getMaxSstablesPerShardFactor();
+            if (sstables.size() > shardThreshold)
+            {
+                List<Set<CompactionSSTable>> groups = shardManager.splitSSTablesInShards(sstables,
+                                                                                         controller.getNumShards(max),
+                                                                                         (sstableShard, shardRange) -> Sets.newHashSet(sstableShard));
+
+                Set<CompactionSSTable> sstablesInOversizeGroup = new HashSet<>();
+                for (Set<CompactionSSTable> ssTables : groups)
+                {
+                    if (ssTables.size() > shardThreshold)
+                    {
+                        sstablesInOversizeGroup.addAll(ssTables);
+                    }
+                }
+
+                if (!sstablesInOversizeGroup.isEmpty())
+                {
+                    // Now combine the groups that share an sstable so that we have valid independent transactions.
+                    // Only keep the groups that were combined with an oversize group.
+                    groups = Overlaps.combineSetsWithCommonElement(groups);
+                    List<CompactionSSTable> unbucketed =  new ArrayList<>();
+
+                    for (Set<CompactionSSTable> group : groups)
+                    {
+                        boolean inOverSizeGroup = false;
+                        for (CompactionSSTable sstable : group)
+                        {
+                            if (sstablesInOversizeGroup.contains(sstable))
+                            {
+                                inOverSizeGroup = true;
+                                break;
+                            }
+                        }
+                        if (inOverSizeGroup)
+                        {
+                            aggregates.add(
+                            CompactionAggregate.createUnified(group,
+                                                              Overlaps.maxOverlap(group,
+                                                                                  CompactionSSTable.startsAfter,
+                                                                                  CompactionSSTable.firstKeyComparator,
+                                                                                  CompactionSSTable.lastKeyComparator),
+                                                              createPick(controller, nextTimeUUID(), index, group),
+                                                              Collections.emptyList(),
+                                                              arena,
+                                                              this)
+                            );
+                        }
+                        else
+                        {
+                            unbucketed.addAll(group);
+                        }
+                    }
+                    // Add all unbucketed sstables separately. Note that this will list the level (with its set of sstables)
+                    // even if it does not need compaction.
+                    if (!unbucketed.isEmpty())
+                        aggregates.add(CompactionAggregate.createUnified(unbucketed,
+                                                                         maxOverlap,
+                                                                         CompactionPick.EMPTY,
+                                                                         Collections.emptySet(),
+                                                                         arena,
+                                                                         this));
+                    return aggregates;
+                }
+            }
+            return aggregates;
+        }
+
         void complete()
         {
             if (logger.isTraceEnabled())
@@ -1379,11 +1470,20 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
         /// Return the compaction aggregate
         Collection<CompactionAggregate.UnifiedAggregate> getCompactionAggregates(Arena arena,
                                                                                  Controller controller,
+                                                                                 ShardManager shardManager,
                                                                                  long spaceAvailable)
         {
             if (logger.isTraceEnabled())
                 logger.trace("Creating compaction aggregate with sstable set {}", sstables);
 
+            List<CompactionAggregate.UnifiedAggregate> aggregates = new ArrayList<>();
+
+            if (sstables.isEmpty())
+            {
+                if (logger.isTraceEnabled())
+                    logger.trace("No sstables in level {} of arena {}, skipping compaction", this, arena);
+                return aggregates;
+            }
 
             // Note that adjacent overlap sets may include deduplicated sstable
             List<Set<CompactionSSTable>> overlaps = Overlaps.constructOverlapSets(sstables,
@@ -1400,9 +1500,19 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
                                                                       this::makeBucket,
                                                                       unbucketed::addAll);
 
-            List<CompactionAggregate.UnifiedAggregate> aggregates = new ArrayList<>();
-            for (Bucket bucket : buckets)
-                aggregates.add(bucket.constructAggregate(controller, spaceAvailable, arena));
+            if (!buckets.isEmpty())
+            {
+                for (Bucket bucket : buckets)
+                    aggregates.add(bucket.constructAggregate(controller, spaceAvailable, arena));
+            }
+            else
+            {
+                // CNDB-14577: If there are no overlaps, we look if some shards have too many SSTables.
+                // If that's the case, we perform a major compaction on those shards.
+                List<CompactionAggregate.UnifiedAggregate> oversizeShardsAggregates = getOversizeShardsAggregates(arena, controller, shardManager);
+                if (!oversizeShardsAggregates.isEmpty())
+                    return oversizeShardsAggregates;
+            }
 
             // Add all unbucketed sstables separately. Note that this will list the level (with its set of sstables)
             // even if it does not need compaction.

--- a/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.md
+++ b/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.md
@@ -319,6 +319,24 @@ on the number of overlapping sources we compact; in that case we use the collect
 select at most limit-many in any included overlap set, making sure that if an sstable is included in this compaction,
 all older ones are also included to maintain time order.
 
+## Non-overlapping sstables trigger
+
+In some scenarios it is possible for (small) non-overlapping sstables to accumulate in numbers that can cause problems
+due to the sheer number of sstables present. For example, in tables with regularly scheduled snapshots, which also use
+time-based partitioning, that regular snapshot will often flush single-partition sstables. When the partition time
+window passes, the normal overlap processing will no longer find newly flushed data that overlaps with older sstables
+and will thus leave those sstables alone. Eventually we can end up with thousands of sstables on a lower level that are
+never compacted.
+
+This can be a problem, especially in combination with SAI indexing, which prefers a lower number of sstables overall.
+To address it, the strategy offers a threshold for the number of sstables that can be present on any of the shards that
+the sharding strategy assigns for a given level. The threshold is specified as a multiple of a level's fan factor: if
+there are no normal compactions to perform on a level, and we can find a shard that has more sstables than the
+threshold, we perform the equivalent of a major compaction for the smallest set of shards that contains it. The result
+is split on each output shard boundary and results in a single sstable for each of the output shards. This should
+create sstables that span many partitions and that will thus progress nicely through the normal processing in the
+next levels of the hierarchy.
+
 ## Prioritization of compactions
 
 Compaction strategies aim to minimize the read amplification of queries, which is defined by the number of sstables
@@ -546,6 +564,14 @@ UCS accepts these compaction strategy parameters:
   Sets $b$ to the specified value, $\lambda$ to 1, and the default minimum sstable size to 'auto'.  
   Disabled by default and cannot be used in combination with `base_shard_count`, `target_sstable_size` or
   `sstable_growth`.
+* `max_sstables_per_shard_factor` Limits the number of SSTables per shard. If the number of sstables in a shard
+    exceeds this factor times the shard compaction threshold, a major compaction of the shard will be triggered.
+    Some conditions like slow writes can lead to SSTables being very small, and never overlap with enough other SSTables
+    to be compacted.
+    So this setting is useful to prevent the number of SSTables in a shard from growing too large, which can cause
+    problems due to the per-sstable overhead. Also these small SSTables may still have overlaps even if under the
+    compaction threshold (eg. due to write replicas) and never compacting them wastes storage space.
+    The default value is 10.
 
 In `cassandra.yaml`:
 

--- a/src/java/org/apache/cassandra/db/compaction/unified/AdaptiveController.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/AdaptiveController.java
@@ -120,6 +120,7 @@ public class AdaptiveController extends Controller
                               Overlaps.InclusionMethod overlapInclusionMethod,
                               boolean parallelizeOutputShards,
                               boolean hasVectorType,
+                              double maxSstablesPerShardFactor,
                               int intervalSec,
                               int minScalingParameter,
                               int maxScalingParameter,
@@ -148,7 +149,8 @@ public class AdaptiveController extends Controller
               reservationsType,
               overlapInclusionMethod,
               parallelizeOutputShards,
-              hasVectorType);
+              hasVectorType,
+              maxSstablesPerShardFactor);
 
         this.scalingParameters = scalingParameters;
         this.previousScalingParameters = previousScalingParameters;
@@ -180,6 +182,7 @@ public class AdaptiveController extends Controller
                                   Overlaps.InclusionMethod overlapInclusionMethod,
                                   boolean parallelizeOutputShards,
                                   boolean hasVectorType,
+                                  double maxSstablesPerShardFactor,
                                   String keyspaceName,
                                   String tableName,
                                   Map<String, String> options)
@@ -280,6 +283,7 @@ public class AdaptiveController extends Controller
                                       overlapInclusionMethod,
                                       parallelizeOutputShards,
                                       hasVectorType,
+                                      maxSstablesPerShardFactor,
                                       intervalSec,
                                       minScalingParameter,
                                       maxScalingParameter,

--- a/src/java/org/apache/cassandra/db/compaction/unified/Controller.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/Controller.java
@@ -44,6 +44,7 @@ import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.compaction.CompactionAggregate;
 import org.apache.cassandra.db.compaction.CompactionPick;
 import org.apache.cassandra.db.compaction.CompactionRealm;
+import org.apache.cassandra.db.compaction.CompactionSSTable;
 import org.apache.cassandra.db.compaction.CompactionStrategy;
 import org.apache.cassandra.db.compaction.UnifiedCompactionStrategy;
 import org.apache.cassandra.db.marshal.VectorType;
@@ -318,6 +319,9 @@ public abstract class Controller
     @Deprecated
     static final String STATIC_SCALING_FACTORS_OPTION = "static_scaling_factors";
 
+    static final String MAX_SSTABLES_PER_SHARD_FACTOR_OPTION = "max_sstables_per_shard_factor";
+    static final double DEFAULT_MAX_SSTABLES_PER_SHARD_FACTOR = Double.parseDouble(getSystemProperty(MAX_SSTABLES_PER_SHARD_FACTOR_OPTION, "10"));
+
     protected final MonotonicClock clock;
     protected final Environment env;
     protected final double[] survivalFactors;
@@ -350,6 +354,8 @@ public abstract class Controller
     final boolean l0ShardsEnabled;
     final boolean hasVectorType;
 
+    final double maxSstablesPerShardFactor;
+
     Controller(MonotonicClock clock,
                Environment env,
                double[] survivalFactors,
@@ -369,7 +375,8 @@ public abstract class Controller
                Reservations.Type reservationsType,
                Overlaps.InclusionMethod overlapInclusionMethod,
                boolean parallelizeOutputShards,
-               boolean hasVectorType)
+               boolean hasVectorType,
+               double maxSstablesPerShardFactor)
     {
         this.clock = clock;
         this.env = env;
@@ -390,6 +397,7 @@ public abstract class Controller
         this.l0ShardsEnabled = Boolean.parseBoolean(getSystemProperty(L0_SHARDS_ENABLED_OPTION, "false")); // FIXME VECTOR-23
         this.parallelizeOutputShards = parallelizeOutputShards;
         this.hasVectorType = hasVectorType;
+        this.maxSstablesPerShardFactor = maxSstablesPerShardFactor;
 
         if (maxSSTablesToCompact <= 0)  // use half the maximum permitted compaction size as upper bound by default
             maxSSTablesToCompact = (int) (dataSetSize * this.maxSpaceOverhead * 0.5 / getMinSstableSizeBytes());
@@ -786,6 +794,11 @@ public abstract class Controller
         return hasVectorType;
     }
 
+    public double getMaxSstablesPerShardFactor()
+    {
+        return maxSstablesPerShardFactor;
+    }
+
     /**
      * @return true if the controller is running
      */
@@ -1033,6 +1046,10 @@ public abstract class Controller
                                           ? Boolean.parseBoolean(options.get(PARALLELIZE_OUTPUT_SHARDS_OPTION))
                                           : DEFAULT_PARALLELIZE_OUTPUT_SHARDS;
 
+        double maxSstablesPerShardFactor = options.containsKey(MAX_SSTABLES_PER_SHARD_FACTOR_OPTION)
+                                           ? Double.parseDouble(options.get(MAX_SSTABLES_PER_SHARD_FACTOR_OPTION))
+                                           : DEFAULT_MAX_SSTABLES_PER_SHARD_FACTOR;
+
         return adaptive
                ? AdaptiveController.fromOptions(env,
                                                 survivalFactors,
@@ -1052,6 +1069,7 @@ public abstract class Controller
                                                 overlapInclusionMethod,
                                                 parallelizeOutputShards,
                                                 hasVectorType,
+                                                maxSstablesPerShardFactor,
                                                 realm.getKeyspaceName(),
                                                 realm.getTableName(),
                                                 options)
@@ -1073,6 +1091,7 @@ public abstract class Controller
                                               overlapInclusionMethod,
                                               parallelizeOutputShards,
                                               hasVectorType,
+                                              maxSstablesPerShardFactor,
                                               realm.getKeyspaceName(),
                                               realm.getTableName(),
                                               options,
@@ -1391,6 +1410,26 @@ public abstract class Controller
             throw new ConfigurationException(String.format("The vector minimum sstable size %s cannot be larger than the target size's lower bound %s.",
                                                            FBUtilities.prettyPrintMemory(vectorMinSSTableSize),
                                                            FBUtilities.prettyPrintMemory((long) (vectorTargetSSTableSize * INVERSE_SQRT_2))));
+
+        s = options.remove(MAX_SSTABLES_PER_SHARD_FACTOR_OPTION);
+        if (s != null)
+        {
+            try
+            {
+                double maxSstablesPerShardFactor = Double.parseDouble(s);
+                if (maxSstablesPerShardFactor < 1)
+                    throw new ConfigurationException(String.format("%s %s must be a float >= 1",
+                                                                   MAX_SSTABLES_PER_SHARD_FACTOR_OPTION,
+                                                                   s));
+            }
+            catch (NumberFormatException e)
+            {
+                throw new ConfigurationException(String.format(floatParseErr,
+                                                               s,
+                                                               MAX_SSTABLES_PER_SHARD_FACTOR_OPTION),
+                                                 e);
+            }
+        }
 
         return adaptive ? AdaptiveController.validateOptions(options) : StaticController.validateOptions(options);
     }

--- a/src/java/org/apache/cassandra/db/compaction/unified/Environment.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/Environment.java
@@ -16,11 +16,6 @@
 
 package org.apache.cassandra.db.compaction.unified;
 
-import java.util.List;
-import java.util.Random;
-
-import org.agrona.collections.IntArrayList;
-import org.apache.cassandra.db.compaction.CompactionAggregate;
 import org.apache.cassandra.db.compaction.CompactionPick;
 import org.apache.cassandra.utils.MovingAverage;
 

--- a/src/java/org/apache/cassandra/db/compaction/unified/StaticController.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/StaticController.java
@@ -70,6 +70,7 @@ public class StaticController extends Controller
                             Overlaps.InclusionMethod overlapInclusionMethod,
                             boolean parallelizeOutputShards,
                             boolean hasVectorType,
+                            double maxSstablesPerShardFactor,
                             String keyspaceName,
                             String tableName)
     {
@@ -92,7 +93,8 @@ public class StaticController extends Controller
               reservationsType,
               overlapInclusionMethod,
               parallelizeOutputShards,
-              hasVectorType);
+              hasVectorType,
+              maxSstablesPerShardFactor);
         this.scalingParameters = scalingParameters;
         this.keyspaceName = keyspaceName;
         this.tableName = tableName;
@@ -116,6 +118,7 @@ public class StaticController extends Controller
                                   Overlaps.InclusionMethod overlapInclusionMethod,
                                   boolean parallelizeOutputShards,
                                   boolean hasVectorType,
+                                  double maxSstablesPerShardFactor,
                                   String keyspaceName,
                                   String tableName,
                                   Map<String, String> options,
@@ -170,6 +173,7 @@ public class StaticController extends Controller
                                     overlapInclusionMethod,
                                     parallelizeOutputShards,
                                     hasVectorType,
+                                    maxSstablesPerShardFactor,
                                     keyspaceName,
                                     tableName);
     }

--- a/test/unit/org/apache/cassandra/db/compaction/CompactionSimulationTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CompactionSimulationTest.java
@@ -222,6 +222,9 @@ public class CompactionSimulationTest extends BaseCompactionStrategyTest
     @Option(name= {"-overlap-inclusion-method"}, description = "Overlap inclusion method, NONE, SINGLE or TRANSITIVE")
     Overlaps.InclusionMethod overlapInclusionMethod = Overlaps.InclusionMethod.TRANSITIVE;
 
+    @Option(name= {"-max-sstables-per-shard-factor"}, description = "Factor used to determine the maximum number of sstables per level shard")
+    double maxSstablesPerShardFactor = 10;
+
     @BeforeClass
     public static void setUpClass()
     {
@@ -411,6 +414,7 @@ public class CompactionSimulationTest extends BaseCompactionStrategyTest
                                                          overlapInclusionMethod,
                                                          true,
                                                          false,
+                                                         maxSstablesPerShardFactor,
                                                          updateTimeSec,
                                                          minW,
                                                          maxW,
@@ -439,6 +443,7 @@ public class CompactionSimulationTest extends BaseCompactionStrategyTest
                                                        overlapInclusionMethod,
                                                        true,
                                                        false,
+                                                       maxSstablesPerShardFactor,
                                                        "ks",
                                                        "tbl");
 

--- a/test/unit/org/apache/cassandra/db/compaction/UnifiedCompactionStrategyTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/UnifiedCompactionStrategyTest.java
@@ -199,6 +199,7 @@ public class UnifiedCompactionStrategyTest extends BaseCompactionStrategyTest
         long minimalSizeBytes = m << 20;
 
         Controller controller = Mockito.mock(Controller.class);
+        ShardManager shardManager = Mockito.mock(ShardManager.class);
         when(controller.getMinSstableSizeBytes()).thenReturn(minimalSizeBytes);
         when(controller.getNumShards(anyDouble())).thenReturn(1);
         when(controller.getBaseSstableSize(anyInt())).thenReturn((double) minimalSizeBytes);
@@ -259,7 +260,7 @@ public class UnifiedCompactionStrategyTest extends BaseCompactionStrategyTest
                 assertEquals(i, level.getIndex());
 
                 Collection<CompactionAggregate.UnifiedAggregate> compactionAggregates =
-                level.getCompactionAggregates(entry.getKey(), controller, dataSetSizeBytes);
+                level.getCompactionAggregates(entry.getKey(), controller, shardManager, dataSetSizeBytes);
 
                 long selectedCount = compactionAggregates.stream()
                                                          .filter(a -> !a.isEmpty())
@@ -315,7 +316,9 @@ public class UnifiedCompactionStrategyTest extends BaseCompactionStrategyTest
         long minimalSizeBytes = m << 20;
 
         Controller controller = Mockito.mock(Controller.class);
+        ShardManager shardManager = Mockito.mock(ShardManager.class);
         when(controller.getMinSstableSizeBytes()).thenReturn(minimalSizeBytes);
+        when(controller.getNumShards(anyDouble())).thenReturn(16);
         when(controller.getNumShards(anyDouble())).thenReturn(1);
         when(controller.getBaseSstableSize(anyInt())).thenReturn((double) minimalSizeBytes);
         when(controller.maxConcurrentCompactions()).thenReturn(1000); // let it generate as many candidates as it can
@@ -371,7 +374,7 @@ public class UnifiedCompactionStrategyTest extends BaseCompactionStrategyTest
                 assertEquals(i, level.getIndex());
 
                 Collection<CompactionAggregate.UnifiedAggregate> compactionAggregates =
-                    level.getCompactionAggregates(entry.getKey(), controller, dataSetSizeBytes);
+                    level.getCompactionAggregates(entry.getKey(), controller, shardManager, dataSetSizeBytes);
 
                 Set<CompactionSSTable> selectedSSTables = new HashSet<>();
                 for (CompactionAggregate.UnifiedAggregate aggregate : compactionAggregates)
@@ -738,6 +741,7 @@ public class UnifiedCompactionStrategyTest extends BaseCompactionStrategyTest
         when(controller.getMaxLevelDensity(anyInt(), anyDouble())).thenCallRealMethod();
         when(controller.getSurvivalFactor(anyInt())).thenReturn(1.0);
         when(controller.getNumShards(anyDouble())).thenReturn(numShards);
+        when(controller.getMaxSstablesPerShardFactor()).thenReturn(10.0);
         when(controller.getMaxSpaceOverhead()).thenReturn(maxSpaceOverhead);
         when(controller.getBaseSstableSize(anyInt())).thenReturn((double) minSstableSizeBytes);
         when(controller.maxConcurrentCompactions()).thenReturn(maxCount);
@@ -1331,6 +1335,7 @@ public class UnifiedCompactionStrategyTest extends BaseCompactionStrategyTest
         when(controller.getThreshold(anyInt())).thenCallRealMethod();
         when(controller.getSurvivalFactor(anyInt())).thenReturn(1.0);
         when(controller.getNumShards(anyDouble())).thenReturn(numShards);
+        when(controller.getMaxSstablesPerShardFactor()).thenReturn(10.0);
         when(controller.getBaseSstableSize(anyInt())).thenReturn((double) minimalSizeBytes);
         when(controller.maxConcurrentCompactions()).thenReturn(1000); // let it generate as many candidates as it can
         when(controller.maxCompactionSpaceBytes()).thenReturn(Long.MAX_VALUE);
@@ -1868,6 +1873,48 @@ public class UnifiedCompactionStrategyTest extends BaseCompactionStrategyTest
         testBucketSelection(repeats(4, arr(6, 3)), arr(6, 6), Overlaps.InclusionMethod.TRANSITIVE, 4, 2, 3);
     }
 
+    // We use a level with only non-overlapping SSTables, so there won't be any standard bucketing compaction.
+    // The per-shard threshold is fanout(3) * maxSstablesPerShardFactor(10) = 30.
+    // We use a number of SSTables per shard just superior to the per-shard threshold.
+    // We use a total number of SSTables just superior to numShards * sstablesPerShard so the SSTables are not aligned
+    // with the shard boundaries. This means that all shards will have an SSTable in common with the next shard.
+    // We drop the SSTables that cross the boundaries between the first and second shard, and between the second and
+    // third shard.
+    // In the end, we get 3 groups of shards with SSTables in common:
+    // - a group with the first shard which has perShardThreshold + 1 SSTables, so will get compacted.
+    // - a group with the second shard which has perShardThreshold SSTables, so will not get compacted.
+    // - a group with the rest of the shards, one of those shards having perShardThreshold + 1 SSTables, so will get compacted.
+    @Test
+    public void testBucketSelectionNonOverlapping()
+    {
+        int numShards = 16;
+        double maxSstablesPerShardFactor = 10.0;
+        int perShardThreshold = (int) (3 * maxSstablesPerShardFactor);
+        int sstablesPerShard = perShardThreshold + 1;
+        testBucketSelection(arr(numShards * sstablesPerShard + 1),
+                            arr(sstablesPerShard, sstablesPerShard * (numShards - 2)),
+                            Overlaps.InclusionMethod.TRANSITIVE,
+                            numShards,
+                            maxSstablesPerShardFactor,
+                            perShardThreshold,
+                            sstablesPerShard, sstablesPerShard * 2);
+    }
+
+    // Same as testBucketSelectionNonOverlapping, but with an infinite maxSstablesPerShardFactor
+    // to deactivate compaction of oversize shards.
+    @Test
+    public void testBucketSelectionNonOverlappingInfiniteFactor()
+    {
+        int numShards = 16;
+        int sstablesPerShard = (3 * 10) + 1;
+        testBucketSelection(arr(numShards * sstablesPerShard + 1),
+                            arr(),
+                            Overlaps.InclusionMethod.TRANSITIVE,
+                            numShards,
+                            Double.POSITIVE_INFINITY,
+                            numShards * sstablesPerShard - 1,
+                            sstablesPerShard, sstablesPerShard * 2);
+    }
 
     private int[] arr(int... values)
     {
@@ -1904,6 +1951,11 @@ public class UnifiedCompactionStrategyTest extends BaseCompactionStrategyTest
 
     public void testBucketSelection(int[] counts, int[] expecteds, Overlaps.InclusionMethod overlapInclusionMethod, int expectedRemaining, int... dropFromFirst)
     {
+        testBucketSelection(counts, expecteds, overlapInclusionMethod, 16, 10.0, expectedRemaining, dropFromFirst);
+    }
+
+    public void testBucketSelection(int[] counts, int[] expecteds, Overlaps.InclusionMethod overlapInclusionMethod, int numShards, double maxSstablesPerShardFactor, int expectedRemaining, int... dropFromFirst)
+    {
         Set<SSTableReader> allSSTables = new HashSet<>();
         int fanout = counts.length;
         for (int i = 0; i < fanout; ++i)
@@ -1922,6 +1974,8 @@ public class UnifiedCompactionStrategyTest extends BaseCompactionStrategyTest
         when(controller.getFanout(anyInt())).thenCallRealMethod();
         when(controller.getThreshold(anyInt())).thenCallRealMethod();
         when(controller.getMaxLevelDensity(anyInt(), anyDouble())).thenCallRealMethod();
+        when(controller.getNumShards(anyDouble())).thenReturn(numShards);
+        when(controller.getMaxSstablesPerShardFactor()).thenReturn(maxSstablesPerShardFactor);
         when(controller.getSurvivalFactor(anyInt())).thenReturn(1.0);
         when(controller.getBaseSstableSize(anyInt())).thenReturn((double) (90 << 20));
         when(controller.overlapInclusionMethod()).thenReturn(overlapInclusionMethod);

--- a/test/unit/org/apache/cassandra/db/compaction/unified/AdaptiveControllerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/unified/AdaptiveControllerTest.java
@@ -87,6 +87,7 @@ public class AdaptiveControllerTest extends ControllerTest
                                       Controller.DEFAULT_OVERLAP_INCLUSION_METHOD,
                                       true,
                                       false,
+                                      Controller.DEFAULT_MAX_SSTABLES_PER_SHARD_FACTOR,
                                       interval,
                                       minW,
                                       maxW,

--- a/test/unit/org/apache/cassandra/db/compaction/unified/ControllerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/unified/ControllerTest.java
@@ -616,6 +616,30 @@ public abstract class ControllerTest
         testBooleanOption(Controller.PARALLELIZE_OUTPUT_SHARDS_OPTION, Controller.DEFAULT_PARALLELIZE_OUTPUT_SHARDS, Controller::parallelizeOutputShards);
     }
 
+    @Test
+    public void testMaxSstablesPerShardFactor()
+    {
+        HashMap<String, String> options = new HashMap<>();
+        Controller controller = Controller.fromOptions(cfs, options);
+        assertEquals(Controller.DEFAULT_MAX_SSTABLES_PER_SHARD_FACTOR, controller.getMaxSstablesPerShardFactor(), epsilon);
+
+        options.put(Controller.MAX_SSTABLES_PER_SHARD_FACTOR_OPTION, "123.456");
+        Controller.validateOptions(options);
+        controller = Controller.fromOptions(cfs, options);
+        assertEquals(123.456, controller.getMaxSstablesPerShardFactor(), epsilon);
+
+        options.put(Controller.MAX_SSTABLES_PER_SHARD_FACTOR_OPTION, "1e1000");
+        Controller.validateOptions(options);
+        controller = Controller.fromOptions(cfs, options);
+        assertEquals(Double.POSITIVE_INFINITY, controller.getMaxSstablesPerShardFactor(), epsilon);
+
+        options.put(Controller.MAX_SSTABLES_PER_SHARD_FACTOR_OPTION, "0.9");
+        assertThrows(ConfigurationException.class, () -> Controller.validateOptions(options));
+
+        options.put(Controller.MAX_SSTABLES_PER_SHARD_FACTOR_OPTION, "invalid");
+        assertThrows(ConfigurationException.class, () -> Controller.validateOptions(options));
+    }
+
     public void testBooleanOption(String name, boolean defaultValue, Predicate<Controller> getter, String... extraSettings)
     {
         Controller controller = Controller.fromOptions(cfs, newOptions(extraSettings));

--- a/test/unit/org/apache/cassandra/db/compaction/unified/StaticControllerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/unified/StaticControllerTest.java
@@ -252,6 +252,7 @@ public class StaticControllerTest extends ControllerTest
                                                            Controller.DEFAULT_OVERLAP_INCLUSION_METHOD,
                                                            true,
                                                            false,
+                                                           Controller.DEFAULT_MAX_SSTABLES_PER_SHARD_FACTOR,
                                                            keyspaceName,
                                                            tableName);
         super.testStartShutdown(controller);
@@ -280,6 +281,7 @@ public class StaticControllerTest extends ControllerTest
                                                            Controller.DEFAULT_OVERLAP_INCLUSION_METHOD,
                                                            true,
                                                            false,
+                                                           Controller.DEFAULT_MAX_SSTABLES_PER_SHARD_FACTOR,
                                                            keyspaceName,
                                                            tableName);
         super.testShutdownNotStarted(controller);
@@ -308,6 +310,7 @@ public class StaticControllerTest extends ControllerTest
                                                            Controller.DEFAULT_OVERLAP_INCLUSION_METHOD,
                                                            true,
                                                            false,
+                                                           Controller.DEFAULT_MAX_SSTABLES_PER_SHARD_FACTOR,
                                                            keyspaceName,
                                                            tableName);
         super.testStartAlreadyStarted(controller);


### PR DESCRIPTION
CNDB-14577: Compact all SSTables of a level shard if their number reaches a limit

CNDB-14577: [UCS by default does not compact many small non-overlapping sstables with very few
rows](riptano/cndb#14577)

This PR limits the number of SSTables for a given compaction level shard by executing a major compaction of the shard instead of the regular compaction of overlapping SSTables if the number of SSTables reaches a threshold.

The threshold is controlled by the `max_sstables_per_shard_factor` setting:
```md
  `max_sstables_per_shard_factor` Limits the number of SSTables per shard. If the number of sstables in a shard
  exceeds this factor times the shard compaction threshold, a major compaction of the shard will be triggered.
  Some conditions like slow writes can lead to SSTables being very small, and never overlap with enough other SSTables
  to be compacted.
  So this setting is useful to prevent the number of SSTables in a shard from growing too large, which can cause
  problems due to the per-sstable overhead. Also these small SSTables may still have overlaps even if under the
  compaction threshold (eg. due to write replicas) and never compacting them wastes storage space.
  The default value is 10.
```

---------

Patch by: Christophe Bornet <cbornet@hotmail.com>
Co-authored-by: Branimir Lambov <branimir.lambov@datastax.com>