### PR TITLE
CNDB-18512: Add metrics about fetched/returned cells to the slow query logger

### DIFF
--- a/src/java/org/apache/cassandra/db/ReadCommandExecutionInfo.java
+++ b/src/java/org/apache/cassandra/db/ReadCommandExecutionInfo.java
@@ -16,6 +16,7 @@
 
 package org.apache.cassandra.db;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
 import org.apache.cassandra.db.monitoring.Monitorable;
@@ -44,6 +45,8 @@ class ReadCommandExecutionInfo implements Monitorable.ExecutionInfo
     private long rowsFetched = 0;
     private long rowsReturned = 0;
     private long rowTombstones = 0;
+    private long cellsFetched = 0;
+    private long cellsReturned = 0;
 
     /**
      * Counts the number of fetched partitions and rows in the specified iterator.
@@ -60,9 +63,20 @@ class ReadCommandExecutionInfo implements Monitorable.ExecutionInfo
             {
                 if (row.hasLiveData(nowInSec, false))
                     rowsFetched++;
+
+                cellsFetched += row.cellsCount();
+
+                return row;
+            }
+
+            @Override
+            protected Row applyToStatic(Row row)
+            {
+                cellsFetched += row.cellsCount();
                 return row;
             }
         };
+
         return Transformation.apply(partitions, new Transformation<>() {
             @Override
             protected UnfilteredRowIterator applyToPartition(UnfilteredRowIterator partition)
@@ -91,6 +105,16 @@ class ReadCommandExecutionInfo implements Monitorable.ExecutionInfo
                     rowsReturned++;
                 else
                     rowTombstones++;
+
+                cellsReturned += row.cellsCount();
+
+                return row;
+            }
+
+            @Override
+            protected Row applyToStatic(Row row)
+            {
+                cellsReturned += row.cellsCount();
                 return row;
             }
 
@@ -128,10 +152,14 @@ class ReadCommandExecutionInfo implements Monitorable.ExecutionInfo
                rowsFetched,
                rowsReturned,
                rowTombstones);
+        append(sb, "cells",
+               cellsFetched,
+               cellsReturned,
+               null);
         return sb.toString();
     }
 
-    private static void append(StringBuilder sb, String name, long fetched, long returned, long tombstones)
+    private static void append(StringBuilder sb, String name, long fetched, long returned, @Nullable Long tombstones)
     {
         sb.append('\n')
           .append(DOUBLE_INDENT)
@@ -140,7 +168,10 @@ class ReadCommandExecutionInfo implements Monitorable.ExecutionInfo
           .append(fetched)
           .append('/')
           .append(returned)
-          .append('/')
-          .append(tombstones);
+          .append('/');
+        if (tombstones == null)
+            sb.append('-');
+        else
+            sb.append(tombstones);
     }
 }

--- a/src/java/org/apache/cassandra/db/rows/BTreeRow.java
+++ b/src/java/org/apache/cassandra/db/rows/BTreeRow.java
@@ -336,6 +336,12 @@ public class BTreeRow extends AbstractRow
         return CellIterator::new;
     }
 
+    @Override
+    public int cellsCount()
+    {
+        return (int) accumulate((cd, count) -> count + (cd.column().isComplex() ? ((ComplexColumnData) cd).cellsCount() : 1), 0L);
+    }
+
     public BTreeSearchIterator<ColumnMetadata, ColumnData> searchIterator()
     {
         return BTree.slice(btree, ColumnMetadata.asymmetricColumnDataComparator, BTree.Dir.ASC);

--- a/src/java/org/apache/cassandra/db/rows/Row.java
+++ b/src/java/org/apache/cassandra/db/rows/Row.java
@@ -168,6 +168,11 @@ public interface Row extends Unfiltered, Iterable<ColumnData>
     public Iterable<Cell<?>> cells();
 
     /**
+     * @return the number of cells in this row.
+     */
+    public int cellsCount();
+
+    /**
      * A collection of the ColumnData representation of this row, for columns with some data (possibly not live) present
      * <p>
      * The data is returned in column order.

--- a/src/java/org/apache/cassandra/index/sai/QueryContext.java
+++ b/src/java/org/apache/cassandra/index/sai/QueryContext.java
@@ -85,6 +85,12 @@ public class QueryContext
     /** Number of deleted individual rows or ranges of rows that have been fetched. */
     private long rowTombstonesFetched = 0;
 
+    /** Number of cells fetched from the storage engine, regardless of liveness, before post-filtering. */
+    private long cellsFetched = 0;
+
+    /** Number of cells returned to the coordinator, regardless of liveness, after post-filtering. */
+    private long cellsReturned = 0;
+
     /** Number of trie (literal or key) segments visited by the query. */
     private long trieSegmentsHit = 0;
 
@@ -185,6 +191,18 @@ public class QueryContext
     {
         checkThreadOwnership();
         rowTombstonesFetched += val;
+    }
+
+    public void addCellsFetched(long val)
+    {
+        checkThreadOwnership();
+        cellsFetched += val;
+    }
+
+    public void addCellsReturned(long val)
+    {
+        checkThreadOwnership();
+        cellsReturned += val;
     }
 
     public void addTrieSegmentsHit(long val)
@@ -313,6 +331,8 @@ public class QueryContext
         public final long rowsFetched;
         public final long rowsReturned;
         public final long rowTombstonesFetched;
+        public final long cellsFetched;
+        public final long cellsReturned;
         public final long trieSegmentsHit;
         public final long triePostingsSkips;
         public final long triePostingsDecodes;
@@ -343,6 +363,8 @@ public class QueryContext
             rowsFetched = context.rowsFetched;
             rowsReturned = context.rowsReturned;
             rowTombstonesFetched = context.rowTombstonesFetched;
+            cellsFetched = context.cellsFetched;
+            cellsReturned = context.cellsReturned;
             trieSegmentsHit = context.trieSegmentsHit;
             triePostingsSkips = context.triePostingsSkips;
             triePostingsDecodes = context.triePostingsDecodes;

--- a/src/java/org/apache/cassandra/index/sai/plan/CountFetchedTransformation.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/CountFetchedTransformation.java
@@ -64,10 +64,21 @@ class CountFetchedTransformation extends Transformation<UnfilteredRowIterator>
     protected Row applyToRow(Row row)
     {
         queryContext.checkpoint();
+
         if (row.hasLiveData(nowInSec, false))
             queryContext.addRowsFetched(1);
         else
             queryContext.addRowTombstonesFetched(1);
+
+        queryContext.addCellsFetched(row.cellsCount());
+
+        return row;
+    }
+
+    @Override
+    protected Row applyToStatic(Row row)
+    {
+        queryContext.addCellsFetched(row.cellsCount());
         return row;
     }
 

--- a/src/java/org/apache/cassandra/index/sai/plan/CountReturnedTransformation.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/CountReturnedTransformation.java
@@ -37,11 +37,20 @@ class CountReturnedTransformation extends Transformation<UnfilteredRowIterator>
         this.queryContext = queryContext;
         this.onClose = onClose;
         rowCounter = new Transformation<>() {
+
             @Override
             protected Row applyToRow(Row row)
             {
                 queryContext.checkpoint();
                 queryContext.addRowsReturned(1);
+                queryContext.addCellsReturned(row.cellsCount());
+                return row;
+            }
+
+            @Override
+            protected Row applyToStatic(Row row)
+            {
+                queryContext.addCellsReturned(row.cellsCount());
                 return row;
             }
         };

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryMonitorableExecutionInfo.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryMonitorableExecutionInfo.java
@@ -77,6 +77,8 @@ public class QueryMonitorableExecutionInfo implements Monitorable.ExecutionInfo
         appendMetric(sb, "rowsFetched", metrics.rowsFetched);
         appendMetric(sb, "rowsReturned", metrics.rowsReturned);
         appendMetric(sb, "rowTombstonesFetched", metrics.rowTombstonesFetched);
+        appendMetric(sb, "cellsFetched", metrics.cellsFetched);
+        appendMetric(sb, "cellsReturned", metrics.cellsReturned);
         appendMetric(sb, "trieSegmentsHit", metrics.trieSegmentsHit);
         appendMetric(sb, "triePostingsSkips", metrics.triePostingsSkips);
         appendMetric(sb, "triePostingsDecodes", metrics.triePostingsDecodes);

--- a/src/java/org/apache/cassandra/index/sai/utils/RowWithSourceTable.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/RowWithSourceTable.java
@@ -177,6 +177,12 @@ public class RowWithSourceTable implements Row
     }
 
     @Override
+    public int cellsCount()
+    {
+        return row.cellsCount();
+    }
+
+    @Override
     public Collection<ColumnData> columnData()
     {
         return Collections2.transform(row.columnData(), this::wrapColumnData);

--- a/test/distributed/org/apache/cassandra/distributed/test/SlowQueryLoggerTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/SlowQueryLoggerTest.java
@@ -145,7 +145,7 @@ public class SlowQueryLoggerTest extends TestBaseImpl
     }
 
     /**
-     * Test that the slow query logger outputs the correct metrics for number of returned partitions, rows, etc.
+     * Test that the slow query logger outputs the correct metrics for number of returned partitions, rows, cells, etc.
      */
     @Test
     public void testLogsReadMetrics()
@@ -169,7 +169,8 @@ public class SlowQueryLoggerTest extends TestBaseImpl
                           format("<SELECT \\* FROM %s\\.%s ALLOW FILTERING>"),
                           "  Fetched/returned/tombstones:",
                           "    partitions: 10/10/0",
-                          "    rows: 100/100/0");
+                          "    rows: 100/100/0",
+                          "    cells: 300/300/-");
 
         // partition query
         mark = node.logs().mark();
@@ -179,7 +180,8 @@ public class SlowQueryLoggerTest extends TestBaseImpl
                           format("<SELECT \\* FROM %s\\.%s WHERE k = \\? ALLOW FILTERING>"),
                           "  Fetched/returned/tombstones:",
                           "    partitions: 1/1/0",
-                          "    rows: 10/10/0");
+                          "    rows: 10/10/0",
+                          "    cells: 30/30/-");
 
         // clustering query
         mark = node.logs().mark();
@@ -189,7 +191,8 @@ public class SlowQueryLoggerTest extends TestBaseImpl
                           format("<SELECT \\* FROM %s\\.%s WHERE k = \\? AND c = \\? ALLOW FILTERING>"),
                           "  Fetched/returned/tombstones:",
                           "    partitions: 1/1/0",
-                          "    rows: 1/1/0");
+                          "    rows: 1/1/0",
+                          "    cells: 3/3/-");
 
         // filtered range query
         mark = node.logs().mark();
@@ -199,7 +202,8 @@ public class SlowQueryLoggerTest extends TestBaseImpl
                           format("<SELECT \\* FROM %s\\.%s WHERE v < \\? ALLOW FILTERING>"),
                           "  Fetched/returned/tombstones:",
                           "    partitions: 10/3/0",
-                          "    rows: 100/25/0");
+                          "    rows: 100/25/0",
+                          "    cells: 300/75/-");
 
         // paged query
         mark = node.logs().mark();
@@ -225,7 +229,8 @@ public class SlowQueryLoggerTest extends TestBaseImpl
                           format("<SELECT \\* FROM %s\\.%s WHERE k = \\? ALLOW FILTERING>"),
                           "  Slowest fetched/returned/tombstones:",
                           "    partitions: 1/1/0",
-                          "    rows: 10/10/0");
+                          "    rows: 10/10/0",
+                          "    cells: 30/30/-");
 
         // delete a partition and query again, to see partition tombstone metrics
         coordinator.execute(format("DELETE FROM %s.%s WHERE k = 0"), ALL);
@@ -236,7 +241,8 @@ public class SlowQueryLoggerTest extends TestBaseImpl
                           format("<SELECT \\* FROM %s\\.%s ALLOW FILTERING>"),
                           "  Fetched/returned/tombstones:",
                           "    partitions: 9/9/1",
-                          "    rows: 90/90/0");
+                          "    rows: 90/90/0",
+                          "    cells: 270/270/-");
 
         // delete a row and query again, to see row tombstone metrics
         coordinator.execute(format("DELETE FROM %s.%s WHERE k = 1 AND c = 1"), ALL);
@@ -247,7 +253,8 @@ public class SlowQueryLoggerTest extends TestBaseImpl
                           format("<SELECT \\* FROM %s\\.%s ALLOW FILTERING>"),
                           "  Fetched/returned/tombstones:",
                           "    partitions: 9/9/1",
-                          "    rows: 89/89/1");
+                          "    rows: 89/89/1",
+                          "    cells: 267/267/-");
 
         // delete a range of rows and query again, to see more row tombstone metrics
         coordinator.execute(format("DELETE FROM %s.%s WHERE k = 2 AND c < 5"), ALL);
@@ -258,7 +265,8 @@ public class SlowQueryLoggerTest extends TestBaseImpl
                           format("<SELECT \\* FROM %s\\.%s ALLOW FILTERING>"),
                           "  Fetched/returned/tombstones:",
                           "    partitions: 9/9/1",
-                          "    rows: 84/84/3"); // one from before, plus opening and closing bounds
+                          "    rows: 84/84/3", // one from before, plus opening and closing bounds
+                          "    cells: 252/252/-");
 
         // query with a legacy index, which doesn't provide its own execution info, so generic execution info should be used
         mark = node.logs().mark();
@@ -268,7 +276,8 @@ public class SlowQueryLoggerTest extends TestBaseImpl
                           format("<SELECT \\* FROM %s\\.%s WHERE l = \\? ALLOW FILTERING>"),
                           "  Fetched/returned/tombstones:",
                           "    partitions: 1/1/0",
-                          "    rows: 1/1/0");
+                          "    rows: 1/1/0",
+                          "    cells: 3/3/-");
 
         // query with a SAI index, which provides its own execution info, so generic execution info shouldn't be used
         mark = node.logs().mark();
@@ -283,6 +292,276 @@ public class SlowQueryLoggerTest extends TestBaseImpl
         coordinator.execute(format("SELECT * FROM %s.%s"), ALL);
         assertLogsContain(mark, node, format("<SELECT \\* FROM %s\\.%s ALLOW FILTERING>"));
         assertLogsDoNotContain(mark, node, "  Fetched/returned/tombstones:");
+    }
+
+    /**
+     * Test that the slow query logger outputs the correct metrics for number of returned cells in collection columns.
+     */
+    @Test
+    public void testCollections()
+    {
+        cluster.schemaChange(format("CREATE TABLE %s.%s (k int, c int, v int, l list<int>, s set<int>, m map<int, int>,  PRIMARY KEY(k, c))"));
+        int numPartitions = 10;
+        int numClusterings = 10;
+        int numRows = 0;
+        String insert = format("INSERT INTO %s.%s (k, c, v, l, s, m) VALUES (?, ?, ?, [1, 2], {1, 2, 3}, {1:10, 2:20, 3:30, 4:40})");
+        for (int k = 0; k < numPartitions; k++)
+            for (int c = 0; c < numClusterings; c++)
+                coordinator.execute(insert, ALL, k, c, numRows++);
+
+        // unrestricted query
+        long mark = node.logs().mark();
+        Object[][] rows = coordinator.execute(format("SELECT * FROM %s.%s"), ALL);
+        Assertions.assertThat(rows).hasNumberOfRows(numRows);
+        assertLogsContain(mark, node,
+                          format("<SELECT \\* FROM %s\\.%s ALLOW FILTERING>"),
+                          "  Fetched/returned/tombstones:",
+                          "    partitions: 10/10/0",
+                          "    rows: 100/100/0",
+                          "    cells: 1000/1000/-");
+
+        // filtered range query
+        mark = node.logs().mark();
+        rows = coordinator.execute(format("SELECT * FROM %s.%s WHERE v >= 50 ALLOW FILTERING"), ALL);
+        Assertions.assertThat(rows).hasNumberOfRows(50);
+        assertLogsContain(mark, node,
+                          format("<SELECT \\* FROM %s\\.%s WHERE v >= \\? ALLOW FILTERING>"),
+                          "  Fetched/returned/tombstones:",
+                          "    partitions: 10/5/0",
+                          "    rows: 100/50/0",
+                          "    cells: 1000/500/-");
+
+        // partition query
+        mark = node.logs().mark();
+        rows = coordinator.execute(format("SELECT * FROM %s.%s WHERE k = 1"), ALL);
+        Assertions.assertThat(rows).hasNumberOfRows(numClusterings);
+        assertLogsContain(mark, node,
+                          format("<SELECT \\* FROM %s\\.%s WHERE k = \\? ALLOW FILTERING>"),
+                          "  Fetched/returned/tombstones:",
+                          "    partitions: 1/1/0",
+                          "    rows: 10/10/0",
+                          "    cells: 100/100/-");
+
+        // filtered partition query
+        mark = node.logs().mark();
+        rows = coordinator.execute(format("SELECT * FROM %s.%s WHERE k = 1 AND v >= 15 ALLOW FILTERING"), ALL);
+        Assertions.assertThat(rows).hasNumberOfRows(5);
+        assertLogsContain(mark, node,
+                          format("<SELECT \\* FROM %s\\.%s WHERE k = \\? AND v >= \\? ALLOW FILTERING>"),
+                          "  Fetched/returned/tombstones:",
+                          "    partitions: 1/1/0",
+                          "    rows: 10/5/0",
+                          "    cells: 100/50/-");
+
+        // row query
+        mark = node.logs().mark();
+        rows = coordinator.execute(format("SELECT * FROM %s.%s WHERE k = 1 AND c = 1"), ALL);
+        Assertions.assertThat(rows).hasNumberOfRows(1);
+        assertLogsContain(mark, node,
+                          format("<SELECT \\* FROM %s\\.%s WHERE k = \\? AND c = \\? ALLOW FILTERING>"),
+                          "  Fetched/returned/tombstones:",
+                          "    partitions: 1/1/0",
+                          "    rows: 1/1/0",
+                          "    cells: 10/10/-");
+
+        // column query (single-cell)
+        mark = node.logs().mark();
+        rows = coordinator.execute(format("SELECT v FROM %s.%s"), ALL);
+        Assertions.assertThat(rows).hasNumberOfRows(numRows);
+        assertLogsContain(mark, node,
+                          format("<SELECT v FROM %s\\.%s ALLOW FILTERING>"),
+                          "  Fetched/returned/tombstones:",
+                          "    partitions: 10/10/0",
+                          "    rows: 100/100/0",
+                          "    cells: 1000/1000/-");
+
+        // column query (list)
+        mark = node.logs().mark();
+        rows = coordinator.execute(format("SELECT l FROM %s.%s"), ALL);
+        Assertions.assertThat(rows).hasNumberOfRows(numRows);
+        assertLogsContain(mark, node,
+                          format("<SELECT l FROM %s\\.%s ALLOW FILTERING>"),
+                          "  Fetched/returned/tombstones:",
+                          "    partitions: 10/10/0",
+                          "    rows: 100/100/0",
+                          "    cells: 1000/1000/-");
+
+        // column query (set)
+        mark = node.logs().mark();
+        rows = coordinator.execute(format("SELECT s FROM %s.%s"), ALL);
+        Assertions.assertThat(rows).hasNumberOfRows(numRows);
+        assertLogsContain(mark, node,
+                          format("<SELECT s FROM %s\\.%s ALLOW FILTERING>"),
+                          "  Fetched/returned/tombstones:",
+                          "    partitions: 10/10/0",
+                          "    rows: 100/100/0",
+                          "    cells: 1000/1000/-");
+
+        // column query (map)
+        mark = node.logs().mark();
+        rows = coordinator.execute(format("SELECT m FROM %s.%s"), ALL);
+        Assertions.assertThat(rows).hasNumberOfRows(numRows);
+        assertLogsContain(mark, node,
+                          format("<SELECT m FROM %s\\.%s ALLOW FILTERING>"),
+                          "  Fetched/returned/tombstones:",
+                          "    partitions: 10/10/0",
+                          "    rows: 100/100/0",
+                          "    cells: 1000/1000/-");
+
+        // remove some cells
+        coordinator.execute(format("UPDATE %s.%s SET l = l - [1] WHERE k = 1 AND c = 1"), ALL);
+        coordinator.execute(format("UPDATE %s.%s SET s = s - {1} WHERE k = 1 AND c = 1"), ALL);
+        coordinator.execute(format("UPDATE %s.%s SET m = m - {1} WHERE k = 1 AND c = 1"), ALL);
+
+        // unrestricted query, with tombstones
+        mark = node.logs().mark();
+        rows = coordinator.execute(format("SELECT * FROM %s.%s"), ALL);
+        Assertions.assertThat(rows).hasNumberOfRows(numRows);
+        assertLogsContain(mark, node,
+                          format("<SELECT \\* FROM %s\\.%s ALLOW FILTERING>"),
+                          "  Fetched/returned/tombstones:",
+                          "    partitions: 10/10/0",
+                          "    rows: 100/100/0",
+                          "    cells: 1000/1000/-");
+
+        // partition query, with tombstones
+        mark = node.logs().mark();
+        rows = coordinator.execute(format("SELECT * FROM %s.%s WHERE k = 1"), ALL);
+        Assertions.assertThat(rows).hasNumberOfRows(numClusterings);
+        assertLogsContain(mark, node,
+                format("<SELECT \\* FROM %s\\.%s WHERE k = \\? ALLOW FILTERING>"),
+                "  Fetched/returned/tombstones:",
+                "    partitions: 1/1/0",
+                "    rows: 10/10/0",
+                "    cells: 100/100/-");
+
+        // row query, with tombstones
+        mark = node.logs().mark();
+        rows = coordinator.execute(format("SELECT * FROM %s.%s WHERE k = 1 AND c = 1"), ALL);
+        Assertions.assertThat(rows).hasNumberOfRows(1);
+        assertLogsContain(mark, node,
+                format("<SELECT \\* FROM %s\\.%s WHERE k = \\? AND c = \\? ALLOW FILTERING>"),
+                "  Fetched/returned/tombstones:",
+                "    partitions: 1/1/0",
+                "    rows: 1/1/0",
+                "    cells: 10/10/-");
+    }
+
+    /**
+     * Test that the slow query logger outputs the correct metrics for static rows.
+     */
+    @Test
+    public void testStaticRows()
+    {
+        cluster.schemaChange(format("CREATE TABLE %s.%s (" +
+                                    "k int, c int, r int, " +
+                                    "v int static, l list<int> static, s set<int> static, m map<int, int> static, " +
+                                    "PRIMARY KEY(k, c))"));
+
+        // Insert a static row without any regular rows for it.
+        coordinator.execute(format("INSERT INTO %s.%s (k, v, l, s, m) VALUES (0, 0, [1, 2], {1, 2, 3}, {1:10, 2:20, 3:30, 4:40})"), ALL);
+        long mark = node.logs().mark();
+        Object[][] rows = coordinator.execute(format("SELECT * FROM %s.%s"), ALL);
+        Assertions.assertThat(rows).hasNumberOfRows(1);
+        assertLogsContain(mark, node,
+                          format("<SELECT \\* FROM %s\\.%s ALLOW FILTERING>"),
+                          "  Fetched/returned/tombstones:",
+                          "    partitions: 1/1/0",
+                          "    rows: 0/0/0",
+                          "    cells: 10/10/-");
+        mark = node.logs().mark();
+        rows = coordinator.execute(format("SELECT v FROM %s.%s"), ALL);
+        Assertions.assertThat(rows).hasNumberOfRows(1);
+        assertLogsContain(mark, node,
+                          format("<SELECT v FROM %s\\.%s ALLOW FILTERING>"),
+                          "  Fetched/returned/tombstones:",
+                          "    partitions: 1/1/0",
+                          "    rows: 0/0/0",
+                          "    cells: 10/10/-");
+
+        // Add a regular row for the partition with the previous static row.
+        coordinator.execute(format("INSERT INTO %s.%s (k, c, r) VALUES (0, 0, 0)"), ALL);
+        mark = node.logs().mark();
+        rows = coordinator.execute(format("SELECT * FROM %s.%s"), ALL);
+        Assertions.assertThat(rows).hasNumberOfRows(1);
+        assertLogsContain(mark, node,
+                          format("<SELECT \\* FROM %s\\.%s ALLOW FILTERING>"),
+                          "  Fetched/returned/tombstones:",
+                          "    partitions: 1/1/0",
+                          "    rows: 1/1/0",
+                          "    cells: 11/11/-");
+        mark = node.logs().mark();
+        rows = coordinator.execute(format("SELECT r FROM %s.%s"), ALL);
+        Assertions.assertThat(rows).hasNumberOfRows(1);
+        assertLogsContain(mark, node,
+                          format("<SELECT r FROM %s\\.%s ALLOW FILTERING>"),
+                          "  Fetched/returned/tombstones:",
+                          "    partitions: 1/1/0",
+                          "    rows: 1/1/0",
+                          "    cells: 11/11/-");
+
+        // Add a second regular row for the previous partition.
+        coordinator.execute(format("INSERT INTO %s.%s (k, c, r) VALUES (0, 1, 0)"), ALL);
+        mark = node.logs().mark();
+        rows = coordinator.execute(format("SELECT * FROM %s.%s"), ALL);
+        Assertions.assertThat(rows).hasNumberOfRows(2);
+        assertLogsContain(mark, node,
+                          format("<SELECT \\* FROM %s\\.%s ALLOW FILTERING>"),
+                          "  Fetched/returned/tombstones:",
+                          "    partitions: 1/1/0",
+                          "    rows: 2/2/0",
+                          "    cells: 12/12/-");
+
+        // Remove a cell from a regular row.
+        coordinator.execute(format("INSERT INTO %s.%s (k, c, r) VALUES (0, 1, null)"), ALL);
+        mark = node.logs().mark();
+        rows = coordinator.execute(format("SELECT * FROM %s.%s"), ALL);
+        Assertions.assertThat(rows).hasNumberOfRows(2);
+        assertLogsContain(mark, node,
+                          format("<SELECT \\* FROM %s\\.%s ALLOW FILTERING>"),
+                          "  Fetched/returned/tombstones:",
+                          "    partitions: 1/1/0",
+                          "    rows: 2/2/0",
+                          "    cells: 12/12/-");
+
+        // Remove some cells from the static row.
+        coordinator.execute(format("UPDATE %s.%s SET l = l - [1] WHERE k = 0"), ALL);
+        coordinator.execute(format("UPDATE %s.%s SET s = s - {1} WHERE k = 0"), ALL);
+        coordinator.execute(format("UPDATE %s.%s SET m = m - {1} WHERE k = 0"), ALL);
+        mark = node.logs().mark();
+        rows = coordinator.execute(format("SELECT * FROM %s.%s"), ALL);
+        Assertions.assertThat(rows).hasNumberOfRows(2);
+        assertLogsContain(mark, node,
+                          format("<SELECT \\* FROM %s\\.%s ALLOW FILTERING>"),
+                          "  Fetched/returned/tombstones:",
+                          "    partitions: 1/1/0",
+                          "    rows: 2/2/0",
+                          "    cells: 12/12/");
+
+        // Add another partition, without statics
+        coordinator.execute(format("INSERT INTO %s.%s (k, c, r) VALUES (1, 1, 0)"), ALL);
+        coordinator.execute(format("INSERT INTO %s.%s (k, c, r) VALUES (1, 2, 0)"), ALL);
+        mark = node.logs().mark();
+        rows = coordinator.execute(format("SELECT * FROM %s.%s"), ALL);
+        Assertions.assertThat(rows).hasNumberOfRows(4);
+        assertLogsContain(mark, node,
+                          format("<SELECT \\* FROM %s\\.%s ALLOW FILTERING>"),
+                          "  Fetched/returned/tombstones:",
+                          "    partitions: 2/2/0",
+                          "    rows: 4/4/0",
+                          "    cells: 14/14/-");
+
+        // Add some static cell to the new partition
+        coordinator.execute(format("INSERT INTO %s.%s (k, l) VALUES (1, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])"), ALL);
+        mark = node.logs().mark();
+        rows = coordinator.execute(format("SELECT * FROM %s.%s"), ALL);
+        Assertions.assertThat(rows).hasNumberOfRows(4);
+        assertLogsContain(mark, node,
+                          format("<SELECT \\* FROM %s\\.%s ALLOW FILTERING>"),
+                          "  Fetched/returned/tombstones:",
+                          "    partitions: 2/2/0",
+                          "    rows: 4/4/0",
+                          "    cells: 24/24/-");
     }
 
     private static String format(String query)

--- a/test/distributed/org/apache/cassandra/distributed/test/SlowQueryLoggerTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/SlowQueryLoggerTest.java
@@ -448,6 +448,79 @@ public class SlowQueryLoggerTest extends TestBaseImpl
     }
 
     /**
+     * Test that the slow query logger outputs the correct metrics for number of returned cells in user-defined types.
+     */
+    @Test
+    public void testUDTs()
+    {
+        cluster.schemaChange(withKeyspace("CREATE TYPE %s.udt (x int, y int, z int)"));
+        cluster.schemaChange(format("CREATE TABLE %s.%s (k int, c int, v int, u udt, fu frozen<udt>, PRIMARY KEY(k, c))"));
+        int numPartitions = 10;
+        int numClusterings = 10;
+        int numRows = 0;
+        String insert = format("INSERT INTO %s.%s (k, c, v, u, fu) VALUES (?, ?, ?, {x:1, y:2, z:3}, {x:1, y:2, z:3})");
+        for (int k = 0; k < numPartitions; k++)
+            for (int c = 0; c < numClusterings; c++)
+                coordinator.execute(insert, ALL, k, c, numRows++);
+
+        // unrestricted query
+        long mark = node.logs().mark();
+        Object[][] rows = coordinator.execute(format("SELECT * FROM %s.%s"), ALL);
+        Assertions.assertThat(rows).hasNumberOfRows(numRows);
+        assertLogsContain(mark, node,
+                          quote(format("<SELECT * FROM %s.%s ALLOW FILTERING>")),
+                          "  Fetched/returned/tombstones:",
+                          "    partitions: 10/10/0",
+                          "    rows: 100/100/0",
+                          "    cells: 500/500/-");
+
+        // partition query
+        mark = node.logs().mark();
+        rows = coordinator.execute(format("SELECT * FROM %s.%s WHERE k = 1 ALLOW FILTERING"), ALL);
+        Assertions.assertThat(rows).hasNumberOfRows(10);
+        assertLogsContain(mark, node,
+                          quote(format("<SELECT * FROM %s.%s WHERE k = ? ALLOW FILTERING>")),
+                          "  Fetched/returned/tombstones:",
+                          "    partitions: 1/1/0",
+                          "    rows: 10/10/0",
+                          "    cells: 50/50/-");
+
+        // filtered partition query
+        mark = node.logs().mark();
+        rows = coordinator.execute(format("SELECT * FROM %s.%s WHERE k = 1 AND v >= 15 ALLOW FILTERING"), ALL);
+        Assertions.assertThat(rows).hasNumberOfRows(5);
+        assertLogsContain(mark, node,
+                          quote(format("<SELECT * FROM %s.%s WHERE k = ? AND v >= ? ALLOW FILTERING>")),
+                          "  Fetched/returned/tombstones:",
+                          "    partitions: 1/1/0",
+                          "    rows: 10/5/0",
+                          "    cells: 50/25/-");
+
+        // row query
+        mark = node.logs().mark();
+        rows = coordinator.execute(format("SELECT * FROM %s.%s WHERE k = 1 AND c = 1"), ALL);
+        Assertions.assertThat(rows).hasNumberOfRows(1);
+        assertLogsContain(mark, node,
+                          quote(format("<SELECT * FROM %s.%s WHERE k = ? AND c = ? ALLOW FILTERING>")),
+                          "  Fetched/returned/tombstones:",
+                          "    partitions: 1/1/0",
+                          "    rows: 1/1/0",
+                          "    cells: 5/5/-");
+
+        // remove a field from the non-frozen UDT
+        coordinator.execute(format("DELETE u.z FROM %s.%s WHERE k = 1 AND c = 1"), ALL);
+        mark = node.logs().mark();
+        rows = coordinator.execute(format("SELECT * FROM %s.%s WHERE k = 1 AND c = 1"), ALL);
+        Assertions.assertThat(rows).hasNumberOfRows(1);
+        assertLogsContain(mark, node,
+                          quote(format("<SELECT * FROM %s.%s WHERE k = ? AND c = ? ALLOW FILTERING>")),
+                          "  Fetched/returned/tombstones:",
+                          "    partitions: 1/1/0",
+                          "    rows: 1/1/0",
+                          "    cells: 5/5/-");
+    }
+
+    /**
      * Test that the slow query logger outputs the correct metrics for static rows.
      */
     @Test

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/SlowSAIQueryLoggerTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/SlowSAIQueryLoggerTest.java
@@ -19,9 +19,12 @@ import java.util.Iterator;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.regex.Pattern;
 
 import com.google.common.util.concurrent.Uninterruptibles;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import net.bytebuddy.ByteBuddy;
@@ -43,12 +46,15 @@ import org.apache.cassandra.distributed.test.TestBaseImpl;
 import org.apache.cassandra.index.SecondaryIndexManager;
 import org.apache.cassandra.index.sai.plan.QueryController;
 import org.apache.cassandra.index.sai.plan.QueryMonitorableExecutionInfo;
+import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
 
 import static java.util.regex.Pattern.quote;
 import static net.bytebuddy.matcher.ElementMatchers.named;
+import static org.apache.cassandra.distributed.api.ConsistencyLevel.ALL;
 import static org.apache.cassandra.distributed.test.SlowQueryLoggerTest.assertLogsContain;
 import static org.apache.cassandra.distributed.test.SlowQueryLoggerTest.assertLogsDoNotContain;
+import static org.apache.cassandra.utils.MonotonicClock.approxTime;
 
 /**
  * Tests {@link QueryMonitorableExecutionInfo} combined with the {@link MonitoringTask} mechanism,
@@ -58,8 +64,15 @@ public class SlowSAIQueryLoggerTest extends TestBaseImpl
 {
     private static final int SLOW_QUERY_LOG_TIMEOUT_IN_MS = 100;
 
-    @Test
-    public void testSlowSAIQueryLogger() throws Throwable
+    private static final AtomicInteger SEQ = new AtomicInteger();
+
+    private static Cluster cluster;
+    private static String table;
+    private static ICoordinator coordinator;
+    private static IInvokableInstance node;
+
+    @BeforeClass
+    public static void setupCluster() throws Exception
     {
         // effectively disable the scheduled monitoring task so we control it manually for better test stability
         CassandraRelevantProperties.MONITORING_REPORT_INTERVAL_MS.setInt((int) TimeUnit.HOURS.toMillis(1));
@@ -67,355 +80,879 @@ public class SlowSAIQueryLoggerTest extends TestBaseImpl
         // enable term statistics, same as in SAITester
         CassandraRelevantProperties.SAI_QUERY_OPTIMIZATION_USE_TERM_STATISTICS.setBoolean(true);
 
-        try (Cluster cluster = init(Cluster.build(1)
-                                           .withConfig(c -> c.set("slow_query_log_timeout_in_ms", SLOW_QUERY_LOG_TIMEOUT_IN_MS))
-                                           .withInstanceInitializer(BB::install)
-                                           .start()))
-        {
-            // create a table with numeric, text and vector indexes
-            cluster.schemaChange(withKeyspace("CREATE TABLE %s.t (k int, c int, n int, s text, v vector<float, 2>, l int, PRIMARY KEY(k, c))"));
-            cluster.schemaChange(withKeyspace("CREATE CUSTOM INDEX ON %s.t (n) USING 'StorageAttachedIndex'"));
-            cluster.schemaChange(withKeyspace("CREATE CUSTOM INDEX ON %s.t (s) USING 'StorageAttachedIndex'"));
-            cluster.schemaChange(withKeyspace("CREATE CUSTOM INDEX ON %s.t (v) USING 'StorageAttachedIndex'"));
+        cluster = init(Cluster.build(1)
+                              .withConfig(c -> c.set("slow_query_log_timeout_in_ms", SLOW_QUERY_LOG_TIMEOUT_IN_MS))
+                              .withInstanceInitializer(BB::install)
+                              .start());
+        coordinator = cluster.coordinator(1);
+        node = cluster.get(1);
+    }
 
-            // insert some data
-            ICoordinator coordinator = cluster.coordinator(1);
-            IInvokableInstance node = cluster.get(1);
-            coordinator.execute(withKeyspace("INSERT INTO %s.t (k, c, n, s, v, l) VALUES (1, 1, 1, 's_1', [1, 1], 1)"), ConsistencyLevel.ONE);
-            coordinator.execute(withKeyspace("INSERT INTO %s.t (k, c, n, s, v, l) VALUES (1, 2, 2, 's_2', [1, 2], 2)"), ConsistencyLevel.ONE);
-            coordinator.execute(withKeyspace("INSERT INTO %s.t (k, c, n, s, v, l) VALUES (2, 1, 3, 's_3', [1, 3], 3)"), ConsistencyLevel.ONE);
-            coordinator.execute(withKeyspace("INSERT INTO %s.t (k, c, n, s, v, l) VALUES (2, 2, 4, 's_4', [1, 4], 4)"), ConsistencyLevel.ONE);
-            node.flush(KEYSPACE);
+    @AfterClass
+    public static void closeCluster()
+    {
+        if (cluster != null)
+            cluster.close();
+    }
 
-            // test single numeric query
-            long mark = node.logs().mark();
-            String numericQuery = withKeyspace("SELECT * FROM %s.t WHERE n > 1");
+    @Before
+    public void before()
+    {
+        CassandraRelevantProperties.MONITORING_EXECUTION_INFO_ENABLED.setBoolean(true);
+        table = "t_" + SEQ.getAndIncrement();
+
+        // trigger the monitoring task to flush any pending slow operations before the test starts
+        node.runOnInstance(() -> MonitoringTask.instance.logOperations(approxTime.now()));
+    }
+
+    @After
+    public void after()
+    {
+        cluster.schemaChange(format("DROP TABLE IF EXISTS %s.%s"));
+    }
+
+    private static String format(String query)
+    {
+        return String.format(query, KEYSPACE, table);
+    }
+
+    @Test
+    public void testSlowSAIQueryLogger()
+    {
+        // effectively disable the scheduled monitoring task so we control it manually for better test stability
+        CassandraRelevantProperties.MONITORING_REPORT_INTERVAL_MS.setInt((int) TimeUnit.HOURS.toMillis(1));
+
+        // enable term statistics, same as in SAITester
+        CassandraRelevantProperties.SAI_QUERY_OPTIMIZATION_USE_TERM_STATISTICS.setBoolean(true);
+
+        // create a table with numeric, text and vector indexes
+        cluster.schemaChange(format("CREATE TABLE %s.%s (k int, c int, n int, s text, v vector<float, 2>, l int, PRIMARY KEY(k, c))"));
+        cluster.schemaChange(format("CREATE CUSTOM INDEX ON %s.%s (n) USING 'StorageAttachedIndex'"));
+        cluster.schemaChange(format("CREATE CUSTOM INDEX ON %s.%s (s) USING 'StorageAttachedIndex'"));
+        cluster.schemaChange(format("CREATE CUSTOM INDEX ON %s.%s (v) USING 'StorageAttachedIndex'"));
+
+        // insert some data
+        coordinator.execute(format("INSERT INTO %s.%s (k, c, n, s, v, l) VALUES (1, 1, 1, 's_1', [1, 1], 1)"), ConsistencyLevel.ONE);
+        coordinator.execute(format("INSERT INTO %s.%s (k, c, n, s, v, l) VALUES (1, 2, 2, 's_2', [1, 2], 2)"), ConsistencyLevel.ONE);
+        coordinator.execute(format("INSERT INTO %s.%s (k, c, n, s, v, l) VALUES (2, 1, 3, 's_3', [1, 3], 3)"), ConsistencyLevel.ONE);
+        coordinator.execute(format("INSERT INTO %s.%s (k, c, n, s, v, l) VALUES (2, 2, 4, 's_4', [1, 4], 4)"), ConsistencyLevel.ONE);
+        node.flush(KEYSPACE);
+
+        // test single numeric query
+        long mark = node.logs().mark();
+        String numericQuery = format("SELECT * FROM %s.%s WHERE n > 1");
+        coordinator.execute(numericQuery, ConsistencyLevel.ONE);
+        assertLogsContain(mark, node,
+                          "SAI slow query metrics:",
+                          "sstablesHit: 1",
+                          "segmentsHit: 1",
+                          "keysFetched: 3",
+                          "partitionsFetched: 2",
+                          "partitionsReturned: 2",
+                          "partitionTombstonesFetched: 0",
+                          "rowsFetched: 3",
+                          "rowsReturned: 3",
+                          "rowTombstonesFetched: 0",
+                          "cellsFetched: 12",
+                          "cellsReturned: 12",
+                          "trieSegmentsHit: 0",
+                          "triePostingsSkips: 0",
+                          "triePostingsDecodes: 0",
+                          "bkdSegmentsHit: 1",
+                          "bkdPostingListsHit: 1",
+                          "bkdPostingsSkips: 0",
+                          "bkdPostingsDecodes: 4",
+                          "annGraphSearchLatencyNanos: 0",
+                          "SAI slow query plan:",
+                          "NumericIndexScan",
+                          quote("predicate: Expression{name: n, op: RANGE, lower: (?, false), upper: (null, false), exclusions: []}"));
+
+        // test aggregated numeric query
+        mark = node.logs().mark();
+        for (int i = 0; i < 2; i++)
             coordinator.execute(numericQuery, ConsistencyLevel.ONE);
-            assertLogsContain(mark, node,
-                              "SAI slow query metrics:",
-                              "sstablesHit: 1",
-                              "segmentsHit: 1",
-                              "keysFetched: 3",
-                              "partitionsFetched: 2",
-                              "partitionsReturned: 2",
-                              "partitionTombstonesFetched: 0",
-                              "rowsFetched: 3",
-                              "rowsReturned: 3",
-                              "rowTombstonesFetched: 0",
-                              "trieSegmentsHit: 0",
-                              "triePostingsSkips: 0",
-                              "triePostingsDecodes: 0",
-                              "bkdSegmentsHit: 1",
-                              "bkdPostingListsHit: 1",
-                              "bkdPostingsSkips: 0",
-                              "bkdPostingsDecodes: 4",
-                              "annGraphSearchLatencyNanos: 0",
-                              "SAI slow query plan:",
-                              "NumericIndexScan",
-                              Pattern.quote("predicate: Expression{name: n, op: RANGE, lower: (?, false), upper: (null, false), exclusions: []}"));
+        assertLogsContain(mark, node,
+                          "SAI slowest query metrics:",
+                          "sstablesHit: 1",
+                          "segmentsHit: 1",
+                          "keysFetched: 3",
+                          "partitionsFetched: 2",
+                          "partitionsReturned: 2",
+                          "partitionTombstonesFetched: 0",
+                          "rowsFetched: 3",
+                          "rowsReturned: 3",
+                          "rowTombstonesFetched: 0",
+                          "cellsFetched: 12",
+                          "cellsReturned: 12",
+                          "trieSegmentsHit: 0",
+                          "triePostingsSkips: 0",
+                          "triePostingsDecodes: 0",
+                          "bkdSegmentsHit: 1",
+                          "bkdPostingListsHit: 1",
+                          "bkdPostingsSkips: 0",
+                          "bkdPostingsDecodes: 4",
+                          "annGraphSearchLatencyNanos: 0",
+                          "SAI slowest query plan:",
+                          "NumericIndexScan",
+                          quote("predicate: Expression{name: n, op: RANGE, lower: (?, false), upper: (null, false), exclusions: []}"));
 
-            // test aggregated numeric query
-            mark = node.logs().mark();
-            for (int i = 0; i < 2; i++)
-                coordinator.execute(numericQuery, ConsistencyLevel.ONE);
-            assertLogsContain(mark, node,
-                              "SAI slowest query metrics:",
-                              "sstablesHit: 1",
-                              "segmentsHit: 1",
-                              "keysFetched: 3",
-                              "partitionsFetched: 2",
-                              "partitionsReturned: 2",
-                              "partitionTombstonesFetched: 0",
-                              "rowsFetched: 3",
-                              "rowsReturned: 3",
-                              "rowTombstonesFetched: 0",
-                              "trieSegmentsHit: 0",
-                              "triePostingsSkips: 0",
-                              "triePostingsDecodes: 0",
-                              "bkdSegmentsHit: 1",
-                              "bkdPostingListsHit: 1",
-                              "bkdPostingsSkips: 0",
-                              "bkdPostingsDecodes: 4",
-                              "annGraphSearchLatencyNanos: 0",
-                              "SAI slowest query plan:",
-                              "NumericIndexScan",
-                              Pattern.quote("predicate: Expression{name: n, op: RANGE, lower: (?, false), upper: (null, false), exclusions: []}"));
+        // test single text query
+        mark = node.logs().mark();
+        String textQuery = format("SELECT * FROM %s.%s WHERE s = 's_2' OR s = 's_3'");
+        coordinator.execute(textQuery, ConsistencyLevel.ONE);
+        assertLogsContain(mark, node,
+                          "SAI slow query metrics:",
+                          "sstablesHit: 2",
+                          "segmentsHit: 2",
+                          "keysFetched: 2",
+                          "partitionsFetched: 2",
+                          "partitionsReturned: 2",
+                          "partitionTombstonesFetched: 0",
+                          "rowsFetched: 2",
+                          "rowsReturned: 2",
+                          "rowTombstonesFetched: 0",
+                          "cellsFetched: 8",
+                          "cellsReturned: 8",
+                          "trieSegmentsHit: 2",
+                          "triePostingsSkips: 0",
+                          "triePostingsDecodes: 2",
+                          "bkdSegmentsHit: 0",
+                          "bkdPostingListsHit: 0",
+                          "bkdPostingsSkips: 0",
+                          "bkdPostingsDecodes: 0",
+                          "annGraphSearchLatencyNanos: 0",
+                          "SAI slow query plan:",
+                          "LiteralIndexScan",
+                          quote("predicate: Expression{name: s, op: EQ, lower: (?, true), upper: (?, true), exclusions: []}"));
 
-            // test single text query
-            mark = node.logs().mark();
-            String textQuery = withKeyspace("SELECT * FROM %s.t WHERE s = 's_2' OR s = 's_3'");
+        // test aggregated text query
+        mark = node.logs().mark();
+        for (int i = 0; i < 2; i++)
             coordinator.execute(textQuery, ConsistencyLevel.ONE);
-            assertLogsContain(mark, node,
-                              "SAI slow query metrics:",
-                              "sstablesHit: 2",
-                              "segmentsHit: 2",
-                              "keysFetched: 2",
-                              "partitionsFetched: 2",
-                              "partitionsReturned: 2",
-                              "partitionTombstonesFetched: 0",
-                              "rowsFetched: 2",
-                              "rowsReturned: 2",
-                              "rowTombstonesFetched: 0",
-                              "trieSegmentsHit: 2",
-                              "triePostingsSkips: 0",
-                              "triePostingsDecodes: 2",
-                              "bkdSegmentsHit: 0",
-                              "bkdPostingListsHit: 0",
-                              "bkdPostingsSkips: 0",
-                              "bkdPostingsDecodes: 0",
-                              "annGraphSearchLatencyNanos: 0",
-                              "SAI slow query plan:",
-                              "LiteralIndexScan",
-                              Pattern.quote("predicate: Expression{name: s, op: EQ, lower: (?, true), upper: (?, true), exclusions: []}"));
+        assertLogsContain(mark, node,
+                          "SAI slowest query metrics:",
+                          "sstablesHit: 2",
+                          "segmentsHit: 2",
+                          "keysFetched: 2",
+                          "partitionsFetched: 2",
+                          "partitionsReturned: 2",
+                          "partitionTombstonesFetched: 0",
+                          "rowsFetched: 2",
+                          "rowsReturned: 2",
+                          "rowTombstonesFetched: 0",
+                          "cellsFetched: 8",
+                          "cellsReturned: 8",
+                          "trieSegmentsHit: 2",
+                          "triePostingsSkips: 0",
+                          "triePostingsDecodes: 2",
+                          "bkdSegmentsHit: 0",
+                          "bkdPostingListsHit: 0",
+                          "bkdPostingsSkips: 0",
+                          "bkdPostingsDecodes: 0",
+                          "annGraphSearchLatencyNanos: 0",
+                          "SAI slowest query plan:",
+                          "LiteralIndexScan",
+                          quote("predicate: Expression{name: s, op: EQ, lower: (?, true), upper: (?, true), exclusions: []}"));
 
-            // test aggregated text query
-            mark = node.logs().mark();
-            for (int i = 0; i < 2; i++)
-                coordinator.execute(textQuery, ConsistencyLevel.ONE);
-            assertLogsContain(mark, node,
-                              "SAI slowest query metrics:",
-                              "sstablesHit: 2",
-                              "segmentsHit: 2",
-                              "keysFetched: 2",
-                              "partitionsFetched: 2",
-                              "partitionsReturned: 2",
-                              "partitionTombstonesFetched: 0",
-                              "rowsFetched: 2",
-                              "rowsReturned: 2",
-                              "rowTombstonesFetched: 0",
-                              "trieSegmentsHit: 2",
-                              "triePostingsSkips: 0",
-                              "triePostingsDecodes: 2",
-                              "bkdSegmentsHit: 0",
-                              "bkdPostingListsHit: 0",
-                              "bkdPostingsSkips: 0",
-                              "bkdPostingsDecodes: 0",
-                              "annGraphSearchLatencyNanos: 0",
-                              "SAI slowest query plan:",
-                              "LiteralIndexScan",
-                              Pattern.quote("predicate: Expression{name: s, op: EQ, lower: (?, true), upper: (?, true), exclusions: []}"));
+        // test single ANN query
+        mark = node.logs().mark();
+        String annQuery = format("SELECT * FROM %s.%s ORDER BY v ANN OF [1, 1] LIMIT 10");
+        coordinator.execute(annQuery, ConsistencyLevel.ONE);
+        assertLogsContain(mark, node,
+                          "SAI slow query metrics:",
+                          "sstablesHit: 1",
+                          "segmentsHit: 1",
+                          "keysFetched: 4",
+                          "partitionsFetched: 4",
+                          "partitionsReturned: 2",
+                          "partitionTombstonesFetched: 0",
+                          "rowsFetched: 4",
+                          "rowsReturned: 4",
+                          "rowTombstonesFetched: 0",
+                          "cellsFetched: 16",
+                          "cellsReturned: 16",
+                          "trieSegmentsHit: 0",
+                          "triePostingsSkips: 0",
+                          "triePostingsDecodes: 0",
+                          "bkdPostingListsHit: 0",
+                          "bkdSegmentsHit: 0",
+                          "bkdPostingsSkips: 0",
+                          "bkdPostingsDecodes: 0",
+                          "annGraphSearchLatencyNanos: [1-9][0-9]*", // unknown, but greater than zero
+                          "SAI slow query plan:",
+                          "AnnIndexScan",
+                          quote("v ANN OF ? DESC"));
 
-            // test single ANN query
-            mark = node.logs().mark();
-            String annQuery = withKeyspace("SELECT * FROM %s.t ORDER BY v ANN OF [1, 1] LIMIT 10");
+        // test aggregated ANN query
+        mark = node.logs().mark();
+        for (int i = 0; i < 2; i++)
             coordinator.execute(annQuery, ConsistencyLevel.ONE);
-            assertLogsContain(mark, node,
-                              "SAI slow query metrics:",
-                              "sstablesHit: 1",
-                              "segmentsHit: 1",
-                              "keysFetched: 4",
-                              "partitionsFetched: 4",
-                              "partitionsReturned: 2",
-                              "partitionTombstonesFetched: 0",
-                              "rowsFetched: 4",
-                              "rowsReturned: 4",
-                              "rowTombstonesFetched: 0",
-                              "trieSegmentsHit: 0",
-                              "triePostingsSkips: 0",
-                              "triePostingsDecodes: 0",
-                              "bkdPostingListsHit: 0",
-                              "bkdSegmentsHit: 0",
-                              "bkdPostingsSkips: 0",
-                              "bkdPostingsDecodes: 0",
-                              "annGraphSearchLatencyNanos: [1-9][0-9]*", // unknown, but greater than zero
-                              "SAI slow query plan:",
-                              "AnnIndexScan",
-                              Pattern.quote("v ANN OF ? DESC"));
+        assertLogsContain(mark, node,
+                          "SAI slowest query metrics:",
+                          "sstablesHit: 1",
+                          "segmentsHit: 1",
+                          "keysFetched: 4",
+                          "partitionsFetched: 4",
+                          "partitionsReturned: 2",
+                          "partitionTombstonesFetched: 0",
+                          "rowsFetched: 4",
+                          "rowsReturned: 4",
+                          "rowTombstonesFetched: 0",
+                          "cellsFetched: 16",
+                          "cellsReturned: 16",
+                          "trieSegmentsHit: 0",
+                          "triePostingsSkips: 0",
+                          "triePostingsDecodes: 0",
+                          "bkdSegmentsHit: 0",
+                          "bkdPostingListsHit: 0",
+                          "bkdPostingsSkips: 0",
+                          "bkdPostingsDecodes: 0",
+                          "annGraphSearchLatencyNanos: [1-9][0-9]*", // unknown, but greater than zero
+                          "SAI slowest query plan:",
+                          "AnnIndexScan",
+                          quote("v ANN OF ? DESC"));
 
-            // test aggregated ANN query
-            mark = node.logs().mark();
-            for (int i = 0; i < 2; i++)
-                coordinator.execute(annQuery, ConsistencyLevel.ONE);
-            assertLogsContain(mark, node,
-                              "SAI slowest query metrics:",
-                              "sstablesHit: 1",
-                              "segmentsHit: 1",
-                              "keysFetched: 4",
-                              "partitionsFetched: 4",
-                              "partitionsReturned: 2",
-                              "partitionTombstonesFetched: 0",
-                              "rowsFetched: 4",
-                              "rowsReturned: 4",
-                              "rowTombstonesFetched: 0",
-                              "trieSegmentsHit: 0",
-                              "triePostingsSkips: 0",
-                              "triePostingsDecodes: 0",
-                              "bkdSegmentsHit: 0",
-                              "bkdPostingListsHit: 0",
-                              "bkdPostingsSkips: 0",
-                              "bkdPostingsDecodes: 0",
-                              "annGraphSearchLatencyNanos: [1-9][0-9]*", // unknown, but greater than zero
-                              "SAI slowest query plan:",
-                              "AnnIndexScan",
-                              Pattern.quote("v ANN OF ? DESC"));
+        // test single hybrid query
+        mark = node.logs().mark();
+        String hybridQuery = format("SELECT * FROM %s.%s WHERE n > 1 ORDER BY s LIMIT 10");
+        coordinator.execute(hybridQuery, ConsistencyLevel.ONE);
+        assertLogsContain(mark, node,
+                          "SAI slow query metrics:",
+                          "sstablesHit: 1",
+                          "segmentsHit: 1",
+                          "keysFetched: 4",
+                          "partitionsFetched: 4",
+                          "partitionsReturned: 2",
+                          "partitionTombstonesFetched: 0",
+                          "rowsFetched: 4",
+                          "rowsReturned: 3",
+                          "rowTombstonesFetched: 0",
+                          "cellsFetched: 16",
+                          "cellsReturned: 12",
+                          "trieSegmentsHit: 0",
+                          "triePostingsSkips: 0",
+                          "triePostingsDecodes: 0",
+                          "bkdSegmentsHit: 0",
+                          "bkdPostingListsHit: 0",
+                          "bkdPostingsSkips: 0",
+                          "bkdPostingsDecodes: 0",
+                          "annGraphSearchLatencyNanos: 0",
+                          "SAI slow query plan:",
+                          "LiteralIndexScan",
+                          quote("ordering: s ASC"));
 
-            // test single hybrid query
-            mark = node.logs().mark();
-            String hybridQuery = withKeyspace("SELECT * FROM %s.t WHERE n > 1 ORDER BY s LIMIT 10");
+        // test aggregated hybrid query
+        mark = node.logs().mark();
+        for (int i = 0; i < 2; i++)
             coordinator.execute(hybridQuery, ConsistencyLevel.ONE);
-            assertLogsContain(mark, node,
-                              "SAI slow query metrics:",
-                              "sstablesHit: 1",
-                              "segmentsHit: 1",
-                              "keysFetched: 4",
-                              "partitionsFetched: 4",
-                              "partitionsReturned: 2",
-                              "partitionTombstonesFetched: 0",
-                              "rowsFetched: 4",
-                              "rowsReturned: 3",
-                              "rowTombstonesFetched: 0",
-                              "trieSegmentsHit: 0",
-                              "triePostingsSkips: 0",
-                              "triePostingsDecodes: 0",
-                              "bkdSegmentsHit: 0",
-                              "bkdPostingListsHit: 0",
-                              "bkdPostingsSkips: 0",
-                              "bkdPostingsDecodes: 0",
-                              "annGraphSearchLatencyNanos: 0",
-                              "SAI slow query plan:",
-                              "LiteralIndexScan",
-                              Pattern.quote("ordering: s ASC"));
+        assertLogsContain(mark, node,
+                          "SAI slowest query metrics:",
+                          "sstablesHit: 1",
+                          "segmentsHit: 1",
+                          "keysFetched: 4",
+                          "partitionsFetched: 4",
+                          "partitionsReturned: 2",
+                          "partitionTombstonesFetched: 0",
+                          "rowsFetched: 4",
+                          "rowsReturned: 3",
+                          "rowTombstonesFetched: 0",
+                          "cellsFetched: 16",
+                          "cellsReturned: 12",
+                          "trieSegmentsHit: 0",
+                          "triePostingsSkips: 0",
+                          "triePostingsDecodes: 0",
+                          "bkdSegmentsHit: 0",
+                          "bkdPostingListsHit: 0",
+                          "bkdPostingsSkips: 0",
+                          "bkdPostingsDecodes: 0",
+                          "annGraphSearchLatencyNanos: 0",
+                          "SAI slowest query plan:",
+                          "LiteralIndexScan",
+                          quote("ordering: s ASC"));
 
-            // test aggregated hybrid query
-            mark = node.logs().mark();
-            for (int i = 0; i < 2; i++)
-                coordinator.execute(hybridQuery, ConsistencyLevel.ONE);
-            assertLogsContain(mark, node,
-                              "SAI slowest query metrics:",
-                              "sstablesHit: 1",
-                              "segmentsHit: 1",
-                              "keysFetched: 4",
-                              "partitionsFetched: 4",
-                              "partitionsReturned: 2",
-                              "partitionTombstonesFetched: 0",
-                              "rowsFetched: 4",
-                              "rowsReturned: 3",
-                              "rowTombstonesFetched: 0",
-                              "trieSegmentsHit: 0",
-                              "triePostingsSkips: 0",
-                              "triePostingsDecodes: 0",
-                              "bkdSegmentsHit: 0",
-                              "bkdPostingListsHit: 0",
-                              "bkdPostingsSkips: 0",
-                              "bkdPostingsDecodes: 0",
-                              "annGraphSearchLatencyNanos: 0",
-                              "SAI slowest query plan:",
-                              "LiteralIndexScan",
-                              Pattern.quote("ordering: s ASC"));
+        // Disable query optimizer to prevent skipping hybrid query logic and hit orderByResults to verify metrics update
+        node.runOnInstance(() -> QueryController.QUERY_OPT_LEVEL = 0);
+        mark = node.logs().mark();
+        coordinator.execute(hybridQuery, ConsistencyLevel.ONE);
+        assertLogsContain(mark, node,
+                          "SAI slow query metrics:",
+                          "sstablesHit: 2",
+                          "segmentsHit: 2",
+                          "keysFetched: 3",
+                          "partitionsFetched: 3",
+                          "partitionsReturned: 2",
+                          "partitionTombstonesFetched: 0",
+                          "rowsFetched: 3",
+                          "rowsReturned: 3",
+                          "rowTombstonesFetched: 0",
+                          "cellsFetched: 12",
+                          "cellsReturned: 12",
+                          "trieSegmentsHit: 0",
+                          "triePostingsSkips: 0",
+                          "triePostingsDecodes: 0",
+                          "bkdSegmentsHit: 1",
+                          "bkdPostingListsHit: 1",
+                          "bkdPostingsSkips: 0",
+                          "bkdPostingsDecodes: 4",
+                          "annGraphSearchLatencyNanos: 0",
+                          "SAI slow query plan:",
+                          "KeysSort",
+                          "NumericIndexScan",
+                          quote("predicate: Expression{name: n, op: RANGE, lower: (?, false), upper: (null, false), exclusions: []}"));
 
-            // Disable query optimizer to prevent skipping hybrid query logic and hit orderByResults to verify metrics update
-            node.runOnInstance(() -> QueryController.QUERY_OPT_LEVEL = 0);
-            mark = node.logs().mark();
-            coordinator.execute(hybridQuery, ConsistencyLevel.ONE);
-            assertLogsContain(mark, node,
-                              "SAI slow query metrics:",
-                              "sstablesHit: 2",
-                              "segmentsHit: 2",
-                              "keysFetched: 3",
-                              "partitionsFetched: 3",
-                              "partitionsReturned: 2",
-                              "partitionTombstonesFetched: 0",
-                              "rowsFetched: 3",
-                              "rowsReturned: 3",
-                              "rowTombstonesFetched: 0",
-                              "trieSegmentsHit: 0",
-                              "triePostingsSkips: 0",
-                              "triePostingsDecodes: 0",
-                              "bkdSegmentsHit: 1",
-                              "bkdPostingListsHit: 1",
-                              "bkdPostingsSkips: 0",
-                              "bkdPostingsDecodes: 4",
-                              "annGraphSearchLatencyNanos: 0",
-                              "SAI slow query plan:",
-                              "KeysSort",
-                              "NumericIndexScan",
-                              Pattern.quote("predicate: Expression{name: n, op: RANGE, lower: (?, false), upper: (null, false), exclusions: []}"));
+        node.runOnInstance(() -> QueryController.QUERY_OPT_LEVEL = CassandraRelevantProperties.SAI_QUERY_OPTIMIZATION_LEVEL.getInt());
 
-            node.runOnInstance(() -> QueryController.QUERY_OPT_LEVEL = CassandraRelevantProperties.SAI_QUERY_OPTIMIZATION_LEVEL.getInt());
+        // test changing data between identical queries, making one of them slower than the other,
+        // so we can check that only the execution info of the slowest query are reported
+        mark = node.logs().mark();
+        coordinator.execute(numericQuery, ConsistencyLevel.ONE);
+        node.runOnInstance(() -> BB.queryDelay.updateAndGet(x -> x * 4)); // make queries 4x slower
+        coordinator.execute(format("INSERT INTO %s.%s (k, c, n) VALUES (1, 3, 5)"), ConsistencyLevel.ONE);
+        coordinator.execute(format("INSERT INTO %s.%s (k, c, n) VALUES (2, 3, 6)"), ConsistencyLevel.ONE);
+        coordinator.execute(format("INSERT INTO %s.%s (k, c, n) VALUES (3, 1, 7)"), ConsistencyLevel.ONE);
+        node.flush(KEYSPACE);
+        coordinator.execute(numericQuery, ConsistencyLevel.ONE);
+        assertLogsContain(mark, node,
+                          "SAI slowest query metrics:",
+                          "sstablesHit: 3",
+                          "segmentsHit: 3",
+                          "partitionsFetched: 3",
+                          "rowsFetched: 6",
+                          "cellsFetched: 15");
+        node.runOnInstance(() -> BB.queryDelay.updateAndGet(x -> x / 4)); // restore the query delay
 
-            // test changing data between identical queries, making one of them slower than the other,
-            // so we can check that only the execution info of the slowest query are reported
-            mark = node.logs().mark();
-            coordinator.execute(numericQuery, ConsistencyLevel.ONE);
-            node.runOnInstance(() -> BB.queryDelay.updateAndGet(x -> x * 4)); // make queries 4x slower
-            coordinator.execute(withKeyspace("INSERT INTO %s.t (k, c, n) VALUES (1, 3, 5)"), ConsistencyLevel.ONE);
-            coordinator.execute(withKeyspace("INSERT INTO %s.t (k, c, n) VALUES (2, 3, 6)"), ConsistencyLevel.ONE);
-            coordinator.execute(withKeyspace("INSERT INTO %s.t (k, c, n) VALUES (3, 1, 7)"), ConsistencyLevel.ONE);
-            node.flush(KEYSPACE);
-            coordinator.execute(numericQuery, ConsistencyLevel.ONE);
-            assertLogsContain(mark, node,
-                              "SAI slowest query metrics:",
-                              "sstablesHit: 3",
-                              "segmentsHit: 3",
-                              "partitionsFetched: 3",
-                              "rowsFetched: 6");
-            node.runOnInstance(() -> BB.queryDelay.updateAndGet(x -> x / 4)); // restore the query delay
+        // disable execution info logging and verify they are not logged
+        CassandraRelevantProperties.SAI_MONITORING_EXECUTION_INFO_ENABLED.setBoolean(false);
+        mark = node.logs().mark();
+        coordinator.execute(numericQuery, ConsistencyLevel.ONE);
+        coordinator.execute(textQuery, ConsistencyLevel.ONE);
+        coordinator.execute(annQuery, ConsistencyLevel.ONE);
+        coordinator.execute(hybridQuery, ConsistencyLevel.ONE);
+        assertLogsContain(mark, node, "4 operations were slow");
+        assertLogsDoNotContainSAIExecutionInfo(mark, node);
+        CassandraRelevantProperties.SAI_MONITORING_EXECUTION_INFO_ENABLED.setBoolean(true);
 
-            // disable execution info logging and verify they are not logged
-            CassandraRelevantProperties.SAI_MONITORING_EXECUTION_INFO_ENABLED.setBoolean(false);
-            mark = node.logs().mark();
-            coordinator.execute(numericQuery, ConsistencyLevel.ONE);
-            coordinator.execute(textQuery, ConsistencyLevel.ONE);
-            coordinator.execute(annQuery, ConsistencyLevel.ONE);
-            coordinator.execute(hybridQuery, ConsistencyLevel.ONE);
-            assertLogsContain(mark, node, "4 operations were slow");
-            assertLogsDoNotContainSAIExecutionInfo(mark, node);
-            CassandraRelevantProperties.SAI_MONITORING_EXECUTION_INFO_ENABLED.setBoolean(true);
+        // test with a legacy index, there should be no SAI execution info
+        cluster.schemaChange(format("CREATE INDEX legacy_idx ON %s.%s (l)"));
+        final String t = table;
+        Awaitility.waitAtMost(1, TimeUnit.MINUTES).until(() -> cluster.get(1).callOnInstance(() -> {
+            SecondaryIndexManager sim = Keyspace.open(KEYSPACE).getColumnFamilyStore(t).indexManager;
+            return sim.isIndexQueryable("legacy_idx");
+        }));
+        mark = node.logs().mark();
+        String legacyIndexQuery = format("SELECT * FROM %s.%s WHERE l = 1");
+        coordinator.execute(legacyIndexQuery, ConsistencyLevel.ONE);
+        assertLogsContain(mark, node, "1 operations were slow", "WHERE l = ?");
+        assertLogsDoNotContainSAIExecutionInfo(mark, node);
 
-            // test with a legacy index, there should be no SAI execution info
-            cluster.schemaChange(withKeyspace("CREATE INDEX legacy_idx ON %s.t (l)"));
-            Awaitility.waitAtMost(1, TimeUnit.MINUTES).until(() -> cluster.get(1).callOnInstance(() -> {
-                SecondaryIndexManager sim = Keyspace.open(KEYSPACE).getColumnFamilyStore("t").indexManager;
-                return sim.isIndexQueryable("legacy_idx");
-            }));
-            mark = node.logs().mark();
-            String legacyIndexQuery = withKeyspace("SELECT * FROM %s.t WHERE l = 1");
-            coordinator.execute(legacyIndexQuery, ConsistencyLevel.ONE);
-            assertLogsContain(mark, node, "1 operations were slow", "WHERE l = ?");
-            assertLogsDoNotContainSAIExecutionInfo(mark, node);
+        // test with a regular, non-indexed query, there should be no SAI execution info
+        mark = node.logs().mark();
+        String regularQuery = format("SELECT * FROM %s.%s WHERE k = 1");
+        coordinator.execute(regularQuery, ConsistencyLevel.ONE);
+        assertLogsContain(mark, node, "1 operations were slow", "WHERE k = ?");
+        assertLogsDoNotContainSAIExecutionInfo(mark, node);
 
-            // test with a regular, non-indexed query, there should be no SAI execution info
-            mark = node.logs().mark();
-            String regularQuery = withKeyspace("SELECT * FROM %s.t WHERE k = 1");
-            coordinator.execute(regularQuery, ConsistencyLevel.ONE);
-            assertLogsContain(mark, node, "1 operations were slow", "WHERE k = ?");
-            assertLogsDoNotContainSAIExecutionInfo(mark, node);
+        // test that queries with the same relations and different values get grouped due to redaction
+        mark = node.logs().mark();
+        coordinator.execute(format("SELECT * FROM %s.%s WHERE n = 1"), ConsistencyLevel.ONE);
+        coordinator.execute(format("SELECT * FROM %s.%s WHERE n = 2"), ConsistencyLevel.ONE);
+        coordinator.execute(format("SELECT * FROM %s.%s WHERE n > 1"), ConsistencyLevel.ONE);
+        coordinator.execute(format("SELECT * FROM %s.%s WHERE n > 2"), ConsistencyLevel.ONE);
+        coordinator.execute(format("SELECT * FROM %s.%s WHERE n > 3"), ConsistencyLevel.ONE);
+        assertLogsContain(mark, node, "was slow 2 times", "WHERE n = ?", "SAI slowest query metrics:");
+        assertLogsContain(mark, node, "was slow 3 times", "WHERE n > ?", "SAI slowest query metrics:");
+        assertLogsDoNotContain(mark, node, "WHERE n = 1", "WHERE n = 2", "WHERE n > 1", "WHERE n > 2", "WHERE n > 3");
 
-            // test that queries with the same relations and different values get grouped due to redaction
-            mark = node.logs().mark();
-            coordinator.execute(withKeyspace("SELECT * FROM %s.t WHERE n = 1"), ConsistencyLevel.ONE);
-            coordinator.execute(withKeyspace("SELECT * FROM %s.t WHERE n = 2"), ConsistencyLevel.ONE);
-            coordinator.execute(withKeyspace("SELECT * FROM %s.t WHERE n > 1"), ConsistencyLevel.ONE);
-            coordinator.execute(withKeyspace("SELECT * FROM %s.t WHERE n > 2"), ConsistencyLevel.ONE);
-            coordinator.execute(withKeyspace("SELECT * FROM %s.t WHERE n > 3"), ConsistencyLevel.ONE);
-            assertLogsContain(mark, node, "was slow 2 times", "WHERE n = ?", "SAI slowest query metrics:");
-            assertLogsContain(mark, node, "was slow 3 times", "WHERE n > ?", "SAI slowest query metrics:");
-            assertLogsDoNotContain(mark, node, "WHERE n = 1", "WHERE n = 2", "WHERE n > 1", "WHERE n > 2", "WHERE n > 3");
+        // test some partition and row deletions
+        coordinator.execute(format("DELETE FROM %s.%s WHERE k = 1 AND c = 1"), ConsistencyLevel.ONE);
+        coordinator.execute(format("DELETE FROM %s.%s WHERE k = 1 AND c = 2"), ConsistencyLevel.ONE);
+        coordinator.execute(format("DELETE FROM %s.%s WHERE k = 2"), ConsistencyLevel.ONE);
+        node.flush(KEYSPACE);
+        String selectAllQuery = format("SELECT * FROM %s.%s WHERE n >= 0");
+        coordinator.execute(selectAllQuery, ConsistencyLevel.ONE);
+        assertLogsContain(mark, node,
+                          "partitionTombstonesFetched: 1",
+                          "rowTombstonesFetched: 2");
 
-            // test some partition and row deletions
-            coordinator.execute(withKeyspace("DELETE FROM %s.t WHERE k = 1 AND c = 1"), ConsistencyLevel.ONE);
-            coordinator.execute(withKeyspace("DELETE FROM %s.t WHERE k = 1 AND c = 2"), ConsistencyLevel.ONE);
-            coordinator.execute(withKeyspace("DELETE FROM %s.t WHERE k = 2"), ConsistencyLevel.ONE);
-            node.flush(KEYSPACE);
-            String selectAllQuery = withKeyspace("SELECT * FROM %s.t WHERE n >= 0");
-            coordinator.execute(selectAllQuery, ConsistencyLevel.ONE);
-            assertLogsContain(mark, node,
-                              "partitionTombstonesFetched: 1",
-                              "rowTombstonesFetched: 2");
+        // test with paged queries
+        mark = node.logs().mark();
+        String query =  format("SELECT * FROM %s.%s WHERE n >= 0");
+        Iterator<Object[]> pagedRows = coordinator.executeWithPaging(query, ConsistencyLevel.ONE, 1);
+        while (pagedRows.hasNext())
+            pagedRows.next();
+        assertLogsContain(mark, node,
+                          quote(format("<SELECT * FROM %s.%s WHERE n >= ? LIMIT 1 ALLOW FILTERING>")),
+                          "NumericIndexScan");
+        assertLogsContain(mark, node,
+                          quote(format("<SELECT * FROM %s.%s WHERE token(k) >= token(?) AND n >= ? LIMIT 1 ALLOW FILTERING [paging continuation]>")),
+                          "NumericIndexScan");
+    }
 
-            // test with paged queries
-            mark = node.logs().mark();
-            String query =  withKeyspace("SELECT * FROM %s.t WHERE n >= 0");
-            Iterator<Object[]> pagedRows = coordinator.executeWithPaging(query, ConsistencyLevel.ONE, 1);
-            while (pagedRows.hasNext())
-                pagedRows.next();
-            assertLogsContain(mark, node,
-                              quote(withKeyspace("<SELECT * FROM %s.t WHERE n >= ? LIMIT 1 ALLOW FILTERING>")),
-                              "NumericIndexScan");
-            assertLogsContain(mark, node,
-                              quote(withKeyspace("<SELECT * FROM %s.t WHERE token(k) >= token(?) AND n >= ? LIMIT 1 ALLOW FILTERING [paging continuation]>")),
-                              "NumericIndexScan");
-        }
+    /**
+     * Test that the slow query logger outputs the correct metrics for number of returned cells in collection columns.
+     */
+    @Test
+    public void testCollections()
+    {
+        cluster.schemaChange(format("CREATE TABLE %s.%s (k int, c int, v int, l list<int>, s set<int>, m map<int, int>,  PRIMARY KEY(k, c))"));
+        cluster.schemaChange(format("CREATE CUSTOM INDEX ON %s.%s (l) USING 'StorageAttachedIndex'"));
+        cluster.schemaChange(format("CREATE CUSTOM INDEX ON %s.%s (s) USING 'StorageAttachedIndex'"));
+        cluster.schemaChange(format("CREATE CUSTOM INDEX ON %s.%s (KEYS(m)) USING 'StorageAttachedIndex'"));
+        cluster.schemaChange(format("CREATE CUSTOM INDEX ON %s.%s (VALUES(m)) USING 'StorageAttachedIndex'"));
+        cluster.schemaChange(format("CREATE CUSTOM INDEX ON %s.%s (ENTRIES(m)) USING 'StorageAttachedIndex'"));
+
+        int numPartitions = 10;
+        int numClusterings = 10;
+        int numRows = 0;
+        String insert = format("INSERT INTO %s.%s (k, c, v, l, s, m) VALUES (?, ?, ?, [1, 2], {1, 2, 3}, {1:10, 2:20, 3:30, 4:40})");
+        for (int k = 0; k < numPartitions; k++)
+            for (int c = 0; c < numClusterings; c++)
+                coordinator.execute(insert, ALL, k, c, numRows++);
+
+        node.flush(KEYSPACE);
+
+        // list query
+        long mark = node.logs().mark();
+        Object[][] rows = coordinator.execute(format("SELECT * FROM %s.%s WHERE l CONTAINS 1"), ALL);
+        Assertions.assertThat(rows).hasNumberOfRows(numRows);
+        assertLogsContain(mark, node,
+                          quote(format("<SELECT * FROM %s.%s WHERE l CONTAINS ? ALLOW FILTERING>")),
+                          "SAI slow query metrics:",
+                          "sstablesHit: 3",
+                          "segmentsHit: 3",
+                          "keysFetched: 100",
+                          "partitionsFetched: 10",
+                          "partitionsReturned: 10",
+                          "partitionTombstonesFetched: 0",
+                          "rowsFetched: 100",
+                          "rowsReturned: 100",
+                          "rowTombstonesFetched: 0",
+                          "cellsFetched: 1000",
+                          "cellsReturned: 1000",
+                          "trieSegmentsHit: 0",
+                          "triePostingsSkips: 0",
+                          "triePostingsDecodes: 0",
+                          "bkdSegmentsHit: 3",
+                          "bkdPostingListsHit: 3",
+                          "bkdPostingsSkips: 0",
+                          "bkdPostingsDecodes: 200",
+                          "annGraphSearchLatencyNanos: 0",
+                          "SAI slow query plan:",
+                          "NumericIndexScan",
+                          quote("predicate: Expression{name: l, op: CONTAINS_VALUE, lower: (?, true), upper: (?, true), exclusions: []}"));
+
+        // set query
+        mark = node.logs().mark();
+        rows = coordinator.execute(format("SELECT * FROM %s.%s WHERE s CONTAINS 1"), ALL);
+        Assertions.assertThat(rows).hasNumberOfRows(numRows);
+        assertLogsContain(mark, node,
+                          quote(format("<SELECT * FROM %s.%s WHERE s CONTAINS ? ALLOW FILTERING>")),
+                          "SAI slow query metrics:",
+                          "sstablesHit: 3",
+                          "segmentsHit: 3",
+                          "keysFetched: 100",
+                          "partitionsFetched: 10",
+                          "partitionsReturned: 10",
+                          "partitionTombstonesFetched: 0",
+                          "rowsFetched: 100",
+                          "rowsReturned: 100",
+                          "rowTombstonesFetched: 0",
+                          "cellsFetched: 1000",
+                          "cellsReturned: 1000",
+                          "trieSegmentsHit: 0",
+                          "triePostingsSkips: 0",
+                          "triePostingsDecodes: 0",
+                          "bkdSegmentsHit: 3",
+                          "bkdPostingListsHit: 3",
+                          "bkdPostingsSkips: 0",
+                          "bkdPostingsDecodes: 300",
+                          "annGraphSearchLatencyNanos: 0",
+                          "SAI slow query plan:",
+                          "NumericIndexScan",
+                          quote("predicate: Expression{name: s, op: CONTAINS_VALUE, lower: (?, true), upper: (?, true), exclusions: []}"));
+
+        // map key query
+        mark = node.logs().mark();
+        rows = coordinator.execute(format("SELECT * FROM %s.%s WHERE m CONTAINS KEY 1"), ALL);
+        Assertions.assertThat(rows).hasNumberOfRows(numRows);
+        assertLogsContain(mark, node,
+                          quote(format("<SELECT * FROM %s.%s WHERE m CONTAINS KEY ? ALLOW FILTERING>")),
+                          "SAI slow query metrics:",
+                          "sstablesHit: 3",
+                          "segmentsHit: 3",
+                          "keysFetched: 100",
+                          "partitionsFetched: 10",
+                          "partitionsReturned: 10",
+                          "partitionTombstonesFetched: 0",
+                          "rowsFetched: 100",
+                          "rowsReturned: 100",
+                          "rowTombstonesFetched: 0",
+                          "cellsFetched: 1000",
+                          "cellsReturned: 1000",
+                          "trieSegmentsHit: 0",
+                          "triePostingsSkips: 0",
+                          "triePostingsDecodes: 0",
+                          "bkdSegmentsHit: 3",
+                          "bkdPostingListsHit: 3",
+                          "bkdPostingsSkips: 0",
+                          "bkdPostingsDecodes: 400",
+                          "annGraphSearchLatencyNanos: 0",
+                          "SAI slow query plan:",
+                          "NumericIndexScan",
+                          quote("predicate: Expression{name: m, op: CONTAINS_KEY, lower: (?, true), upper: (?, true), exclusions: []}"));
+
+        // map value query
+        mark = node.logs().mark();
+        rows = coordinator.execute(format("SELECT * FROM %s.%s WHERE m CONTAINS 10"), ALL);
+        Assertions.assertThat(rows).hasNumberOfRows(numRows);
+        assertLogsContain(mark, node,
+                          quote(format("<SELECT * FROM %s.%s WHERE m CONTAINS ? ALLOW FILTERING>")),
+                          "SAI slow query metrics:",
+                          "sstablesHit: 3",
+                          "segmentsHit: 3",
+                          "keysFetched: 100",
+                          "partitionsFetched: 10",
+                          "partitionsReturned: 10",
+                          "partitionTombstonesFetched: 0",
+                          "rowsFetched: 100",
+                          "rowsReturned: 100",
+                          "rowTombstonesFetched: 0",
+                          "cellsFetched: 1000",
+                          "cellsReturned: 1000",
+                          "trieSegmentsHit: 0",
+                          "triePostingsSkips: 0",
+                          "triePostingsDecodes: 0",
+                          "bkdSegmentsHit: 3",
+                          "bkdPostingListsHit: 3",
+                          "bkdPostingsSkips: 0",
+                          "bkdPostingsDecodes: 400",
+                          "annGraphSearchLatencyNanos: 0",
+                          "SAI slow query plan:",
+                          "NumericIndexScan",
+                          quote("predicate: Expression{name: m, op: CONTAINS_VALUE, lower: (?, true), upper: (?, true), exclusions: []}"));
+
+        // map entry query
+        mark = node.logs().mark();
+        rows = coordinator.execute(format("SELECT * FROM %s.%s WHERE m[1] = 10"), ALL);
+        Assertions.assertThat(rows).hasNumberOfRows(numRows);
+        assertLogsContain(mark, node,
+                          quote(format("<SELECT * FROM %s.%s WHERE m[?] = ? ALLOW FILTERING>")),
+                          "SAI slow query metrics:",
+                          "sstablesHit: 3",
+                          "segmentsHit: 3",
+                          "keysFetched: 100",
+                          "partitionsFetched: 10",
+                          "partitionsReturned: 10",
+                          "partitionTombstonesFetched: 0",
+                          "rowsFetched: 100",
+                          "rowsReturned: 100",
+                          "rowTombstonesFetched: 0",
+                          "cellsFetched: 1000",
+                          "cellsReturned: 1000",
+                          "trieSegmentsHit: 3",
+                          "triePostingsSkips: 0",
+                          "triePostingsDecodes: 100",
+                          "bkdSegmentsHit: 0",
+                          "bkdPostingListsHit: 0",
+                          "bkdPostingsSkips: 0",
+                          "bkdPostingsDecodes: 0",
+                          "annGraphSearchLatencyNanos: 0",
+                          "SAI slow query plan:",
+                          "LiteralIndexScan",
+                          quote("predicate: Expression{name: m, op: EQ, lower: (?, true), upper: (?, true), exclusions: []}"));
+
+        // remove some cells
+        coordinator.execute(format("UPDATE %s.%s SET l = l - [1] WHERE k = 1 AND c = 1"), ALL);
+        coordinator.execute(format("UPDATE %s.%s SET s = s - {1} WHERE k = 1 AND c = 1"), ALL);
+        coordinator.execute(format("UPDATE %s.%s SET m = m - {1} WHERE k = 1 AND c = 1"), ALL);
+
+        // list query
+        mark = node.logs().mark();
+        rows = coordinator.execute(format("SELECT * FROM %s.%s WHERE l CONTAINS 1"), ALL);
+        Assertions.assertThat(rows).hasNumberOfRows(numRows - 1);
+        assertLogsContain(mark, node,
+                          quote(format("<SELECT * FROM %s.%s WHERE l CONTAINS ? ALLOW FILTERING>")),
+                          "SAI slow query metrics:",
+                          "sstablesHit: 3",
+                          "segmentsHit: 3",
+                          "keysFetched: 100",
+                          "partitionsFetched: 10",
+                          "partitionsReturned: 10",
+                          "partitionTombstonesFetched: 0",
+                          "rowsFetched: 100",
+                          "rowsReturned: 99",
+                          "rowTombstonesFetched: 0",
+                          "cellsFetched: 1000",
+                          "cellsReturned: 990",
+                          "trieSegmentsHit: 0",
+                          "triePostingsSkips: 0",
+                          "triePostingsDecodes: 0",
+                          "bkdSegmentsHit: 3",
+                          "bkdPostingListsHit: 3",
+                          "bkdPostingsSkips: 0",
+                          "bkdPostingsDecodes: 200",
+                          "annGraphSearchLatencyNanos: 0",
+                          "SAI slow query plan:",
+                          "NumericIndexScan",
+                          quote("predicate: Expression{name: l, op: CONTAINS_VALUE, lower: (?, true), upper: (?, true), exclusions: []}"));
+
+        // set query
+        mark = node.logs().mark();
+        rows = coordinator.execute(format("SELECT * FROM %s.%s WHERE s CONTAINS 1"), ALL);
+        Assertions.assertThat(rows).hasNumberOfRows(numRows - 1);
+        assertLogsContain(mark, node,
+                          quote(format("<SELECT * FROM %s.%s WHERE s CONTAINS ? ALLOW FILTERING>")),
+                          "SAI slow query metrics:",
+                          "sstablesHit: 3",
+                          "segmentsHit: 3",
+                          "keysFetched: 100",
+                          "partitionsFetched: 10",
+                          "partitionsReturned: 10",
+                          "partitionTombstonesFetched: 0",
+                          "rowsFetched: 100",
+                          "rowsReturned: 99",
+                          "rowTombstonesFetched: 0",
+                          "cellsFetched: 1000",
+                          "cellsReturned: 990",
+                          "trieSegmentsHit: 0",
+                          "triePostingsSkips: 0",
+                          "triePostingsDecodes: 0",
+                          "bkdSegmentsHit: 3",
+                          "bkdPostingListsHit: 3",
+                          "bkdPostingsSkips: 0",
+                          "bkdPostingsDecodes: 300",
+                          "annGraphSearchLatencyNanos: 0",
+                          "SAI slow query plan:",
+                          "NumericIndexScan",
+                          quote("predicate: Expression{name: s, op: CONTAINS_VALUE, lower: (?, true), upper: (?, true), exclusions: []}"));
+
+        // map key query
+        mark = node.logs().mark();
+        rows = coordinator.execute(format("SELECT * FROM %s.%s WHERE m CONTAINS KEY 1"), ALL);
+        Assertions.assertThat(rows).hasNumberOfRows(numRows - 1);
+        assertLogsContain(mark, node,
+                          quote(format("<SELECT * FROM %s.%s WHERE m CONTAINS KEY ? ALLOW FILTERING>")),
+                          "SAI slow query metrics:",
+                          "sstablesHit: 3",
+                          "segmentsHit: 3",
+                          "keysFetched: 100",
+                          "partitionsFetched: 10",
+                          "partitionsReturned: 10",
+                          "partitionTombstonesFetched: 0",
+                          "rowsFetched: 100",
+                          "rowsReturned: 99",
+                          "rowTombstonesFetched: 0",
+                          "cellsFetched: 1000",
+                          "cellsReturned: 990",
+                          "trieSegmentsHit: 0",
+                          "triePostingsSkips: 0",
+                          "triePostingsDecodes: 0",
+                          "bkdSegmentsHit: 3",
+                          "bkdPostingListsHit: 3",
+                          "bkdPostingsSkips: 0",
+                          "bkdPostingsDecodes: 400",
+                          "annGraphSearchLatencyNanos: 0",
+                          "SAI slow query plan:",
+                          "NumericIndexScan",
+                          quote("predicate: Expression{name: m, op: CONTAINS_KEY, lower: (?, true), upper: (?, true), exclusions: []}"));
+
+        // map value query
+        mark = node.logs().mark();
+        rows = coordinator.execute(format("SELECT * FROM %s.%s WHERE m CONTAINS 10"), ALL);
+        Assertions.assertThat(rows).hasNumberOfRows(numRows - 1);
+        assertLogsContain(mark, node,
+                          quote(format("<SELECT * FROM %s.%s WHERE m CONTAINS ? ALLOW FILTERING>")),
+                          "SAI slow query metrics:",
+                          "sstablesHit: 3",
+                          "segmentsHit: 3",
+                          "keysFetched: 100",
+                          "partitionsFetched: 10",
+                          "partitionsReturned: 10",
+                          "partitionTombstonesFetched: 0",
+                          "rowsFetched: 100",
+                          "rowsReturned: 99",
+                          "rowTombstonesFetched: 0",
+                          "cellsFetched: 1000",
+                          "cellsReturned: 990",
+                          "trieSegmentsHit: 0",
+                          "triePostingsSkips: 0",
+                          "triePostingsDecodes: 0",
+                          "bkdSegmentsHit: 3",
+                          "bkdPostingListsHit: 3",
+                          "bkdPostingsSkips: 0",
+                          "bkdPostingsDecodes: 400",
+                          "annGraphSearchLatencyNanos: 0",
+                          "SAI slow query plan:",
+                          "NumericIndexScan",
+                          quote("predicate: Expression{name: m, op: CONTAINS_VALUE, lower: (?, true), upper: (?, true), exclusions: []}"));
+
+        // map entry query
+        mark = node.logs().mark();
+        rows = coordinator.execute(format("SELECT * FROM %s.%s WHERE m[1] = 10"), ALL);
+        Assertions.assertThat(rows).hasNumberOfRows(numRows - 1);
+        assertLogsContain(mark, node,
+                          quote(format("<SELECT * FROM %s.%s WHERE m[?] = ? ALLOW FILTERING>")),
+                          "SAI slow query metrics:",
+                          "sstablesHit: 3",
+                          "segmentsHit: 3",
+                          "keysFetched: 100",
+                          "partitionsFetched: 10",
+                          "partitionsReturned: 10",
+                          "partitionTombstonesFetched: 0",
+                          "rowsFetched: 100",
+                          "rowsReturned: 99",
+                          "rowTombstonesFetched: 0",
+                          "cellsFetched: 1000",
+                          "cellsReturned: 990",
+                          "trieSegmentsHit: 3",
+                          "triePostingsSkips: 0",
+                          "triePostingsDecodes: 100",
+                          "bkdSegmentsHit: 0",
+                          "bkdPostingListsHit: 0",
+                          "bkdPostingsSkips: 0",
+                          "bkdPostingsDecodes: 0",
+                          "annGraphSearchLatencyNanos: 0",
+                          "SAI slow query plan:",
+                          "LiteralIndexScan",
+                          quote("predicate: Expression{name: m, op: EQ, lower: (?, true), upper: (?, true), exclusions: []}"));
+    }
+
+    /**
+     * Test that the slow query logger outputs the correct metrics for static rows.
+     */
+    @Test
+    public void testStaticRows()
+    {
+        cluster.schemaChange(format("CREATE TABLE %s.%s (" +
+                                    "k int, c int, r int, " +
+                                    "v int static, l list<int> static, s set<int> static, m map<int, int> static, " +
+                                    "PRIMARY KEY(k, c))"));
+        cluster.schemaChange(format("CREATE CUSTOM INDEX ON %s.%s (v) USING 'StorageAttachedIndex'"));
+
+        String query = format("SELECT * FROM %s.%s WHERE v = 0");
+        String loggedQuery = quote(format("SELECT * FROM %s.%s WHERE v = ? ALLOW FILTERING"));
+
+        // Insert a static row without any regular rows for it.
+        coordinator.execute(format("INSERT INTO %s.%s (k, v, l, s, m) VALUES (0, 0, [1, 2], {1, 2, 3}, {1:10, 2:20, 3:30, 4:40})"), ALL);
+        long mark = node.logs().mark();
+        Object[][] rows = coordinator.execute(query, ALL);
+        Assertions.assertThat(rows).hasNumberOfRows(1);
+        assertLogsContain(mark, node, loggedQuery,
+                          "SAI slow query metrics:",
+                          "keysFetched: 1",
+                          "partitionsFetched: 1",
+                          "partitionsReturned: 1",
+                          "partitionTombstonesFetched: 0",
+                          "rowsFetched: 0",
+                          "rowsReturned: 0",
+                          "rowTombstonesFetched: 0",
+                          "cellsFetched: 10",
+                          "cellsReturned: 10");
+
+        // Add a regular row for the partition with the previous static row.
+        coordinator.execute(format("INSERT INTO %s.%s (k, c, r) VALUES (0, 0, 0)"), ALL);
+        mark = node.logs().mark();
+        rows = coordinator.execute(query, ALL);
+        Assertions.assertThat(rows).hasNumberOfRows(1);
+        assertLogsContain(mark, node, loggedQuery,
+                          "SAI slow query metrics:",
+                          "keysFetched: 1",
+                          "partitionsFetched: 1",
+                          "partitionsReturned: 1",
+                          "partitionTombstonesFetched: 0",
+                          "rowsFetched: 1",
+                          "rowsReturned: 1",
+                          "rowTombstonesFetched: 0",
+                          "cellsFetched: 11",
+                          "cellsReturned: 11");
+
+        // Add a second regular row for the previous partition.
+        coordinator.execute(format("INSERT INTO %s.%s (k, c, r) VALUES (0, 1, 0)"), ALL);
+        mark = node.logs().mark();
+        rows = coordinator.execute(query, ALL);
+        Assertions.assertThat(rows).hasNumberOfRows(2);
+        assertLogsContain(mark, node, loggedQuery,
+                          "SAI slow query metrics:",
+                          "keysFetched: 1",
+                          "partitionsFetched: 1",
+                          "partitionsReturned: 1",
+                          "partitionTombstonesFetched: 0",
+                          "rowsFetched: 2",
+                          "rowsReturned: 2",
+                          "rowTombstonesFetched: 0",
+                          "cellsFetched: 12",
+                          "cellsReturned: 12");
+
+        // Remove a cell from a regular row.
+        coordinator.execute(format("INSERT INTO %s.%s (k, c, r) VALUES (0, 1, null)"), ALL);
+        mark = node.logs().mark();
+        rows = coordinator.execute(query, ALL);
+        Assertions.assertThat(rows).hasNumberOfRows(2);
+        assertLogsContain(mark, node, loggedQuery,
+                          "SAI slow query metrics:",
+                          "keysFetched: 1",
+                          "partitionsFetched: 1",
+                          "partitionsReturned: 1",
+                          "partitionTombstonesFetched: 0",
+                          "rowsFetched: 2",
+                          "rowsReturned: 2",
+                          "rowTombstonesFetched: 0",
+                          "cellsFetched: 12",
+                          "cellsReturned: 12");
+
+        // Remove some cells from the static row.
+        coordinator.execute(format("UPDATE %s.%s SET l = l - [1] WHERE k = 0"), ALL);
+        coordinator.execute(format("UPDATE %s.%s SET s = s - {1} WHERE k = 0"), ALL);
+        coordinator.execute(format("UPDATE %s.%s SET m = m - {1} WHERE k = 0"), ALL);
+        mark = node.logs().mark();
+        rows = coordinator.execute(query, ALL);
+        Assertions.assertThat(rows).hasNumberOfRows(2);
+        assertLogsContain(mark, node, loggedQuery,
+                          "SAI slow query metrics:",
+                          "keysFetched: 1",
+                          "partitionsFetched: 1",
+                          "partitionsReturned: 1",
+                          "partitionTombstonesFetched: 0",
+                          "rowsFetched: 2",
+                          "rowsReturned: 2",
+                          "rowTombstonesFetched: 0",
+                          "cellsFetched: 12",
+                          "cellsReturned: 12");
+
+        // Add another partition, without statics
+        coordinator.execute(format("INSERT INTO %s.%s (k, c, r) VALUES (1, 1, 0)"), ALL);
+        coordinator.execute(format("INSERT INTO %s.%s (k, c, r) VALUES (1, 2, 0)"), ALL);
+        mark = node.logs().mark();
+        rows = coordinator.execute(query, ALL);
+        Assertions.assertThat(rows).hasNumberOfRows(2);
+        assertLogsContain(mark, node, loggedQuery,
+                          "SAI slow query metrics:",
+                          "keysFetched: 1",
+                          "partitionsFetched: 1",
+                          "partitionsReturned: 1",
+                          "partitionTombstonesFetched: 0",
+                          "rowsFetched: 2",
+                          "rowsReturned: 2",
+                          "rowTombstonesFetched: 0",
+                          "cellsFetched: 12",
+                          "cellsReturned: 12");
+
+        // Add some static cell to the new partition, so it get reachable by the index
+        coordinator.execute(format("INSERT INTO %s.%s (k, v, l) VALUES (1, 0, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])"), ALL);
+        mark = node.logs().mark();
+        rows = coordinator.execute(query, ALL);
+        Assertions.assertThat(rows).hasNumberOfRows(4);
+        assertLogsContain(mark, node, loggedQuery,
+                          "SAI slow query metrics:",
+                          "keysFetched: 2",
+                          "partitionsFetched: 2",
+                          "partitionsReturned: 2",
+                          "partitionTombstonesFetched: 0",
+                          "rowsFetched: 4",
+                          "rowsReturned: 4",
+                          "rowTombstonesFetched: 0",
+                          "cellsFetched: 25",
+                          "cellsReturned: 25");
     }
 
     private static void assertLogsDoNotContainSAIExecutionInfo(long mark, IInvokableInstance node)

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/SlowSAIQueryLoggerTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/SlowSAIQueryLoggerTest.java
@@ -818,6 +818,64 @@ public class SlowSAIQueryLoggerTest extends TestBaseImpl
     }
 
     /**
+     * Test that the slow query logger outputs the correct metrics for number of returned cells in user-defined types.
+     */
+    @Test
+    public void testUDTs()
+    {
+        cluster.schemaChange(withKeyspace("CREATE TYPE %s.udt (x int, y int, z int)"));
+        cluster.schemaChange(format("CREATE TABLE %s.%s (k int, c int, v int, u udt, fu frozen<udt>, PRIMARY KEY(k, c))"));
+        cluster.schemaChange(format("CREATE CUSTOM INDEX ON %s.%s (v) USING 'StorageAttachedIndex'"));
+        int numPartitions = 10;
+        int numClusterings = 10;
+        int numRows = 0;
+        String insert = format("INSERT INTO %s.%s (k, c, v, u, fu) VALUES (?, ?, ?, {x:1, y:2, z:3}, {x:1, y:2, z:3})");
+        for (int k = 0; k < numPartitions; k++)
+            for (int c = 0; c < numClusterings; c++)
+                coordinator.execute(insert, ALL, k, c, numRows++);
+
+        node.flush(KEYSPACE);
+
+        // filtered range query
+        long mark = node.logs().mark();
+        Object[][] rows = coordinator.execute(format("SELECT * FROM %s.%s WHERE v >= 20"), ALL);
+        Assertions.assertThat(rows).hasNumberOfRows(80);
+        assertLogsContain(mark, node,
+                          quote(format("<SELECT * FROM %s.%s WHERE v >= ? ALLOW FILTERING>")),
+                          "SAI slow query metrics:",
+                          "sstablesHit: 3",
+                          "segmentsHit: 3",
+                          "keysFetched: 80",
+                          "partitionsFetched: 8",
+                          "partitionsReturned: 8",
+                          "partitionTombstonesFetched: 0",
+                          "rowsFetched: 80",
+                          "rowsReturned: 80",
+                          "rowTombstonesFetched: 0",
+                          "cellsFetched: 400",
+                          "cellsReturned: 400");
+
+        // filtered partition query
+        mark = node.logs().mark();
+        rows = coordinator.execute(format("SELECT * FROM %s.%s WHERE k = 1 AND v >= 15"), ALL);
+        Assertions.assertThat(rows).hasNumberOfRows(5);
+        assertLogsContain(mark, node,
+                          quote(format("<SELECT * FROM %s.%s WHERE k = ? AND v >= ? ALLOW FILTERING>")),
+                          "SAI slow query metrics:",
+                          "sstablesHit: 1",
+                          "segmentsHit: 1",
+                          "keysFetched: 5",
+                          "partitionsFetched: 1",
+                          "partitionsReturned: 1",
+                          "partitionTombstonesFetched: 0",
+                          "rowsFetched: 5",
+                          "rowsReturned: 5",
+                          "rowTombstonesFetched: 0",
+                          "cellsFetched: 25",
+                          "cellsReturned: 25");
+    }
+
+    /**
      * Test that the slow query logger outputs the correct metrics for static rows.
      */
     @Test

--- a/test/microbench/org/apache/cassandra/test/microbench/ReadCommandExecutionInfoBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/ReadCommandExecutionInfoBench.java
@@ -18,6 +18,8 @@ package org.apache.cassandra.test.microbench;
 
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Random;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -64,7 +66,13 @@ import org.openjdk.jmh.annotations.Warmup;
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @Warmup(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 10, time = 10, timeUnit = TimeUnit.SECONDS)
-@Fork(value = 1)
+@Fork(value = 1, jvmArgsAppend = {
+"-Xmx512M",
+"-Dcassandra.disable_user_defined_functions=true",
+"--add-exports", "java.base/jdk.internal.ref=ALL-UNNAMED",
+"--add-exports", "java.base/sun.nio.ch=ALL-UNNAMED",
+"--add-opens", "java.base/jdk.internal.ref=ALL-UNNAMED"
+})
 @Threads(1)
 @State(Scope.Benchmark)
 public class ReadCommandExecutionInfoBench extends CQLTester
@@ -73,7 +81,7 @@ public class ReadCommandExecutionInfoBench extends CQLTester
     private static final Random RANDOM = new Random(1234);
     private static final String QUERY = "SELECT * FROM %%s WHERE k = %d AND v IN (%d, %<d) ALLOW FILTERING";
     private static final int NUM_PARTITIONS = 100;
-    private static final int NUM_CLUSTERINGS = 10_000;
+    private static final int NUM_CLUSTERINGS = 1000;
     private static final int NUM_VALUES = 10;
 
     /**
@@ -81,6 +89,12 @@ public class ReadCommandExecutionInfoBench extends CQLTester
      */
     @Param({ "false", "true" })
     public boolean enabled;
+
+    /**
+     * Size of the written collections, used to control the number of cells per row.
+     */
+    @Param({ "1", "100" })
+    public int collectionSize;
 
     private ReadCommand command;
 
@@ -93,7 +107,7 @@ public class ReadCommandExecutionInfoBench extends CQLTester
         beforeTest();
 
         // create the schema
-        createTable("CREATE TABLE %s (k int, c int, v int, PRIMARY KEY (k, c))");
+        createTable("CREATE TABLE %s (k int, c int, v int, l list<int>, PRIMARY KEY (k, c))");
 
         // insert some data
         for (int k = 0; k < NUM_PARTITIONS; k++)
@@ -101,7 +115,10 @@ public class ReadCommandExecutionInfoBench extends CQLTester
             for (int c = 0; c < NUM_CLUSTERINGS; c++)
             {
                 int v = RANDOM.nextInt(NUM_VALUES);
-                execute("INSERT INTO %s (k, c, v) VALUES (?, ?, ?)", k, c, v);
+                List<Integer> l = new ArrayList<>(collectionSize);
+                for (int i = 0; i < collectionSize; i++)
+                    l.add(RANDOM.nextInt());
+                execute("INSERT INTO %s (k, c, v, l) VALUES (?, ?, ?, ?)", k, c, v, l);
             }
         }
         flush();

--- a/test/microbench/org/apache/cassandra/test/microbench/index/sai/QueryMonitorableExecutionInfoBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/index/sai/QueryMonitorableExecutionInfoBench.java
@@ -18,6 +18,8 @@ package org.apache.cassandra.test.microbench.index.sai;
 
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Random;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -32,6 +34,8 @@ import org.apache.cassandra.db.ReadCommand;
 import org.apache.cassandra.db.commitlog.CommitLog;
 import org.apache.cassandra.db.monitoring.Monitorable;
 import org.apache.cassandra.db.monitoring.MonitoringTask;
+import org.apache.cassandra.db.partitions.UnfilteredPartitionIterator;
+import org.apache.cassandra.db.rows.UnfilteredRowIterator;
 import org.apache.cassandra.index.sai.SAITester;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -62,7 +66,13 @@ import org.openjdk.jmh.annotations.Warmup;
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @Warmup(iterations = 10, time = 10, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 10, time = 10, timeUnit = TimeUnit.SECONDS)
-@Fork(value = 1)
+@Fork(value = 1, jvmArgsAppend = {
+"-Xmx512M",
+"-Dcassandra.disable_user_defined_functions=true",
+"--add-exports", "java.base/jdk.internal.ref=ALL-UNNAMED",
+"--add-exports", "java.base/sun.nio.ch=ALL-UNNAMED",
+"--add-opens", "java.base/jdk.internal.ref=ALL-UNNAMED"
+})
 @Threads(1)
 @State(Scope.Benchmark)
 public class QueryMonitorableExecutionInfoBench extends SAITester
@@ -76,6 +86,12 @@ public class QueryMonitorableExecutionInfoBench extends SAITester
     @Param({ "false", "true" })
     public boolean enabled;
 
+    /**
+     * Size of the written collections, used to control the number of cells per row.
+     */
+    @Param({ "1", "100" })
+    public int collectionSize;
+
     private ReadCommand command;
 
     @Setup(Level.Trial)
@@ -87,11 +103,12 @@ public class QueryMonitorableExecutionInfoBench extends SAITester
         beforeTest();
 
         // create the schema
-        createTable("CREATE TABLE %s (k int, c int, n int, b bigint, s text, v vector<float, 2>, PRIMARY KEY (k, c))");
+        createTable("CREATE TABLE %s (k int, c int, n int, b bigint, s text, v vector<float, 2>, l list<int>, PRIMARY KEY (k, c))");
         createIndex("CREATE CUSTOM INDEX ON %s(n) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(b) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(s) USING 'StorageAttachedIndex'");
         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX ON %s(l) USING 'StorageAttachedIndex'");
 
         // insert some data
         for (int k = 0; k < 100; k++)
@@ -99,20 +116,39 @@ public class QueryMonitorableExecutionInfoBench extends SAITester
             for (int c = 0; c < 100; c++)
             {
                 int n = RANDOM.nextInt(100);
-                execute("INSERT INTO %s (k, c, n, b, s, v) VALUES (?, ?, ?, ?, ?, ?)",
-                        k, c, n, (long) n, "value_" + n, vector(1, n));
+                List<Integer> l = new ArrayList<>(collectionSize);
+                for (int i = 0; i < collectionSize; i++)
+                    l.add(RANDOM.nextInt());
+                execute("INSERT INTO %s (k, c, n, b, s, v, l) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                        k, c, n, (long) n, "value_" + n, vector(1, n), l);
             }
         }
         flush();
     }
 
     @Setup(Level.Invocation)
-    public void generateCommand()
+    public void setupTest()
+    {
+        command = generateRunAndConsumeCommand();
+    }
+
+    private ReadCommand generateRunAndConsumeCommand()
     {
         int n = RANDOM.nextInt(100);
         String query = "SELECT * FROM %%s WHERE n = %d AND (b >= %<d OR s = 'value_%<d') ORDER BY v ANN OF [1, %<d] LIMIT 10";
-        command = parseReadCommand(String.format(query, n));
-        command.executeLocally(command.executionController(false));
+        ReadCommand command = parseReadCommand(String.format(query, n));
+        try (UnfilteredPartitionIterator partitions = command.executeLocally(command.executionController(false)))
+        {
+            while (partitions.hasNext())
+            {
+                try (UnfilteredRowIterator partition = partitions.next())
+                {
+                    while (partition.hasNext())
+                        partition.next();
+                }
+            }
+        }
+        return command;
     }
 
     @TearDown(Level.Trial)
@@ -163,5 +199,15 @@ public class QueryMonitorableExecutionInfoBench extends SAITester
         }
 
         return logSlowOperation();
+    }
+
+    /**
+     * Test the cost of running a query without logging it as slow, just to see the effect of counting things in case
+     * it is slow.
+     */
+    @Benchmark
+    public Object runFastOperation()
+    {
+        return generateRunAndConsumeCommand();
     }
 }


### PR DESCRIPTION
### What is the issue

The slow query logger shows counts the number of fetched/returned partitions/rows/tombstones. However, it doesn't say the number of fetched/returned cells, nor cell tombstones. This is problematic for incidents where we see slow queries and all query metrics look normal despite of having massive rows.

### What does this PR fix and why was it fixed

It adds the number of fetched and returned cells to the log reports produced for slow queries. This is done for both SAI and regular queries.

Differently to the counts of partitions and rows, there are no separate counts of live and deleted cells. This is because having separate counts of live/deleted cells would require to iterate the b-tree of cells checking timestamps or every returned row of every query. Benchmarking has proven that that has a significative impact on performance, so we should probably limit this to just counting cells regardless of liveness info.

This is how the log reports for regular queries would look like:
```
<SELECT * FROM distributed_test_keyspace.t_0 WHERE k = ? AND c = ? ALLOW FILTERING>, time 204 msec - slow timeout 100 msec/cross-node
  Fetched/returned/tombstones:
    partitions: 1/1/0
    rows: 1/1/0
    cells: 3/3/-
```
The SAI log reports would look like:
```
<SELECT * FROM distributed_test_keyspace.t_0 WHERE n > ? ALLOW FILTERING>, was slow 3 times: avg/min/max 202/201/204 msec - slow timeout 100 msec
  SAI slowest query metrics:
    sstablesHit: 3
    segmentsHit: 3
    keysFetched: 5
    partitionsFetched: 3
    partitionsReturned: 3
    partitionTombstonesFetched: 0
    rowsFetched: 5
    rowsReturned: 5
    rowTombstonesFetched: 0
    cellsFetched: 11
    cellsReturned: 11
    ...
```

Here are some runs of the included JMH benchmarks, showing that the current approach doesn't seem to have a noticeable impact of performance:

`ReadCommandExecutionInfoBench` with this patch:
```
     [java] Benchmark                                       (collectionSize)  (enabled)  Mode  Cnt        Score       Error  Units
     [java] ReadCommandExecutionInfoBench.runFastOperation                 1       true  avgt   10   378971.832 ±  1550.965  ns/op
     [java] ReadCommandExecutionInfoBench.runFastOperation                 1      false  avgt   10   387224.594 ±  2625.383  ns/op
     [java] ReadCommandExecutionInfoBench.runFastOperation               100       true  avgt   10  8632622.367 ± 41134.977  ns/op
     [java] ReadCommandExecutionInfoBench.runFastOperation               100      false  avgt   10  8513550.972 ± 34949.929  ns/op

     [java] Benchmark                                       (collectionSize)  (enabled)  Mode  Cnt        Score       Error  Units
     [java] ReadCommandExecutionInfoBench.runFastOperation                 1       true  avgt   10   399866.043 ±  3757.132  ns/op
     [java] ReadCommandExecutionInfoBench.runFastOperation                 1      false  avgt   10   371497.284 ±  3403.850  ns/op
     [java] ReadCommandExecutionInfoBench.runFastOperation               100       true  avgt   10  8754278.108 ± 27658.522  ns/op
     [java] ReadCommandExecutionInfoBench.runFastOperation               100      false  avgt   10  8947810.908 ± 31871.260  ns/op
```

`ReadCommandExecutionInfoBench` on main branch:
```
     [java] Benchmark                                       (collectionSize)  (enabled)  Mode  Cnt        Score       Error  Units
     [java] ReadCommandExecutionInfoBench.runFastOperation                 1       true  avgt   10   366901.666 ±  5755.936  ns/op
     [java] ReadCommandExecutionInfoBench.runFastOperation                 1      false  avgt   10   393852.609 ±  2937.295  ns/op
     [java] ReadCommandExecutionInfoBench.runFastOperation               100       true  avgt   10  8664451.503 ± 72259.871  ns/op
     [java] ReadCommandExecutionInfoBench.runFastOperation               100      false  avgt   10  8650261.390 ± 31970.636  ns/op

     [java] Benchmark                                       (collectionSize)  (enabled)  Mode  Cnt        Score       Error  Units
     [java] ReadCommandExecutionInfoBench.runFastOperation                 1       true  avgt   10   398991.785 ±  3557.741  ns/op
     [java] ReadCommandExecutionInfoBench.runFastOperation                 1      false  avgt   10   405107.572 ±  3733.606  ns/op
     [java] ReadCommandExecutionInfoBench.runFastOperation               100       true  avgt   10  8896887.390 ± 41780.075  ns/op
     [java] ReadCommandExecutionInfoBench.runFastOperation               100      false  avgt   10  8721552.856 ± 31947.872  ns/op
```

`QueryMonitorableExecutionInfoBench` with this patch:
```
     [java] Benchmark                                            (collectionSize)  (enabled)  Mode  Cnt       Score      Error  Units
     [java] QueryMonitorableExecutionInfoBench.runFastOperation                 1      false  avgt   10  239929.967 ± 1235.564  ns/op
     [java] QueryMonitorableExecutionInfoBench.runFastOperation                 1       true  avgt   10  263140.131 ± 1693.898  ns/op
     [java] QueryMonitorableExecutionInfoBench.runFastOperation               100      false  avgt   10  419729.244 ± 1652.791  ns/op
     [java] QueryMonitorableExecutionInfoBench.runFastOperation               100       true  avgt   10  426651.719 ± 1665.732  ns/op

     [java] Benchmark                                            (collectionSize)  (enabled)  Mode  Cnt       Score      Error  Units
     [java] QueryMonitorableExecutionInfoBench.runFastOperation                 1       true  avgt   10  251559.435 ± 2249.120  ns/op
     [java] QueryMonitorableExecutionInfoBench.runFastOperation                 1      false  avgt   10  238255.888 ± 1148.742  ns/op
     [java] QueryMonitorableExecutionInfoBench.runFastOperation               100       true  avgt   10  433454.617 ± 1427.334  ns/op
     [java] QueryMonitorableExecutionInfoBench.runFastOperation               100      false  avgt   10  416087.187 ± 2593.538  ns/op
```

`QueryMonitorableExecutionInfoBench` on main branch:
```
     [java] Benchmark                                            (collectionSize)  (enabled)  Mode  Cnt       Score      Error  Units
     [java] QueryMonitorableExecutionInfoBench.runFastOperation                 1       true  avgt   10  249044.062 ± 1052.077  ns/op
     [java] QueryMonitorableExecutionInfoBench.runFastOperation                 1      false  avgt   10  238268.592 ± 3380.588  ns/op
     [java] QueryMonitorableExecutionInfoBench.runFastOperation               100       true  avgt   10  434175.615 ± 2261.294  ns/op
     [java] QueryMonitorableExecutionInfoBench.runFastOperation               100      false  avgt   10  415184.194 ± 3747.166  ns/op

     [java] Benchmark                                            (collectionSize)  (enabled)  Mode  Cnt       Score      Error  Units
     [java] QueryMonitorableExecutionInfoBench.runFastOperation                 1       true  avgt   10  244556.510 ± 1015.289  ns/op
     [java] QueryMonitorableExecutionInfoBench.runFastOperation                 1      false  avgt   10  239677.399 ± 1839.077  ns/op
     [java] QueryMonitorableExecutionInfoBench.runFastOperation               100       true  avgt   10  438373.482 ± 1428.749  ns/op
     [java] QueryMonitorableExecutionInfoBench.runFastOperation               100      false  avgt   10  421489.016 ± 1266.341  ns/op
```
