### PR TITLE
CNDB-18165 fix ordering of STATIC and WIDE primary keys within partition in 5.0

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/memory/TrieMemoryIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/TrieMemoryIndex.java
@@ -681,6 +681,12 @@ public class TrieMemoryIndex extends MemoryIndex
             if (lastComputedKey != null && nextKey.compareTo(lastComputedKey) <= 0)
                 return;
 
+            // If this set holds static-row keys, convert the skip target to the static form of
+            // the same partition so that tailSet does not skip past the static key.  This mirrors
+            // the identical conversion in PostingListKeyRangeIterator.performSkipTo().
+            if (!primaryKeySet.isEmpty() && primaryKeySet.first().isStaticRow() && !nextKey.isStaticRow())
+                nextKey = nextKey.forStaticRow();
+
             primaryKeySet = primaryKeySet.tailSet(nextKey);
             iterator = null;
         }

--- a/src/java/org/apache/cassandra/index/sai/utils/PrimaryKey.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/PrimaryKey.java
@@ -171,7 +171,7 @@ public interface PrimaryKey extends Comparable<PrimaryKey>, Accountable
     }
 
     /**
-     * Load the primary key from the {@link Supplier<PrimaryKey>} (if one
+     * Load the primary key from the {@link Supplier} (if one
      * is available) and fully populate the primary key.
      *
      * @return the fully populated {@link PrimaryKey}

--- a/src/java/org/apache/cassandra/index/sai/utils/PrimaryKey.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/PrimaryKey.java
@@ -31,6 +31,8 @@ import org.apache.cassandra.index.sai.disk.v2.TokenOnlyPrimaryKey;
 import org.apache.cassandra.utils.bytecomparable.ByteComparable;
 import org.apache.cassandra.utils.bytecomparable.ByteSource;
 
+import static org.apache.cassandra.db.ClusteringPrefix.Kind.STATIC_CLUSTERING;
+
 /**
  * Representation of the primary key for a row consisting of the {@link DecoratedKey} and
  * {@link Clustering} associated with a {@link org.apache.cassandra.db.rows.Row}.
@@ -159,7 +161,17 @@ public interface PrimaryKey extends Comparable<PrimaryKey>, Accountable
     }
 
     /**
-     * Load the primary key from the {@link Supplier (PrimaryKey)} (if one
+     * Return whether this primary key represents a static row (i.e., its clustering is
+     * {@link Clustering#STATIC_CLUSTERING}).
+     */
+    default boolean isStaticRow()
+    {
+        Clustering<?> c = clustering();
+        return c != null && c.kind() == STATIC_CLUSTERING;
+    }
+
+    /**
+     * Load the primary key from the {@link Supplier<PrimaryKey>} (if one
      * is available) and fully populate the primary key.
      *
      * @return the fully populated {@link PrimaryKey}

--- a/src/java/org/apache/cassandra/index/sai/utils/PrimaryKeys.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/PrimaryKeys.java
@@ -17,6 +17,7 @@
  */
 package org.apache.cassandra.index.sai.utils;
 
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.SortedSet;
 import java.util.concurrent.ConcurrentSkipListMap;
@@ -38,7 +39,28 @@ public class PrimaryKeys implements Iterable<MemoryIndex.PkWithFrequency>
     // from https://github.com/gaul/java-collection-overhead
     private static final long MAP_ENTRY_OVERHEAD = 40 + Integer.BYTES;
 
-    private final ConcurrentSkipListMap<PrimaryKey, Integer> keys = new ConcurrentSkipListMap<>();
+    /**
+     * Comparator for the internal map. It extends the natural {@link PrimaryKey} order with one extra rule:
+     * when a STATIC key and a WIDE key (one with real clustering values) compare as equal via
+     * {@code compareTo} — because {@code hasClustering()} is {@code false} for both — the STATIC key
+     * sorts before the WIDE key. This prevents the two from being treated as duplicates in the map
+     * while leaving the natural ordering used by iterators and {@code skipTo} completely unchanged.
+     * <p>
+     * Static row keys sort before all wide-row keys in the same partition.
+     */
+    static final Comparator<PrimaryKey> KEY_COMPARATOR = (a, b) -> {
+        int cmp = a.compareTo(b);
+        if (cmp != 0)
+            return cmp;
+        // Break the STATIC-vs-WIDE tie: STATIC < WIDE, STATIC == no-clustering, WIDE == WIDE.
+        if (a.isStaticRow() && b.hasClustering())
+            return -1;
+        if (b.isStaticRow() && a.hasClustering())
+            return 1;
+        return 0;
+    };
+
+    private final ConcurrentSkipListMap<PrimaryKey, Integer> keys = new ConcurrentSkipListMap<>(KEY_COMPARATOR);
 
     /**
      * Adds the specified {@link PrimaryKey} incrementing its frequency.

--- a/test/unit/org/apache/cassandra/index/sai/cql/CompositePartitionKeyIndexStaticTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/CompositePartitionKeyIndexStaticTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.cql;
+
+import java.math.BigInteger;
+
+import org.junit.Test;
+
+import org.apache.cassandra.db.marshal.SimpleDateType;
+import org.apache.cassandra.db.marshal.TimeType;
+import org.apache.cassandra.index.sai.SAITester;
+
+public class CompositePartitionKeyIndexStaticTest extends SAITester
+{
+    @Test
+    public void testIntersectionWithStaticOverlap() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk0 int, pk1 int, ck0 int, s1 int static, v0 int, PRIMARY KEY((pk0, pk1), ck0))");
+        createIndex("CREATE CUSTOM INDEX ON %s(pk0) USING 'StorageAttachedIndex'");
+
+        execute("UPDATE %s USING TIMESTAMP 1 SET s1 = 0, v0 = 0 WHERE pk0 = 0 AND pk1 = 1 AND ck0 = 0");
+        execute("DELETE FROM %s USING TIMESTAMP 2 WHERE pk0 = 0 AND pk1 = 1");
+
+        // If the STATIC and WIDE PrimaryKey objects in this partition are not compared strictly, the new WIDE key
+        // will be interpreted as a duplicate and not added to the Memtable-adjacent index. Then, on flush, the row
+        // corresponding to that WIDE key will be missing from the index.
+        execute("UPDATE %s USING TIMESTAMP 3 SET v0 = 1 WHERE pk0 = 0 AND pk1 = 1 AND ck0 = 1");
+
+        beforeAndAfterFlush(() -> assertRows(execute("SELECT * FROM %s WHERE v0 = 1 AND pk0 = 0 ALLOW FILTERING"), row(0, 1, 1, null, 1)));
+    }
+
+    @Test
+    public void testIntersectionWithStaticUpdate() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk0 time, pk1 varint, ck0 date, s0 boolean static, s1 text static, v0 boolean, PRIMARY KEY ((pk0, pk1), ck0))");
+        createIndex("CREATE CUSTOM INDEX tbl_pk0 ON %s(pk0) USING 'StorageAttachedIndex'");
+        createIndex("CREATE CUSTOM INDEX tbl_s0 ON %s(s0) USING 'StorageAttachedIndex'");
+
+        // pk0: 23:15:13.897962392 -> (static clustering, -1296648-01-08)
+        // s0: false -> (static clustering, -1296648-01-08)
+        execute("INSERT INTO %s (pk0, pk1, ck0, s0, s1, v0) VALUES ('23:15:13.897962392', -2272, '-1296648-01-08', false, 'ᕊଖꥬ㨢걲映㚃', false)");
+
+        // pk0: 23:15:13.897962392 -> (static clustering (existing), -1296648-01-08, -1306427-11-21)
+        // s0: true -> (static clustering, -1306427-11-21)
+        // TODO: C* uses s1='뾕⌒籖' + '鋿紞', which is not yet supported by CC, but will be supported in CC 5.0
+        execute("UPDATE %s SET s0=true, s1='뾕⌒籖鋿紞', v0=true WHERE  pk0 = '23:15:13.897962392' AND  pk1 = -2272 AND  ck0 = '-1306427-11-21'");
+
+        // Since the value of "true" is never mapped to the clustering -1296648-01-08, the intersection must begin
+        // at the STATIC key. Otherwise, we will miss the WIDE key for clustering -1296648-01-08.
+        beforeAndAfterFlush(() ->
+                            assertRows(execute("SELECT * FROM %s WHERE s0 = true AND pk0 = '23:15:13.897962392'"),
+                                       row(TimeType.instance.fromString("23:15:13.897962392"), new BigInteger("-2272"),
+                                           SimpleDateType.instance.fromString("-1306427-11-21"), true, "뾕⌒籖鋿紞", true),
+                                       row(TimeType.instance.fromString("23:15:13.897962392"), new BigInteger("-2272"),
+                                           SimpleDateType.instance.fromString("-1296648-01-08"), true, "뾕⌒籖鋿紞", false)));
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/CompositePartitionKeyIndexStaticTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/CompositePartitionKeyIndexStaticTest.java
@@ -58,8 +58,7 @@ public class CompositePartitionKeyIndexStaticTest extends SAITester
 
         // pk0: 23:15:13.897962392 -> (static clustering (existing), -1296648-01-08, -1306427-11-21)
         // s0: true -> (static clustering, -1306427-11-21)
-        // TODO: C* uses s1='뾕⌒籖' + '鋿紞', which is not yet supported by CC, but will be supported in CC 5.0
-        execute("UPDATE %s SET s0=true, s1='뾕⌒籖鋿紞', v0=true WHERE  pk0 = '23:15:13.897962392' AND  pk1 = -2272 AND  ck0 = '-1306427-11-21'");
+        execute("UPDATE %s SET s0=true, s1='뾕⌒籖' + '鋿紞', v0=true WHERE  pk0 = '23:15:13.897962392' AND  pk1 = -2272 AND  ck0 = '-1306427-11-21'");
 
         // Since the value of "true" is never mapped to the clustering -1296648-01-08, the intersection must begin
         // at the STATIC key. Otherwise, we will miss the WIDE key for clustering -1296648-01-08.


### PR DESCRIPTION
Port of https://github.com/datastax/cassandra/pull/2559 to `main-5.0`
CNDB's PR: https://github.com/riptano/cndb/pull/18933

Fixes https://github.com/riptano/cndb/issues/18165, which originates from
[CASSANDRA-20238](https://issues.apache.org/jira/browse/CASSANDRA-20238).

Primary key comparing logic treats STATIC primary keys equivalent to WIDE primary keys from the same partition, which allows to avoid duplicates. However, it means that the order of them non-deterministic and can lead that rows will be missing after flush.

It ports the reproduction test from of
https://github.com/apache/cassandra/pull/3825. However, the actual fix is not ported from Apache as its approach is to pass a flag to `compareTo` on how STATIC and WIDE primary keys should be compared (equivalent or preceding).

Instead the bug is fixed by introducing a custom comparator for primary keys collection, so an iterator on the keys will always order a STATIC primary key before WIDE primary keys of the same partition. With this fix it was also necessary to fix `performSkipTo` in `TrieMemoryIndex` to convert incoming primary keys into static if the index is on static clustering, i.e., in the same way as
`PostingListKeyRangeIterator.performSkipTo()`.
