### PR TITLE
CNDB-18152: Apply write affinity filter when readdressing hints

### DIFF
--- a/src/java/org/apache/cassandra/hints/HintsDispatchExecutor.java
+++ b/src/java/org/apache/cassandra/hints/HintsDispatchExecutor.java
@@ -293,9 +293,6 @@ final class HintsDispatchExecutor
                 return false;
             }
 
-            // Use the minimum of peer's messaging version and storage compatibility mode's version.
-            // This ensures hints written with the storage-compatible version can be dispatched using the
-            // encoded path without deserialization, as long as the peer supports that version.
             int dispatchVersion = Math.min(optVersion.get(), StorageCompatibilityMode.current().storageMessagingVersion());
 
             try (HintsDispatcher dispatcher = HintsDispatcher.create(file, rateLimiter, address, descriptor.hostId, dispatchVersion, shouldAbort))

--- a/src/java/org/apache/cassandra/hints/HintsDispatcher.java
+++ b/src/java/org/apache/cassandra/hints/HintsDispatcher.java
@@ -17,15 +17,19 @@
  */
 package org.apache.cassandra.hints;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.*;
 import java.util.function.BooleanSupplier;
-import java.util.function.Function;
 
 import com.google.common.util.concurrent.RateLimiter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.exceptions.UnknownTableException;
+import org.apache.cassandra.io.FSReadError;
+import org.apache.cassandra.io.util.DataInputBuffer;
 import org.apache.cassandra.net.RequestCallback;
 import org.apache.cassandra.exceptions.RequestFailureReason;
 import org.apache.cassandra.io.util.File;
@@ -45,8 +49,7 @@ import static org.apache.cassandra.utils.concurrent.Condition.newOneTimeConditio
 /**
  * Dispatches a single hints file to a specified node in a batched manner.
  *
- * Uses either {@link HintMessage.Encoded} - when dispatching hints into a node with the same messaging version as the hints file,
- * or {@link HintMessage}, when conversion is required.
+ * Decodes hints before dispatch so endpoint writability can be checked against the hint's keyspace.
  */
 final class HintsDispatcher implements AutoCloseable
 {
@@ -77,10 +80,10 @@ final class HintsDispatcher implements AutoCloseable
                                   RateLimiter rateLimiter,
                                   InetAddressAndPort address,
                                   UUID hostId,
-                                  int peerMessagingVersion,
+                                  int messagingVersion,
                                   BooleanSupplier abortRequested)
     {
-        HintsDispatcher dispatcher = new HintsDispatcher(HintsReader.open(file, rateLimiter), hostId, address, peerMessagingVersion, abortRequested);
+        HintsDispatcher dispatcher = new HintsDispatcher(HintsReader.open(file, rateLimiter), hostId, address, messagingVersion, abortRequested);
         HintDiagnostics.dispatcherCreated(dispatcher);
         return dispatcher;
     }
@@ -131,16 +134,7 @@ final class HintsDispatcher implements AutoCloseable
     {
         Collection<Callback> callbacks = new ArrayList<>();
 
-        /*
-         * If hints file messaging version matches the version of the target host, we'll use the optimised path -
-         * skipping the redundant decoding/encoding cycle of the already encoded hint.
-         *
-         * If that is not the case, we'll need to perform conversion to a newer (or an older) format, and decoding the hint
-         * is an unavoidable intermediate step.
-         */
-        Action action = reader.descriptor().messagingVersion() == messagingVersion
-                      ? sendHints(page.buffersIterator(), callbacks, this::sendEncodedHint)
-                      : sendHints(page.hintsIterator(), callbacks, this::sendHint);
+        Action action = sendHints(page.buffersIterator(), callbacks);
 
         if (action == Action.ABORT)
             return action;
@@ -175,22 +169,63 @@ final class HintsDispatcher implements AutoCloseable
         HintsServiceMetrics.hintsTimedOut.mark(timeouts);
     }
 
-    /*
-     * Sending hints in compatibility mode.
-     */
-
-    private <T> Action sendHints(Iterator<T> hints, Collection<Callback> callbacks, Function<T, Callback> sendFunction)
+    private Action sendHints(Iterator<ByteBuffer> encodedHints, Collection<Callback> callbacks)
     {
-        while (hints.hasNext())
+        List<ByteBuffer> buffersToSend = new ArrayList<>();
+        List<Hint> hintsToSend = new ArrayList<>();
+        int fileVersion = reader.descriptor().messagingVersion();
+
+        while (encodedHints.hasNext())
         {
             if (abortRequested.getAsBoolean())
             {
                 HintDiagnostics.abortRequested(this);
                 return Action.ABORT;
             }
-            callbacks.add(sendFunction.apply(hints.next()));
+
+            ByteBuffer buffer = encodedHints.next();
+            Hint hint;
+            try (DataInputBuffer in = new DataInputBuffer(buffer, true))
+            {
+                hint = Hint.serializer.deserialize(in, fileVersion);
+            }
+            catch (UnknownTableException e)
+            {
+                if (fileVersion != messagingVersion)
+                    continue;
+                hint = null;
+            }
+            catch (IOException e)
+            {
+                throw new FSReadError(e, reader.descriptor().fileName());
+            }
+
+            if (hint != null && !isWritable(hint))
+                return Action.ABORT;
+
+            buffersToSend.add(buffer);
+            hintsToSend.add(hint);
+        }
+
+        for (int i = 0; i < buffersToSend.size(); i++)
+        {
+            if (abortRequested.getAsBoolean())
+            {
+                HintDiagnostics.abortRequested(this);
+                return Action.ABORT;
+            }
+
+            callbacks.add(fileVersion == messagingVersion
+                          ? sendEncodedHint(buffersToSend.get(i))
+                          : sendHint(hintsToSend.get(i)));
         }
         return Action.CONTINUE;
+    }
+
+    private boolean isWritable(Hint hint)
+    {
+        String keyspace = hint.mutation().getKeyspaceName();
+        return DatabaseDescriptor.getEndpointSnitch().filterByAffinityForWrites(keyspace).test(address);
     }
 
     private Callback sendHint(Hint hint)
@@ -200,10 +235,6 @@ final class HintsDispatcher implements AutoCloseable
         MessagingService.instance().sendWithCallback(message, address, callback);
         return callback;
     }
-
-    /*
-     * Sending hints in raw mode.
-     */
 
     private Callback sendEncodedHint(ByteBuffer hint)
     {

--- a/src/java/org/apache/cassandra/hints/HintsService.java
+++ b/src/java/org/apache/cassandra/hints/HintsService.java
@@ -192,11 +192,13 @@ public final class HintsService implements HintsServiceMBean
         Token token = hint.mutation().key().getToken();
 
         EndpointsForToken replicas = ReplicaLayout.forTokenWriteLiveAndDown(Keyspace.open(keyspaceName), token).all();
+        Predicate<InetAddressAndPort> writeEndpointFilter = DatabaseDescriptor.getEndpointSnitch().filterByAffinityForWrites(keyspaceName);
 
         // judicious use of streams: eagerly materializing probably cheaper
         // than performing filters / translations 2x extra via Iterables.filter/transform
         List<UUID> hostIds = replicas.stream()
                 .filter(replica -> StorageProxy.shouldHint(replica, false))
+                .filter(replica -> writeEndpointFilter.test(replica.endpoint()))
                 .map(replica -> HintsEndpointProvider.instance.hostForEndpoint(replica.endpoint()))
                 .collect(Collectors.toList());
 

--- a/test/unit/org/apache/cassandra/hints/HintsServiceTest.java
+++ b/test/unit/org/apache/cassandra/hints/HintsServiceTest.java
@@ -18,11 +18,13 @@
 package org.apache.cassandra.hints;
 
 import java.net.UnknownHostException;
+import java.util.Collections;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Predicate;
 import javax.annotation.Nullable;
 
 import com.google.common.util.concurrent.Futures;
@@ -36,6 +38,13 @@ import org.junit.Test;
 
 import com.datastax.driver.core.utils.MoreFutures;
 import org.apache.cassandra.SchemaLoader;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.db.DecoratedKey;
+import org.apache.cassandra.db.partitions.PartitionUpdate;
+import org.apache.cassandra.net.Message;
+import org.apache.cassandra.net.NoPayload;
+import org.apache.cassandra.locator.AbstractNetworkTopologySnitch;
+import org.apache.cassandra.locator.IEndpointSnitch;
 import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.locator.TokenMetadata;
 import org.apache.cassandra.metrics.HintsServiceMetrics;
@@ -54,7 +63,11 @@ import static org.junit.Assert.assertEquals;
 import org.awaitility.Awaitility;
 import org.awaitility.core.ConditionFactory;
 
+import static org.apache.cassandra.Util.dk;
 import static org.apache.cassandra.config.CassandraRelevantProperties.SKIP_REWRITING_HINTS_ON_HOST_LEFT;
+import static org.apache.cassandra.net.Verb.HINT_REQ;
+import static org.apache.cassandra.net.Verb.HINT_RSP;
+import static org.apache.cassandra.net.MockMessagingService.verb;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -63,7 +76,6 @@ public class HintsServiceTest
 {
     private static final String KEYSPACE = "hints_service_test";
     private static final String TABLE = "table";
-
     private final MockFailureDetector failureDetector = new MockFailureDetector();
     private static TableMetadata metadata;
     private final AtomicBoolean isAlive = new AtomicBoolean(true);
@@ -302,5 +314,116 @@ public class HintsServiceTest
         assertFalse(anotherStore.hasFiles());
         assertThat(HintsServiceMetrics.hintsOnDisk.getCount()).isEqualTo(0);
         assertThat(HintsServiceMetrics.corruptedHintsOnDisk.getCount()).isZero();
+    }
+
+    @Test
+    public void testReplayWaitsForWriteAffinity() throws Exception
+    {
+        UUID hostId = StorageService.instance.getLocalHostUUID();
+        InetAddressAndPort endpoint = HintsEndpointProvider.instance.endpointForHost(hostId);
+        IEndpointSnitch savedSnitch = DatabaseDescriptor.getEndpointSnitch();
+
+        try
+        {
+            DatabaseDescriptor.setEndpointSnitch(new WriteAffinityExcludingSnitch(endpoint));
+            HintsStore store = writeAndFlushHints(hostId, 1);
+            MockMessagingSpy spy = MockMessagingService.when(verb(HINT_REQ))
+                                                       .respond(Message.internalResponse(HINT_RSP, NoPayload.noPayload));
+
+            HintsService.instance.dispatcherExecutor().dispatch(store).get();
+            spy.interceptNoMsg(500, TimeUnit.MILLISECONDS).get();
+            assertTrue(store.hasFiles());
+
+            DatabaseDescriptor.setEndpointSnitch(savedSnitch);
+            HintsService.instance.dispatcherExecutor().dispatch(store).get();
+            spy.interceptMessageOut(1).get();
+            assertFalse(store.hasFiles());
+        }
+        finally
+        {
+            DatabaseDescriptor.setEndpointSnitch(savedSnitch);
+        }
+    }
+
+    private static class WriteAffinityExcludingSnitch extends AbstractNetworkTopologySnitch
+    {
+        private final InetAddressAndPort excluded;
+
+        WriteAffinityExcludingSnitch(InetAddressAndPort excluded)
+        {
+            this.excluded = excluded;
+        }
+
+        public String getRack(InetAddressAndPort endpoint)
+        {
+            return "rack1";
+        }
+
+        public String getDatacenter(InetAddressAndPort endpoint)
+        {
+            return "datacenter1";
+        }
+
+        @Override
+        public Predicate<InetAddressAndPort> filterByAffinityForWrites(String keyspace)
+        {
+            return endpoint -> !endpoint.equals(excluded);
+        }
+    }
+
+    private MockMessagingSpy sendHintsAndResponses(TableMetadata ignored, int noOfHints, int noOfResponses)
+    {
+        return sendHintsAndResponses(noOfHints, noOfResponses);
+    }
+
+    private MockMessagingSpy sendHintsAndResponses(int noOfHints, int noOfResponses)
+    {
+        // create spy for hint messages, but only create responses for noOfResponses hints
+        Message<NoPayload> message = Message.internalResponse(HINT_RSP, NoPayload.noPayload);
+
+        MockMessagingSpy spy;
+        if (noOfResponses != -1)
+        {
+            spy = MockMessagingService.when(verb(HINT_REQ)).respondN(message, noOfResponses);
+        }
+        else
+        {
+            spy = MockMessagingService.when(verb(HINT_REQ)).respond(message);
+        }
+
+        writeHints(StorageService.instance.getLocalHostUUID(), noOfHints);
+        return spy;
+    }
+
+    private HintsStore writeAndFlushHints(TableMetadata ignored, UUID hostId, int noOfHints)
+    {
+        return writeAndFlushHints(hostId, noOfHints);
+    }
+
+    private HintsStore writeAndFlushHints(UUID hostId, int noOfHints)
+    {
+        writeHints(hostId, noOfHints);
+        HintsService.instance.flushAndFsyncBlockingly(Collections.singleton(hostId));
+
+        // close the write so hints are available for dispatching
+        HintsStore store = HintsService.instance.getCatalog().get(hostId);
+        store.closeWriter();
+
+        return store;
+    }
+
+    private void writeHints(UUID hostId, int noOfHints)
+    {
+        // create and write noOfHints using service
+        for (int i = 0; i < noOfHints; i++)
+        {
+            long now = System.currentTimeMillis();
+            DecoratedKey dkey = dk(String.valueOf(i));
+            TableMetadata metadata = Schema.instance.getTableMetadata(KEYSPACE, TABLE);
+            PartitionUpdate.SimpleBuilder builder = PartitionUpdate.simpleBuilder(metadata, dkey).timestamp(now);
+            builder.row("column0").add("val", "value0");
+            Hint hint = Hint.create(builder.buildAsMutation(), now);
+            HintsService.instance.write(hostId, hint);
+        }
     }
 }


### PR DESCRIPTION
### What is the issue

Fixes #18152

### What does this PR fix and why was it fixed
Applies the endpoint snitch’s write-affinity filter when readdressing and dispatching hints. Hints targeting endpoints that are not writable for the mutation’s keyspace are retained rather than dispatched.
