### PR TITLE
CNDB-18845: fix CompressionMetadata ref leak in BtiTableWriter.IndexWriter

### DIFF
--- a/src/java/org/apache/cassandra/io/sstable/format/bti/BtiTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/bti/BtiTableWriter.java
@@ -87,6 +87,12 @@ public class BtiTableWriter extends SortedTableWriter<BtiFormatPartitionWriter, 
         super(builder, lifecycleNewTracker, owner);
     }
 
+    @VisibleForTesting
+    IndexWriter indexWriter()
+    {
+        return indexWriter;
+    }
+
     @Override
     protected TrieIndexEntry createRowIndexEntry(DecoratedKey key, DeletionTime partitionLevelDeletion, long finishResult) throws IOException
     {
@@ -197,53 +203,84 @@ public class BtiTableWriter extends SortedTableWriter<BtiFormatPartitionWriter, 
         @Nullable
         private final TableMetrics tableMetrics;
 
+        // Encryption-only metadata handed to the index FileHandle builders when encryption is enabled;
+        // the builders keep this same instance until FileHandle.Builder.complete() takes its own shared
+        // copy, so it must stay open for the writer's whole lifetime and be released on cleanup.
+        // Null when encryption is not used.
+        @Nullable
+        final CompressionMetadata indexEncryptionMetadata;
+
         IndexWriter(Builder b, SequentialWriter dataWriter)
         {
             super(b);
-            
+
             // Check if encryption is enabled (following trie-index pattern)
             boolean compression = b.getComponents().contains(SSTableFormat.Components.COMPRESSION_INFO);
             TableMetadata metadata = b.getTableMetadataRef().getLocal();
             CompressionParams params = metadata.params.compression;
             ICompressor encryptor = compression ? params.getSstableCompressor().encryptionOnly() : null;
-            
-            if (encryptor != null)
-            {
-                // Create encrypted writers and configure FileHandle builders for encryption
-                CompressionMetadata compressionMetadata = CompressionMetadata.encryptedOnly(params);
-                rowIndexWriter = new EncryptedSequentialWriter(descriptor.fileFor(Components.ROW_INDEX), 
-                                                               b.getIOOptions().writerOptions, 
-                                                               encryptor);
-                rowIndexFHBuilder = IndexComponent.fileBuilder(Components.ROW_INDEX, b, b.operationType)
-                                                  .withMmappedRegionsCache(b.getMmappedRegionsCache())
-                                                  .withCompressionMetadata(compressionMetadata)
-                                                  .maybeEncrypted(true);
-                
-                partitionIndexWriter = new EncryptedSequentialWriter(descriptor.fileFor(Components.PARTITION_INDEX), 
-                                                                    b.getIOOptions().writerOptions, 
-                                                                    encryptor);
-                partitionIndexFHBuilder = IndexComponent.fileBuilder(Components.PARTITION_INDEX, b, b.operationType)
-                                                        .withMmappedRegionsCache(b.getMmappedRegionsCache())
-                                                        .withCompressionMetadata(compressionMetadata)
-                                                        .maybeEncrypted(true);
-            }
-            else
-            {
-                // Create regular writers
-                rowIndexWriter = new SequentialWriter(descriptor.fileFor(Components.ROW_INDEX), b.getIOOptions().writerOptions);
-                rowIndexFHBuilder = IndexComponent.fileBuilder(Components.ROW_INDEX, b, b.operationType)
-                                                  .withMmappedRegionsCache(b.getMmappedRegionsCache());
-                partitionIndexWriter = new SequentialWriter(descriptor.fileFor(Components.PARTITION_INDEX), b.getIOOptions().writerOptions);
-                partitionIndexFHBuilder = IndexComponent.fileBuilder(Components.PARTITION_INDEX, b, b.operationType)
-                                                        .withMmappedRegionsCache(b.getMmappedRegionsCache());
-            }
-            partitionIndex = new PartitionIndexBuilder(partitionIndexWriter, partitionIndexFHBuilder, descriptor.version.getByteComparableVersion());
 
-            // register listeners to be alerted when the data files are flushed
-            partitionIndexWriter.setPostFlushListener(partitionIndex::markPartitionIndexSynced);
-            rowIndexWriter.setPostFlushListener(partitionIndex::markRowIndexSynced);
-            dataWriter.setPostFlushListener(partitionIndex::markDataSynced);
+            // Build into locals so that a failure partway through construction can release whatever was
+            // already created: SortedTableWriter's constructor only sees a null indexWriter in that case
+            // and cannot close any of it (including the bloom filter created by the super constructor).
+            CompressionMetadata encryptionMetadata = null;
+            SequentialWriter riWriter = null;
+            SequentialWriter piWriter = null;
+            PartitionIndexBuilder pIndexBuilder = null;
+            try
+            {
+                if (encryptor != null)
+                {
+                    // Create encrypted writers and configure FileHandle builders for encryption
+                    encryptionMetadata = CompressionMetadata.encryptedOnly(params);
+                    riWriter = new EncryptedSequentialWriter(descriptor.fileFor(Components.ROW_INDEX),
+                                                             b.getIOOptions().writerOptions,
+                                                             encryptor);
+                    rowIndexFHBuilder = IndexComponent.fileBuilder(Components.ROW_INDEX, b, b.operationType)
+                                                      .withMmappedRegionsCache(b.getMmappedRegionsCache())
+                                                      .withCompressionMetadata(encryptionMetadata)
+                                                      .maybeEncrypted(true);
 
+                    piWriter = new EncryptedSequentialWriter(descriptor.fileFor(Components.PARTITION_INDEX),
+                                                             b.getIOOptions().writerOptions,
+                                                             encryptor);
+                    partitionIndexFHBuilder = IndexComponent.fileBuilder(Components.PARTITION_INDEX, b, b.operationType)
+                                                            .withMmappedRegionsCache(b.getMmappedRegionsCache())
+                                                            .withCompressionMetadata(encryptionMetadata)
+                                                            .maybeEncrypted(true);
+                }
+                else
+                {
+                    // Create regular writers
+                    riWriter = new SequentialWriter(descriptor.fileFor(Components.ROW_INDEX), b.getIOOptions().writerOptions);
+                    rowIndexFHBuilder = IndexComponent.fileBuilder(Components.ROW_INDEX, b, b.operationType)
+                                                      .withMmappedRegionsCache(b.getMmappedRegionsCache());
+                    piWriter = new SequentialWriter(descriptor.fileFor(Components.PARTITION_INDEX), b.getIOOptions().writerOptions);
+                    partitionIndexFHBuilder = IndexComponent.fileBuilder(Components.PARTITION_INDEX, b, b.operationType)
+                                                            .withMmappedRegionsCache(b.getMmappedRegionsCache());
+                }
+                pIndexBuilder = new PartitionIndexBuilder(piWriter, partitionIndexFHBuilder, descriptor.version.getByteComparableVersion());
+
+                // register listeners to be alerted when the data files are flushed
+                piWriter.setPostFlushListener(pIndexBuilder::markPartitionIndexSynced);
+                riWriter.setPostFlushListener(pIndexBuilder::markRowIndexSynced);
+                dataWriter.setPostFlushListener(pIndexBuilder::markDataSynced);
+            }
+            catch (RuntimeException | Error ex)
+            {
+                Throwables.closeNonNullAndAddSuppressed(ex, pIndexBuilder, piWriter, riWriter, encryptionMetadata, bf);
+                throw ex;
+            }
+            indexEncryptionMetadata = encryptionMetadata;
+            rowIndexWriter = riWriter;
+            partitionIndexWriter = piWriter;
+            partitionIndex = pIndexBuilder;
+
+            // Everything from here on must not throw and must not open further resources: a failure past
+            // the catch above would leak all of the above, since this instance never reaches the caller
+            // and doPostCleanup never runs. In particular the bloom filter memory accounting must stay
+            // last -- doPostCleanup's matching decrement does not run on the construction-failure path,
+            // so the increment may only happen once construction can no longer fail.
 
             // The per-table bloom filter memory is tracked when:
             // 1. Periodic early open: Opens incomplete sstables when size threshold is hit during writing.
@@ -393,7 +430,7 @@ public class BtiTableWriter extends SortedTableWriter<BtiFormatPartitionWriter, 
         {
             if (tableMetrics != null && bf != null)
                 tableMetrics.inFlightBloomFilterOffHeapMemoryUsed.getAndAdd(-bf.offHeapSize());
-            return Throwables.close(accumulate, bf, partitionIndex, rowIndexWriter, partitionIndexWriter);
+            return Throwables.close(accumulate, bf, partitionIndex, rowIndexWriter, partitionIndexWriter, indexEncryptionMetadata);
         }
     }
 

--- a/test/distributed/org/apache/cassandra/distributed/test/SSTableEncryptionTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/SSTableEncryptionTest.java
@@ -259,6 +259,51 @@ public class SSTableEncryptionTest extends TestBaseImpl
         }
     }
 
+    @Test
+    public void shouldNotLeakCompressionMetadataOnFlushAndCompaction() throws Exception
+    {
+        try (Cluster cluster = builder().withNodes(1)
+                                        .withConfig(config -> config.with(GOSSIP).with(NETWORK))
+                                        .start())
+        {
+            // given a table with data encrypted using local key
+            String keyspace = createKeyspace(cluster);
+            Path secretKey = createLocalSecretKey(cluster);
+            String table = createEncryptedTable(cluster, keyspace, secretKey);
+
+            // write through the flush path twice so that the subsequent major compaction has work to do;
+            // both the flush and the compaction create BTI writers with encrypted index components
+            insertAndFlush(cluster, keyspace, table, 10);
+            insertAndFlush(cluster, keyspace, table, 10);
+            cluster.get(1).nodetoolResult("compact", keyspace, table).asserts().success();
+
+            cluster.schemaChange(String.format("DROP TABLE %s.%s", keyspace, table));
+
+            // all writers are gone by now; force garbage collection so that any CompressionMetadata
+            // whose reference was not released gets flagged by the reference reaper.
+            // Note this check is best-effort: System.gc() is advisory and the reaper logs
+            // asynchronously, so a regression may occasionally go unnoticed here — the deterministic
+            // guard is BtiTableWriterEncryptionTest, this test covers the end-to-end wiring
+            cluster.get(1).runOnInstance(() -> {
+                for (int i = 0; i < 5; i++)
+                {
+                    System.gc();
+                    try
+                    {
+                        Thread.sleep(200);
+                    }
+                    catch (InterruptedException e)
+                    {
+                        throw new RuntimeException(e);
+                    }
+                }
+            });
+
+            List<String> leaks = cluster.get(1).logs().grep("LEAK DETECTED.*ChunkOffsetMemory").getResult();
+            assertThat(leaks).isEmpty();
+        }
+    }
+
     private TestTable createTableWithSampleData(Cluster cluster, String keyspace, String tableDefSuffix) throws IOException
     {
         String tableName = randomTableName();

--- a/test/unit/org/apache/cassandra/io/sstable/format/bti/BtiTableWriterEncryptionTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/format/bti/BtiTableWriterEncryptionTest.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.io.sstable.format.bti;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.SchemaLoader;
+import org.apache.cassandra.UpdateBuilder;
+import org.apache.cassandra.Util;
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.db.compaction.OperationType;
+import org.apache.cassandra.db.lifecycle.LifecycleTransaction;
+import org.apache.cassandra.io.compress.CompressionMetadata;
+import org.apache.cassandra.io.compress.EncryptionConfig;
+import org.apache.cassandra.io.compress.Encryptor;
+import org.apache.cassandra.io.compress.EncryptorTest;
+import org.apache.cassandra.io.sstable.SSTableWriterTestBase;
+import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.io.sstable.format.SSTableWriter;
+import org.apache.cassandra.io.util.File;
+import org.apache.cassandra.schema.CompressionParams;
+import org.apache.cassandra.schema.KeyspaceParams;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Verifies that the ref-counted {@link CompressionMetadata} which {@link BtiTableWriter.IndexWriter}
+ * creates for encrypted ROW_INDEX / PARTITION_INDEX components is released when the writer is
+ * closed, on both the commit and the abort path. The instance holds the chunk-offset index in
+ * off-heap memory, so failing to release it leaks native memory and triggers
+ * "LEAK DETECTED ... ChunkOffsetMemory" reports for every flushed or compacted SSTable of a
+ * TDE-enabled table.
+ */
+public class BtiTableWriterEncryptionTest
+{
+    private static final String KEYSPACE = "BtiTableWriterEncryptionTest";
+    private static final String ENCRYPTED_TABLE = "encrypted_table";
+    private static final String PLAIN_TABLE = "plain_table";
+
+    @BeforeClass
+    public static void defineSchema()
+    {
+        SchemaLoader.prepareServer();
+        SchemaLoader.createKeyspace(KEYSPACE,
+                                    KeyspaceParams.simple(1),
+                                    SchemaLoader.standardCFMD(KEYSPACE, ENCRYPTED_TABLE).compression(encryptionParams()),
+                                    SchemaLoader.standardCFMD(KEYSPACE, PLAIN_TABLE));
+    }
+
+    private static CompressionParams encryptionParams()
+    {
+        Map<String, String> opts = new HashMap<>();
+        opts.put(CompressionParams.CLASS, Encryptor.class.getName());
+        opts.put(EncryptionConfig.CIPHER_ALGORITHM, "AES/CBC/PKCS5Padding");
+        opts.put(EncryptionConfig.SECRET_KEY_STRENGTH, Integer.toString(128));
+        opts.put(EncryptionConfig.KEY_PROVIDER, EncryptorTest.KeyProviderFactoryStub.class.getName());
+        return CompressionParams.fromMap(opts);
+    }
+
+    @Test
+    public void testIndexEncryptionMetadataReleasedOnCommit()
+    {
+        ColumnFamilyStore cfs = Keyspace.open(KEYSPACE).getColumnFamilyStore(ENCRYPTED_TABLE);
+        cfs.truncateBlocking();
+        File dir = cfs.getDirectories().getDirectoryForNewSSTables();
+        CompressionMetadata indexMetadata;
+        try (LifecycleTransaction txn = LifecycleTransaction.offline(OperationType.WRITE, cfs.metadata))
+        {
+            try (SSTableWriter writer = SSTableWriterTestBase.getWriter(BtiFormat.getInstance(), cfs, dir, txn))
+            {
+                indexMetadata = indexEncryptionMetadata(writer);
+                assertNotNull("an encrypted table must use encryption metadata for its index components", indexMetadata);
+                assertFalse(indexMetadata.isCleanedUp());
+
+                appendRows(cfs, writer);
+                writer.finish(false, null);
+            }
+            assertTrue("the IndexWriter must release its CompressionMetadata when the writer is closed",
+                       indexMetadata.isCleanedUp());
+        }
+        LifecycleTransaction.waitForDeletions();
+    }
+
+    @Test
+    public void testIndexEncryptionMetadataReleasedOnAbort()
+    {
+        ColumnFamilyStore cfs = Keyspace.open(KEYSPACE).getColumnFamilyStore(ENCRYPTED_TABLE);
+        cfs.truncateBlocking();
+        File dir = cfs.getDirectories().getDirectoryForNewSSTables();
+        CompressionMetadata indexMetadata;
+        try (LifecycleTransaction txn = LifecycleTransaction.offline(OperationType.WRITE, cfs.metadata))
+        {
+            try (SSTableWriter writer = SSTableWriterTestBase.getWriter(BtiFormat.getInstance(), cfs, dir, txn))
+            {
+                indexMetadata = indexEncryptionMetadata(writer);
+                assertNotNull(indexMetadata);
+
+                appendRows(cfs, writer);
+                writer.abort();
+            }
+            assertTrue("the IndexWriter must release its CompressionMetadata when the writer is aborted",
+                       indexMetadata.isCleanedUp());
+        }
+        LifecycleTransaction.waitForDeletions();
+    }
+
+    @Test
+    public void testIndexEncryptionMetadataReleasedAfterReaderIsClosed()
+    {
+        ColumnFamilyStore cfs = Keyspace.open(KEYSPACE).getColumnFamilyStore(ENCRYPTED_TABLE);
+        cfs.truncateBlocking();
+        File dir = cfs.getDirectories().getDirectoryForNewSSTables();
+        CompressionMetadata indexMetadata;
+        try (LifecycleTransaction txn = LifecycleTransaction.offline(OperationType.WRITE, cfs.metadata))
+        {
+            try (SSTableWriter writer = SSTableWriterTestBase.getWriter(BtiFormat.getInstance(), cfs, dir, txn))
+            {
+                indexMetadata = indexEncryptionMetadata(writer);
+                assertNotNull(indexMetadata);
+
+                appendRows(cfs, writer);
+
+                // opening the result makes the reader's index FileHandles take shared copies of the metadata,
+                // so the last reference is released only once the reader is closed as well
+                SSTableReader reader = writer.finish(true, null);
+                try
+                {
+                    assertFalse(indexMetadata.isCleanedUp());
+                }
+                finally
+                {
+                    reader.selfRef().release();
+                }
+            }
+        }
+        LifecycleTransaction.waitForDeletions();
+        // the reader tidier runs asynchronously
+        Util.spinAssertEquals(true, indexMetadata::isCleanedUp, 10);
+    }
+
+    @Test
+    public void testNoIndexEncryptionMetadataWithoutEncryption()
+    {
+        ColumnFamilyStore cfs = Keyspace.open(KEYSPACE).getColumnFamilyStore(PLAIN_TABLE);
+        cfs.truncateBlocking();
+        File dir = cfs.getDirectories().getDirectoryForNewSSTables();
+        try (LifecycleTransaction txn = LifecycleTransaction.offline(OperationType.WRITE, cfs.metadata))
+        {
+            try (SSTableWriter writer = SSTableWriterTestBase.getWriter(BtiFormat.getInstance(), cfs, dir, txn))
+            {
+                assertNull("index components are not encrypted, so no encryption metadata is expected",
+                           indexEncryptionMetadata(writer));
+                writer.abort();
+            }
+        }
+        LifecycleTransaction.waitForDeletions();
+    }
+
+    private static CompressionMetadata indexEncryptionMetadata(SSTableWriter writer)
+    {
+        assertTrue(writer instanceof BtiTableWriter);
+        return ((BtiTableWriter) writer).indexWriter().indexEncryptionMetadata;
+    }
+
+    private static void appendRows(ColumnFamilyStore cfs, SSTableWriter writer)
+    {
+        List<ByteBuffer> keys = new ArrayList<>();
+        for (int i = 0; i < 100; i++)
+            keys.add(SSTableWriterTestBase.random(i, 10));
+        keys.sort(Comparator.comparing((ByteBuffer key) -> cfs.getPartitioner().decorateKey(key)));
+
+        for (ByteBuffer key : keys)
+        {
+            UpdateBuilder builder = UpdateBuilder.create(cfs.metadata(), key).withTimestamp(1);
+            for (int j = 0; j < 10; j++)
+                builder.newRow("" + j).add("val", ByteBuffer.allocate(100));
+            writer.append(builder.build().unfilteredIterator());
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/riptano/cndb/issues/18845

### What is the issue

When a table uses TDE, the BTI IndexWriter creates a ref-counted CompressionMetadata (CompressionMetadata.encryptedOnly) for the encrypted ROW_INDEX/PARTITION_INDEX components and hands it to the index FileHandle builders. FileHandle.Builder.complete() takes its own shared copy, so the original instance stays owned by the writer -- but it was never closed, leaking one instance (holding its chunk-offset index in off-heap ChunkOffsetMemory) per flushed or compacted sstable of an encrypted table, reported at GC time as:

    ERROR [Ref] LEAK DETECTED: a reference (... WrappedSharedCloseable$Tidy
    ...:[...CompressionMetadata$ChunkOffsetMemory...]) ... was not released
    before the reference was garbage collected

This is the same leak signature CNDB-18535 fixed in MetadataSerializer.getEncryptor, coming from a different call site.

### What does this PR fix and why was it fixed

Keep the instance in a field (indexEncryptionMetadata) and release it in doPostCleanup, which runs at writer teardown on both the commit and the abort path, after every possible FileHandle.Builder.complete() call. This mirrors what SortedTableWriter.openDataFile already does for the data component.

Additionally harden the IndexWriter constructor against partial failure: if construction failed after creating the metadata (e.g. the second EncryptedSequentialWriter failing to open its file), nothing released it, because SortedTableWriter's constructor only sees a null indexWriter. The constructor now builds its resources into locals inside a try block and closes whatever was already created (including the row index writer and the bloom filter allocated by the AbstractIndexWriter super constructor) before propagating the error, and documents that the constructor tail must not throw.

Add a unit test asserting the release on the commit, abort and open-result paths, and a jvm-dtest asserting that no ChunkOffsetMemory leak is reported after flushing and major-compacting an encrypted table.
