### PR TITLE
CNDB-18842: Fix: FusedPQ compaction should write codebook-only PQ file; add regression test

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraOnHeapGraph.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/CassandraOnHeapGraph.java
@@ -70,7 +70,6 @@ import io.github.jbellis.jvector.vector.VectorizationProvider;
 import io.github.jbellis.jvector.vector.types.VectorFloat;
 import io.github.jbellis.jvector.vector.types.VectorTypeSupport;
 import org.agrona.collections.IntHashSet;
-import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.db.compaction.CompactionSSTable;
 import org.apache.cassandra.db.marshal.VectorType;
 import org.apache.cassandra.db.memtable.Memtable;

--- a/src/java/org/apache/cassandra/index/sai/disk/vector/CompactionGraph.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/vector/CompactionGraph.java
@@ -116,7 +116,8 @@ public class CompactionGraph implements Closeable, Accountable
     @VisibleForTesting
     public static int PQ_TRAINING_SIZE = ProductQuantization.MAX_PQ_TRAINING_SET_SIZE;
 
-    private static boolean PARALLEL_ENCODING_WRITING = CassandraRelevantProperties.SAI_ENCODE_AND_WRITE_VECTOR_GRAPH_IN_PARALLEL_ENABLED.getBoolean();
+    @VisibleForTesting
+    public static boolean PARALLEL_ENCODING_WRITING = CassandraRelevantProperties.SAI_ENCODE_AND_WRITE_VECTOR_GRAPH_IN_PARALLEL_ENABLED.getBoolean();
     private static int PARALLEL_ENCODING_WRITING_NUM_THREADS = CassandraRelevantProperties.SAI_ENCODE_AND_WRITE_VECTOR_GRAPH_IN_PARALLEL_NUM_THREADS.getInt();
     private static boolean PARALLEL_ENCODING_WRITING_USE_DIRECT_BUFFERS = CassandraRelevantProperties.SAI_ENCODE_AND_WRITE_VECTOR_GRAPH_IN_PARALLEL_USE_DIRECT_BUFFERS.getBoolean();
 
@@ -457,8 +458,15 @@ public class CompactionGraph implements Closeable, Accountable
             // write PQ (time to do this is negligible, don't bother doing it async)
             long pqOffset = pqOutput.getFilePointer();
             Version version = context.version();
+            boolean writeFusedPQ = JVectorVersionUtil.shouldWriteFused(version);
             CassandraOnHeapGraph.writePqHeader(pqOutput.asSequentialWriter(), unitVectors, VectorCompression.CompressionType.PRODUCT_QUANTIZATION, version);
-            compressedVectors.write(pqOutput.asSequentialWriter(), version.onDiskFormat().jvectorFileFormatVersion());
+            if (writeFusedPQ)
+                // With FusedPQ the per-vector codes are embedded in TERMS_DATA; only the codebook
+                // (compressor metadata) is needed in the PQ file so that the query vector can be
+                // encoded at search time. Writing full PQVectors here would duplicate the codes on disk.
+                compressor.write(pqOutput.asSequentialWriter(), version.onDiskFormat().jvectorFileFormatVersion());
+            else
+                compressedVectors.write(pqOutput.asSequentialWriter(), version.onDiskFormat().jvectorFileFormatVersion());
             long pqLength = pqOutput.getFilePointer() - pqOffset;
 
             // write postings asynchronously while we run cleanup()

--- a/test/unit/org/apache/cassandra/index/sai/SAIUtil.java
+++ b/test/unit/org/apache/cassandra/index/sai/SAIUtil.java
@@ -29,6 +29,7 @@ import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.index.Index;
 import org.apache.cassandra.index.SecondaryIndexManager;
 import org.apache.cassandra.index.sai.disk.format.Version;
+import org.apache.cassandra.index.sai.disk.vector.CompactionGraph;
 import org.apache.cassandra.index.sai.disk.vector.JVectorVersionUtil;
 import org.apache.cassandra.schema.Schema;
 import org.apache.cassandra.utils.ReflectionUtils;
@@ -134,6 +135,11 @@ public class SAIUtil
         {
             throw new RuntimeException(e);
         }
+    }
+
+    public static void setParallelEncodingWriting(boolean enabled)
+    {
+        CompactionGraph.PARALLEL_ENCODING_WRITING = enabled;
     }
 
     public static class CustomVersionSelector implements Version.Selector

--- a/test/unit/org/apache/cassandra/index/sai/functional/VectorFormatDiskUsageTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/functional/VectorFormatDiskUsageTest.java
@@ -30,7 +30,9 @@ import org.apache.cassandra.index.sai.cql.VectorTester;
 import org.apache.cassandra.index.sai.disk.format.IndexComponentType;
 import org.apache.cassandra.index.sai.disk.format.IndexComponents;
 import org.apache.cassandra.index.sai.disk.format.Version;
+import org.apache.cassandra.index.sai.disk.v1.IndexWriterConfig;
 import org.apache.cassandra.index.sai.disk.vector.CassandraOnHeapGraph;
+import org.apache.cassandra.index.sai.disk.vector.VectorSourceModel;
 
 import static org.junit.Assert.*;
 
@@ -42,7 +44,7 @@ public class VectorFormatDiskUsageTest extends VectorTester
 
     /// Number of flushes before compaction. Each flush produces one SSTable. With only
     /// [CassandraOnHeapGraph#MIN_PQ_ROWS] rows per flush the memory limit is not reached,
-    /// so each SSTable contains exactly one segment — asserted in [#measureDiskUsage].
+    /// so each SSTable contains exactly one segment — asserted in [#measurePostFlushAndPostCompaction].
     private static final int NUM_FLUSHES = 2;
 
     /// TERMS_DATA delta from EC (jvector format 4) to FB (jvector format 6) per segment:
@@ -53,6 +55,12 @@ public class VectorFormatDiskUsageTest extends VectorTester
     /// FB writes: start-header + footer-header + FOOTER_SIZE(=Long+Int=12)          = 604 bytes
     /// Δ = 604 − 292 = 312 bytes per segment
     private static final long EXPECTED_TERMS_DATA_DELTA_PER_SEGMENT = 312L;
+
+    /// `PQVectors.write` writes two extra ints — `vectorCount` and `subspaceCount` — before the
+    /// per-vector data that `ProductQuantization.write` (the FusedPQ codebook-only path) does not.
+    /// This means the fixed overhead `F` in EC PQ files is 8 bytes larger than in FB FusedPQ PQ files:
+    ///   F_EC = F_FB + PQVECTORS_EXTRA_HEADER_BYTES
+    private static final long PQVECTORS_EXTRA_HEADER_BYTES = 2L * Integer.BYTES;
 
     @BeforeClass
     public static void setUpClass()
@@ -116,17 +124,15 @@ public class VectorFormatDiskUsageTest extends VectorTester
     @Test
     public void testDiskUsageECvsFB()
     {
-        testDiskUsageECvsFB(false);
-        testDiskUsageECvsFB(true);
+        DiskMeasurement[] ec = measurePostFlushAndPostCompaction(Version.EC, "EC", null);
+        DiskMeasurement[] fb = measurePostFlushAndPostCompaction(Version.FB, "FB", null);
+
+        verifyECvsFB(ec[0], fb[0], "preCompaction");
+        verifyECvsFB(ec[1], fb[1], "postCompaction");
     }
 
-    private void testDiskUsageECvsFB(boolean compact)
+    private void verifyECvsFB(DiskMeasurement ec, DiskMeasurement fb, String phase)
     {
-        String phase = compact ? "postCompaction" : "preCompaction";
-
-        DiskMeasurement ec = measureDiskUsage(Version.EC, "EC-" + phase, compact);
-        DiskMeasurement fb = measureDiskUsage(Version.FB, "FB-" + phase, compact);
-
         assertTrue("EC index must have non-zero disk usage", ec.totalBytes > 0);
         assertTrue("FB index must have non-zero disk usage", fb.totalBytes > 0);
 
@@ -155,29 +161,26 @@ public class VectorFormatDiskUsageTest extends VectorTester
     @Test
     public void testDiskGrowthAcrossVersions()
     {
-        testDiskGrowthAcrossVersions(false);
-        testDiskGrowthAcrossVersions(true);
-    }
-
-    private void testDiskGrowthAcrossVersions(boolean compact)
-    {
-        String name = compact ? "postCompaction" : "preCompaction";
-        DiskMeasurement latest = measureDiskUsage(Version.LATEST, Version.LATEST + "-" + name, compact);
+        DiskMeasurement[] latest = measurePostFlushAndPostCompaction(Version.LATEST, Version.LATEST.toString(), null);
 
         for (Version version : Version.ALL)
         {
             if (version == Version.LATEST || !version.onOrAfter(Version.JVECTOR_EARLIEST))
                 continue;
 
-            DiskMeasurement older = measureDiskUsage(version, version + "-" + name, compact);
+            DiskMeasurement[] older = measurePostFlushAndPostCompaction(version, version.toString(), null);
 
-            double diskGrowthPercent = 100.0 * (latest.totalBytes - older.totalBytes) / older.totalBytes;
+            for (int i = 0; i < 2; i++)
+            {
+                String phase = i == 0 ? "preCompaction" : "postCompaction";
+                double diskGrowthPercent = 100.0 * (latest[i].totalBytes - older[i].totalBytes) / older[i].totalBytes;
 
-            logger.debug("  {} → {} {}  : {} → {} bytes ({} %)",
-                         version, Version.LATEST, name, older.totalBytes, latest.totalBytes,
-                         String.format("%.4f", diskGrowthPercent));
+                logger.debug("  {} → {} {}  : {} → {} bytes ({} %)",
+                        version, Version.LATEST, phase, older[i].totalBytes, latest[i].totalBytes,
+                        String.format("%.4f", diskGrowthPercent));
 
-            verifyTotalDiskGrowthUnder5Percent(diskGrowthPercent, version + " → " + Version.LATEST + ' ' + name);
+                verifyTotalDiskGrowthUnder5Percent(diskGrowthPercent, version + " → " + Version.LATEST + ' ' + phase);
+            }
         }
     }
 
@@ -235,7 +238,6 @@ public class VectorFormatDiskUsageTest extends VectorTester
                 diskGrowthPercent < 5.0);
     }
 
-    /// Snapshot of per-component file sizes and segment count for one index build.
     private static class DiskMeasurement
     {
         final long totalBytes;
@@ -316,18 +318,14 @@ public class VectorFormatDiskUsageTest extends VectorTester
         }
     }
 
-    /// Builds a fresh table at `version`, writes [#NUM_FLUSHES] × [CassandraOnHeapGraph#MIN_PQ_ROWS]
-    /// vectors in separate flushes, then either returns the pre-compaction measurement
-    /// (`compact == false`) or runs major compaction first (`compact == true`).
-    ///
-    /// Each flush produces one SSTable with one segment (one graph in TERMS_DATA), so
-    /// pre-compaction there are [#NUM_FLUSHES] segments across [#NUM_FLUSHES] SSTables;
-    /// post-compaction there is exactly 1 segment in 1 SSTable.
-    private DiskMeasurement measureDiskUsage(Version version, String label, boolean compact)
+    private DiskMeasurement[] measurePostFlushAndPostCompaction(Version version, String label, String indexOptions)
     {
         SAIUtil.setCurrentVersion(version);
         createTable("CREATE TABLE %s (pk int, v vector<float, " + DIMENSION + ">, PRIMARY KEY(pk))");
-        String indexName = createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
+        String createIndex = "CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'";
+        if (indexOptions != null)
+            createIndex += " WITH OPTIONS = " + indexOptions;
+        String indexName = createIndex(createIndex);
         disableCompaction();
 
         for (int flush = 0; flush < NUM_FLUSHES; flush++)
@@ -338,9 +336,14 @@ public class VectorFormatDiskUsageTest extends VectorTester
             flush();
         }
 
-        if (compact)
-            compact();
+        DiskMeasurement afterFlush = snapshot(indexName, label + "-flush", false);
+        compact();
+        DiskMeasurement afterCompact = snapshot(indexName, label + "-compact", true);
+        return new DiskMeasurement[]{ afterFlush, afterCompact };
+    }
 
+    private DiskMeasurement snapshot(String indexName, String label, boolean compact)
+    {
         StorageAttachedIndex sai = (StorageAttachedIndex) getCurrentColumnFamilyStore().indexManager.getIndexByName(indexName);
         assertNotNull("Index not found: " + indexName, sai);
         IndexContext indexContext = sai.getIndexContext();
@@ -355,8 +358,7 @@ public class VectorFormatDiskUsageTest extends VectorTester
         List<SSTableIndex> sstableIndexes = List.copyOf(indexContext.getView().getIndexes());
         int totalSegments = sstableIndexes.stream().mapToInt(s -> s.getSegments().size()).sum();
         int expectedSegments = compact ? 1 : NUM_FLUSHES;
-        assertEquals("Expected " + expectedSegments + " segment(s) " + label,
-                expectedSegments, totalSegments);
+        assertEquals("Expected " + expectedSegments + " segment(s) " + label, expectedSegments, totalSegments);
 
         logger.debug("[{}] diskUsage()                : {} ({} segment(s))", label, totalDiskBytes, totalSegments);
         logger.debug("[{}] TERMS_DATA component bytes : {}", label, graphComponentBytes);
@@ -374,6 +376,129 @@ public class VectorFormatDiskUsageTest extends VectorTester
                 .completionMarkerBytes(completionMarkerBytes)
                 .segmentCount(totalSegments)
                 .build();
+    }
+
+    /// Regression test for the FusedPQ compaction bug - CNDB-18842
+    ///
+    /// CompactionGraph unconditionally wrote full PQVectors (codebook + N×m
+    /// per-vector codes) to the PQ file even when FusedPQ was active, duplicating on disk
+    /// the same codes already embedded in TERMS_DATA. The flush path ([CassandraOnHeapGraph])
+    /// was already correct: with FusedPQ it writes only the codebook to the PQ file.
+    @Test
+    public void testFusedPQPqFileContainsCodebookOnlyAfterFlushAndCompaction()
+    {
+        // FusedPQ should be always run with hierarchy and parallel graph writing enabled
+        String hierarchyOptions = "{'" + IndexWriterConfig.ENABLE_HIERARCHY + "': 'true'}";
+        SAIUtil.setParallelEncodingWriting(true);
+
+        try
+        {
+            // The PQ file size follows:
+            //
+            //   EC (PQVectors.write):           pqBytes(N) = F_EC + N×m
+            //   FB FusedPQ (PQ.write codebook): pqBytes    = F_FB          (independent of N)
+            //
+            //   F  = fixed overhead: SAI header + SAI PQ header (magic/version/unitVectors/type) + PQ codebook body
+            //   m  = bytes per PQ-encoded vector (compressedVectorSize), from VectorSourceModel
+            //   N  = number of indexed vectors in the segment
+            //
+            // F_EC ≠ F_FB: PQVectors.write prepends the codebook write with two extra ints before the
+            // per-vector data — vectorCount (4 bytes) + subspaceCount (4 bytes) — that
+            // ProductQuantization.write (codebook only) does not write.
+            // Therefore, F_EC = F_FB + 8.
+            //
+            // m is statically known: the test uses no explicit source-model option, so
+            // VectorSourceModel.OTHER applies. For DIMENSION=128, defaultPQBytesFor(128)
+            // falls in the 64 < D <= 200 branch → m = (int)(128 * 0.5) = 64 bytes.
+            //
+            // Each flushed SSTable has N = MIN_PQ_ROWS vectors.
+            // The compacted SSTable has N = NUM_FLUSHES × MIN_PQ_ROWS vectors.
+            //
+            // EC:
+            //   ecFlush.pqBytes / NUM_FLUSHES  = F_EC + MIN_PQ_ROWS × m
+            //   ecCompact.pqBytes              = F_EC + NUM_FLUSHES × MIN_PQ_ROWS × m
+            //
+            // FB FusedPQ:
+            //   fbFlush.pqBytes / NUM_FLUSHES  = F_FB = F_EC - 8
+            //   fbCompact.pqBytes              = F_FB = F_EC - 8  (independent of N)
+            int m = VectorSourceModel.OTHER.compressionProvider.apply(DIMENSION).getCompressedSize();
+
+            DiskMeasurement[] ec = measurePostFlushAndPostCompaction(Version.EC, "EC", hierarchyOptions);
+            DiskMeasurement ecFlush = ec[0], ecCompact = ec[1];
+
+            long ecFlushPqBytesPerSegment = ecFlush.pqBytes / NUM_FLUSHES;
+            // The extra vectors compaction adds over a single flush: (NUM_FLUSHES-1) × MIN_PQ_ROWS
+            long extraVectors = (long) (NUM_FLUSHES - 1) * CassandraOnHeapGraph.MIN_PQ_ROWS;
+            // Derive the measured m from EC observations and cross-check against the static value.
+            long measuredM = (ecCompact.pqBytes - ecFlushPqBytesPerSegment) / extraVectors;
+            assertEquals("Measured per-vector PQ code bytes from EC must match VectorSourceModel.OTHER formula",
+                    m, measuredM);
+            long expectedEcCompactPqBytes = ecFlushPqBytesPerSegment + extraVectors * m;
+
+            // FB + FusedPQ enabled via -D flag + hierarchy + parallel graph writing.
+            SAIUtil.setEnableFused(true);
+            try
+            {
+                DiskMeasurement[] fb = measurePostFlushAndPostCompaction(Version.FB, "FB", hierarchyOptions);
+                DiskMeasurement fbFlush = fb[0], fbCompact = fb[1];
+
+                long fbFlushPqBytesPerSegment = fbFlush.pqBytes / NUM_FLUSHES;
+
+                logger.info("EC flush    PQ bytes/segment : {}", ecFlushPqBytesPerSegment);
+                logger.info("EC compact  PQ bytes (actual)  : {}", ecCompact.pqBytes);
+                logger.info("EC compact  PQ bytes (expected, m={} per vector): {}", m, expectedEcCompactPqBytes);
+                logger.info("FB flush    PQ bytes/segment : {}", fbFlushPqBytesPerSegment);
+                logger.info("FB compact  PQ bytes         : {}", fbCompact.pqBytes);
+
+                assertEquals("EC compacted PQ must equal F + NUM_FLUSHES×MIN_PQ_ROWS×m " +
+                                "(full PQVectors, size scales linearly with N)",
+                        expectedEcCompactPqBytes, ecCompact.pqBytes);
+
+                verifyFusedPQPqFileIsCodebookOnly(ecFlushPqBytesPerSegment, ecCompact.pqBytes,
+                        fbFlushPqBytesPerSegment, fbCompact.pqBytes, m);
+
+                verifyFusedPQSearchWorks();
+            }
+            finally
+            {
+                SAIUtil.setEnableFused(false);
+            }
+        }
+        finally
+        {
+            SAIUtil.setParallelEncodingWriting(false);
+        }
+    }
+
+    private static void verifyFusedPQPqFileIsCodebookOnly(long ecFlushPqBytesPerSegment, long ecCompactPqBytes,
+                                                          long fbFlushPqBytesPerSegment, long fbCompactPqBytes,
+                                                          int m)
+    {
+        assertFusedPqSavings("flush PQ/segment", ecFlushPqBytesPerSegment,
+                (long) CassandraOnHeapGraph.MIN_PQ_ROWS * m, fbFlushPqBytesPerSegment);
+
+        assertEquals("FB-FusedPQ compacted PQ must equal FB-FusedPQ flushed PQ/segment " +
+                        "(both codebook-only, F; bug wrote F + N×m on compaction).",
+                fbFlushPqBytesPerSegment, fbCompactPqBytes);
+
+        assertFusedPqSavings("compact PQ", ecCompactPqBytes,
+                (long) NUM_FLUSHES * CassandraOnHeapGraph.MIN_PQ_ROWS * m, fbCompactPqBytes);
+    }
+
+    private static void assertFusedPqSavings(String label, long ecBytes, long perVectorBytes, long actualFb)
+    {
+        long expected = ecBytes - perVectorBytes - PQVECTORS_EXTRA_HEADER_BYTES;
+        assertEquals("FB-FusedPQ " + label + " must be exactly N×m + PQVECTORS_EXTRA_HEADER_BYTES smaller than EC " +
+                        "(codebook only vs full PQVectors)",
+                expected, actualFb);
+    }
+
+    private void verifyFusedPQSearchWorks()
+    {
+        int limit = 10;
+        var results = execute("SELECT pk FROM %s ORDER BY v ANN OF ? LIMIT ?", randomVectorBoxed(DIMENSION), limit);
+        assertEquals("ANN search must return " + limit + " results on FB-FusedPQ compacted index",
+                limit, results.size());
     }
 
     private long componentSize(IndexContext indexContext,

--- a/test/unit/org/apache/cassandra/index/sai/functional/VectorFormatDiskUsageTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/functional/VectorFormatDiskUsageTest.java
@@ -142,10 +142,10 @@ public class VectorFormatDiskUsageTest extends VectorTester
         logger.debug("  EC {}  diskUsage() : {} ({} segments)", phase, ec.totalBytes, ec.segmentCount);
         logger.debug("  FB {}  diskUsage() : {} ({} segments)", phase, fb.totalBytes, fb.segmentCount);
         logger.debug("  Total disk usage growth {}  : +{} bytes ({} %)",
-                phase, fb.totalBytes - ec.totalBytes, String.format("%.4f", diskGrowthPercent));
+                     phase, fb.totalBytes - ec.totalBytes, String.format("%.4f", diskGrowthPercent));
         logger.debug("  TERMS_DATA delta {}  : {} (expected {} × {} = {})",
-                phase, termsDataDelta, NUM_FLUSHES, EXPECTED_TERMS_DATA_DELTA_PER_SEGMENT,
-                NUM_FLUSHES * EXPECTED_TERMS_DATA_DELTA_PER_SEGMENT);
+                     phase, termsDataDelta, NUM_FLUSHES, EXPECTED_TERMS_DATA_DELTA_PER_SEGMENT,
+                     NUM_FLUSHES * EXPECTED_TERMS_DATA_DELTA_PER_SEGMENT);
 
         verifyComponentAccounting(ec, fb, phase);
         verifyTermsDataDelta(termsDataDelta, ec.segmentCount, phase);
@@ -176,8 +176,8 @@ public class VectorFormatDiskUsageTest extends VectorTester
                 double diskGrowthPercent = 100.0 * (latest[i].totalBytes - older[i].totalBytes) / older[i].totalBytes;
 
                 logger.debug("  {} → {} {}  : {} → {} bytes ({} %)",
-                        version, Version.LATEST, phase, older[i].totalBytes, latest[i].totalBytes,
-                        String.format("%.4f", diskGrowthPercent));
+                             version, Version.LATEST, phase, older[i].totalBytes, latest[i].totalBytes,
+                             String.format("%.4f", diskGrowthPercent));
 
                 verifyTotalDiskGrowthUnder5Percent(diskGrowthPercent, version + " → " + Version.LATEST + ' ' + phase);
             }
@@ -188,9 +188,9 @@ public class VectorFormatDiskUsageTest extends VectorTester
     private static void verifyComponentAccounting(DiskMeasurement ec, DiskMeasurement fb, String phase)
     {
         assertEquals("EC " + phase + ": totalBytes must equal sum of all per-index components",
-                ec.totalBytes, ec.termsDataBytes + ec.pqBytes + ec.metaBytes + ec.postingListsBytes + ec.completionMarkerBytes);
+                     ec.totalBytes, ec.termsDataBytes + ec.pqBytes + ec.metaBytes + ec.postingListsBytes + ec.completionMarkerBytes);
         assertEquals("FB " + phase + ": totalBytes must equal sum of all per-index components",
-                fb.totalBytes, fb.termsDataBytes + fb.pqBytes + fb.metaBytes + fb.postingListsBytes + fb.completionMarkerBytes);
+                     fb.totalBytes, fb.termsDataBytes + fb.pqBytes + fb.metaBytes + fb.postingListsBytes + fb.completionMarkerBytes);
     }
 
     /// The TERMS_DATA delta must equal exactly [#EXPECTED_TERMS_DATA_DELTA_PER_SEGMENT] × segmentCount.
@@ -199,19 +199,19 @@ public class VectorFormatDiskUsageTest extends VectorTester
     {
         long expected = EXPECTED_TERMS_DATA_DELTA_PER_SEGMENT * segmentCount;
         assertEquals("TERMS_DATA delta " + phase + " must equal " + EXPECTED_TERMS_DATA_DELTA_PER_SEGMENT
-                        + " bytes × " + segmentCount + " segment(s) = " + expected
-                        + " (jvector format 4→6 header layout change only)",
-                expected, actualTermsDataDelta);
+                     + " bytes × " + segmentCount + " segment(s) = " + expected
+                     + " (jvector format 4→6 header layout change only)",
+                     expected, actualTermsDataDelta);
     }
 
     private static void verifyUnchangedComponents(DiskMeasurement ec, DiskMeasurement fb, String phase)
     {
         assertEquals("PQ component size must be the same for EC and FB (" + phase + ')',
-                ec.pqBytes, fb.pqBytes);
+                     ec.pqBytes, fb.pqBytes);
         assertEquals("POSTING_LISTS must be the same size for EC and FB (" + phase + ')',
-                ec.postingListsBytes, fb.postingListsBytes);
+                     ec.postingListsBytes, fb.postingListsBytes);
         assertEquals("COLUMN_COMPLETION_MARKER must be the same size for EC and FB (" + phase + ')',
-                ec.completionMarkerBytes, fb.completionMarkerBytes);
+                     ec.completionMarkerBytes, fb.completionMarkerBytes);
     }
 
     /// META grows by exactly 8 bytes per segment EC → FB (a `totalTermCount` long added in ED).
@@ -221,11 +221,11 @@ public class VectorFormatDiskUsageTest extends VectorTester
                                            long actualTermsDataDelta, String phase)
     {
         assertEquals("FB META must be exactly " + Long.BYTES + " bytes × " + ec.segmentCount
-                        + " segment(s) larger than EC META (" + phase + ')',
-                ec.metaBytes + (long) Long.BYTES * ec.segmentCount, fb.metaBytes);
+                     + " segment(s) larger than EC META (" + phase + ')',
+                     ec.metaBytes + (long) Long.BYTES * ec.segmentCount, fb.metaBytes);
         assertEquals("FB.totalBytes must equal ec.totalBytes + TERMS_DATA delta + 8 × segmentCount(" + phase + ')',
-                ec.totalBytes + actualTermsDataDelta + (long) Long.BYTES * ec.segmentCount,
-                fb.totalBytes);
+                     ec.totalBytes + actualTermsDataDelta + (long) Long.BYTES * ec.segmentCount,
+                     fb.totalBytes);
     }
 
     /// Total disk usage must grow by less than 5% between consecutive format versions.
@@ -234,8 +234,8 @@ public class VectorFormatDiskUsageTest extends VectorTester
     private static void verifyTotalDiskGrowthUnder5Percent(double diskGrowthPercent, String phase)
     {
         assertTrue(String.format("Total disk usage growth %s must be < 5%% but was %.4f%%",
-                        phase, diskGrowthPercent),
-                diskGrowthPercent < 5.0);
+                                 phase, diskGrowthPercent),
+                   diskGrowthPercent < 5.0);
     }
 
     private static class DiskMeasurement
@@ -368,14 +368,14 @@ public class VectorFormatDiskUsageTest extends VectorTester
         logger.debug("[{}] COMPLETION_MARKER bytes    : {}", label, completionMarkerBytes);
 
         return new DiskMeasurement.Builder()
-                .totalBytes(totalDiskBytes)
-                .termsDataBytes(graphComponentBytes)
-                .pqBytes(pqComponentBytes)
-                .metaBytes(metaComponentBytes)
-                .postingListsBytes(postingListsBytes)
-                .completionMarkerBytes(completionMarkerBytes)
-                .segmentCount(totalSegments)
-                .build();
+               .totalBytes(totalDiskBytes)
+               .termsDataBytes(graphComponentBytes)
+               .pqBytes(pqComponentBytes)
+               .metaBytes(metaComponentBytes)
+               .postingListsBytes(postingListsBytes)
+               .completionMarkerBytes(completionMarkerBytes)
+               .segmentCount(totalSegments)
+               .build();
     }
 
     /// Regression test for the FusedPQ compaction bug - CNDB-18842
@@ -432,7 +432,7 @@ public class VectorFormatDiskUsageTest extends VectorTester
             // Derive the measured m from EC observations and cross-check against the static value.
             long measuredM = (ecCompact.pqBytes - ecFlushPqBytesPerSegment) / extraVectors;
             assertEquals("Measured per-vector PQ code bytes from EC must match VectorSourceModel.OTHER formula",
-                    m, measuredM);
+                         m, measuredM);
             long expectedEcCompactPqBytes = ecFlushPqBytesPerSegment + extraVectors * m;
 
             // FB + FusedPQ enabled via -D flag + hierarchy + parallel graph writing.
@@ -451,11 +451,11 @@ public class VectorFormatDiskUsageTest extends VectorTester
                 logger.info("FB compact  PQ bytes         : {}", fbCompact.pqBytes);
 
                 assertEquals("EC compacted PQ must equal F + NUM_FLUSHES×MIN_PQ_ROWS×m " +
-                                "(full PQVectors, size scales linearly with N)",
-                        expectedEcCompactPqBytes, ecCompact.pqBytes);
+                             "(full PQVectors, size scales linearly with N)",
+                             expectedEcCompactPqBytes, ecCompact.pqBytes);
 
                 verifyFusedPQPqFileIsCodebookOnly(ecFlushPqBytesPerSegment, ecCompact.pqBytes,
-                        fbFlushPqBytesPerSegment, fbCompact.pqBytes, m);
+                                                  fbFlushPqBytesPerSegment, fbCompact.pqBytes, m);
 
                 verifyFusedPQSearchWorks();
             }
@@ -475,22 +475,22 @@ public class VectorFormatDiskUsageTest extends VectorTester
                                                           int m)
     {
         assertFusedPqSavings("flush PQ/segment", ecFlushPqBytesPerSegment,
-                (long) CassandraOnHeapGraph.MIN_PQ_ROWS * m, fbFlushPqBytesPerSegment);
+                             (long) CassandraOnHeapGraph.MIN_PQ_ROWS * m, fbFlushPqBytesPerSegment);
 
         assertEquals("FB-FusedPQ compacted PQ must equal FB-FusedPQ flushed PQ/segment " +
-                        "(both codebook-only, F; bug wrote F + N×m on compaction).",
-                fbFlushPqBytesPerSegment, fbCompactPqBytes);
+                     "(both codebook-only, F; bug wrote F + N×m on compaction).",
+                     fbFlushPqBytesPerSegment, fbCompactPqBytes);
 
         assertFusedPqSavings("compact PQ", ecCompactPqBytes,
-                (long) NUM_FLUSHES * CassandraOnHeapGraph.MIN_PQ_ROWS * m, fbCompactPqBytes);
+                             (long) NUM_FLUSHES * CassandraOnHeapGraph.MIN_PQ_ROWS * m, fbCompactPqBytes);
     }
 
     private static void assertFusedPqSavings(String label, long ecBytes, long perVectorBytes, long actualFb)
     {
         long expected = ecBytes - perVectorBytes - PQVECTORS_EXTRA_HEADER_BYTES;
         assertEquals("FB-FusedPQ " + label + " must be exactly N×m + PQVECTORS_EXTRA_HEADER_BYTES smaller than EC " +
-                        "(codebook only vs full PQVectors)",
-                expected, actualFb);
+                     "(codebook only vs full PQVectors)",
+                     expected, actualFb);
     }
 
     private void verifyFusedPQSearchWorks()
@@ -498,18 +498,18 @@ public class VectorFormatDiskUsageTest extends VectorTester
         int limit = 10;
         var results = execute("SELECT pk FROM %s ORDER BY v ANN OF ? LIMIT ?", randomVectorBoxed(DIMENSION), limit);
         assertEquals("ANN search must return " + limit + " results on FB-FusedPQ compacted index",
-                limit, results.size());
+                     limit, results.size());
     }
 
     private long componentSize(IndexContext indexContext,
                                IndexComponentType type)
     {
         return indexContext.getView().getIndexes()
-                .stream()
-                .mapToLong(idx -> {
-                    IndexComponents.ForRead perIndex = idx.usedPerIndexComponents();
-                    return perIndex.has(type) ? perIndex.get(type).file().length() : 0L;
-                })
-                .sum();
+                           .stream()
+                           .mapToLong(idx -> {
+                               IndexComponents.ForRead perIndex = idx.usedPerIndexComponents();
+                               return perIndex.has(type) ? perIndex.get(type).file().length() : 0L;
+                           })
+                           .sum();
     }
 }


### PR DESCRIPTION
…

### What is the issue
...
When FusedPQ is enabled (version FA always; version FB with -Dcassandra.sai.vector.enable_fused=true), the compaction path writes the full PQVectors — codebook + all N×m per-vector codes — to the PQ component file unconditionally. The same per-vector codes are already embedded in TERMS_DATA by the graph writer. This duplicates N×m bytes on disk for every compacted SSTable, where N is the number of vectors and m is the compressed vector size.

The flush path (CassandraOnHeapGraph) was implemented correctly from the start: with FusedPQ it writes only the codebook to the PQ file.

###Impact
For a segment with N vectors and m bytes per PQ code, the wasted disk space per compacted SSTable is exactly N×m bytes — the same order of magnitude as the in-memory savings FusedPQ was designed to deliver. At 500M vectors with D=256 (m=100), this is ~47 GiB of duplicate data per compacted SSTable.

There is no correctness or memory impact at runtime: CassandraDiskAnn reads only the codebook from the PQ file when FUSED_PQ is present in the graph's feature set, so the duplicated codes are written but never read.

###Root cause
CompactionGraph.flush() calls compressedVectors.write(pqOutput, ...) unconditionally, writing full PQVectors regardless of whether FusedPQ is active. The equivalent branch in CassandraOnHeapGraph.writePQ() correctly switches to compressor.write() (codebook only) when writeFusedPQ=true.

### What does this PR fix and why was it fixed
...
Apply the same writeFusedPQ branch in CompactionGraph.flush().