### PR TITLE
CNDB-18565: Track latencies of indexed queries separately

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -419,6 +419,11 @@ public enum CassandraRelevantProperties
      */
     SKIP_INDEXES_ON_FULL_PRIMARY_KEYS("cassandra.index.skip_on_full_primary_keys", "true"),
 
+    /**
+     * Whether to use a separate histogram for the latencies of indexed queries. Enabled by default.
+     */
+    SEPARATE_INDEX_LATENCY_HISTOGRAM_ENABLED("cassandra.index.separate_latency_histogram.enabled", "true"),
+
     /** The current version of the SAI on-disk index format. */
     SAI_CURRENT_VERSION("cassandra.sai.latest.version", "ec"),
 

--- a/src/java/org/apache/cassandra/db/MultiRangeReadCommand.java
+++ b/src/java/org/apache/cassandra/db/MultiRangeReadCommand.java
@@ -306,7 +306,10 @@ public class MultiRangeReadCommand extends ReadCommand implements MultiPartition
     @Override
     protected void recordReadLatency(TableMetrics metric, long latencyNanos)
     {
-        metric.rangeLatency.addNano(latencyNanos);
+        if (recordIndexLatency())
+            metric.indexLatency.addNano(latencyNanos);
+        else
+            metric.rangeLatency.addNano(latencyNanos);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/PartitionRangeReadCommand.java
+++ b/src/java/org/apache/cassandra/db/PartitionRangeReadCommand.java
@@ -275,9 +275,13 @@ public class PartitionRangeReadCommand extends ReadCommand implements PartitionR
         return StorageProxy.getRangeSlice(this, consistency, queryStartNanoTime, queryState.getClientState());
     }
 
+    @Override
     protected void recordReadLatency(TableMetrics metric, long latencyNanos)
     {
-        metric.rangeLatency.addNano(latencyNanos);
+        if (recordIndexLatency())
+            metric.indexLatency.addNano(latencyNanos);
+        else
+            metric.rangeLatency.addNano(latencyNanos);
     }
 
     protected void recordReadRequest(TableMetrics metric)

--- a/src/java/org/apache/cassandra/db/ReadCommand.java
+++ b/src/java/org/apache/cassandra/db/ReadCommand.java
@@ -578,6 +578,11 @@ public abstract class ReadCommand extends AbstractReadQuery
     protected abstract void recordReadRequest(TableMetrics metric);
     protected abstract void recordReadLatency(TableMetrics metric, long latencyNanos);
 
+    protected boolean recordIndexLatency()
+    {
+        return indexQueryPlan != null && CassandraRelevantProperties.SEPARATE_INDEX_LATENCY_HISTOGRAM_ENABLED.getBoolean();
+    }
+
     public ReadExecutionController executionController(boolean trackRepairedStatus)
     {
         return ReadExecutionController.forCommand(this, trackRepairedStatus);

--- a/src/java/org/apache/cassandra/db/SinglePartitionReadCommand.java
+++ b/src/java/org/apache/cassandra/db/SinglePartitionReadCommand.java
@@ -416,9 +416,13 @@ public class SinglePartitionReadCommand extends ReadCommand implements SinglePar
         return StorageProxy.read(Group.one(this), consistency, queryState, queryStartNanoTime);
     }
 
+    @Override
     protected void recordReadLatency(TableMetrics metric, long latencyNanos)
     {
-        metric.readLatency.addNano(latencyNanos);
+        if (recordIndexLatency())
+            metric.indexLatency.addNano(latencyNanos);
+        else
+            metric.readLatency.addNano(latencyNanos);
     }
 
     protected void recordReadRequest(TableMetrics metric)

--- a/src/java/org/apache/cassandra/metrics/KeyspaceMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/KeyspaceMetrics.java
@@ -75,6 +75,8 @@ public class KeyspaceMetrics
     public final LatencyMetrics readLatency;
     /** (Local) range slice metrics */
     public final LatencyMetrics rangeLatency;
+    /** (Local) index read metrics */
+    public final LatencyMetrics indexLatency;
     /** (Local) write metrics */
     public final LatencyMetrics writeLatency;
     /** Histogram of the number of sstable data files accessed per read */
@@ -237,6 +239,7 @@ public class KeyspaceMetrics
         readLatency = createLatencyMetrics("Read");
         writeLatency = createLatencyMetrics("Write");
         rangeLatency = createLatencyMetrics("Range");
+        indexLatency = createLatencyMetrics("Index");
 
         // create histograms for TableMetrics to replicate updates to
         sstablesPerReadHistogram = createKeyspaceHistogram("SSTablesPerReadHistogram", true);

--- a/src/java/org/apache/cassandra/metrics/TableMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/TableMetrics.java
@@ -155,6 +155,7 @@ public class TableMetrics
     public final static Optional<LatencyMetrics> GLOBAL_READ_LATENCY = EXPORT_GLOBAL_METRICS ? Optional.of(new LatencyMetrics(GLOBAL_FACTORY, GLOBAL_ALIAS_FACTORY, "Read")) : Optional.empty();
     public final static Optional<LatencyMetrics> GLOBAL_WRITE_LATENCY = EXPORT_GLOBAL_METRICS ? Optional.of(new LatencyMetrics(GLOBAL_FACTORY, GLOBAL_ALIAS_FACTORY, "Write")) : Optional.empty();
     public final static Optional<LatencyMetrics> GLOBAL_RANGE_LATENCY = EXPORT_GLOBAL_METRICS ? Optional.of(new LatencyMetrics(GLOBAL_FACTORY, GLOBAL_ALIAS_FACTORY, "Range")) : Optional.empty();
+    public final static Optional<LatencyMetrics> GLOBAL_INDEX_LATENCY = EXPORT_GLOBAL_METRICS ? Optional.of(new LatencyMetrics(GLOBAL_FACTORY, GLOBAL_ALIAS_FACTORY, "Index")) : Optional.empty();
 
     /** Total amount of data stored in the memtable that resides on-heap, including column related overhead and partitions overwritten. */
     public final Gauge<Long> memtableOnHeapDataSize;
@@ -201,6 +202,8 @@ public class TableMetrics
     public final TableLatencyMetrics readLatency;
     /** (Local) range slice metrics */
     public final TableLatencyMetrics rangeLatency;
+    /** (Local) index read metrics */
+    public final TableLatencyMetrics indexLatency;
     /** (Local) write metrics */
     public final TableLatencyMetrics writeLatency;
     /** The number of single partition read requests, including those dropped due to timeouts */
@@ -792,6 +795,7 @@ public class TableMetrics
         readLatency = createLatencyMetrics("Read", cfs.getKeyspaceMetrics().readLatency, GLOBAL_READ_LATENCY);
         writeLatency = createLatencyMetrics("Write", cfs.getKeyspaceMetrics().writeLatency, GLOBAL_WRITE_LATENCY);
         rangeLatency = createLatencyMetrics("Range", cfs.getKeyspaceMetrics().rangeLatency, GLOBAL_RANGE_LATENCY);
+        indexLatency = createLatencyMetrics("Index", cfs.getKeyspaceMetrics().indexLatency, GLOBAL_INDEX_LATENCY);
 
         readRequests = createTableCounter("ReadRequests");
         rangeRequests = createTableCounter("RangeRequests");

--- a/test/unit/org/apache/cassandra/index/sai/metrics/IndexMetricsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/metrics/IndexMetricsTest.java
@@ -17,6 +17,7 @@
  */
 package org.apache.cassandra.index.sai.metrics;
 
+import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.cassandra.config.CassandraRelevantProperties;
@@ -29,6 +30,8 @@ import org.apache.cassandra.utils.Throwables;
 
 import javax.management.ObjectName;
 
+import static org.apache.cassandra.index.sai.metrics.TableQueryMetrics.AbstractQueryMetrics.makeName;
+import static org.apache.cassandra.index.sai.metrics.TableQueryMetrics.QueryKind;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.*;
 
@@ -213,7 +216,11 @@ public class IndexMetricsTest extends AbstractMetricsTest
     private void assertMetricExistsIfEnabled(boolean shouldExist, String metricName, String table, String index, String metricType)
     {
         ObjectName name = objectName(metricName, KEYSPACE, table, index, metricType);
+        assertMetricsExistsIfEnabled(shouldExist, name);
+    }
 
+    private void assertMetricsExistsIfEnabled(boolean shouldExist, ObjectName name)
+    {
         if (shouldExist)
             assertMetricExists(name);
         else
@@ -233,11 +240,14 @@ public class IndexMetricsTest extends AbstractMetricsTest
     private void assertTableQueryMetricsExistsIfEnabled(boolean shouldExist, String metricName, String table)
     {
         ObjectName name = objectNameNoIndex(metricName, KEYSPACE, table, "PerQuery");
+        assertMetricsExistsIfEnabled(shouldExist, name);
+    }
 
-        if (shouldExist)
-            assertMetricExists(name);
-        else
-            assertMetricDoesNotExist(name);
+    private void assertPerQueryKindMetricExistsIfEnabled(boolean shouldExist, String metricName, String table, TableQueryMetrics.QueryKind kind)
+    {
+        String type = makeName(TableQueryMetrics.PerQuery.METRIC_TYPE, kind);
+        ObjectName name = objectNameNoIndex(metricName, KEYSPACE, table, type);
+        assertMetricsExistsIfEnabled(shouldExist, name);
     }
 
     private void assertIndexQueryCount(String index, long expectedCount)
@@ -466,14 +476,17 @@ public class IndexMetricsTest extends AbstractMetricsTest
     @Test
     public void testHistogramMetricsEnabledAndDisabled()
     {
-        testHistogramMetrics(false);
-        testHistogramMetrics(true);
+        testHistogramMetrics(false, false);
+        testHistogramMetrics(false, true);
+        testHistogramMetrics(true, false);
+        testHistogramMetrics(true, true);
     }
 
-    private void testHistogramMetrics(boolean histogramsEnabled)
+    private void testHistogramMetrics(boolean histogramsEnabled, boolean perQueryKindEnabled)
     {
-        // Set the property before creating any indexes
+        // Set the properties before creating any indexes
         CassandraRelevantProperties.SAI_HISTOGRAMS_ENABLED.setBoolean(histogramsEnabled);
+        CassandraRelevantProperties.SAI_QUERY_KIND_PER_QUERY_METRICS_ENABLED.setBoolean(perQueryKindEnabled);
 
         try
         {
@@ -519,7 +532,11 @@ public class IndexMetricsTest extends AbstractMetricsTest
             assertColumnQueryMetricsExistsIfEnabled(histogramsEnabled, "TermsLookupLatency", table, indexV2);
 
             // Test QueryLatency timer (TableQueryMetrics.PerQuery - table-level metric, no index name)
-            assertTableQueryMetricsExistsIfEnabled(histogramsEnabled, "QueryLatency", table);
+            for (QueryKind kind : QueryKind.values())
+            {
+                boolean shouldExist = histogramsEnabled && (perQueryKindEnabled || kind == QueryKind.ALL);
+                assertPerQueryKindMetricExistsIfEnabled(shouldExist, "QueryLatency", table, kind);
+            }
 
             // Verify that other PerQuery histograms are always enabled (not affected by the flag)
             assertTableQueryMetricsExistsIfEnabled(true, "SSTableIndexesHit", table);

--- a/test/unit/org/apache/cassandra/metrics/TabeMetricsCQLTest.java
+++ b/test/unit/org/apache/cassandra/metrics/TabeMetricsCQLTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.metrics;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.net.MessagingService;
+import org.assertj.core.api.Assertions;
+
+public class TabeMetricsCQLTest extends CQLTester
+{
+    @BeforeClass
+    @SuppressWarnings("deprecation")
+    public static void setUpClass()
+    {
+        // Set the messaging version that adds support for index hints before starting the server
+        CassandraRelevantProperties.DS_CURRENT_MESSAGING_VERSION.setInt(MessagingService.VERSION_DS_12);
+        CQLTester.setUpClass();
+        CQLTester.enableCoordinatorExecution();
+    }
+
+    @Test
+    public void testQueryLatency()
+    {
+        testQueryLatency(true);
+        testQueryLatency(false);
+    }
+
+    private void testQueryLatency(boolean separateIndexLatency)
+    {
+        CassandraRelevantProperties.SEPARATE_INDEX_LATENCY_HISTOGRAM_ENABLED.setBoolean(separateIndexLatency);
+
+        createTable("CREATE TABLE %s (k int, c int, v1 int, v2 int, PRIMARY KEY(k, c))");
+        String idx1 = createIndex("CREATE CUSTOM INDEX ON %s(v1) USING 'StorageAttachedIndex'");
+        String idx2 = createIndex("CREATE INDEX ON %s(v2)");
+        execute("INSERT INTO %s (k, c, v1, v2) VALUES (0, 0, 0, 0)");
+
+        TableMetrics metrics = getCurrentColumnFamilyStore().metric;
+
+        // range query
+        execute("SELECT * FROM %s");
+        assertLatency(metrics.readLatency, 0);
+        assertLatency(metrics.rangeLatency, 1);
+        assertLatency(metrics.indexLatency, 0);
+
+        // partition query
+        execute("SELECT * FROM %s WHERE k = 0");
+        execute("SELECT * FROM %s WHERE k = 1");
+        assertLatency(metrics.readLatency, 2);
+        assertLatency(metrics.rangeLatency, 1);
+        assertLatency(metrics.indexLatency, 0);
+
+        // index range query (SAI)
+        execute("SELECT * FROM %s WHERE v1 = 0");
+        execute("SELECT * FROM %s WHERE v1 = 1");
+        execute("SELECT * FROM %s WHERE v1 = 2");
+        assertLatency(metrics.readLatency, 2);
+        assertLatency(metrics.rangeLatency, separateIndexLatency ? 1 : 4);
+        assertLatency(metrics.indexLatency, separateIndexLatency ? 3 : 0);
+
+        // index range query (legacy)
+        execute("SELECT * FROM %s WHERE v2 = 0");
+        execute("SELECT * FROM %s WHERE v2 = 1");
+        execute("SELECT * FROM %s WHERE v2 = 2");
+        execute("SELECT * FROM %s WHERE v2 = 3");
+        assertLatency(metrics.readLatency, 2);
+        assertLatency(metrics.rangeLatency, separateIndexLatency ? 1 : 8);
+        assertLatency(metrics.indexLatency, separateIndexLatency ? 7 : 0);
+
+        // index partition queries
+        execute("SELECT * FROM %s WHERE k = 0 AND v1 = 0");
+        execute("SELECT * FROM %s WHERE k = 0 AND v2 = 0");
+        assertLatency(metrics.readLatency, separateIndexLatency ? 2 : 4);
+        assertLatency(metrics.rangeLatency, separateIndexLatency ? 1 : 8);
+        assertLatency(metrics.indexLatency, separateIndexLatency ? 9 : 0);
+
+        // queries with index hints
+        execute("SELECT * FROM %s WHERE v1 = 0 ALLOW FILTERING WITH excluded_indexes={" + idx1 + '}');
+        execute("SELECT * FROM %s WHERE v2 = 0 ALLOW FILTERING WITH excluded_indexes={" + idx2 + '}');
+        assertLatency(metrics.readLatency, separateIndexLatency ? 2 : 4);
+        assertLatency(metrics.rangeLatency, separateIndexLatency ? 3 : 10);
+        assertLatency(metrics.indexLatency, separateIndexLatency ? 9 : 0);
+    }
+
+    private void assertLatency(TableMetrics.TableLatencyMetrics metrics, int expectedCount)
+    {
+        Assertions.assertThat(metrics.tableOrKeyspaceMetric().latency.getCount()).isEqualTo(expectedCount);
+    }
+}


### PR DESCRIPTION
### What is the issue

Addresses https://github.com/riptano/cndb/issues/18565.

### What does this PR fix and why was it fixed

Adds separate latency metrics for read commands using secondary indexes of any kind.

That way, queries are tracked by the metrics of one of:
* readLatency: single-partition queries not using indexes
* rangeLatency: multi-partition queries not using indexes
* indexLatency: any query using indexes

This is done at the `Index` level rather than at the SAI level because https://github.com/riptano/cndb/issues/16859 also works at the `Index` level. That is, CQL single-partition queries using any kind of index are translated into `SinglePartitionReadCommand`s. This pollutes the the metrics of the very fast primary key queries with the probably not so fast index queries. This already happened with range queries, where `ALLOW FILTERING` and index queries were mixed, but it wasn't that problematic because not-indexed range queries are rare.

There is a `cassandra.index.separate_latency_histogram.enabled` property to fallback to the previous behaviour.
