### PR TITLE
CNDB-18639: Enable hierarchy and parallel graph writing for FusedPQ test runs.  Exclude Version.FA from parameterized vector test suites

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/vector/CompactionGraph.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/CompactionGraph.java
@@ -116,7 +116,8 @@ public class CompactionGraph implements Closeable, Accountable
     @VisibleForTesting
     public static int PQ_TRAINING_SIZE = ProductQuantization.MAX_PQ_TRAINING_SET_SIZE;
 
-    private static boolean PARALLEL_ENCODING_WRITING = CassandraRelevantProperties.SAI_ENCODE_AND_WRITE_VECTOR_GRAPH_IN_PARALLEL_ENABLED.getBoolean();
+    @VisibleForTesting
+    public static boolean PARALLEL_ENCODING_WRITING = CassandraRelevantProperties.SAI_ENCODE_AND_WRITE_VECTOR_GRAPH_IN_PARALLEL_ENABLED.getBoolean();
     private static int PARALLEL_ENCODING_WRITING_NUM_THREADS = CassandraRelevantProperties.SAI_ENCODE_AND_WRITE_VECTOR_GRAPH_IN_PARALLEL_NUM_THREADS.getInt();
     private static boolean PARALLEL_ENCODING_WRITING_USE_DIRECT_BUFFERS = CassandraRelevantProperties.SAI_ENCODE_AND_WRITE_VECTOR_GRAPH_IN_PARALLEL_USE_DIRECT_BUFFERS.getBoolean();
 

--- a/test/unit/org/apache/cassandra/index/sai/SAIUtil.java
+++ b/test/unit/org/apache/cassandra/index/sai/SAIUtil.java
@@ -29,6 +29,7 @@ import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.index.Index;
 import org.apache.cassandra.index.SecondaryIndexManager;
 import org.apache.cassandra.index.sai.disk.format.Version;
+import org.apache.cassandra.index.sai.disk.vector.CompactionGraph;
 import org.apache.cassandra.index.sai.disk.vector.JVectorVersionUtil;
 import org.apache.cassandra.schema.Schema;
 import org.apache.cassandra.utils.ReflectionUtils;
@@ -98,6 +99,11 @@ public class SAIUtil
         {
             throw new RuntimeException(e);
         }
+    }
+
+    public static void setParallelGraphWriting(boolean enabled)
+    {
+        CompactionGraph.PARALLEL_ENCODING_WRITING = enabled;
     }
 
     public static void setEnableFused(boolean enableFused)

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorColumnPositionsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorColumnPositionsTest.java
@@ -44,7 +44,7 @@ public class VectorColumnPositionsTest extends VectorTester.Versioned
     public void testPartitionKeyComponentWithColumns() throws Throwable
     {
         createTable("CREATE TABLE %s (k1 int, k2 vector<float, 2>, v int, PRIMARY KEY((k1, k2)))");
-        createIndex("CREATE CUSTOM INDEX ON %s(k2) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "k2"));
         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
 
         String insert = "INSERT INTO %s (k1, k2, v) VALUES (?, ?, ?)";
@@ -85,7 +85,7 @@ public class VectorColumnPositionsTest extends VectorTester.Versioned
     public void testPartitionKeyComponentWithoutColumns() throws Throwable
     {
         createTable("CREATE TABLE %s (k1 int, k2 vector<float, 2>, v int, PRIMARY KEY((k1, k2)))");
-        createIndex("CREATE CUSTOM INDEX ON %s(k2) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "k2"));
 
         String insert = "INSERT INTO %s (k1, k2) VALUES (?, ?)";
         execute(insert, row(1, vector(0.1f, 0.1f)));
@@ -113,7 +113,7 @@ public class VectorColumnPositionsTest extends VectorTester.Versioned
     public void testPartitionKeyComponentWithClustering() throws Throwable
     {
         createTable("CREATE TABLE %s (k1 int, k2 vector<float, 2>, c int, v int, PRIMARY KEY((k1, k2), c))");
-        createIndex("CREATE CUSTOM INDEX ON %s(k2) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "k2"));
         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
 
         // insert static rows and non-static rows all at once
@@ -155,7 +155,7 @@ public class VectorColumnPositionsTest extends VectorTester.Versioned
     public void testClusteringKey() throws Throwable
     {
         createTable("CREATE TABLE %s (k int, c vector<float, 2>, v int, PRIMARY KEY(k, c))");
-        createIndex("CREATE CUSTOM INDEX ON %s(c) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "c"));
         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
 
         String insert = "INSERT INTO %s (k, c, v) VALUES (?, ?, ?)";
@@ -196,7 +196,7 @@ public class VectorColumnPositionsTest extends VectorTester.Versioned
     public void testClusteringKeyComponent() throws Throwable
     {
         createTable("CREATE TABLE %s (k int, c1 int, c2 vector<float, 2>, v int, PRIMARY KEY(k, c1, c2))");
-        createIndex("CREATE CUSTOM INDEX ON %s(c2) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "c2"));
         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
 
         String insert = "INSERT INTO %s (k, c1, c2, v) VALUES (?, ?, ?, ?)";
@@ -237,7 +237,7 @@ public class VectorColumnPositionsTest extends VectorTester.Versioned
     public void testRegularColumnWithoutClustering() throws Throwable
     {
         createTable("CREATE TABLE %s (k int PRIMARY KEY, r vector<float, 2>, v int)");
-        createIndex("CREATE CUSTOM INDEX ON %s(r) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "r"));
         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
 
         String insert = "INSERT INTO %s (k, r, v) VALUES (?, ?, ?)";
@@ -278,7 +278,7 @@ public class VectorColumnPositionsTest extends VectorTester.Versioned
     public void testRegularColumnWithClustering() throws Throwable
     {
         createTable("CREATE TABLE %s (k int, c int, r vector<float, 2>, v int, PRIMARY KEY(k, c))");
-        createIndex("CREATE CUSTOM INDEX ON %s(r) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "r"));
         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
 
         String insert = "INSERT INTO %s (k, c, r, v) VALUES (?, ?, ?, ?)";
@@ -345,7 +345,7 @@ public class VectorColumnPositionsTest extends VectorTester.Versioned
     public void testStaticColumnWithoutRows() throws Throwable
     {
         createTable("CREATE TABLE %s (k int, c int, s vector<float, 2> static, PRIMARY KEY(k, c))");
-        createIndex("CREATE CUSTOM INDEX ON %s(s) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "s"));
 
         // insert static rows alone, without non-static rows
         String insert = "INSERT INTO %s (k, s) VALUES (?, ?)";
@@ -390,7 +390,7 @@ public class VectorColumnPositionsTest extends VectorTester.Versioned
     public void testStaticColumnWithRowsTogether() throws Throwable
     {
         createTable("CREATE TABLE %s (k int, c int, s vector<float, 2> static, v int, PRIMARY KEY(k, c))");
-        createIndex("CREATE CUSTOM INDEX ON %s(s) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "s"));
         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
 
         // insert static rows and non-static rows all at once
@@ -460,7 +460,7 @@ public class VectorColumnPositionsTest extends VectorTester.Versioned
     public void testStaticColumnWithRowsSeparate() throws Throwable
     {
         createTable("CREATE TABLE %s (k int, c int, s vector<float, 2> static, v int, PRIMARY KEY(k, c))");
-        createIndex("CREATE CUSTOM INDEX ON %s(s) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "s"));
         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
 
         // insert static rows alone, without non-static rows
@@ -517,7 +517,7 @@ public class VectorColumnPositionsTest extends VectorTester.Versioned
     public void testStaticColumnWithDifferentSourcesWithRegulars() throws Throwable
     {
         createTable("CREATE TABLE %s (k int, c int, s vector<float, 2> static, v int, PRIMARY KEY(k, c))");
-        createIndex("CREATE CUSTOM INDEX ON %s(s) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "s"));
         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
 
         // insert static rows alone, with non-static rows
@@ -567,7 +567,7 @@ public class VectorColumnPositionsTest extends VectorTester.Versioned
     public void testStaticColumnWithDifferentSourcesWithoutRegulars() throws Throwable
     {
         createTable("CREATE TABLE %s (k int, c int, s vector<float, 2> static, PRIMARY KEY(k, c))");
-        createIndex("CREATE CUSTOM INDEX ON %s(s) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "s"));
 
         // insert static rows alone, without non-static rows
         String insert = "INSERT INTO %s (k, s) VALUES (?, ?)";
@@ -604,7 +604,7 @@ public class VectorColumnPositionsTest extends VectorTester.Versioned
     public void testStaticColumnWithDifferentSourcesWithAndWithoutRegulars() throws Throwable
     {
         createTable("CREATE TABLE %s (k int, c int, s vector<float, 2> static, v int, PRIMARY KEY(k, c))");
-        createIndex("CREATE CUSTOM INDEX ON %s(s) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "s"));
         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
 
         // insert static rows alone, with non-static rows

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorCompactionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorCompactionTest.java
@@ -49,6 +49,7 @@ import org.apache.cassandra.index.sai.disk.v2.V2VectorIndexSearcher;
 import org.apache.cassandra.index.sai.disk.v5.V5OnDiskFormat;
 import org.apache.cassandra.index.sai.disk.v5.V5VectorPostingsWriter;
 import org.apache.cassandra.index.sai.disk.vector.JVectorVersionUtil;
+import org.apache.cassandra.index.sai.disk.vector.VectorCompression;
 import org.apache.cassandra.io.sstable.format.SSTableReadsListener;
 
 import static org.apache.cassandra.index.sai.disk.vector.CassandraOnHeapGraph.MIN_PQ_ROWS;
@@ -69,18 +70,30 @@ abstract public class VectorCompactionTest extends VectorTester
     @Parameterized.Parameter(1)
     public boolean enableNVQ;
 
-    @Parameterized.Parameters(name = "version={0} enableNVQ={1}")
+    @Parameterized.Parameter(2)
+    public boolean enableFused;
+
+    @Parameterized.Parameters(name = "version={0} enableNVQ={1} enableFused={2}")
     public static Collection<Object[]> data()
     {
         // See Version file for explanation of changes associated with each version
+        // FA is excluded: it always has FusedPQ on and is superseded by FB.
         return Version.ALL.stream()
                           .filter(v -> v.onOrAfter(Version.JVECTOR_EARLIEST))
+                          .filter(v -> !v.equals(Version.FA))
                           .flatMap(vd -> {
                               // NVQ is only relevant some of the time
                               Boolean[] enableNVQ = JVectorVersionUtil.versionSupportsNVQ(vd)
                                                     ? new Boolean[]{ true, false }
                                                     : new Boolean[]{ false };
-                              return Arrays.stream(enableNVQ).map(b -> new Object[]{ vd, b });
+                              // FB+ allows toggling FusedPQ via the flag, so test both values.
+                              // Pre-FA versions don't support FusedPQ at all.
+                              Boolean[] enableFused = vd.onOrAfter(Version.FB)
+                                                      ? new Boolean[]{ true, false }
+                                                      : new Boolean[]{ false };
+                              return Arrays.stream(enableNVQ).flatMap(nvq ->
+                                  Arrays.stream(enableFused).map(fused -> new Object[]{ vd, nvq, fused })
+                              );
                           })
                           .collect(Collectors.toList());
     }
@@ -95,6 +108,19 @@ abstract public class VectorCompactionTest extends VectorTester
     public void setEnableNVQ()
     {
         SAIUtil.setEnableNVQ(enableNVQ);
+    }
+
+    @Before
+    public void setEnableFused()
+    {
+        SAIUtil.setEnableFused(enableFused);
+    }
+
+    @Before
+    public void setParallelGraphWriting()
+    {
+        // Enable parallel graph writing when running with FusedPQ (FB+ with enableFused=true)
+        SAIUtil.setParallelGraphWriting(enableFused);
     }
 
     @Test
@@ -277,7 +303,7 @@ abstract public class VectorCompactionTest extends VectorTester
             var duplicateExists = false;
             while (vectorsInserted.size() < vectorsPerSstable || !duplicateExists)
             {
-                if (!nullInserted && vectorsInserted.size() == vectorsPerSstable/2)
+                if (!nullInserted && vectorsInserted.size() == vectorsPerSstable / 2)
                 {
                     // Insert one null vector in the middle
                     execute("INSERT INTO %s (pk, v) VALUES (?, null)", j++);
@@ -405,14 +431,15 @@ abstract public class VectorCompactionTest extends VectorTester
                                 // reasonable for now.
                                 assertEquals(1.0f, quantizedSim, 0.01f);
                             }
-                            else if (numRows >= MIN_PQ_ROWS)
+                            else
                             {
-                                // With fused PQ (FA always; GA+ only when enabled), PQ metadata is stored inline
-                                // with the graph nodes — there is no standalone CompressedVectors to validate against.
-                                // Without fused PQ (GA+ default, pre-FA), we should never reach this branch.
-                                assertTrue("Found " + numRows + " rows without CompressedVectors; expected fused PQ for version " + version,
-                                           JVectorVersionUtil.shouldWriteFused(version));
-                                assertNotNull("Expected PQ metadata for fused PQ on version " + version, searcher.getPQ());
+                                // compressedVectors is null either because there weren't enough rows to build PQ,
+                                // or because FusedPQ is active (the PQ is embedded in the graph, not loaded
+                                // separately).  Both are valid; only flag an error if neither applies.
+                                boolean fusedPQ = searcher.graph.getCompression().type
+                                                  == VectorCompression.CompressionType.PRODUCT_QUANTIZATION;
+                                assertTrue("Found " + numRows + " but no PQ",
+                                           MIN_PQ_ROWS > numRows || fusedPQ);
                             }
                         }
                     }
@@ -499,7 +526,7 @@ abstract public class VectorCompactionTest extends VectorTester
     private String createTableAndReturnIndexName()
     {
         createTable("CREATE TABLE %s (pk int, v vector<float, " + dimension() + ">, PRIMARY KEY(pk))");
-        return createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
+        return createIndex(vectorIndexDDL("%s", "v", null, enableFused));
     }
 
     private void validateQueries()
@@ -519,8 +546,9 @@ abstract public class VectorCompactionTest extends VectorTester
         }
     }
 
-    private static float[] create2DVector() {
+    private static float[] create2DVector()
+    {
         var R = getRandom();
-        return new float[] { R.nextFloatBetween(-100, 100), R.nextFloatBetween(-100, 100) };
+        return new float[]{ R.nextFloatBetween(-100, 100), R.nextFloatBetween(-100, 100) };
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorHybridSearchTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorHybridSearchTest.java
@@ -33,7 +33,7 @@ public class VectorHybridSearchTest extends VectorTester.VersionedWithChecksums
     {
         setMaxBruteForceRows(0);
         createTable(KEYSPACE, "CREATE TABLE %s (pk int primary key, val text, vec vector<float, 2>)");
-        createIndex("CREATE CUSTOM INDEX ON %s(vec) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "vec"));
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
 
         // Insert rows into two sstables. The tokens for each PK are in each line's comment.
@@ -62,7 +62,7 @@ public class VectorHybridSearchTest extends VectorTester.VersionedWithChecksums
     {
         setMaxBruteForceRows(0);
         createTable(KEYSPACE, "CREATE TABLE %s (pk int, a int, val text, vec vector<float, 2>, PRIMARY KEY(pk, a))");
-        createIndex("CREATE CUSTOM INDEX ON %s(vec) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "vec"));
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
 
         // Insert rows into two sstables. The tokens for each PK are in each line's comment.
@@ -89,7 +89,7 @@ public class VectorHybridSearchTest extends VectorTester.VersionedWithChecksums
     {
         setMaxBruteForceRows(0);
         createTable(KEYSPACE, "CREATE TABLE %s (pk int, a int, val text, vec vector<float, 2>, PRIMARY KEY(pk, a))");
-        createIndex("CREATE CUSTOM INDEX ON %s(vec) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "vec"));
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
 
         execute("INSERT INTO %s (pk, a, val, vec) VALUES (1, 1, 'A', [1, 3])");
@@ -111,7 +111,7 @@ public class VectorHybridSearchTest extends VectorTester.VersionedWithChecksums
         setMaxBruteForceRows(0);
         QueryController.QUERY_OPT_LEVEL = 0;
         createTable(KEYSPACE, "CREATE TABLE %s (pk int, a int, val text, vec vector<float, 2>, PRIMARY KEY(pk, a))");
-        createIndex("CREATE CUSTOM INDEX ON %s(vec) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "vec"));
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
 
         // Create two sstables. The first needs a hole forcing us to skip.
@@ -133,7 +133,7 @@ public class VectorHybridSearchTest extends VectorTester.VersionedWithChecksums
     public void testHybridSearchSeqLogicForMappingPKsBackToRowIds() throws Throwable
     {
         createTable(KEYSPACE, "CREATE TABLE %s (pk int, a int, val text, vec vector<float, 2>, PRIMARY KEY(pk, a))");
-        createIndex("CREATE CUSTOM INDEX ON %s(vec) USING 'StorageAttachedIndex' WITH OPTIONS = { 'similarity_function' : 'euclidean' }");
+        createIndex(vectorIndexDDL("%s", "vec", "'similarity_function' : 'euclidean'"));
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
 
         // Insert rows into two sstables. The rows are interleaved to ensure binary search is less efficient, which
@@ -166,7 +166,7 @@ public class VectorHybridSearchTest extends VectorTester.VersionedWithChecksums
         // This test requires the non-bruteforce route
         setMaxBruteForceRows(0);
         createTable("CREATE TABLE %s (pk int, val text, vec vector<float, 2>, PRIMARY KEY(pk))");
-        createIndex("CREATE CUSTOM INDEX ON %s(vec) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
+        createIndex(vectorIndexDDL("%s", "vec", "'similarity_function' : 'euclidean'"));
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
 
         execute("INSERT INTO %s (pk, val, vec) VALUES (1, 'A', [1, 1])");
@@ -198,7 +198,7 @@ public class VectorHybridSearchTest extends VectorTester.VersionedWithChecksums
         // The bug this test exposed happens when the last row(s) in a segment, based on PK order, are present
         // in a peer index for an sstable's search index but not its vector index.
         createTable("CREATE TABLE %s (k int, i int, v vector<float, 2>, c int,  PRIMARY KEY(k, i))");
-        createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "v"));
         createIndex("CREATE CUSTOM INDEX ON %s(c) USING 'StorageAttachedIndex'");
         // We'll manually control compaction.
         disableCompaction();
@@ -227,7 +227,7 @@ public class VectorHybridSearchTest extends VectorTester.VersionedWithChecksums
         QueryController.QUERY_OPT_LEVEL = 0;
 
         createTable("CREATE TABLE %s (pk int, val int, vec vector<float, 128>, PRIMARY KEY(pk))");
-        createIndex("CREATE CUSTOM INDEX ON %s(vec) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "vec"));
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
 
         // Insert many rows in parallel

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorHybridSearchTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorHybridSearchTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.cassandra.index.sai.cql;
 
+import java.util.Map;
 import java.util.stream.IntStream;
 
 import org.junit.Test;
@@ -133,7 +134,7 @@ public class VectorHybridSearchTest extends VectorTester.VersionedWithChecksums
     public void testHybridSearchSeqLogicForMappingPKsBackToRowIds() throws Throwable
     {
         createTable(KEYSPACE, "CREATE TABLE %s (pk int, a int, val text, vec vector<float, 2>, PRIMARY KEY(pk, a))");
-        createIndex(vectorIndexDDL("%s", "vec", "'similarity_function' : 'euclidean'"));
+        createIndex(vectorIndexDDL("%s", "vec", Map.of("similarity_function", "euclidean")));
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
 
         // Insert rows into two sstables. The rows are interleaved to ensure binary search is less efficient, which
@@ -166,7 +167,7 @@ public class VectorHybridSearchTest extends VectorTester.VersionedWithChecksums
         // This test requires the non-bruteforce route
         setMaxBruteForceRows(0);
         createTable("CREATE TABLE %s (pk int, val text, vec vector<float, 2>, PRIMARY KEY(pk))");
-        createIndex(vectorIndexDDL("%s", "vec", "'similarity_function' : 'euclidean'"));
+        createIndex(vectorIndexDDL("%s", "vec", Map.of("similarity_function", "euclidean")));
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
 
         execute("INSERT INTO %s (pk, val, vec) VALUES (1, 'A', [1, 1])");

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorKeyRestrictedOnPartitionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorKeyRestrictedOnPartitionTest.java
@@ -20,6 +20,7 @@ package org.apache.cassandra.index.sai.cql;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -184,7 +185,7 @@ public class VectorKeyRestrictedOnPartitionTest extends VectorKeyRestrictedTeste
         // The bug this test exposed happens when the last row(s) in a segment, based on PK order, are present
         // in a peer index for an sstable's search index but not its vector index.
         createTable("CREATE TABLE %s (partition int, i int, v vector<float, 2>, c int, PRIMARY KEY(partition, i))");
-        createIndex(vectorIndexDDL("%s", "v", "'similarity_function': 'euclidean'"));
+        createIndex(vectorIndexDDL("%s", "v", Map.of("similarity_function", "euclidean")));
         createIndex("CREATE CUSTOM INDEX ON %s(c) USING 'StorageAttachedIndex'");
 
         var partitionKeys = new ArrayList<Integer>();

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorKeyRestrictedOnPartitionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorKeyRestrictedOnPartitionTest.java
@@ -55,7 +55,7 @@ public class VectorKeyRestrictedOnPartitionTest extends VectorKeyRestrictedTeste
     public void partitionRestrictedTest()
     {
         createTable(String.format("CREATE TABLE %%s (pk int, str_val text, val vector<float, %d>, PRIMARY KEY(pk))", word2vec.dimension()));
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "val"));
 
         int vectorCount = getRandom().nextIntBetween(500, 1000);
 
@@ -116,7 +116,7 @@ public class VectorKeyRestrictedOnPartitionTest extends VectorKeyRestrictedTeste
     public void partitionRestrictedWidePartitionTest(int dimension, int minvectorCount, int maxvectorCount)
     {
         createTable(String.format("CREATE TABLE %%s (pk int, ck int, val vector<float, %d>, PRIMARY KEY(pk, ck))", dimension));
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "val"));
 
         int partitions = getRandom().nextIntBetween(20, 40);
         int vectorCountPerPartition = getRandom().nextIntBetween(50, 100);
@@ -184,7 +184,7 @@ public class VectorKeyRestrictedOnPartitionTest extends VectorKeyRestrictedTeste
         // The bug this test exposed happens when the last row(s) in a segment, based on PK order, are present
         // in a peer index for an sstable's search index but not its vector index.
         createTable("CREATE TABLE %s (partition int, i int, v vector<float, 2>, c int, PRIMARY KEY(partition, i))");
-        createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function': 'euclidean'}");
+        createIndex(vectorIndexDDL("%s", "v", "'similarity_function': 'euclidean'"));
         createIndex("CREATE CUSTOM INDEX ON %s(c) USING 'StorageAttachedIndex'");
 
         var partitionKeys = new ArrayList<Integer>();

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorKeyRestrictedOnRangeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorKeyRestrictedOnRangeTest.java
@@ -33,7 +33,7 @@ public class VectorKeyRestrictedOnRangeTest extends VectorKeyRestrictedTester
     public void rangeSearchTest() throws Throwable
     {
         createTable("CREATE TABLE %s (partition int, val vector<float, 2>, PRIMARY KEY(partition))");
-        createIndex(vectorIndexDDL("%s", "val", "'similarity_function' : 'euclidean'"));
+        createIndex(vectorIndexDDL("%s", "val", Map.of("similarity_function", "euclidean")));
 
         var nPartitions = 100;
         Map<Integer, float[]> vectorsByKey = new HashMap<>();

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorKeyRestrictedOnRangeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorKeyRestrictedOnRangeTest.java
@@ -33,7 +33,7 @@ public class VectorKeyRestrictedOnRangeTest extends VectorKeyRestrictedTester
     public void rangeSearchTest() throws Throwable
     {
         createTable("CREATE TABLE %s (partition int, val vector<float, 2>, PRIMARY KEY(partition))");
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
+        createIndex(vectorIndexDDL("%s", "val", "'similarity_function' : 'euclidean'"));
 
         var nPartitions = 100;
         Map<Integer, float[]> vectorsByKey = new HashMap<>();

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorLocalTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorLocalTest.java
@@ -84,7 +84,7 @@ public class VectorLocalTest extends VectorTester.VersionedWithChecksums
                   "    PRIMARY KEY ((lat_low_precision, lon_low_precision), lat_high_precision, lon_high_precision, id)\n" +
                   ") WITH CLUSTERING ORDER BY (lat_high_precision ASC, lon_high_precision ASC, id ASC);");
         createIndex("CREATE CUSTOM INDEX lat_high_precision_index ON %s (lat_high_precision) USING 'org.apache.cassandra.index.sai.StorageAttachedIndex';");
-        createIndex("CREATE CUSTOM INDEX lat_lon_embedding_index ON %s (lat_lon_embedding) USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' WITH OPTIONS = {'similarity_function': 'EUCLIDEAN'};");
+        createIndex("CREATE CUSTOM INDEX lat_lon_embedding_index ON %s (lat_lon_embedding) USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' WITH OPTIONS = {'similarity_function': 'EUCLIDEAN'" + (ENABLE_FUSED ? ", 'enable_hierarchy': 'true'" : "") + "}");
         createIndex("CREATE CUSTOM INDEX lon_high_precision_index ON %s (lon_high_precision) USING 'org.apache.cassandra.index.sai.StorageAttachedIndex';");
 
         int vectorCount = getRandom().nextIntBetween(500, 1000);
@@ -140,7 +140,7 @@ public class VectorLocalTest extends VectorTester.VersionedWithChecksums
     private void randomizedTest(int dimension)
     {
         createTable(String.format("CREATE TABLE %%s (pk int, str_val text, val vector<float, %d>, PRIMARY KEY(pk))", dimension));
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "val"));
 
         int vectorCount = getRandom().nextIntBetween(500, 1000);
         List<Vector<Float>> vectors = IntStream.range(0, vectorCount).mapToObj(s -> randomVectorBoxed(dimension)).collect(Collectors.toList());
@@ -194,7 +194,7 @@ public class VectorLocalTest extends VectorTester.VersionedWithChecksums
     public void multiSSTablesTest()
     {
         createTable(String.format("CREATE TABLE %%s (pk int, str_val text, val vector<float, %d>, PRIMARY KEY(pk))", word2vec.dimension()));
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "val"));
         disableCompaction(keyspace());
 
         int sstableCount = getRandom().nextIntBetween(3, 6);
@@ -234,7 +234,7 @@ public class VectorLocalTest extends VectorTester.VersionedWithChecksums
     public void rangeRestrictedTest() throws Throwable
     {
         createTable(String.format("CREATE TABLE %%s (pk int, str_val text, val vector<float, %d>, PRIMARY KEY(pk))", word2vec.dimension()));
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "val"));
 
         int vectorCount = getRandom().nextIntBetween(500, 1000);
 
@@ -321,7 +321,7 @@ public class VectorLocalTest extends VectorTester.VersionedWithChecksums
 
         // create index on existing sstable to produce multiple segments
         SegmentBuilder.updateLastValidSegmentRowId(50); // 50 rows per segment
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "val"));
         verifyChecksum();
 
         // query multiple on-disk indexes
@@ -381,7 +381,7 @@ public class VectorLocalTest extends VectorTester.VersionedWithChecksums
 
         // create indexes on existing sstable to produce multiple segments
         SegmentBuilder.updateLastValidSegmentRowId(50); // 50 rows per segment
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "val"));
         createIndex("CREATE CUSTOM INDEX ON %s(str_val) USING 'StorageAttachedIndex'");
         flush();
         verifyChecksum();

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorMetricsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorMetricsTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.cassandra.index.sai.cql;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.stream.Collectors;
 
@@ -31,7 +32,6 @@ import org.apache.cassandra.index.sai.SAIUtil;
 import org.apache.cassandra.index.sai.StorageAttachedIndex;
 import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.index.sai.disk.vector.CassandraOnHeapGraph;
-import org.apache.cassandra.index.sai.disk.vector.JVectorVersionUtil;
 import org.apache.cassandra.index.sai.metrics.ColumnQueryMetrics;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -41,16 +41,27 @@ import static org.junit.Assert.assertTrue;
 @RunWith(Parameterized.class)
 public class VectorMetricsTest extends VectorTester
 {
-    @Parameterized.Parameter
+    @Parameterized.Parameter()
     public Version version;
 
-    @Parameterized.Parameters(name = "version={0}")
+    @Parameterized.Parameter(1)
+    public boolean enableFused;
+
+    @Parameterized.Parameters(name = "version={0} enableFused={1}")
     public static Collection<Object[]> data()
     {
-        // Test all versions that support vector indexes
+        // Test all versions that support vector indexes.
+        // FA is excluded: it always has FusedPQ on and is superseded by FB.
         return Version.ALL.stream()
                           .filter(v -> v.onOrAfter(Version.JVECTOR_EARLIEST))
-                          .map(v -> new Object[]{ v })
+                          .filter(v -> !v.equals(Version.FA))
+                          .flatMap(v -> {
+                              // FB+ allows toggling FusedPQ; pre-FA versions don't support it
+                              Boolean[] fusedValues = v.onOrAfter(Version.FB)
+                                                      ? new Boolean[]{ true, false }
+                                                      : new Boolean[]{ false };
+                              return Arrays.stream(fusedValues).map(fused -> new Object[]{ v, fused });
+                          })
                           .collect(Collectors.toList());
     }
 
@@ -66,13 +77,15 @@ public class VectorMetricsTest extends VectorTester
     {
         super.setup();
         SAIUtil.setCurrentVersion(version);
+        SAIUtil.setEnableFused(enableFused);
+        SAIUtil.setParallelGraphWriting(enableFused);
     }
 
     @Test
     public void testBasicColumnQueryMetricsVectorIndexMetrics()
     {
         createTable("CREATE TABLE %s (pk int, val vector<float, 3>, PRIMARY KEY(pk))");
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "val", null, enableFused));
         disableCompaction();
 
         // Get the metrics
@@ -100,22 +113,21 @@ public class VectorMetricsTest extends VectorTester
             execute("INSERT INTO %s (pk, val) VALUES (?, ?)", i, vector(1 + i, 2 + i, 3 + i));
         flush();
 
-        // FA always uses FusedPQ; FB+ uses it only when cassandra.sai.vector.enable_fused=true (default false).
+        // FusedPQ is active when enableFused=true (FB+ with the flag set).
         // Pre-FA versions never use FusedPQ.
-        boolean fusedPQ = JVectorVersionUtil.shouldWriteFused(version);
         long pqMemoryAfterFlush = vectorMetrics.quantizationMemoryBytes.sum();
 
-        if (fusedPQ)
+        if (enableFused)
         {
             // With FusedPQ, quantized vectors are stored inline with graph nodes, so no separate PQ memory
             assertEquals("Version " + version + " should have no separate PQ memory with FusedPQ",
-                        0L, pqMemoryAfterFlush);
+                         0L, pqMemoryAfterFlush);
         }
         else
         {
             // Without FusedPQ, PQ vectors are stored separately, so we expect some memory usage
             assertTrue("Version " + version + " should have PQ memory without FusedPQ",
-                      pqMemoryAfterFlush > 0);
+                       pqMemoryAfterFlush > 0);
         }
 
         assertEquals(0, vectorMetrics.ordinalsMapMemoryBytes.sum()); // unique vectors means no cache required
@@ -125,19 +137,19 @@ public class VectorMetricsTest extends VectorTester
         compact();
         long pqMemoryAfterCompaction = vectorMetrics.quantizationMemoryBytes.sum();
 
-        if (fusedPQ)
+        if (enableFused)
         {
             // With FusedPQ, quantized vectors are stored inline with graph nodes, so no separate PQ memory
             assertEquals("Version " + version + " should have no separate PQ memory with FusedPQ after compaction",
-                        0L, pqMemoryAfterCompaction);
+                         0L, pqMemoryAfterCompaction);
         }
         else
         {
             // Without FusedPQ, PQ vectors are stored separately, so we expect some memory usage
             assertTrue("Version " + version + " should have PQ memory without FusedPQ after compaction",
-                      pqMemoryAfterCompaction > 0);
+                       pqMemoryAfterCompaction > 0);
         }
-        
+
         assertEquals(0, vectorMetrics.ordinalsMapMemoryBytes.sum()); // unique vectors means no cache required
         assertEquals(1, vectorMetrics.onDiskGraphsCount.sum());
         assertEquals(CassandraOnHeapGraph.MIN_PQ_ROWS, vectorMetrics.onDiskGraphVectorsCount.sum());

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorSiftSmallTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorSiftSmallTest.java
@@ -99,7 +99,7 @@ public class VectorSiftSmallTest extends VectorTester.Versioned
             var recall = testRecall(limit, queryVectors, groundTruth, rerankK, null);
             // All recalls should be better than rerank_k = 0
             assertTrue("Recall for rerank_k = " + rerankK + " should be at least as good as with rerank_k = 0",
-                      recall >= zeroRerankRecall);
+                       recall >= zeroRerankRecall);
 
             // Recall varies, so we can only assert that it does not get worse on a per-run basis. However, it should
             // get better strictly at least some of the time
@@ -125,7 +125,7 @@ public class VectorSiftSmallTest extends VectorTester.Versioned
     private void testUsePruningOptionCompatibility(List<float[]> queryVectors, List<List<Integer>> groundTruth)
     {
         int limit = 10;
-        
+
         // Test with pruning "enabled" (actually disabled by JVector)
         double recallWithPruningTrue = testRecall(limit, queryVectors, groundTruth, null, true);
 
@@ -135,9 +135,9 @@ public class VectorSiftSmallTest extends VectorTester.Versioned
         // Since JVector always disables pruning, recall should be identical
         // (allowing for minor floating point differences)
         assertTrue("Recall with use_pruning=true (" + recallWithPruningTrue +
-                  ") should equal recall with use_pruning=false (" + recallWithPruningFalse +
-                  ") since JVector always disables pruning for top-K queries",
-                  Math.abs(recallWithPruningTrue - recallWithPruningFalse) < 0.001);
+                   ") should equal recall with use_pruning=false (" + recallWithPruningFalse +
+                   ") since JVector always disables pruning for top-K queries",
+                   Math.abs(recallWithPruningTrue - recallWithPruningFalse) < 0.001);
     }
 
     // Note: test only fails when scores are sent from replica to coordinator.
@@ -167,7 +167,7 @@ public class VectorSiftSmallTest extends VectorTester.Versioned
 
             // Execute query with rerank_k = 0 and get the similarity scores computed by the coordinator
             String query = String.format("SELECT pk, similarity_euclidean(val, %s) as similarity FROM %%s ORDER BY val ANN OF %s LIMIT %d WITH ann_options = {'rerank_k': 0}",
-                                        queryVectorAsString, queryVectorAsString, limit);
+                                         queryVectorAsString, queryVectorAsString, limit);
             UntypedResultSet result = execute(query);
 
             // Verify that results are in descending order of similarity score
@@ -178,9 +178,9 @@ public class VectorSiftSmallTest extends VectorTester.Versioned
             {
                 float similarity = row.getFloat("similarity");
                 assertTrue(String.format("Query %d: Similarity scores should be in descending order (higher score = more similar). " +
-                                       "Previous: %.10f, Current: %.10f",
-                                       queryIdx, lastSimilarity, similarity),
-                          similarity <= lastSimilarity);
+                                         "Previous: %.10f, Current: %.10f",
+                                         queryIdx, lastSimilarity, similarity),
+                           similarity <= lastSimilarity);
                 lastSimilarity = similarity;
             }
         }
@@ -351,12 +351,13 @@ public class VectorSiftSmallTest extends VectorTester.Versioned
             float[] queryVector = queryVectors.get(i);
             String queryVectorAsString = Arrays.toString(queryVector);
 
-            try {
+            try
+            {
                 StringBuilder query = new StringBuilder()
-                    .append("SELECT pk FROM %s ORDER BY val ANN OF ")
-                    .append(queryVectorAsString)
-                    .append(" LIMIT ")
-                    .append(topK);
+                                      .append("SELECT pk FROM %s ORDER BY val ANN OF ")
+                                      .append(queryVectorAsString)
+                                      .append(" LIMIT ")
+                                      .append(topK);
 
                 if (rerankK != null || usePruning != null)
                 {
@@ -379,9 +380,11 @@ public class VectorSiftSmallTest extends VectorTester.Versioned
                 // we don't care about order within the topK but we do need to restrict the size first
                 var gtSet = new HashSet<>(gt.subList(0, topK));
 
-                int n = (int)result.stream().filter(row -> gtSet.contains(row.getInt("pk"))).count();
+                int n = (int) result.stream().filter(row -> gtSet.contains(row.getInt("pk"))).count();
                 topKfound.addAndGet(n);
-            } catch (Throwable throwable) {
+            }
+            catch (Throwable throwable)
+            {
                 throw new RuntimeException(throwable);
             }
         });
@@ -397,7 +400,7 @@ public class VectorSiftSmallTest extends VectorTester.Versioned
     private void createIndex()
     {
         // we need a long timeout because we are adding many vectors
-        String index = createIndexAsync("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean', 'enable_hierarchy': 'true'}");
+        String index = createIndexAsync(vectorIndexDDL("%s", "val", "'similarity_function' : 'euclidean'"));
         waitForIndexQueryable(KEYSPACE, index, 5, TimeUnit.MINUTES);
     }
 
@@ -405,9 +408,12 @@ public class VectorSiftSmallTest extends VectorTester.Versioned
     {
         IntStream.range(0, vectors.size()).parallel().forEach(i -> {
             float[] arrayVector = vectors.get(i);
-            try {
+            try
+            {
                 execute("INSERT INTO %s (pk, val) VALUES (?, ?)", baseRowId + i, vector(arrayVector));
-            } catch (Throwable throwable) {
+            }
+            catch (Throwable throwable)
+            {
                 throw new RuntimeException(throwable);
             }
         });

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorSiftSmallTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorSiftSmallTest.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
@@ -400,7 +401,7 @@ public class VectorSiftSmallTest extends VectorTester.Versioned
     private void createIndex()
     {
         // we need a long timeout because we are adding many vectors
-        String index = createIndexAsync(vectorIndexDDL("%s", "val", "'similarity_function' : 'euclidean'"));
+        String index = createIndexAsync(vectorIndexDDL("%s", "val", Map.of("similarity_function", "euclidean")));
         waitForIndexQueryable(KEYSPACE, index, 5, TimeUnit.MINUTES);
     }
 

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorTester.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorTester.java
@@ -21,8 +21,12 @@ package org.apache.cassandra.index.sai.cql;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
+
+import org.apache.cassandra.cql3.CqlBuilder;
 
 import org.apache.commons.lang.reflect.FieldUtils;
 import org.junit.Before;
@@ -182,31 +186,35 @@ public class VectorTester extends SAITester
 
     /**
      * Builds a CREATE CUSTOM INDEX DDL string for a vector column.
-     * When {@code enableFused} is true, {@code 'enable_hierarchy': 'true'} is appended so that
-     * every FusedPQ run exercises the hierarchical graph code path — the two features must
-     * always be tested together.
+     * When {@code enableHierarchy} is true, {@code 'enable_hierarchy': 'true'} is appended to the
+     * index options.
      *
-     * @param table        the table placeholder, typically {@code "%s"}
-     * @param column       the vector column name
-     * @param extraOptions additional options such as {@code "'similarity_function': 'euclidean'"},
-     *                     or {@code null} for none
-     * @param enableFused  whether FusedPQ is enabled for this test run
+     * <p>Callers that run with FusedPQ enabled <em>must</em> pass {@code true} here, because FusedPQ
+     * requires the hierarchical graph. The two features are inseparable in production and must
+     * always be co-tested.
+     *
+     * @param table           the table placeholder, typically {@code "%s"}
+     * @param column          the vector column name
+     * @param extraOptions    a map of additional index options, or {@code null} for none
+     * @param enableHierarchy whether to include {@code 'enable_hierarchy': 'true'} in the DDL
      */
-    protected static String vectorIndexDDL(String table, String column, String extraOptions, boolean enableFused)
+    protected static String vectorIndexDDL(String table, String column, Map<String, String> extraOptions, boolean enableHierarchy)
     {
-        StringBuilder opts = new StringBuilder();
+        Map<String, String> options = new LinkedHashMap<>();
         if (extraOptions != null)
-            opts.append(extraOptions);
-        if (enableFused)
-        {
-            if (opts.length() > 0)
-                opts.append(", ");
-            opts.append("'enable_hierarchy': 'true'");
-        }
-        if (opts.length() > 0)
-            return "CREATE CUSTOM INDEX ON " + table + '(' + column + ") USING 'StorageAttachedIndex'"
-                   + " WITH OPTIONS = {" + opts + '}';
-        return "CREATE CUSTOM INDEX ON " + table + '(' + column + ") USING 'StorageAttachedIndex'";
+            options.putAll(extraOptions);
+        if (enableHierarchy)
+            options.put("enable_hierarchy", "true");
+
+        CqlBuilder builder = new CqlBuilder();
+        builder.append("CREATE CUSTOM INDEX ON ")
+               .append(table)
+               .append('(')
+               .append(column)
+               .append(") USING 'StorageAttachedIndex'");
+        if (!options.isEmpty())
+            builder.append(" WITH OPTIONS = ").append(options);
+        return builder.toString();
     }
 
     /**
@@ -290,13 +298,16 @@ public class VectorTester extends SAITester
         /**
          * Like {@link #vectorIndexDDL(String, String)} but merges additional index options.
          *
+         * <p>Hierarchy should always be enabled when FusedPQ is active, so the two must always be
+         * co-tested.
+         *
          * @param table        the table placeholder, typically {@code "%s"}
          * @param column       the vector column name
-         * @param extraOptions additional options to include, e.g. {@code "'similarity_function': 'euclidean'"},
-         *                     or {@code null} for none
+         * @param extraOptions a map of additional index options, or {@code null} for none
          */
-        protected String vectorIndexDDL(String table, String column, String extraOptions)
+        protected String vectorIndexDDL(String table, String column, Map<String, String> extraOptions)
         {
+            // FusedPQ requires the hierarchical graph — always enable hierarchy together with fused.
             return VectorTester.vectorIndexDDL(table, column, extraOptions, ENABLE_FUSED);
         }
     }

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorTester.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorTester.java
@@ -129,7 +129,8 @@ public class VectorTester extends SAITester
         return (double) matches / topK;
     }
 
-    protected void verifyChecksum() {
+    protected void verifyChecksum()
+    {
         ColumnFamilyStore cfs = Keyspace.open(KEYSPACE).getColumnFamilyStore(currentTable());
         cfs.indexManager.listIndexes().stream().forEach(index -> {
             try
@@ -140,7 +141,8 @@ public class VectorTester extends SAITester
                 logger.info("Verifying checksum for index {}", index.getIndexMetadata().name);
                 boolean checksumValid = verifyChecksum(indexContext);
                 assertThat(checksumValid).isTrue();
-            } catch (IllegalAccessException e)
+            }
+            catch (IllegalAccessException e)
             {
                 throw new RuntimeException(e);
             }
@@ -179,6 +181,35 @@ public class VectorTester extends SAITester
     }
 
     /**
+     * Builds a CREATE CUSTOM INDEX DDL string for a vector column.
+     * When {@code enableFused} is true, {@code 'enable_hierarchy': 'true'} is appended so that
+     * every FusedPQ run exercises the hierarchical graph code path — the two features must
+     * always be tested together.
+     *
+     * @param table        the table placeholder, typically {@code "%s"}
+     * @param column       the vector column name
+     * @param extraOptions additional options such as {@code "'similarity_function': 'euclidean'"},
+     *                     or {@code null} for none
+     * @param enableFused  whether FusedPQ is enabled for this test run
+     */
+    protected static String vectorIndexDDL(String table, String column, String extraOptions, boolean enableFused)
+    {
+        StringBuilder opts = new StringBuilder();
+        if (extraOptions != null)
+            opts.append(extraOptions);
+        if (enableFused)
+        {
+            if (opts.length() > 0)
+                opts.append(", ");
+            opts.append("'enable_hierarchy': 'true'");
+        }
+        if (opts.length() > 0)
+            return "CREATE CUSTOM INDEX ON " + table + '(' + column + ") USING 'StorageAttachedIndex'"
+                   + " WITH OPTIONS = {" + opts + '}';
+        return "CREATE CUSTOM INDEX ON " + table + '(' + column + ") USING 'StorageAttachedIndex'";
+    }
+
+    /**
      * {@link VectorTester} parameterized for all {@link Version}s supporting vector indexes.
      */
     @Ignore
@@ -198,22 +229,21 @@ public class VectorTester extends SAITester
         public static Collection<Object[]> data()
         {
             // See Version file for explanation of changes associated with each version
+            // FA is excluded: it always has FusedPQ on and is superseded by FB.
             return Version.ALL.stream()
                               .filter(v -> v.onOrAfter(Version.JVECTOR_EARLIEST))
+                              .filter(v -> !v.equals(Version.FA))
                               .flatMap(v -> {
                                   var enableNVQ = JVectorVersionUtil.versionSupportsNVQ(v)
                                                   ? new Boolean[]{ true, false }
                                                   : new Boolean[]{ false };
-                                  // FA always uses FusedPQ regardless of the flag, so only test enableFused=true there.
-                                  // FB+ allows toggling the flag, so test both values.
+                                  // FB+ allows toggling FusedPQ via the flag, so test both values.
                                   // Pre-FA versions don't support FusedPQ at all.
                                   var enableFused = v.onOrAfter(Version.FB)
                                                     ? new Boolean[]{ true, false }
-                                                    : JVectorVersionUtil.versionSupportsFused(v)
-                                                      ? new Boolean[]{ true }   // FA: always-on
-                                                      : new Boolean[]{ false };  // pre-FA: unsupported
+                                                    : new Boolean[]{ false };  // pre-FA: unsupported
                                   return Arrays.stream(enableNVQ).flatMap(nvq ->
-                                      Arrays.stream(enableFused).map(fused -> new Object[]{ v, nvq, fused })
+                                                                          Arrays.stream(enableFused).map(fused -> new Object[]{ v, nvq, fused })
                                   );
                               }).collect(Collectors.toList());
         }
@@ -234,6 +264,40 @@ public class VectorTester extends SAITester
         public void setEnableFused()
         {
             SAIUtil.setEnableFused(ENABLE_FUSED);
+        }
+
+        @Before
+        public void setParallelGraphWriting()
+        {
+            // Enable parallel graph writing when running with FusedPQ (FB+ with ENABLE_FUSED=true)
+            SAIUtil.setParallelGraphWriting(ENABLE_FUSED);
+        }
+
+        /**
+         * Returns a CREATE CUSTOM INDEX DDL string for a vector column.
+         * When {@link #ENABLE_FUSED} is true, {@code enable_hierarchy: true} is included so that
+         * every FusedPQ run exercises the hierarchical graph code path — the two features must
+         * always be tested together.
+         *
+         * @param table the table placeholder, typically {@code "%s"}
+         * @param column the vector column name
+         */
+        protected String vectorIndexDDL(String table, String column)
+        {
+            return vectorIndexDDL(table, column, null);
+        }
+
+        /**
+         * Like {@link #vectorIndexDDL(String, String)} but merges additional index options.
+         *
+         * @param table        the table placeholder, typically {@code "%s"}
+         * @param column       the vector column name
+         * @param extraOptions additional options to include, e.g. {@code "'similarity_function': 'euclidean'"},
+         *                     or {@code null} for none
+         */
+        protected String vectorIndexDDL(String table, String column, String extraOptions)
+        {
+            return VectorTester.vectorIndexDDL(table, column, extraOptions, ENABLE_FUSED);
         }
     }
 

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorTracingTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorTracingTest.java
@@ -40,7 +40,7 @@ public class VectorTracingTest extends VectorTester.VersionedWithChecksums
     public void tracingTest()
     {
         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "val"));
 
         execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', [1.0, 2.0, 3.0])");
         execute("INSERT INTO %s (pk, str_val, val) VALUES (1, 'B', [2.0, 3.0, 4.0])");

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorTypeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorTypeTest.java
@@ -372,7 +372,7 @@ public class VectorTypeTest extends VectorTester.Versioned
     public void changingOptionsTest()
     {
         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
-        createIndex(vectorIndexDDL("%s", "val", "'maximum_node_connections' : 10, 'construction_beam_width' : 200, 'similarity_function' : 'euclidean'"));
+        createIndex(vectorIndexDDL("%s", "val", Map.of("maximum_node_connections", "10", "construction_beam_width", "200", "similarity_function", "euclidean")));
 
         execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', [1.0, 2.0, 3.0])");
         execute("INSERT INTO %s (pk, str_val, val) VALUES (1, 'B', [2.0, 3.0, 4.0])");
@@ -426,7 +426,7 @@ public class VectorTypeTest extends VectorTester.Versioned
     public void obsoleteOptionsTest()
     {
         createTable("CREATE TABLE %s (pk int, v vector<float, 3>, PRIMARY KEY(pk))");
-        createIndex(vectorIndexDDL("%s", "v", "'optimize_for' : 'recall'"));
+        createIndex(vectorIndexDDL("%s", "v", Map.of("optimize_for", "recall")));
         // as long as CREATE doesn't error out, we're good
     }
 
@@ -550,7 +550,7 @@ public class VectorTypeTest extends VectorTester.Versioned
     public void partitionKeySearchTest()
     {
         createTable("CREATE TABLE %s (partition int, row int, val vector<float, 2>, PRIMARY KEY(partition, row))");
-        createIndex(vectorIndexDDL("%s", "val", "'similarity_function' : 'euclidean'"));
+        createIndex(vectorIndexDDL("%s", "val", Map.of("similarity_function", "euclidean")));
 
         var nPartitions = 5;
         var rowsPerPartition = 10;
@@ -687,7 +687,7 @@ public class VectorTypeTest extends VectorTester.Versioned
     {
         createTable(KEYSPACE, "CREATE TABLE %s (pk int, vec vector<float, 2>, PRIMARY KEY(pk))");
         // Use euclidean distance to more easily verify correctness of caching
-        createIndex(vectorIndexDDL("%s", "vec", "'similarity_function' : 'euclidean'"));
+        createIndex(vectorIndexDDL("%s", "vec", Map.of("similarity_function", "euclidean")));
 
         // Put one row in the first ss table to guarantee brute force method. This vector is also the most similar.
         execute("INSERT INTO %s (pk, vec) VALUES (?, ?)", 10, vector(1f, 1f));
@@ -708,7 +708,7 @@ public class VectorTypeTest extends VectorTester.Versioned
     {
         createTable(KEYSPACE, "CREATE TABLE %s (pk int, vec vector<float, 2>, PRIMARY KEY(pk))");
         // Use euclidean distance to more easily verify correctness of caching
-        createIndex(vectorIndexDDL("%s", "vec", "'similarity_function' : 'euclidean'"));
+        createIndex(vectorIndexDDL("%s", "vec", Map.of("similarity_function", "euclidean")));
 
         // Put one row in the first ss table to guarantee brute force method. This vector is also the most similar.
         execute("INSERT INTO %s (pk, vec) VALUES (?, ?)", 10, vector(1f, 1f));
@@ -824,7 +824,7 @@ public class VectorTypeTest extends VectorTester.Versioned
         }
 
         // create indexes on existing sstable to produce multiple segments
-        createIndex(vectorIndexDDL("%s", "val", "'similarity_function' : 'euclidean'"));
+        createIndex(vectorIndexDDL("%s", "val", Map.of("similarity_function", "euclidean")));
         createIndex("CREATE CUSTOM INDEX ON %s(constant) USING 'StorageAttachedIndex'");
 
         // query multiple on-disk indexes
@@ -1030,7 +1030,7 @@ public class VectorTypeTest extends VectorTester.Versioned
     public void testMemtableInsertSearchInsertSearchHandling()
     {
         createTable("CREATE TABLE %s (id text PRIMARY KEY, embedding vector<float, 5>)");
-        createIndex(vectorIndexDDL("%s", "embedding", "'similarity_function': 'dot_product', 'source_model': 'OTHER'"));
+        createIndex(vectorIndexDDL("%s", "embedding", Map.of("similarity_function", "dot_product", "source_model", "OTHER")));
 
         // Insert initial data
         execute("INSERT INTO %s (id, embedding) VALUES ('row1', [0.1, 0.1, 0.1, 0.1, 0.1])");

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorTypeTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorTypeTest.java
@@ -79,7 +79,7 @@ public class VectorTypeTest extends VectorTester.Versioned
     public void endToEndTest()
     {
         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "val"));
 
         execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', [1.0, 2.0, 3.0])");
         execute("INSERT INTO %s (pk, str_val, val) VALUES (1, 'B', [2.0, 3.0, 4.0])");
@@ -121,7 +121,7 @@ public class VectorTypeTest extends VectorTester.Versioned
     public void tracingTest()
     {
         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "val"));
 
         execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', [1.0, 2.0, 3.0])");
         execute("INSERT INTO %s (pk, str_val, val) VALUES (1, 'B', [2.0, 3.0, 4.0])");
@@ -154,7 +154,7 @@ public class VectorTypeTest extends VectorTester.Versioned
         execute("INSERT INTO %s (pk, str_val, val) VALUES (3, 'D', [4.0, 5.0, 6.0])");
 
         flush();
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "val"));
 
         UntypedResultSet result = execute("SELECT * FROM %s ORDER BY val ann of [2.5, 3.5, 4.5] LIMIT 3");
         assertThat(result).hasSize(3);
@@ -181,7 +181,7 @@ public class VectorTypeTest extends VectorTester.Versioned
     {
         createTable("CREATE TABLE %s (pk int, b boolean, v vector<float, 3>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(b) USING 'StorageAttachedIndex'");
-        createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "v"));
 
         execute("INSERT INTO %s (pk, b, v) VALUES (0, true, [1.0, 2.0, 3.0])");
         execute("INSERT INTO %s (pk, b, v) VALUES (1, true, [2.0, 3.0, 4.0])");
@@ -207,7 +207,7 @@ public class VectorTypeTest extends VectorTester.Versioned
         setMaxBruteForceRows(0);
         createTable("CREATE TABLE %s (pk int, b boolean, v vector<float, 3>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(b) USING 'StorageAttachedIndex'");
-        createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "v"));
 
         execute("INSERT INTO %s (pk, b, v) VALUES (1, true, [1.0, 2.0, 3.0])");
         execute("INSERT INTO %s (pk, b, v) VALUES (2, true, [2.0, 3.0, 4.0])");
@@ -237,7 +237,7 @@ public class VectorTypeTest extends VectorTester.Versioned
     public void testTwoPredicatesWithUnnecessaryAllowFiltering()
     {
         createTable("CREATE TABLE %s (pk int, b int, v vector<float, 3>, PRIMARY KEY(pk, b))");
-        createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "v"));
         createIndex("CREATE CUSTOM INDEX ON %s(b) USING 'StorageAttachedIndex'");
 
         execute("INSERT INTO %s (pk, b, v) VALUES (0, 0, [1.0, 2.0, 3.0])");
@@ -255,7 +255,7 @@ public class VectorTypeTest extends VectorTester.Versioned
     {
         createTable("CREATE TABLE %s (pk int, b boolean, v vector<float, 3>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(b) USING 'StorageAttachedIndex'");
-        createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "v"));
 
         for (int i = 0; i < 100; i++)
             execute("INSERT INTO %s (pk, b, v) VALUES (?, true, ?)",
@@ -276,7 +276,7 @@ public class VectorTypeTest extends VectorTester.Versioned
     {
         createTable("CREATE TABLE %s (pk int, b boolean, v vector<float, 3>, str text, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(b) USING 'StorageAttachedIndex'");
-        createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "v"));
         createIndex("CREATE CUSTOM INDEX ON %s(str) USING 'StorageAttachedIndex'");
 
         execute("INSERT INTO %s (pk, b, v, str) VALUES (0, true, [1.0, 2.0, 3.0], 'A')");
@@ -299,7 +299,7 @@ public class VectorTypeTest extends VectorTester.Versioned
     public void testSameVectorMultipleRows()
     {
         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "val"));
 
         execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', [1.0, 2.0, 3.0])");
         execute("INSERT INTO %s (pk, str_val, val) VALUES (1, 'A', [1.0, 2.0, 3.0])");
@@ -319,7 +319,7 @@ public class VectorTypeTest extends VectorTester.Versioned
     public void testQueryEmptyTable()
     {
         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "val"));
 
         var result = execute("SELECT * FROM %s ORDER BY val ANN OF [2.5, 3.5, 4.5] LIMIT 1");
         assertThat(result).hasSize(0);
@@ -329,7 +329,7 @@ public class VectorTypeTest extends VectorTester.Versioned
     public void testQueryTableWithNulls()
     {
         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "val"));
 
         execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', null)");
         var result = execute("SELECT * FROM %s ORDER BY val ANN OF [2.5, 3.5, 4.5] LIMIT 1");
@@ -344,7 +344,7 @@ public class VectorTypeTest extends VectorTester.Versioned
     public void testLimitLessThanInsertedRowCount()
     {
         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "val"));
 
         // Insert more rows than the query limit
         execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', [1.0, 2.0, 3.0])");
@@ -360,7 +360,7 @@ public class VectorTypeTest extends VectorTester.Versioned
     public void testQueryMoreRowsThanInserted()
     {
         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "val"));
 
         execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', [1.0, 2.0, 3.0])");
 
@@ -372,8 +372,7 @@ public class VectorTypeTest extends VectorTester.Versioned
     public void changingOptionsTest()
     {
         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex' WITH OPTIONS = " +
-                    "{'maximum_node_connections' : 10, 'construction_beam_width' : 200, 'similarity_function' : 'euclidean' }");
+        createIndex(vectorIndexDDL("%s", "val", "'maximum_node_connections' : 10, 'construction_beam_width' : 200, 'similarity_function' : 'euclidean'"));
 
         execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', [1.0, 2.0, 3.0])");
         execute("INSERT INTO %s (pk, str_val, val) VALUES (1, 'B', [2.0, 3.0, 4.0])");
@@ -403,7 +402,7 @@ public class VectorTypeTest extends VectorTester.Versioned
     public void defaultOptionsTest()
     {
         createTable("CREATE TABLE %s (pk int, v vector<float, 3>, PRIMARY KEY(pk))");
-        createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "v"));
 
         var sim = getCurrentColumnFamilyStore().indexManager;
         var index = (StorageAttachedIndex) sim.listIndexes().iterator().next();
@@ -427,7 +426,7 @@ public class VectorTypeTest extends VectorTester.Versioned
     public void obsoleteOptionsTest()
     {
         createTable("CREATE TABLE %s (pk int, v vector<float, 3>, PRIMARY KEY(pk))");
-        createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = {'optimize_for' : 'recall' }");
+        createIndex(vectorIndexDDL("%s", "v", "'optimize_for' : 'recall'"));
         // as long as CREATE doesn't error out, we're good
     }
 
@@ -435,7 +434,7 @@ public class VectorTypeTest extends VectorTester.Versioned
     public void bindVariablesTest()
     {
         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "val"));
 
         execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', ?)", vector(1, 2 , 3));
         execute("INSERT INTO %s (pk, str_val, val) VALUES (1, 'B', ?)", vector(2 , 3, 4));
@@ -453,7 +452,7 @@ public class VectorTypeTest extends VectorTester.Versioned
         // the closest rows to the query vector
         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(str_val) USING 'StorageAttachedIndex'");
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "val"));
 
         execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', ?)", vector(1, 2 , 3));
         execute("INSERT INTO %s (pk, str_val, val) VALUES (1, 'B', ?)", vector(2 , 3, 4));
@@ -474,7 +473,7 @@ public class VectorTypeTest extends VectorTester.Versioned
     {
         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(str_val) USING 'StorageAttachedIndex'");
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "val"));
 
         execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', ?)", vector(1, 2 , 3));
         execute("INSERT INTO %s (pk, str_val) VALUES (1, 'B')"); // no vector
@@ -501,7 +500,7 @@ public class VectorTypeTest extends VectorTester.Versioned
     public void lwtTest()
     {
         createTable("CREATE TABLE %s (p int, c int, v text, vec vector<float, 2>, PRIMARY KEY(p, c))");
-        createIndex("CREATE CUSTOM INDEX ON %s(vec) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "vec"));
 
         execute("INSERT INTO %s (p, c, v) VALUES (?, ?, ?)", 0, 0, "test");
         execute("INSERT INTO %s (p, c, v) VALUES (?, ?, ?)", 0, 1, "00112233445566");
@@ -517,15 +516,15 @@ public class VectorTypeTest extends VectorTester.Versioned
     public void twoVectorFieldsTest()
     {
         createTable("CREATE TABLE %s (pk int, v2 vector<float, 2>, v3 vector<float, 3>, PRIMARY KEY(pk))");
-        createIndex("CREATE CUSTOM INDEX ON %s(v2) USING 'StorageAttachedIndex'");
-        createIndex("CREATE CUSTOM INDEX ON %s(v3) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "v2"));
+        createIndex(vectorIndexDDL("%s", "v3"));
     }
 
     @Test
     public void primaryKeySearchTest()
     {
         createTable("CREATE TABLE %s (pk int, val vector<float, 3>, i int, PRIMARY KEY(pk))");
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "val"));
 
         var N = 5;
         for (int i = 0; i < N; i++)
@@ -551,7 +550,7 @@ public class VectorTypeTest extends VectorTester.Versioned
     public void partitionKeySearchTest()
     {
         createTable("CREATE TABLE %s (partition int, row int, val vector<float, 2>, PRIMARY KEY(partition, row))");
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
+        createIndex(vectorIndexDDL("%s", "val", "'similarity_function' : 'euclidean'"));
 
         var nPartitions = 5;
         var rowsPerPartition = 10;
@@ -618,7 +617,7 @@ public class VectorTypeTest extends VectorTester.Versioned
     public void selectSimilarityWithAnn()
     {
         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "val"));
 
         execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', [1.0, 2.0, 3.0])");
         execute("INSERT INTO %s (pk, str_val, val) VALUES (1, 'B', [2.0, 3.0, 4.0])");
@@ -688,7 +687,7 @@ public class VectorTypeTest extends VectorTester.Versioned
     {
         createTable(KEYSPACE, "CREATE TABLE %s (pk int, vec vector<float, 2>, PRIMARY KEY(pk))");
         // Use euclidean distance to more easily verify correctness of caching
-        createIndex("CREATE CUSTOM INDEX ON %s(vec) USING 'StorageAttachedIndex' WITH OPTIONS = { 'similarity_function' : 'euclidean' }");
+        createIndex(vectorIndexDDL("%s", "vec", "'similarity_function' : 'euclidean'"));
 
         // Put one row in the first ss table to guarantee brute force method. This vector is also the most similar.
         execute("INSERT INTO %s (pk, vec) VALUES (?, ?)", 10, vector(1f, 1f));
@@ -709,7 +708,7 @@ public class VectorTypeTest extends VectorTester.Versioned
     {
         createTable(KEYSPACE, "CREATE TABLE %s (pk int, vec vector<float, 2>, PRIMARY KEY(pk))");
         // Use euclidean distance to more easily verify correctness of caching
-        createIndex("CREATE CUSTOM INDEX ON %s(vec) USING 'StorageAttachedIndex' WITH OPTIONS = { 'similarity_function' : 'euclidean' }");
+        createIndex(vectorIndexDDL("%s", "vec", "'similarity_function' : 'euclidean'"));
 
         // Put one row in the first ss table to guarantee brute force method. This vector is also the most similar.
         execute("INSERT INTO %s (pk, vec) VALUES (?, ?)", 10, vector(1f, 1f));
@@ -730,7 +729,7 @@ public class VectorTypeTest extends VectorTester.Versioned
     public void testRowWithMissingVectorThatMatchesQueryPredicates()
     {
         createTable(KEYSPACE, "CREATE TABLE %s (pk int, val text, vec vector<float, 2>, PRIMARY KEY(pk))");
-        createIndex("CREATE CUSTOM INDEX ON %s(vec) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "vec"));
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
 
         // There was an edge case where we failed because there was just a single row in the table.
@@ -745,7 +744,7 @@ public class VectorTypeTest extends VectorTester.Versioned
     public void testMultipleVectorsInMemoryWithPredicate()
     {
         createTable(KEYSPACE, "CREATE TABLE %s (pk int, val text, vec vector<float, 2>, PRIMARY KEY(pk))");
-        createIndex("CREATE CUSTOM INDEX ON %s(vec) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "vec"));
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
 
         // When we search the memtable, we filter out PKs outside the memtable's bounrdaries.
@@ -764,7 +763,7 @@ public class VectorTypeTest extends VectorTester.Versioned
     public void testNestedANNQuery()
     {
         createTable("CREATE TABLE %s (pk int, name text, body text, vals vector<float, 2>, PRIMARY KEY(pk))");
-        createIndex("CREATE CUSTOM INDEX ON %s(vals) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "vals"));
         createIndex("CREATE CUSTOM INDEX ON %s(name) USING 'StorageAttachedIndex'");
         execute("INSERT INTO %s (pk, name, body, vals) VALUES (1, 'Ann', 'A lizard said bad things to the snakes', [0.1, 0.1])");
         execute("INSERT INTO %s (pk, name, body, vals) VALUES (2, 'Bea', 'Please wear protective gear before operating the machine', [0.2, -0.3])");
@@ -780,7 +779,7 @@ public class VectorTypeTest extends VectorTester.Versioned
         createTable("CREATE TABLE %s (pk int, a int, b int, c int, vec vector<float, 2>, PRIMARY KEY(pk, a))");
         createIndex("CREATE CUSTOM INDEX ON %s(b) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(c) USING 'StorageAttachedIndex'");
-        createIndex("CREATE CUSTOM INDEX ON %s(vec) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "vec"));
 
         // This row is created so that it matches the query parameters, and so that the PK is before the other PKs.
         // The token for 5 is -7509452495886106294 and the token for 1 is -4069959284402364209.
@@ -825,7 +824,7 @@ public class VectorTypeTest extends VectorTester.Versioned
         }
 
         // create indexes on existing sstable to produce multiple segments
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
+        createIndex(vectorIndexDDL("%s", "val", "'similarity_function' : 'euclidean'"));
         createIndex("CREATE CUSTOM INDEX ON %s(constant) USING 'StorageAttachedIndex'");
 
         // query multiple on-disk indexes
@@ -867,7 +866,7 @@ public class VectorTypeTest extends VectorTester.Versioned
     public void testEnsureIndexQueryableAfterTransientFailure() throws Throwable
     {
         createTable("CREATE TABLE %s (pk int, vec vector<float, 2>, PRIMARY KEY(pk))");
-        createIndex("CREATE CUSTOM INDEX ON %s(vec) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "vec"));
 
         var injection = Injections.newCustom("fail_on_searcher_search")
                                   .add(InvokePointBuilder.newInvokePoint().onClass(GraphSearcher.class).onMethod("search").atEntry())
@@ -890,7 +889,7 @@ public class VectorTypeTest extends VectorTester.Versioned
     public void testCompactionWithEnoughRowsForPQAndDeleteARow()
     {
         createTable("CREATE TABLE %s (pk int, vec vector<float, 2>, PRIMARY KEY(pk))");
-        createIndex("CREATE CUSTOM INDEX ON %s(vec) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "vec"));
 
         disableCompaction();
 
@@ -914,7 +913,7 @@ public class VectorTypeTest extends VectorTester.Versioned
     public void testCompactionWithEnoughRowsForPQAndARowWithAMissingVector() throws Throwable
     {
         createTable("CREATE TABLE %s (pk int, vec vector<float, 2>, PRIMARY KEY(pk))");
-        createIndex("CREATE CUSTOM INDEX ON %s(vec) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "vec"));
 
         disableCompaction();
 
@@ -937,7 +936,7 @@ public class VectorTypeTest extends VectorTester.Versioned
     public void testFilterThenSortQueryWithConcurrentVectorDeletion() throws Throwable
     {
         createTable("CREATE TABLE %s (k int PRIMARY KEY, v vector<float, 2>, c int)");
-        createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "v"));
         createIndex("CREATE CUSTOM INDEX ON %s(c) USING 'StorageAttachedIndex'");
 
         // write into memtable
@@ -1031,8 +1030,7 @@ public class VectorTypeTest extends VectorTester.Versioned
     public void testMemtableInsertSearchInsertSearchHandling()
     {
         createTable("CREATE TABLE %s (id text PRIMARY KEY, embedding vector<float, 5>)");
-        createIndex("CREATE CUSTOM INDEX ON %s(embedding) USING 'StorageAttachedIndex' " +
-                    "WITH OPTIONS = {'similarity_function': 'dot_product', 'source_model': 'OTHER'}");
+        createIndex(vectorIndexDDL("%s", "embedding", "'similarity_function': 'dot_product', 'source_model': 'OTHER'"));
 
         // Insert initial data
         execute("INSERT INTO %s (id, embedding) VALUES ('row1', [0.1, 0.1, 0.1, 0.1, 0.1])");
@@ -1066,7 +1064,7 @@ public class VectorTypeTest extends VectorTester.Versioned
     public void testUpdateRowScoreToWorsePositionButIncludeInBatch()
     {
         createTable("CREATE TABLE %s (k int, c int, r vector<float, 2>, v int, PRIMARY KEY(k, c))");
-        createIndex("CREATE CUSTOM INDEX ON %s(r) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "r"));
 
         String insert = "INSERT INTO %s (k, c, r, v) VALUES (?, ?, ?, ?)";
         execute(insert, row(0, 1, vector(0.1f, 0.1f), 0));
@@ -1084,8 +1082,8 @@ public class VectorTypeTest extends VectorTester.Versioned
     public void testIndexingMultipleVectorColumns() throws Throwable
     {
         createTable("CREATE TABLE %s (pk int, val1 vector<float, 128>, val2 vector<float, 128>, PRIMARY KEY(pk))");
-        createIndex("CREATE CUSTOM INDEX ON %s(val1) USING 'StorageAttachedIndex'");
-        createIndex("CREATE CUSTOM INDEX ON %s(val2) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "val1"));
+        createIndex(vectorIndexDDL("%s", "val2"));
 
         for (int i = 0; i < 2 * CassandraOnHeapGraph.MIN_PQ_ROWS; i++)
             execute("INSERT INTO %s (pk, val1, val2) VALUES (?, ?, ?)", i, randomVectorBoxed(128), randomVectorBoxed(128));
@@ -1101,7 +1099,7 @@ public class VectorTypeTest extends VectorTester.Versioned
     public void testRowIdIteratorClosedOnHasNextFailure() throws Throwable
     {
         createTable("CREATE TABLE %s (pk int, vec vector<float, 2>, PRIMARY KEY(pk))");
-        createIndex("CREATE CUSTOM INDEX ON %s(vec) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "vec"));
 
         // Track if the rowIdIterator's close method is called
         Injections.Counter closeCounter = Injections.newCounter("rowIdIteratorCloseCounter")

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorUpdateDeleteTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorUpdateDeleteTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.cassandra.index.sai.cql;
 
+import java.util.Map;
+
 import org.junit.Test;
 
 import org.apache.cassandra.cql3.UntypedResultSet;
@@ -648,7 +650,7 @@ public class VectorUpdateDeleteTest extends VectorTester.VersionedWithChecksums
     {
         createTable(KEYSPACE, "CREATE TABLE %s (pk int, val text, vec vector<float, 2>, PRIMARY KEY(pk))");
         // Use euclidean distance to more easily verify correctness of caching
-        createIndex(vectorIndexDDL("%s", "vec", "'similarity_function' : 'euclidean'"));
+        createIndex(vectorIndexDDL("%s", "vec", Map.of("similarity_function", "euclidean")));
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
 
         // We will search for [11,11]
@@ -989,7 +991,7 @@ public class VectorUpdateDeleteTest extends VectorTester.VersionedWithChecksums
     public void testMemtableInsertSearchUpdateSearchHandling()
     {
         createTable("CREATE TABLE %s (id text PRIMARY KEY, embedding vector<float, 5>)");
-        createIndex(vectorIndexDDL("%s", "embedding", "'similarity_function': 'dot_product', 'source_model': 'OTHER'"));
+        createIndex(vectorIndexDDL("%s", "embedding", Map.of("similarity_function", "dot_product", "source_model", "OTHER")));
 
         // Insert initial data
         execute("INSERT INTO %s (id, embedding) VALUES ('row1', [0.1, 0.1, 0.1, 0.1, 0.1])");

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorUpdateDeleteTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorUpdateDeleteTest.java
@@ -38,7 +38,7 @@ public class VectorUpdateDeleteTest extends VectorTester.VersionedWithChecksums
     public void partitionDeleteVectorInMemoryTest()
     {
         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "val"));
 
         execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', [1.0, 2.0, 3.0])");
         execute("INSERT INTO %s (pk, str_val, val) VALUES (1, 'B', [2.0, 3.0, 4.0])");
@@ -70,7 +70,7 @@ public class VectorUpdateDeleteTest extends VectorTester.VersionedWithChecksums
     public void rowDeleteVectorInMemoryAndFlushTest()
     {
         createTable("CREATE TABLE %s (pk int, ck int, str_val text, val vector<float, 3>, PRIMARY KEY(pk, ck))");
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "val"));
 
         execute("INSERT INTO %s (pk, ck, str_val, val) VALUES (0, 0, 'A', [1.0, 2.0, 3.0])");
         execute("INSERT INTO %s (pk, ck, str_val, val) VALUES (1, 1, 'B', [2.0, 3.0, 4.0])");
@@ -91,7 +91,7 @@ public class VectorUpdateDeleteTest extends VectorTester.VersionedWithChecksums
     public void testFlushWithDeletedVectors()
     {
         createTable("CREATE TABLE %s (pk int, v vector<float, 2>, PRIMARY KEY(pk))");
-        createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "v"));
 
         execute("INSERT INTO %s (pk, v) VALUES (0, [1.0, 2.0])");
         execute("INSERT INTO %s (pk, v) VALUES (0, null)");
@@ -107,7 +107,7 @@ public class VectorUpdateDeleteTest extends VectorTester.VersionedWithChecksums
     public void rangeDeleteVectorInMemoryAndFlushTest()
     {
         createTable("CREATE TABLE %s (pk int, ck int, ck2 int, str_val text, val vector<float, 3>, PRIMARY KEY(pk, ck, ck2))");
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "val"));
 
         execute("INSERT INTO %s (pk, ck, ck2, str_val, val) VALUES (0, 0, 0, 'A', [1.0, 2.0, 3.0])");
         execute("INSERT INTO %s (pk, ck, ck2, str_val, val) VALUES (1, 1, 1, 'B', [2.0, 3.0, 4.0])");
@@ -128,7 +128,7 @@ public class VectorUpdateDeleteTest extends VectorTester.VersionedWithChecksums
     public void updateVectorInMemoryAndFlushTest()
     {
         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "val"));
 
         execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', [1.0, 2.0, 3.0])");
         execute("INSERT INTO %s (pk, str_val, val) VALUES (1, 'B', [2.0, 3.0, 4.0])");
@@ -149,7 +149,7 @@ public class VectorUpdateDeleteTest extends VectorTester.VersionedWithChecksums
     public void deleteVectorPostFlushTest()
     {
         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "val"));
 
         execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', [1.0, 2.0, 3.0])");
         execute("INSERT INTO %s (pk, str_val, val) VALUES (1, 'B', [2.0, 3.0, 4.0])");
@@ -176,7 +176,7 @@ public class VectorUpdateDeleteTest extends VectorTester.VersionedWithChecksums
     public void deletedInOtherSSTablesTest() throws Throwable
     {
         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "val"));
 
         execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', [1.0, 2.0, 3.0])");
         execute("INSERT INTO %s (pk, str_val, val) VALUES (1, 'B', [2.0, 3.0, 4.0])");
@@ -201,7 +201,7 @@ public class VectorUpdateDeleteTest extends VectorTester.VersionedWithChecksums
     {
         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
         createIndex("CREATE CUSTOM INDEX ON %s(str_val) USING 'StorageAttachedIndex'");
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "val"));
 
         execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', [1.0, 2.0, 3.0])");
         execute("INSERT INTO %s (pk, str_val, val) VALUES (1, 'A', [2.0, 3.0, 4.0])");
@@ -223,7 +223,7 @@ public class VectorUpdateDeleteTest extends VectorTester.VersionedWithChecksums
     public void rangeDeletedInOtherSSTablesTest()
     {
         createTable("CREATE TABLE %s (pk int, ck1 int, ck2 int, str_val text, val vector<float, 3>, PRIMARY KEY(pk, ck1, ck2))");
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "val"));
 
         execute("INSERT INTO %s (pk, ck1, ck2, str_val, val) VALUES (0, 0, 1, 'A', [1.0, 2.0, 3.0])");
         execute("INSERT INTO %s (pk, ck1, ck2, str_val, val) VALUES (0, 0, 2, 'B', [2.0, 3.0, 4.0])");
@@ -250,7 +250,7 @@ public class VectorUpdateDeleteTest extends VectorTester.VersionedWithChecksums
     public void partitionDeletedInOtherSSTablesTest()
     {
         createTable("CREATE TABLE %s (pk int, ck1 int, ck2 int, str_val text, val vector<float, 3>, PRIMARY KEY(pk, ck1, ck2))");
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "val"));
 
         execute("INSERT INTO %s (pk, ck1, ck2, str_val, val) VALUES (0, 0, 1, 'A', [1.0, 2.0, 3.0])");
         execute("INSERT INTO %s (pk, ck1, ck2, str_val, val) VALUES (0, 0, 2, 'B', [2.0, 3.0, 4.0])");
@@ -277,7 +277,7 @@ public class VectorUpdateDeleteTest extends VectorTester.VersionedWithChecksums
     public void upsertTest()
     {
         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "val"));
 
         // insert row A redundantly, and row B once
         execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', [1.0, 2.0, 3.0])");
@@ -313,7 +313,7 @@ public class VectorUpdateDeleteTest extends VectorTester.VersionedWithChecksums
     public void updateTest()
     {
         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "val"));
 
         // overwrite row A a bunch of times; also write row B with the same vector as a deleted A value
         execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', [1.0, 2.0, 3.0])");
@@ -370,7 +370,7 @@ public class VectorUpdateDeleteTest extends VectorTester.VersionedWithChecksums
     {
         // contrived example to make sure we exercise VectorIndexSearcher.limitToTopResults
         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "val"));
         createIndex("CREATE CUSTOM INDEX ON %s(str_val) USING 'StorageAttachedIndex'");
 
         // overwrite row A a bunch of times
@@ -402,7 +402,7 @@ public class VectorUpdateDeleteTest extends VectorTester.VersionedWithChecksums
     public void updateOtherColumnsTest()
     {
         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "val"));
 
         execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', [1.0, 2.0, 3.0])");
         execute("INSERT INTO %s (pk, str_val, val) VALUES (1, 'B', [2.0, 3.0, 4.0])");
@@ -416,7 +416,7 @@ public class VectorUpdateDeleteTest extends VectorTester.VersionedWithChecksums
     public void updateManySSTablesTest()
     {
         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "val"));
 
         execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', [1.0, 2.0, 3.0])");
         flush();
@@ -454,7 +454,7 @@ public class VectorUpdateDeleteTest extends VectorTester.VersionedWithChecksums
     public void shadowedPrimaryKeyInDifferentSSTable()
     {
         createTable(KEYSPACE, "CREATE TABLE %s (pk int primary key, str_val text, val vector<float, 3>)");
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "val"));
         disableCompaction(KEYSPACE);
 
         // flush a sstable with one vector
@@ -478,7 +478,7 @@ public class VectorUpdateDeleteTest extends VectorTester.VersionedWithChecksums
     public void shadowedPrimaryKeyWithSharedVector()
     {
         createTable(KEYSPACE, "CREATE TABLE %s (pk int primary key, str_val text, val vector<float, 3>)");
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "val"));
         disableCompaction(KEYSPACE);
 
         // flush a sstable with one vector that is shared by two rows
@@ -505,7 +505,7 @@ public class VectorUpdateDeleteTest extends VectorTester.VersionedWithChecksums
         setMaxBruteForceRows(0);
         createTable(KEYSPACE, "CREATE TABLE %s (pk int primary key, str_val text, val vector<float, 3>)");
         createIndex("CREATE CUSTOM INDEX ON %s(str_val) USING 'StorageAttachedIndex'");
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "val"));
         disableCompaction(KEYSPACE);
 
         // flush a sstable with one vector that is shared by two rows
@@ -532,7 +532,7 @@ public class VectorUpdateDeleteTest extends VectorTester.VersionedWithChecksums
         setMaxBruteForceRows(0);
         createTable(KEYSPACE, "CREATE TABLE %s (pk int primary key, num int, val vector<float, 3>)");
         createIndex("CREATE CUSTOM INDEX ON %s(num) USING 'StorageAttachedIndex'");
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "val"));
         disableCompaction(KEYSPACE);
 
         // Same PK, different num, different vectors
@@ -555,7 +555,7 @@ public class VectorUpdateDeleteTest extends VectorTester.VersionedWithChecksums
     {
         setMaxBruteForceRows(0);
         createTable(String.format("CREATE TABLE %%s (pk int, str_val text, val vector<float, %d>, PRIMARY KEY(pk))", 2));
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "val"));
 
         execute("INSERT INTO %s (pk, val) VALUES (0, [1.0, 2.0])"); // -3485513579396041028
         execute("INSERT INTO %s (pk, val) VALUES (1, [1.0, 2.0])"); // -4069959284402364209
@@ -581,7 +581,7 @@ public class VectorUpdateDeleteTest extends VectorTester.VersionedWithChecksums
     {
         setMaxBruteForceRows(0);
         createTable(String.format("CREATE TABLE %%s (pk int, str_val text, val vector<float, %d>, PRIMARY KEY(pk))", 2));
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "val"));
 
 
         execute("INSERT INTO %s (pk, val) VALUES (0, [1.0, 2.0])");
@@ -613,7 +613,7 @@ public class VectorUpdateDeleteTest extends VectorTester.VersionedWithChecksums
     public void testVectorRowWhereUpdateMakesRowMatchNonOrderingPredicates()
     {
         createTable(KEYSPACE, "CREATE TABLE %s (pk int, val text, vec vector<float, 2>, PRIMARY KEY(pk))");
-        createIndex("CREATE CUSTOM INDEX ON %s(vec) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "vec"));
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
 
         // Split the row across 1 sstable and the memtable.
@@ -648,7 +648,7 @@ public class VectorUpdateDeleteTest extends VectorTester.VersionedWithChecksums
     {
         createTable(KEYSPACE, "CREATE TABLE %s (pk int, val text, vec vector<float, 2>, PRIMARY KEY(pk))");
         // Use euclidean distance to more easily verify correctness of caching
-        createIndex("CREATE CUSTOM INDEX ON %s(vec) USING 'StorageAttachedIndex' WITH OPTIONS = { 'similarity_function' : 'euclidean' }");
+        createIndex(vectorIndexDDL("%s", "vec", "'similarity_function' : 'euclidean'"));
         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
 
         // We will search for [11,11]
@@ -670,7 +670,7 @@ public class VectorUpdateDeleteTest extends VectorTester.VersionedWithChecksums
     public void testUpdateNonVectorColumnWhereNoSingleSSTableRowMatchesAllPredicates()
     {
         createTable(KEYSPACE, "CREATE TABLE %s (pk int, val1 text, val2 text, vec vector<float, 2>, PRIMARY KEY(pk))");
-        createIndex("CREATE CUSTOM INDEX ON %s(vec) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "vec"));
         createIndex("CREATE CUSTOM INDEX ON %s(val1) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(val2) USING 'StorageAttachedIndex'");
 
@@ -693,7 +693,7 @@ public class VectorUpdateDeleteTest extends VectorTester.VersionedWithChecksums
     public void shadowedPrimaryKeyInDifferentSSTableEachWithMultipleRows()
     {
         createTable(KEYSPACE, "CREATE TABLE %s (pk int primary key, str_val text, val vector<float, 3>)");
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "val"));
         disableCompaction(KEYSPACE);
 
         // flush a sstable with one vector
@@ -722,7 +722,7 @@ public class VectorUpdateDeleteTest extends VectorTester.VersionedWithChecksums
     public void shadowedPrimaryKeysRequireDeeperSearch() throws Throwable
     {
         createTable(KEYSPACE, "CREATE TABLE %s (pk int primary key, str_val text, val vector<float, 2>)");
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "val"));
         createIndex("CREATE CUSTOM INDEX ON %s(str_val) USING 'StorageAttachedIndex'");
         disableCompaction(KEYSPACE);
 
@@ -759,7 +759,7 @@ public class VectorUpdateDeleteTest extends VectorTester.VersionedWithChecksums
     public void testUpdateVectorToWorseAndBetterPositions() throws Throwable
     {
         createTable("CREATE TABLE %s (pk int, val vector<float, 2>, PRIMARY KEY(pk))");
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "val"));
 
         execute("INSERT INTO %s (pk, val) VALUES (0, [1.0, 2.0])");
         execute("INSERT INTO %s (pk, val) VALUES (1, [1.0, 3.0])");
@@ -798,7 +798,7 @@ public class VectorUpdateDeleteTest extends VectorTester.VersionedWithChecksums
         setMaxBruteForceRows(0);
 
         createTable(KEYSPACE, "CREATE TABLE %s (pk int primary key, str_val text, val vector<float, 2>)");
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "val"));
         createIndex("CREATE CUSTOM INDEX ON %s(str_val) USING 'StorageAttachedIndex'");
         disableCompaction(KEYSPACE);
 
@@ -840,7 +840,7 @@ public class VectorUpdateDeleteTest extends VectorTester.VersionedWithChecksums
     {
         setMaxBruteForceRows(0);
         createTable("CREATE TABLE %s (pk int, val vector<float, " + vectorDimension + ">, PRIMARY KEY(pk))");
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "val"));
 
         // Insert 100 vectors
         for (int i = 0; i < 100; i++)
@@ -874,7 +874,7 @@ public class VectorUpdateDeleteTest extends VectorTester.VersionedWithChecksums
         setMaxBruteForceRows(0);
         createTable(KEYSPACE, "CREATE TABLE %s (pk int, a int, str_val text, val vector<float, 3>, PRIMARY KEY(pk, a))");
         createIndex("CREATE CUSTOM INDEX ON %s(str_val) USING 'StorageAttachedIndex'");
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "val"));
         disableCompaction(KEYSPACE);
 
         // Insert a row with a vector
@@ -897,7 +897,7 @@ public class VectorUpdateDeleteTest extends VectorTester.VersionedWithChecksums
         setMaxBruteForceRows(0);
         createTable(KEYSPACE, "CREATE TABLE %s (pk int, a int, str_val text, val vector<float, 3>, PRIMARY KEY(pk, a))");
         createIndex("CREATE CUSTOM INDEX ON %s(str_val) USING 'StorageAttachedIndex'");
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "val"));
         disableCompaction(KEYSPACE);
 
         // Insert two rows with different vectors to get different ordinals
@@ -920,7 +920,7 @@ public class VectorUpdateDeleteTest extends VectorTester.VersionedWithChecksums
     public void ensureCompressedVectorsCanFlush()
     {
         createTable("CREATE TABLE %s (pk int, val vector<float, 4>, PRIMARY KEY(pk))");
-        var indexName = createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        var indexName = createIndex(vectorIndexDDL("%s", "val"));
 
         // insert enough vectors for pq plus 1 because we need quantization and we're deleting a row
         for (int i = 0; i < MIN_PQ_ROWS + 1; i++)
@@ -938,7 +938,7 @@ public class VectorUpdateDeleteTest extends VectorTester.VersionedWithChecksums
     public void testTTLOverwriteHasCorrectOnDiskRowCount() throws Throwable
     {
         createTable("CREATE TABLE %s (pk int primary key, val vector<float, 3>)");
-        var indexName = createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        var indexName = createIndex(vectorIndexDDL("%s", "val"));
 
         execute("INSERT INTO %s (pk, val) VALUES (0, [1.0, 2.0, 3.0]) USING TTL 1");
 
@@ -965,7 +965,7 @@ public class VectorUpdateDeleteTest extends VectorTester.VersionedWithChecksums
     public void testSameRowInMultipleSSTablesWithSameTimestamp() throws Throwable
     {
         createTable("CREATE TABLE %s (pk int, ck int, val vector<float, 3>, PRIMARY KEY(pk, ck))");
-        createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        createIndex(vectorIndexDDL("%s", "val"));
         // We don't want compaction preventing us from hitting the intended code path.
         disableCompaction();
 
@@ -989,8 +989,7 @@ public class VectorUpdateDeleteTest extends VectorTester.VersionedWithChecksums
     public void testMemtableInsertSearchUpdateSearchHandling()
     {
         createTable("CREATE TABLE %s (id text PRIMARY KEY, embedding vector<float, 5>)");
-        createIndex("CREATE CUSTOM INDEX ON %s(embedding) USING 'StorageAttachedIndex' " +
-                    "WITH OPTIONS = {'similarity_function': 'dot_product', 'source_model': 'OTHER'}");
+        createIndex(vectorIndexDDL("%s", "embedding", "'similarity_function': 'dot_product', 'source_model': 'OTHER'"));
 
         // Insert initial data
         execute("INSERT INTO %s (id, embedding) VALUES ('row1', [0.1, 0.1, 0.1, 0.1, 0.1])");


### PR DESCRIPTION
### What is the issue
...
#18639
### What does this PR fix and why was it fixed
...
Enable hierarchy and parallel graph writing for FusedPQ test runs (Latest recommendation is that FusedPQ is supposed to run **only** with them enabled and no other way).  Exclude Version.FA from parameterized vector test suites as we are not supposed to ever use that version. The way to enable FusedPQ would be by using FB or later version and enable FusedPQ with -D property. 