### PR TITLE
HCD-468: Increase the caching time of estimated partition count

### DIFF
--- a/src/java/org/apache/cassandra/metrics/TableMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/TableMetrics.java
@@ -102,6 +102,9 @@ public class TableMetrics
 
     public static final String TABLE_EXTENSIONS_HISTOGRAMS_METRICS_KEY = "HISTOGRAM_METRICS";
 
+    @VisibleForTesting // Length of the caching period for estimated partition count. Changed by tests.
+    static long ESTIMATED_PARTITION_COUNT_CACHE_PERIOD_SECONDS = TimeUnit.MINUTES.toSeconds(5);
+
     public enum MetricsAggregation
     {
         AGGREGATED((byte) 0x00),
@@ -709,7 +712,9 @@ public class TableMetrics
                 return estimatedPartitions;
             }
         }, null);
-        estimatedPartitionCountInSSTablesCached = new CachedGauge<Long>(1, TimeUnit.SECONDS)
+        // This cached guage is used by compaction to calculate a size for single-partition sstables. It does not need
+        // to be up-to-date, only to give a rough indication of the number of partitions.
+        estimatedPartitionCountInSSTablesCached = new CachedGauge<Long>(ESTIMATED_PARTITION_COUNT_CACHE_PERIOD_SECONDS, TimeUnit.SECONDS)
         {
             public Long loadValue()
             {

--- a/src/java/org/apache/cassandra/metrics/TableMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/TableMetrics.java
@@ -102,6 +102,9 @@ public class TableMetrics
 
     public static final String TABLE_EXTENSIONS_HISTOGRAMS_METRICS_KEY = "HISTOGRAM_METRICS";
 
+    @VisibleForTesting // Length of the caching period for estimated partition count. Changed by tests.
+    static long ESTIMATED_PARTITION_COUNT_CACHE_PERIOD_SECONDS = TimeUnit.MINUTES.toSeconds(5);
+
     public enum MetricsAggregation
     {
         AGGREGATED((byte) 0x00),
@@ -716,7 +719,9 @@ public class TableMetrics
                 return estimatedPartitions;
             }
         }, null);
-        estimatedPartitionCountInSSTablesCached = new CachedGauge<Long>(1, TimeUnit.SECONDS)
+        // This cached guage is used by compaction to calculate a size for single-partition sstables. It does not need
+        // to be up-to-date, only to give a rough indication of the number of partitions.
+        estimatedPartitionCountInSSTablesCached = new CachedGauge<Long>(ESTIMATED_PARTITION_COUNT_CACHE_PERIOD_SECONDS, TimeUnit.SECONDS)
         {
             public Long loadValue()
             {

--- a/test/unit/org/apache/cassandra/metrics/TableMetricsTest.java
+++ b/test/unit/org/apache/cassandra/metrics/TableMetricsTest.java
@@ -411,6 +411,20 @@ public class TableMetricsTest
     @Test
     public void testEstimatedPartitionCount() throws InterruptedException
     {
+        long prevPeriod = TableMetrics.ESTIMATED_PARTITION_COUNT_CACHE_PERIOD_SECONDS;
+        try
+        {
+            TableMetrics.ESTIMATED_PARTITION_COUNT_CACHE_PERIOD_SECONDS = 1;
+            doTestEstimatedPartitionCount();
+        }
+        finally
+        {
+            TableMetrics.ESTIMATED_PARTITION_COUNT_CACHE_PERIOD_SECONDS = prevPeriod;
+        }
+    }
+
+    private void doTestEstimatedPartitionCount()
+    {
         ColumnFamilyStore cfs = recreateTable();
         assertEquals(0L, cfs.metric.estimatedPartitionCount.getValue().longValue());
         assertEquals(0L, cfs.metric.estimatedPartitionCountInSSTablesCached.getValue().longValue());


### PR DESCRIPTION
### What is the issue
[HCD-468](https://datastax.jira.com/browse/HCD-468)

Significant CPU pressure from interval tree construction during sstable set updates when the number of sstables is high.

### What does this PR fix and why was it fixed

Increases the caching time of the estimated partition count metric, which can also cause CPU pressure in the presence of many single-partition sstables (usually from repair).

C* 5 already includes the interval tree improvements.

CC4 PR: https://github.com/datastax/cassandra/pull/2553


[HCD-468]: https://datastax.jira.com/browse/HCD-468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ