### PR TITLE
HCD 2.x - CC-5 only - Mutator API: allow onCasCommit to throw RequestExecutionException

### DIFF
--- a/src/java/org/apache/cassandra/service/Mutator.java
+++ b/src/java/org/apache/cassandra/service/Mutator.java
@@ -32,6 +32,7 @@ import org.apache.cassandra.exceptions.CasWriteUnknownResultException;
 import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.exceptions.IsBootstrappingException;
 import org.apache.cassandra.exceptions.OverloadedException;
+import org.apache.cassandra.exceptions.RequestExecutionException;
 import org.apache.cassandra.exceptions.RequestFailureException;
 import org.apache.cassandra.exceptions.RequestTimeoutException;
 import org.apache.cassandra.exceptions.UnavailableException;
@@ -182,6 +183,13 @@ public interface Mutator
      *       time. An agreed value is decided: it WILL be completed (by the dispatched commit, or
      *       by any later operation or repair touching the partition) even though this operation
      *       reported failure to the client;</li>
+     *   <li>throws because {@link #onCasCommit} itself threw a {@link RequestExecutionException}
+     *       (a "veto", see {@link #onCasCommit}) — either for this operation's own
+     *       {@link CasCommitOrigin#CLIENT_OPERATION} commit, or for a foreign round's repair/refresh
+     *       encountered while completing it: the vetoed value is decided (or already committed) and
+     *       WILL be completed, but the vetoed dispatch was skipped (earlier iterations of the same
+     *       operation may have dispatched and completed other rounds' commits) — completion of the
+     *       vetoed round relies on a later operation or repair touching the partition;</li>
      *   <li>throws otherwise: this coordinator dispatched no commit (but see the v2 caveat above
      *       for propose-phase timeouts).</li>
      * </ul>
@@ -229,9 +237,47 @@ public interface Mutator
      * they never produce this callback. Low-level re-transmissions inside the v2 prepare exchange
      * ({@code PaxosPrepareRefresh}) are transport details and are not reported.
      * <p>
-     * Implementations should not throw and must not block. Throwing is contained by the caller
-     * ({@link MutatorProvider#notifyCasCommit}): the exception is logged and ignored, never
-     * failing the operation, read or repair dispatching the commit.
+     * Throwing: an implementation may VETO the dispatch — for any origin — by throwing a
+     * {@link RequestExecutionException} (e.g. {@link OverloadedException} to apply backpressure):
+     * the commit (or refresh) is NOT sent and the exception propagates out of
+     * {@link MutatorProvider#notifyCasCommit} to whatever drives the dispatch. The exception
+     * surfaces as thrown, with one caveat: the v1 engine rewraps a timeout-typed veto
+     * ({@link WriteTimeoutException}) into its standard CAS/read timeout conversions rather than
+     * rethrowing the exact instance — prefer non-timeout types such as {@link OverloadedException}. A veto never loses
+     * the value — when this callback fires the value is already agreed by a quorum, i.e. decided
+     * (or, for {@link CasCommitOrigin#REFRESH_COMMITTED}, already committed), and the
+     * still-uncommitted round WILL be re-attempted, re-firing this callback each time: by the next
+     * operation touching the partition (either engine) and, under the v2 engine with paxos repairs
+     * enabled, by the periodic auto-repair machinery ({@code PaxosUncommittedTracker},
+     * {@code cassandra.auto_repair_frequency_seconds}, default 5 minutes). A veto is therefore a
+     * "defer, retry later" signal, not a rejection — implementations need not block the calling
+     * thread to await downstream capacity. Per-origin consequences:
+     * <ul>
+     *   <li>{@link CasCommitOrigin#CLIENT_OPERATION}: the client CAS fails with the thrown
+     *       exception (every {@link RequestExecutionException} maps to a native-protocol error
+     *       code); {@link #onCasCommitCompleted} fires with {@link CasCommitOutcome#UNCONFIRMED},
+     *       including at commit consistency {@code ANY};</li>
+     *   <li>{@link CasCommitOrigin#REPAIR_IN_PROGRESS} / {@link CasCommitOrigin#REFRESH_COMMITTED}
+     *       fired from an operation (v1 {@code beginAndRepairPaxos}, v2 {@code Paxos.begin}): the
+     *       DRIVING operation — possibly another client's CAS or SERIAL/LOCAL_SERIAL read — fails
+     *       with the thrown exception (the operation cannot safely proceed without completing the
+     *       round, so backpressure here affects readers of the partition too). The v2 sites and the
+     *       v1 in-progress site deliver an {@link CasCommitOutcome#UNCONFIRMED} terminal; the v1
+     *       fire-and-forget refresh site delivers none (as ever);</li>
+     *   <li>background {@code PaxosRepair}: only that repair attempt fails (on its arbitrary
+     *       thread, no client involved, no terminal); the auto-repair machinery re-attempts it
+     *       later. The same sites also run under operator-driven paxos cleanup (anti-entropy
+     *       repair, topology operations), where a veto fails that cleanup session — it must be
+     *       re-run. Note the v1 engine has no auto-repair: an idle partition's vetoed round is
+     *       only re-attempted when traffic next touches it.</li>
+     * </ul>
+     * Sustained vetoing has operational cost: uncommitted rounds accumulate, serial operations on
+     * those partitions keep failing, and (v2) paxos repairs — a prerequisite for topology changes —
+     * cannot complete. Treat it as a transient overload response, not a steady state.
+     * <p>
+     * Any throwable that is not a {@link RequestExecutionException} is contained by
+     * {@link MutatorProvider#notifyCasCommit}: logged and ignored, never failing the operation,
+     * read or repair dispatching the commit. Implementations must not block.
      */
     default void onCasCommit(Commit committed, ConsistencyLevel consistencyLevel, CasCommitOrigin origin)
     {
@@ -276,11 +322,16 @@ public interface Mutator
      * NO terminal is delivered (only the dispatched {@link #onCasCommit} is) for the v1
      * {@link CasCommitOrigin#REFRESH_COMMITTED} fire-and-forget {@code sendCommit} (no awaited ack),
      * nor for any commit performed at {@code consistencyForCommit == ANY} (which does not block for a
-     * replica ack). For those, rely on a deferred serial read.
+     * replica ack). A veto (see {@link #onCasCommit}) delivers an
+     * {@link CasCommitOutcome#UNCONFIRMED} terminal — ANY included — at every site except the v1
+     * fire-and-forget refresh and the background {@code PaxosRepair} sites, which deliver none on
+     * failure (as ever). For sites without a terminal, rely on a deferred serial read.
      * <p>
-     * Threading and containment mirror {@link #onCasCommit}: implementations should not throw and
-     * must not block; a thrown exception is logged and ignored by
-     * {@link MutatorProvider#notifyCasCommitCompleted} and never fails the operation, read or repair.
+     * Threading mirrors {@link #onCasCommit}. Containment is unconditional here — unlike
+     * {@link #onCasCommit} there is no propagating (veto) case, since the outcome is already
+     * decided when this fires: implementations should not throw and must not block; a thrown
+     * exception is logged and ignored by {@link MutatorProvider#notifyCasCommitCompleted} and
+     * never fails the operation, read or repair.
      */
     default void onCasCommitCompleted(Commit committed, ConsistencyLevel consistencyLevel,
                                       CasCommitOrigin origin, CasCommitOutcome outcome)

--- a/src/java/org/apache/cassandra/service/Mutator.java
+++ b/src/java/org/apache/cassandra/service/Mutator.java
@@ -265,8 +265,9 @@ public interface Mutator
      *       v1 in-progress site deliver an {@link CasCommitOutcome#UNCONFIRMED} terminal; the v1
      *       fire-and-forget refresh site delivers none (as ever);</li>
      *   <li>background {@code PaxosRepair}: only that repair attempt fails (on its arbitrary
-     *       thread, no client involved, no terminal); the auto-repair machinery re-attempts it
-     *       later. The same sites also run under operator-driven paxos cleanup (anti-entropy
+     *       thread, no client involved), closing the announce with an
+     *       {@link CasCommitOutcome#UNCONFIRMED} terminal; the auto-repair machinery re-attempts
+     *       it later. The same sites also run under operator-driven paxos cleanup (anti-entropy
      *       repair, topology operations), where a veto fails that cleanup session — it must be
      *       re-run. Note the v1 engine has no auto-repair: an idle partition's vetoed round is
      *       only re-attempted when traffic next touches it.</li>
@@ -315,17 +316,20 @@ public interface Mutator
      *       ({@code beginAndRepairPaxos}): {@link CasCommitOutcome#APPLIED} or
      *       {@link CasCommitOutcome#UNCONFIRMED};</li>
      *   <li>background {@code PaxosRepair} ({@link CasCommitOrigin#REPAIR_IN_PROGRESS} /
-     *       {@link CasCommitOrigin#REFRESH_COMMITTED}): {@link CasCommitOutcome#APPLIED} only — this
-     *       background state machine retries on failure rather than delivering a negative terminal,
-     *       so a non-success outcome is not reported (best-effort, on an arbitrary repair thread).</li>
+     *       {@link CasCommitOrigin#REFRESH_COMMITTED}): {@link CasCommitOutcome#APPLIED} when the
+     *       commit is acknowledged, else {@link CasCommitOutcome#UNCONFIRMED} — delivered when a
+     *       retry re-announces the commit, or when the repair ends (failure, cancellation, veto or
+     *       exhausted retry budget) with the announce still open, so an implementation tracking
+     *       in-flight state per announce never leaks it (best-effort ordering, on an arbitrary
+     *       repair thread).</li>
      * </ul>
      * NO terminal is delivered (only the dispatched {@link #onCasCommit} is) for the v1
      * {@link CasCommitOrigin#REFRESH_COMMITTED} fire-and-forget {@code sendCommit} (no awaited ack),
      * nor for any commit performed at {@code consistencyForCommit == ANY} (which does not block for a
      * replica ack). A veto (see {@link #onCasCommit}) delivers an
      * {@link CasCommitOutcome#UNCONFIRMED} terminal — ANY included — at every site except the v1
-     * fire-and-forget refresh and the background {@code PaxosRepair} sites, which deliver none on
-     * failure (as ever). For sites without a terminal, rely on a deferred serial read.
+     * fire-and-forget refresh, which delivers none (as ever). For sites without a terminal, rely on
+     * a deferred serial read.
      * <p>
      * Threading mirrors {@link #onCasCommit}. Containment is unconditional here — unlike
      * {@link #onCasCommit} there is no propagating (veto) case, since the outcome is already

--- a/src/java/org/apache/cassandra/service/MutatorProvider.java
+++ b/src/java/org/apache/cassandra/service/MutatorProvider.java
@@ -24,6 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.db.ConsistencyLevel;
+import org.apache.cassandra.exceptions.RequestExecutionException;
 import org.apache.cassandra.service.paxos.Commit;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.JVMStabilityInspector;
@@ -49,8 +50,13 @@ public abstract class MutatorProvider
 
     /**
      * Notifies the installed Mutator of a commit dispatch (see {@link Mutator#onCasCommit}),
-     * containing any exception a misbehaving implementation throws: a notification failure must
-     * never abort the paxos operation, serial read or repair that is dispatching the commit.
+     * containing any exception a misbehaving implementation throws — with one deliberate
+     * exception: a {@link RequestExecutionException} is a VETO of this dispatch and propagates,
+     * for every origin (see {@link Mutator#onCasCommit} for the per-origin consequences). The
+     * commit is skipped, the caller fails, and the decided-but-uncommitted round is re-attempted
+     * later — re-firing the notification — so a veto defers the commit, it never loses it.
+     * Everything else is logged and ignored: a notification bug must never abort the operation,
+     * read or repair dispatching the commit.
      */
     public static void notifyCasCommit(Commit committed, ConsistencyLevel consistencyLevel, Mutator.CasCommitOrigin origin)
     {
@@ -62,6 +68,8 @@ public abstract class MutatorProvider
         {
             // Let fatal errors (OOM etc.) reach the JVM failure policy before we swallow.
             JVMStabilityInspector.inspectThrowable(t);
+            if (t instanceof RequestExecutionException)
+                throw (RequestExecutionException) t;
             noSpamLogger.warn("Custom mutator onCasCommit({}) failed; ignoring", origin, t);
         }
     }
@@ -70,6 +78,8 @@ public abstract class MutatorProvider
      * Notifies the installed Mutator of the terminal outcome of a previously-announced commit (see
      * {@link Mutator#onCasCommitCompleted}), containing any exception a misbehaving implementation
      * throws: a notification failure must never abort the paxos operation, serial read or repair.
+     * Unlike {@link #notifyCasCommit} there is no propagating case here — the outcome is already
+     * decided when this fires, so throwing could change nothing.
      */
     public static void notifyCasCommitCompleted(Commit committed, ConsistencyLevel consistencyLevel,
                                                 Mutator.CasCommitOrigin origin, Mutator.CasCommitOutcome outcome)

--- a/src/java/org/apache/cassandra/service/StorageProxy.java
+++ b/src/java/org/apache/cassandra/service/StorageProxy.java
@@ -90,6 +90,7 @@ import org.apache.cassandra.exceptions.QueryCancelledException;
 import org.apache.cassandra.exceptions.ReadAbortException;
 import org.apache.cassandra.exceptions.ReadFailureException;
 import org.apache.cassandra.exceptions.ReadTimeoutException;
+import org.apache.cassandra.exceptions.RequestExecutionException;
 import org.apache.cassandra.exceptions.RequestFailureException;
 import org.apache.cassandra.exceptions.RequestFailureReason;
 import org.apache.cassandra.exceptions.RequestTimeoutException;
@@ -665,6 +666,33 @@ public class StorageProxy implements StorageProxyMBean
             lwtTracker.onError(e);
             throw e;
         }
+        catch (OverloadedException e)
+        {
+            // Thrown by checkHintOverload during the commit phase, or by a Mutator.onCasCommit veto.
+            metrics.casWriteMetrics.unavailables.mark();
+            metrics.writeMetricsForLevel(consistencyForPaxos).unavailables.mark();
+            Tracing.trace("Overloaded");
+            lwtTracker.onError(e);
+            throw e;
+        }
+        catch (RequestExecutionException e)
+        {
+            // Fallback for types outside the concrete families above -- typically a base-typed or
+            // custom Mutator.onCasCommit veto: mark the closest family meter (none for unknown
+            // families) and keep the tracker informed.
+            if (e instanceof RequestTimeoutException)
+            {
+                metrics.casWriteMetrics.timeouts.mark();
+                metrics.writeMetricsForLevel(consistencyForPaxos).timeouts.mark();
+            }
+            else if (e instanceof RequestFailureException)
+            {
+                metrics.casWriteMetrics.failures.mark();
+                metrics.writeMetricsForLevel(consistencyForPaxos).failures.mark();
+            }
+            lwtTracker.onError(e);
+            throw e;
+        }
         finally
         {
             // We track latency based on request processing time, since the amount of time that request spends in the queue
@@ -775,18 +803,23 @@ public class StorageProxy implements StorageProxyMBean
                     // them), this is worth bothering.
                     if (!proposal.update.isEmpty())
                     {
-                        MutatorProvider.notifyCasCommit(proposal, consistencyForCommit, Mutator.CasCommitOrigin.CLIENT_OPERATION);
                         try
                         {
+                            // The notification may veto the commit: a RequestExecutionException thrown by
+                            // Mutator.onCasCommit propagates (see MutatorProvider.notifyCasCommit), skipping the
+                            // commit dispatch, and is handled below like any other commit failure.
+                            MutatorProvider.notifyCasCommit(proposal, consistencyForCommit, Mutator.CasCommitOrigin.CLIENT_OPERATION);
                             commitPaxos(proposal, consistencyForCommit, true, requestTime, casMetrics);
                         }
                         catch (RuntimeException e)
                         {
                             // proposePaxos already returned true, so the value is DECIDED; any failure to confirm
-                            // the commit here (timeout, replica failure, interruption surfaced as
-                            // UncheckedInterruptedException) leaves it decided-but-not-confirmed: report UNCONFIRMED
-                            // before the failure surfaces to the client. (At CL=ANY commitPaxos does not block, so it
-                            // does not throw here; that case delivers no terminal, only the dispatched onCasCommit.)
+                            // the commit here (a mutator veto skipping the dispatch, timeout, replica failure,
+                            // interruption surfaced as UncheckedInterruptedException) leaves it
+                            // decided-but-not-confirmed: report UNCONFIRMED before the failure surfaces to the
+                            // client. (At CL=ANY commitPaxos does not block, so it does not throw here; that case
+                            // delivers no terminal, only the dispatched onCasCommit — unless the notification
+                            // itself vetoed, which does deliver UNCONFIRMED.)
                             MutatorProvider.notifyCasCommitCompleted(proposal, consistencyForCommit, Mutator.CasCommitOrigin.CLIENT_OPERATION, Mutator.CasCommitOutcome.UNCONFIRMED);
                             throw e;
                         }
@@ -904,15 +937,20 @@ public class StorageProxy implements StorageProxyMBean
                     Commit refreshedInProgress = Commit.newProposal(ballot, inProgress.update);
                     if (proposePaxos(refreshedInProgress, paxosPlan, false, requestTime, casMetrics))
                     {
-                        MutatorProvider.notifyCasCommit(refreshedInProgress, consistencyForCommit, Mutator.CasCommitOrigin.REPAIR_IN_PROGRESS);
                         try
                         {
+                            // The notification may veto the commit: a RequestExecutionException thrown by
+                            // Mutator.onCasCommit propagates (see MutatorProvider.notifyCasCommit), skipping the
+                            // dispatch and aborting the driving operation; the recovered round stays uncommitted
+                            // and is re-attempted by a later operation on the partition.
+                            MutatorProvider.notifyCasCommit(refreshedInProgress, consistencyForCommit, Mutator.CasCommitOrigin.REPAIR_IN_PROGRESS);
                             commitPaxos(refreshedInProgress, consistencyForCommit, false, requestTime, casMetrics);
                         }
-                        catch (WriteTimeoutException e)
+                        catch (RuntimeException e)
                         {
-                            // recovered value decided but the commit was not acknowledged in time: report UNCONFIRMED
-                            // before the failure propagates. (CL=ANY does not block/throw here; no terminal then.)
+                            // recovered value decided but the commit was vetoed or not acknowledged in time: report
+                            // UNCONFIRMED before the failure propagates. (CL=ANY does not block/throw in commitPaxos;
+                            // absent a veto no terminal is delivered then.)
                             MutatorProvider.notifyCasCommitCompleted(refreshedInProgress, consistencyForCommit, Mutator.CasCommitOrigin.REPAIR_IN_PROGRESS, Mutator.CasCommitOutcome.UNCONFIRMED);
                             throw e;
                         }
@@ -941,6 +979,9 @@ public class StorageProxy implements StorageProxyMBean
                 {
                     Tracing.trace("Repairing replicas that missed the most recent commit");
                     casMetrics.missingMostRecentCommit.inc(missingMRCSize);
+                    // A veto (RequestExecutionException from Mutator.onCasCommit) propagates here too, skipping
+                    // the refresh and aborting the driving operation; the lagging replicas are refreshed by a
+                    // later operation instead. No terminal is delivered either way (fire-and-forget site).
                     MutatorProvider.notifyCasCommit(mostRecent, consistencyForCommit, Mutator.CasCommitOrigin.REFRESH_COMMITTED);
                     sendCommit(mostRecent, missingMRC);
                     // TODO: provided commits don't invalid the prepare we just did above (which they don't), we could just wait
@@ -2296,6 +2337,18 @@ public class StorageProxy implements StorageProxyMBean
             readTracker.onError(e);
             throw e;
         }
+        catch (OverloadedException e)
+        {
+            // Thrown by checkHintOverload while committing a repaired round, or by a Mutator.onCasCommit veto
+            // of that commit (the serial read must complete in-progress rounds before it can proceed).
+            metrics.readMetrics.unavailables.mark();
+            metrics.casReadMetrics.unavailables.mark();
+            metrics.readMetricsForLevel(consistencyLevel).unavailables.mark();
+            Tracing.trace("Overloaded");
+            logRequestException(e, group.queries);
+            readTracker.onError(e);
+            throw e;
+        }
         catch (ReadTimeoutException e)
         {
             metrics.readMetrics.timeouts.mark();
@@ -2318,6 +2371,29 @@ public class StorageProxy implements StorageProxyMBean
             metrics.readMetrics.failures.mark();
             metrics.casReadMetrics.failures.mark();
             metrics.readMetricsForLevel(consistencyLevel).failures.mark();
+            readTracker.onError(e);
+            throw e;
+        }
+        catch (RequestExecutionException e)
+        {
+            // Fallback for types outside the concrete families above -- typically a base-typed or
+            // custom Mutator.onCasCommit veto: mark the closest family meter (none for unknown
+            // families) and keep the tracker informed.
+            if (e instanceof RequestTimeoutException)
+            {
+                metrics.readMetrics.timeouts.mark();
+                metrics.casReadMetrics.timeouts.mark();
+                metrics.readMetricsForLevel(consistencyLevel).timeouts.mark();
+                // logged for timeouts only, matching the concrete catches above (the failure-family
+                // ones deliberately do not log)
+                logRequestException(e, group.queries);
+            }
+            else if (e instanceof RequestFailureException)
+            {
+                metrics.readMetrics.failures.mark();
+                metrics.casReadMetrics.failures.mark();
+                metrics.readMetricsForLevel(consistencyLevel).failures.mark();
+            }
             readTracker.onError(e);
             throw e;
         }

--- a/src/java/org/apache/cassandra/service/StorageProxy.java
+++ b/src/java/org/apache/cassandra/service/StorageProxy.java
@@ -192,6 +192,7 @@ public class StorageProxy implements StorageProxyMBean
     private static final Logger logger = LoggerFactory.getLogger(StorageProxy.class);
 
     public static final String UNREACHABLE = "UNREACHABLE";
+    private static final String OVERLOADED_TRACE_MESSAGE = "Overloaded";
 
     private static final int FAILURE_LOGGING_INTERVAL_SECONDS = CassandraRelevantProperties.FAILURE_LOGGING_INTERVAL_SECONDS.getInt();
 
@@ -671,7 +672,7 @@ public class StorageProxy implements StorageProxyMBean
             // Thrown by checkHintOverload during the commit phase, or by a Mutator.onCasCommit veto.
             metrics.casWriteMetrics.unavailables.mark();
             metrics.writeMetricsForLevel(consistencyForPaxos).unavailables.mark();
-            Tracing.trace("Overloaded");
+            Tracing.trace(OVERLOADED_TRACE_MESSAGE);
             lwtTracker.onError(e);
             throw e;
         }
@@ -802,32 +803,7 @@ public class StorageProxy implements StorageProxyMBean
                     // comment there). As empty update are somewhat common (serial reads and non-applying CAS propose
                     // them), this is worth bothering.
                     if (!proposal.update.isEmpty())
-                    {
-                        try
-                        {
-                            // The notification may veto the commit: a RequestExecutionException thrown by
-                            // Mutator.onCasCommit propagates (see MutatorProvider.notifyCasCommit), skipping the
-                            // commit dispatch, and is handled below like any other commit failure.
-                            MutatorProvider.notifyCasCommit(proposal, consistencyForCommit, Mutator.CasCommitOrigin.CLIENT_OPERATION);
-                            commitPaxos(proposal, consistencyForCommit, true, requestTime, casMetrics);
-                        }
-                        catch (RuntimeException e)
-                        {
-                            // proposePaxos already returned true, so the value is DECIDED; any failure to confirm
-                            // the commit here (a mutator veto skipping the dispatch, timeout, replica failure,
-                            // interruption surfaced as UncheckedInterruptedException) leaves it
-                            // decided-but-not-confirmed: report UNCONFIRMED before the failure surfaces to the
-                            // client. (At CL=ANY commitPaxos does not block, so it does not throw here; that case
-                            // delivers no terminal, only the dispatched onCasCommit — unless the notification
-                            // itself vetoed, which does deliver UNCONFIRMED.)
-                            MutatorProvider.notifyCasCommitCompleted(proposal, consistencyForCommit, Mutator.CasCommitOrigin.CLIENT_OPERATION, Mutator.CasCommitOutcome.UNCONFIRMED);
-                            throw e;
-                        }
-                        // commitPaxos blocks until a consistencyForCommit quorum acknowledged the commit
-                        // (unless CL=ANY); reaching here means the value is now readable at that CL.
-                        if (consistencyForCommit != ConsistencyLevel.ANY)
-                            MutatorProvider.notifyCasCommitCompleted(proposal, consistencyForCommit, Mutator.CasCommitOrigin.CLIENT_OPERATION, Mutator.CasCommitOutcome.APPLIED);
-                    }
+                        notifyAndCommitPaxos(proposal, consistencyForCommit, true, requestTime, casMetrics, Mutator.CasCommitOrigin.CLIENT_OPERATION);
                     RowIterator result = proposalPair.right;
                     if (result != null)
                         Tracing.trace("CAS did not apply");
@@ -864,6 +840,43 @@ public class StorageProxy implements StorageProxyMBean
     }
 
     /**
+     * Announces a decided proposal to the installed {@link Mutator} and dispatches its commit, pairing the
+     * announcement with a terminal {@link Mutator.CasCommitOutcome}.
+     *
+     * <p>The notification may veto the commit: a RequestExecutionException thrown by
+     * {@link Mutator#onCasCommit} propagates (see {@link MutatorProvider#notifyCasCommit}), skipping the
+     * commit dispatch, and surfaces to the caller like any other commit failure.
+     *
+     * <p>The proposal is already DECIDED when this is called, so any failure to confirm the commit here
+     * (a mutator veto skipping the dispatch, timeout, replica failure, interruption surfaced as
+     * UncheckedInterruptedException) leaves it decided-but-not-confirmed: UNCONFIRMED is reported before
+     * the failure surfaces. At commit consistency ANY the commit dispatch does not block and thus cannot
+     * fail here, delivering no terminal beyond the announcement itself — unless the notification vetoed,
+     * which does deliver UNCONFIRMED. For any other commit consistency, returning normally means a quorum
+     * acknowledged the commit and the value is now readable at that consistency, reported as APPLIED.
+     */
+    private static void notifyAndCommitPaxos(Commit proposal,
+                                             ConsistencyLevel consistencyForCommit,
+                                             boolean allowHints,
+                                             Dispatcher.RequestTime requestTime,
+                                             CASClientRequestMetrics casMetrics,
+                                             Mutator.CasCommitOrigin origin)
+    {
+        try
+        {
+            MutatorProvider.notifyCasCommit(proposal, consistencyForCommit, origin);
+            commitPaxos(proposal, consistencyForCommit, allowHints, requestTime, casMetrics);
+        }
+        catch (RuntimeException e)
+        {
+            MutatorProvider.notifyCasCommitCompleted(proposal, consistencyForCommit, origin, Mutator.CasCommitOutcome.UNCONFIRMED);
+            throw e;
+        }
+        if (consistencyForCommit != ConsistencyLevel.ANY)
+            MutatorProvider.notifyCasCommitCompleted(proposal, consistencyForCommit, origin, Mutator.CasCommitOutcome.APPLIED);
+    }
+
+    /**
      * begin a Paxos session by sending a prepare request and completing any in-progress requests seen in the replies
      *
      * @return the Paxos ballot promised by the replicas if no in-progress requests were seen and a quorum of
@@ -885,14 +898,7 @@ public class StorageProxy implements StorageProxyMBean
         long deadline = requestTime.computeDeadline(timeoutNanos);
         while (nanoTime() < deadline)
         {
-            // We want a timestamp that is guaranteed to be unique for that node (so that the ballot is globally unique), but if we've got a prepare rejected
-            // already we also want to make sure we pick a timestamp that has a chance to be promised, i.e. one that is greater that the most recently known
-            // in progress (#5667). Lastly, we don't want to use a timestamp that is older than the last one assigned by ClientState or operations may appear
-            // out-of-order (#7801).
-            long minTimestampMicrosToUse = summary == null ? Long.MIN_VALUE : 1 + summary.mostRecentInProgressCommit.ballot.unixMicros();
-            // Note that ballotMicros is not guaranteed to be unique if two proposal are being handled concurrently by the same coordinator. But we still
-            // need ballots to be unique for each proposal so we have to use getRandomTimeUUIDFromMicros.
-            Ballot ballot = nextBallot(minTimestampMicrosToUse, consistencyForPaxos == SERIAL ? GLOBAL : LOCAL);
+            Ballot ballot = nextPrepareBallot(summary, consistencyForPaxos);
 
             // prepare
             try
@@ -934,32 +940,7 @@ public class StorageProxy implements StorageProxyMBean
                 {
                     Tracing.trace("Finishing incomplete paxos round {}", inProgress);
                     casMetrics.unfinishedCommit.inc();
-                    Commit refreshedInProgress = Commit.newProposal(ballot, inProgress.update);
-                    if (proposePaxos(refreshedInProgress, paxosPlan, false, requestTime, casMetrics))
-                    {
-                        try
-                        {
-                            // The notification may veto the commit: a RequestExecutionException thrown by
-                            // Mutator.onCasCommit propagates (see MutatorProvider.notifyCasCommit), skipping the
-                            // dispatch and aborting the driving operation; the recovered round stays uncommitted
-                            // and is re-attempted by a later operation on the partition.
-                            MutatorProvider.notifyCasCommit(refreshedInProgress, consistencyForCommit, Mutator.CasCommitOrigin.REPAIR_IN_PROGRESS);
-                            commitPaxos(refreshedInProgress, consistencyForCommit, false, requestTime, casMetrics);
-                        }
-                        catch (RuntimeException e)
-                        {
-                            // recovered value decided but the commit was vetoed or not acknowledged in time: report
-                            // UNCONFIRMED before the failure propagates. (CL=ANY does not block/throw in commitPaxos;
-                            // absent a veto no terminal is delivered then.)
-                            MutatorProvider.notifyCasCommitCompleted(refreshedInProgress, consistencyForCommit, Mutator.CasCommitOrigin.REPAIR_IN_PROGRESS, Mutator.CasCommitOutcome.UNCONFIRMED);
-                            throw e;
-                        }
-                        // commitPaxos blocks until a consistencyForCommit quorum acknowledged the commit
-                        // (unless CL=ANY); reaching here means the recovered value is now readable at that CL.
-                        if (consistencyForCommit != ConsistencyLevel.ANY)
-                            MutatorProvider.notifyCasCommitCompleted(refreshedInProgress, consistencyForCommit, Mutator.CasCommitOrigin.REPAIR_IN_PROGRESS, Mutator.CasCommitOutcome.APPLIED);
-                    }
-                    else
+                    if (!finishInProgressPaxosRound(inProgress, ballot, paxosPlan, consistencyForCommit, requestTime, casMetrics))
                     {
                         Tracing.trace("Some replicas have already promised a higher ballot than ours; aborting");
                         // sleep a random amount to give the other proposer a chance to finish
@@ -1001,6 +982,46 @@ public class StorageProxy implements StorageProxyMBean
         }
 
         throw new CasWriteTimeoutException(WriteType.CAS, consistencyForPaxos, 0, consistencyForPaxos.blockFor(paxosPlan.replicationStrategy()), contentions);
+    }
+
+    /**
+     * Picks the ballot for the next prepare attempt of {@link #beginAndRepairPaxos}.
+     *
+     * <p>We want a timestamp that is guaranteed to be unique for that node (so that the ballot is globally unique), but if we've got a prepare rejected
+     * already we also want to make sure we pick a timestamp that has a chance to be promised, i.e. one that is greater that the most recently known
+     * in progress (#5667). Lastly, we don't want to use a timestamp that is older than the last one assigned by ClientState or operations may appear
+     * out-of-order (#7801).
+     *
+     * <p>Note that ballotMicros is not guaranteed to be unique if two proposal are being handled concurrently by the same coordinator. But we still
+     * need ballots to be unique for each proposal so we have to use getRandomTimeUUIDFromMicros.
+     */
+    private static Ballot nextPrepareBallot(PrepareCallback summary, ConsistencyLevel consistencyForPaxos)
+    {
+        long minTimestampMicrosToUse = summary == null ? Long.MIN_VALUE : 1 + summary.mostRecentInProgressCommit.ballot.unixMicros();
+        return nextBallot(minTimestampMicrosToUse, consistencyForPaxos == SERIAL ? GLOBAL : LOCAL);
+    }
+
+    /**
+     * Completes an in-progress paxos round witnessed by {@link #beginAndRepairPaxos}, re-proposing its update
+     * under our own ballot. If the proposal is accepted, the commit is announced to the installed
+     * {@link Mutator} (which may veto it, see {@link #notifyAndCommitPaxos}: the recovered round then stays
+     * uncommitted and is re-attempted by a later operation on the partition) and dispatched.
+     *
+     * @return true if the re-proposal was accepted (and its commit dispatched), false if it was pre-empted
+     * by a higher ballot and the caller must back off and retry.
+     */
+    private static boolean finishInProgressPaxosRound(Commit inProgress,
+                                                      Ballot ballot,
+                                                      ReplicaPlan.ForPaxosWrite paxosPlan,
+                                                      ConsistencyLevel consistencyForCommit,
+                                                      Dispatcher.RequestTime requestTime,
+                                                      CASClientRequestMetrics casMetrics)
+    {
+        Commit refreshedInProgress = Commit.newProposal(ballot, inProgress.update);
+        if (!proposePaxos(refreshedInProgress, paxosPlan, false, requestTime, casMetrics))
+            return false;
+        notifyAndCommitPaxos(refreshedInProgress, consistencyForCommit, false, requestTime, casMetrics, Mutator.CasCommitOrigin.REPAIR_IN_PROGRESS);
+        return true;
     }
 
     /**
@@ -1323,7 +1344,7 @@ public class StorageProxy implements StorageProxyMBean
         {
             metrics.writeMetrics.unavailables.mark();
             metrics.writeMetricsForLevel(consistencyLevel).unavailables.mark();
-            Tracing.trace("Overloaded");
+            Tracing.trace(OVERLOADED_TRACE_MESSAGE);
             writeTracker.onError(e);
             throw e;
         }
@@ -2344,7 +2365,7 @@ public class StorageProxy implements StorageProxyMBean
             metrics.readMetrics.unavailables.mark();
             metrics.casReadMetrics.unavailables.mark();
             metrics.readMetricsForLevel(consistencyLevel).unavailables.mark();
-            Tracing.trace("Overloaded");
+            Tracing.trace(OVERLOADED_TRACE_MESSAGE);
             logRequestException(e, group.queries);
             readTracker.onError(e);
             throw e;

--- a/src/java/org/apache/cassandra/service/paxos/Paxos.java
+++ b/src/java/org/apache/cassandra/service/paxos/Paxos.java
@@ -74,6 +74,7 @@ import org.apache.cassandra.db.rows.RowIterator;
 import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.exceptions.IsBootstrappingException;
+import org.apache.cassandra.exceptions.OverloadedException;
 import org.apache.cassandra.exceptions.ReadFailureException;
 import org.apache.cassandra.exceptions.ReadTimeoutException;
 import org.apache.cassandra.exceptions.RequestExecutionException;
@@ -780,7 +781,19 @@ public class Paxos
                         if (!proposal.update.isEmpty())
                         {
                             Agreed agreed = proposal.agreed();
-                            MutatorProvider.notifyCasCommit(agreed, consistencyForCommit, Mutator.CasCommitOrigin.CLIENT_OPERATION);
+                            try
+                            {
+                                MutatorProvider.notifyCasCommit(agreed, consistencyForCommit, Mutator.CasCommitOrigin.CLIENT_OPERATION);
+                            }
+                            catch (RequestExecutionException e)
+                            {
+                                // The installed Mutator vetoed the commit of a DECIDED value (see
+                                // MutatorProvider.notifyCasCommit): skip the dispatch, report UNCONFIRMED (a later
+                                // operation or repair will complete it) and fail the operation with the veto.
+                                markCasVeto(e, true, consistencyForCommit, metrics);
+                                MutatorProvider.notifyCasCommitCompleted(agreed, consistencyForCommit, Mutator.CasCommitOrigin.CLIENT_OPERATION, Mutator.CasCommitOutcome.UNCONFIRMED);
+                                throw e;
+                            }
                             commit = commit(agreed, participants, consistencyForConsensus, consistencyForCommit, true);
                             committedAgreed = agreed;
                         }
@@ -1053,7 +1066,19 @@ public class Paxos
                 {
                     FoundIncompleteCommitted incomplete = prepare.incompleteCommitted();
                     Tracing.trace("Repairing replicas that missed the most recent commit");
-                    MutatorProvider.notifyCasCommit(incomplete.committed, consistencyForConsensus, Mutator.CasCommitOrigin.REFRESH_COMMITTED);
+                    try
+                    {
+                        MutatorProvider.notifyCasCommit(incomplete.committed, consistencyForConsensus, Mutator.CasCommitOrigin.REFRESH_COMMITTED);
+                    }
+                    catch (RequestExecutionException e)
+                    {
+                        // The installed Mutator vetoed the refresh (see MutatorProvider.notifyCasCommit): skip the
+                        // dispatch, report UNCONFIRMED, and abort the driving operation; the lagging replicas are
+                        // refreshed by a later operation or repair instead.
+                        markCasVeto(e, isWrite, consistencyForConsensus, metrics);
+                        MutatorProvider.notifyCasCommitCompleted(incomplete.committed, consistencyForConsensus, Mutator.CasCommitOrigin.REFRESH_COMMITTED, Mutator.CasCommitOutcome.UNCONFIRMED);
+                        throw e;
+                    }
                     retry = commitAndPrepare(incomplete.committed, incomplete.participants, query, isWrite, acceptEarlyReadPermission);
                     pendingFused = incomplete.committed;           // terminal delivered when 'retry' resolves
                     pendingFusedOrigin = Mutator.CasCommitOrigin.REFRESH_COMMITTED;
@@ -1086,7 +1111,20 @@ public class Paxos
                         case SUCCESS:
                         {
                             Agreed reproposeAgreed = repropose.agreed();
-                            MutatorProvider.notifyCasCommit(reproposeAgreed, consistencyForConsensus, Mutator.CasCommitOrigin.REPAIR_IN_PROGRESS);
+                            try
+                            {
+                                MutatorProvider.notifyCasCommit(reproposeAgreed, consistencyForConsensus, Mutator.CasCommitOrigin.REPAIR_IN_PROGRESS);
+                            }
+                            catch (RequestExecutionException e)
+                            {
+                                // The installed Mutator vetoed the repair commit of a DECIDED round (see
+                                // MutatorProvider.notifyCasCommit): skip the dispatch, report UNCONFIRMED, and abort
+                                // the driving operation; the round stays uncommitted and is re-attempted by a later
+                                // operation or by the paxos auto-repair machinery, re-firing the notification.
+                                markCasVeto(e, isWrite, consistencyForConsensus, metrics);
+                                MutatorProvider.notifyCasCommitCompleted(reproposeAgreed, consistencyForConsensus, Mutator.CasCommitOrigin.REPAIR_IN_PROGRESS, Mutator.CasCommitOutcome.UNCONFIRMED);
+                                throw e;
+                            }
                             retry = commitAndPrepare(reproposeAgreed, inProgress.participants, query, isWrite, acceptEarlyReadPermission);
                             pendingFused = reproposeAgreed;        // terminal delivered when 'retry' resolves
                             pendingFusedOrigin = Mutator.CasCommitOrigin.REPAIR_IN_PROGRESS;
@@ -1216,6 +1254,25 @@ public class Paxos
             toMark.apply(metrics.casReadMetrics).mark();
             toMark.apply(metrics.readMetricsForLevel(consistency)).mark();
         }
+    }
+
+    /**
+     * Marks the client request metrics for a {@link Mutator#onCasCommit} veto (see
+     * {@link MutatorProvider#notifyCasCommit}) with the meter matching the exception family, mirroring
+     * what the v1 engine's catch chains record for the same client-visible outcomes. Exception types
+     * without a dedicated meter mark nothing; the callers' finally blocks still record latency.
+     * Known family divergence, accepted for such an exotic veto type: a {@code ReadAbortException}
+     * (a {@code ReadFailureException} subtype) counts as a failure here, where the v1 chains would
+     * route it to {@code markAbort}.
+     */
+    private static void markCasVeto(RequestExecutionException veto, boolean isWrite, ConsistencyLevel consistency, ClientRequestsMetrics metrics)
+    {
+        if (veto instanceof OverloadedException || veto instanceof UnavailableException)
+            mark(isWrite, m -> m.unavailables, consistency, metrics);
+        else if (veto instanceof RequestTimeoutException)
+            mark(isWrite, m -> m.timeouts, consistency, metrics);
+        else if (veto instanceof RequestFailureException)
+            mark(isWrite, m -> m.failures, consistency, metrics);
     }
 
     public static Ballot newBallot(@Nullable Ballot minimumBallot, ConsistencyLevel consistency)

--- a/src/java/org/apache/cassandra/service/paxos/Paxos.java
+++ b/src/java/org/apache/cassandra/service/paxos/Paxos.java
@@ -90,6 +90,7 @@ import org.apache.cassandra.io.IVersionedSerializer;
 import org.apache.cassandra.io.util.DataInputPlus;
 import org.apache.cassandra.io.util.DataOutputPlus;
 import org.apache.cassandra.locator.InetAddressAndPort;
+import org.apache.cassandra.metrics.CASClientRequestMetrics;
 import org.apache.cassandra.metrics.ClientRequestMetrics;
 import org.apache.cassandra.service.CASRequest;
 import org.apache.cassandra.service.ClientState;
@@ -668,14 +669,7 @@ public class Paxos
         SinglePartitionReadCommand readCommand = request.readCommand(FBUtilities.nowInSeconds());
         TableMetadata metadata = readCommand.metadata();
 
-        // Register sensors for CAS operations so coordinator can aggregate replica sensor values
-        RequestSensors sensors = RequestTracker.instance.get();
-        if (sensors != null)
-        {
-            Context context = Context.from(metadata);
-            sensors.registerSensor(context, Type.READ_BYTES);
-            sensors.registerSensor(context, Type.WRITE_BYTES);
-        }
+        registerCasSensors(metadata);
 
         consistencyForConsensus.validateForCas(metadata.keyspace, clientState);
         consistencyForCommit.validateForCasCommit(Keyspace.open(metadata.keyspace).getReplicationStrategy(), metadata.keyspace, clientState);
@@ -685,8 +679,8 @@ public class Paxos
         ClientRequestsMetrics metrics = ClientRequestsMetricsProvider.instance.metrics(metadata.keyspace);
         try (PaxosOperationLock lock = PaxosState.lock(partitionKey, metadata, proposeDeadline, consistencyForConsensus, true))
         {
-            Paxos.Async<PaxosCommit.Status> commit = null;
-            Agreed committedAgreed = null; // the value behind 'commit', for the onCasCommitCompleted notification
+            Agreed committedAgreed = null;
+            Participants committedParticipants = null;
             done: while (true)
             {
                 // read the current values and check they validate the conditions
@@ -694,7 +688,6 @@ public class Paxos
 
                 BeginResult begin = begin(proposeDeadline, readCommand, consistencyForConsensus,
                         true, minimumBallot, failedAttemptsDueToContention);
-                Ballot ballot = begin.ballot;
                 Participants participants = begin.participants;
                 failedAttemptsDueToContention = begin.failedAttemptsDueToContention;
 
@@ -704,65 +697,13 @@ public class Paxos
                     current = FilteredPartition.create(iter);
                 }
 
-                Proposal proposal;
-                boolean conditionMet = request.appliesTo(current);
-                if (!conditionMet)
-                {
-                    if (getPaxosVariant() == v2_without_linearizable_reads_or_rejected_writes)
-                    {
-                        Tracing.trace("CAS precondition rejected", current);
-                        metrics.casWriteMetrics.conditionNotMet.inc();
-                        return current.rowIterator();
-                    }
+                CasProposalAttempt attempt = prepareCasProposal(request, current, begin, partitionKey, metadata, clientState, metrics);
+                if (attempt.earlyResult != null)
+                    return attempt.earlyResult;
+                if (attempt.proposal == null)
+                    continue; // ballot went stale, retry
 
-                    // If we failed to meet our condition, it does not mean we can do nothing: if we do not propose
-                    // anything that is accepted by a quorum, it is possible for our !conditionMet state
-                    // to not be serialized wrt other operations.
-                    // If a later read encounters an "in progress" write that did not reach a majority,
-                    // but that would have permitted conditionMet had it done so (and hence we evidently did not witness),
-                    // that operation will complete the in-progress proposal before continuing, so that this and future
-                    // reads will perceive conditionMet without any intervening modification from the time at which we
-                    // assured a conditional write that !conditionMet.
-                    // So our evaluation is only serialized if we invalidate any in progress operations by proposing an empty update
-                    // See also CASSANDRA-12126
-                    if (begin.isLinearizableRead)
-                    {
-                        Tracing.trace("CAS precondition does not match current values {}; read is already linearizable; aborting", current);
-                        return conditionNotMet(current);
-                    }
-
-                    Tracing.trace("CAS precondition does not match current values {}; proposing empty update", current);
-                    proposal = Proposal.empty(ballot, partitionKey, metadata);
-                }
-                else if (begin.isPromised)
-                {
-                    // finish the paxos round w/ the desired updates
-                    // TODO "turn null updates into delete?" - what does this TODO even mean?
-                    PartitionUpdate updates = request.makeUpdates(current, clientState, begin.ballot);
-
-                    // Update the metrics before triggers potentially add mutations.
-                    ClientRequestSizeMetrics.recordRowAndColumnCountMetrics(updates);
-
-                    // Apply triggers to cas updates. A consideration here is that
-                    // triggers emit Mutations, and so a given trigger implementation
-                    // may generate mutations for partitions other than the one this
-                    // paxos round is scoped for. In this case, TriggerExecutor will
-                    // validate that the generated mutations are targetted at the same
-                    // partition as the initial updates and reject (via an
-                    // InvalidRequestException) any which aren't.
-                    updates = TriggerExecutor.instance.execute(updates);
-
-                    proposal = Proposal.of(ballot, updates);
-                    Tracing.trace("CAS precondition is met; proposing client-requested updates for {}", ballot);
-                }
-                else
-                {
-                    // must retry, as only achieved read success in begin
-                    Tracing.trace("CAS precondition is met, but ballot stale for proposal; retrying", current);
-                    continue;
-                }
-
-                PaxosPropose.Status propose = propose(proposal, participants, conditionMet).awaitUntil(proposeDeadline);
+                PaxosPropose.Status propose = propose(attempt.proposal, participants, attempt.conditionMet).awaitUntil(proposeDeadline);
                 switch (propose.outcome)
                 {
                     default: throw new IllegalStateException();
@@ -772,30 +713,16 @@ public class Paxos
 
                     case SUCCESS:
                     {
-                        if (!conditionMet)
+                        if (!attempt.conditionMet)
                             return conditionNotMet(current);
 
                         // no need to commit a no-op; either it
                         //   1) reached a majority, in which case it was agreed, had no effect and we can do nothing; or
                         //   2) did not reach a majority, was not agreed, and was not user visible as a result so we can ignore it
-                        if (!proposal.update.isEmpty())
+                        if (!attempt.proposal.update.isEmpty())
                         {
-                            Agreed agreed = proposal.agreed();
-                            try
-                            {
-                                MutatorProvider.notifyCasCommit(agreed, consistencyForCommit, Mutator.CasCommitOrigin.CLIENT_OPERATION);
-                            }
-                            catch (RequestExecutionException e)
-                            {
-                                // The installed Mutator vetoed the commit of a DECIDED value (see
-                                // MutatorProvider.notifyCasCommit): skip the dispatch, report UNCONFIRMED (a later
-                                // operation or repair will complete it) and fail the operation with the veto.
-                                markCasVeto(e, true, consistencyForCommit, metrics);
-                                MutatorProvider.notifyCasCommitCompleted(agreed, consistencyForCommit, Mutator.CasCommitOrigin.CLIENT_OPERATION, Mutator.CasCommitOutcome.UNCONFIRMED);
-                                throw e;
-                            }
-                            commit = commit(agreed, participants, consistencyForConsensus, consistencyForCommit, true);
-                            committedAgreed = agreed;
+                            committedAgreed = attempt.proposal.agreed();
+                            committedParticipants = participants;
                         }
 
                         break done;
@@ -803,66 +730,272 @@ public class Paxos
 
                     case SUPERSEDED:
                     {
-                        switch (propose.superseded().hadSideEffects)
-                        {
-                            default: throw new IllegalStateException();
-
-                            case MAYBE:
-                                // We don't know if our update has been applied, as the competing ballot may have completed
-                                // our proposal.  We yield our uncertainty to the caller via timeout exception.
-                                // TODO: should return more useful result to client, and should also avoid this situation where possible
-                                throw new MaybeFailure(false, participants.sizeOfPoll(), participants.sizeOfConsensusQuorum, 0, emptyMap())
-                                        .markAndThrowAsTimeoutOrFailure(true, consistencyForConsensus, failedAttemptsDueToContention, metrics);
-
-                            case NO:
-                                minimumBallot = propose.superseded().by;
-                                // We have been superseded without our proposal being accepted by anyone, so we can safely retry
-                                Tracing.trace("Paxos proposal not accepted (pre-empted by a higher ballot)");
-                                if (!waitForContention(proposeDeadline, ++failedAttemptsDueToContention, metadata, partitionKey, consistencyForConsensus, WRITE))
-                                    throw MaybeFailure.noResponses(participants).markAndThrowAsTimeoutOrFailure(true, consistencyForConsensus, failedAttemptsDueToContention, metrics);
-                        }
+                        throwIfMayHaveSideEffects(propose.superseded(), participants, consistencyForConsensus, failedAttemptsDueToContention, metrics);
+                        minimumBallot = propose.superseded().by;
+                        // We have been superseded without our proposal being accepted by anyone, so we can safely retry
+                        Tracing.trace("Paxos proposal not accepted (pre-empted by a higher ballot)");
+                        waitForContentionOrThrow(proposeDeadline, ++failedAttemptsDueToContention, metadata, partitionKey,
+                                                 consistencyForConsensus, WRITE, participants, metrics);
                     }
                 }
                 // continue to retry
             }
 
-            if (commit != null)
-            {
-                PaxosCommit.Status result = commit.awaitUntil(commitDeadline);
-                if (!result.isSuccess())
-                {
-                    // decided (agreed by a quorum) but the commit was not acknowledged in time: report the
-                    // terminal as UNCONFIRMED before surfacing the failure to the client. The value may still
-                    // be completed by a later operation or repair.
-                    MutatorProvider.notifyCasCommitCompleted(committedAgreed, consistencyForCommit, Mutator.CasCommitOrigin.CLIENT_OPERATION, Mutator.CasCommitOutcome.UNCONFIRMED);
-                    throw result.maybeFailure().markAndThrowAsTimeoutOrFailure(true, consistencyForCommit, failedAttemptsDueToContention, metrics);
-                }
-                // the commit reached a consistencyForCommit quorum: the value is now readable at that CL.
-                // Note that, unlike the v1 path in StorageProxy, we do not need to special case CL=ANY here:
-                // v1 does not block at all for ANY (it fires the commits off and returns), so it must suppress
-                // this notification; here we always await PaxosCommit, which requires blockForWrite(ANY) == 1
-                // genuine replica acknowledgement (hints are not counted as accepts), so reaching this point
-                // means the commit really was applied on at least the replicas that consistencyForCommit requires.
-                MutatorProvider.notifyCasCommitCompleted(committedAgreed, consistencyForCommit, Mutator.CasCommitOrigin.CLIENT_OPERATION, Mutator.CasCommitOutcome.APPLIED);
-            }
+            completeCasCommit(committedAgreed, committedParticipants, consistencyForConsensus, consistencyForCommit,
+                              commitDeadline, failedAttemptsDueToContention, metrics);
             Tracing.trace("CAS successful");
             return null;
 
         }
         finally
         {
-            final long latency = nanoTime() - start;
+            recordCasWriteLatency(metadata, partitionKey, consistencyForConsensus, metrics, start, failedAttemptsDueToContention);
+        }
+    }
 
-            if (failedAttemptsDueToContention > 0)
+    /**
+     * Registers sensors for CAS operations so the coordinator can aggregate replica sensor values.
+     */
+    private static void registerCasSensors(TableMetadata metadata)
+    {
+        RequestSensors sensors = RequestTracker.instance.get();
+        if (sensors != null)
+        {
+            Context context = Context.from(metadata);
+            sensors.registerSensor(context, Type.READ_BYTES);
+            sensors.registerSensor(context, Type.WRITE_BYTES);
+        }
+    }
+
+    /**
+     * Outcome of evaluating the CAS condition against the current values and building the proposal for one
+     * round of {@link #cas}: either a client-visible result short-circuiting the whole operation
+     * ({@link #earlyResult} non-null), a proposal to submit ({@link #proposal} non-null, with
+     * {@link #conditionMet} telling whether it carries the requested updates or is an empty update
+     * linearizing the rejected condition), or neither, meaning the ballot went stale and the round must be
+     * retried.
+     */
+    private static final class CasProposalAttempt
+    {
+        @Nullable final Proposal proposal;
+        final boolean conditionMet;
+        @Nullable final RowIterator earlyResult;
+
+        private CasProposalAttempt(Proposal proposal, boolean conditionMet, RowIterator earlyResult)
+        {
+            this.proposal = proposal;
+            this.conditionMet = conditionMet;
+            this.earlyResult = earlyResult;
+        }
+
+        static CasProposalAttempt propose(Proposal proposal, boolean conditionMet)
+        {
+            return new CasProposalAttempt(proposal, conditionMet, null);
+        }
+
+        static CasProposalAttempt earlyResult(RowIterator result)
+        {
+            return new CasProposalAttempt(null, false, result);
+        }
+
+        static CasProposalAttempt retry()
+        {
+            return new CasProposalAttempt(null, false, null);
+        }
+    }
+
+    private static CasProposalAttempt prepareCasProposal(CASRequest request,
+                                                         FilteredPartition current,
+                                                         BeginResult begin,
+                                                         DecoratedKey partitionKey,
+                                                         TableMetadata metadata,
+                                                         ClientState clientState,
+                                                         ClientRequestsMetrics metrics)
+    {
+        boolean conditionMet = request.appliesTo(current);
+        if (!conditionMet)
+        {
+            if (getPaxosVariant() == v2_without_linearizable_reads_or_rejected_writes)
             {
-                metrics.casWriteMetrics.contention.update(failedAttemptsDueToContention);
-                openAndGetStore(metadata).metric.topCasPartitionContention.addSample(partitionKey.getKey(), failedAttemptsDueToContention);
+                Tracing.trace("CAS precondition rejected", current);
+                metrics.casWriteMetrics.conditionNotMet.inc();
+                return CasProposalAttempt.earlyResult(current.rowIterator());
             }
 
+            // If we failed to meet our condition, it does not mean we can do nothing: if we do not propose
+            // anything that is accepted by a quorum, it is possible for our !conditionMet state
+            // to not be serialized wrt other operations.
+            // If a later read encounters an "in progress" write that did not reach a majority,
+            // but that would have permitted conditionMet had it done so (and hence we evidently did not witness),
+            // that operation will complete the in-progress proposal before continuing, so that this and future
+            // reads will perceive conditionMet without any intervening modification from the time at which we
+            // assured a conditional write that !conditionMet.
+            // So our evaluation is only serialized if we invalidate any in progress operations by proposing an empty update
+            // See also CASSANDRA-12126
+            if (begin.isLinearizableRead)
+            {
+                Tracing.trace("CAS precondition does not match current values {}; read is already linearizable; aborting", current);
+                return CasProposalAttempt.earlyResult(conditionNotMet(current));
+            }
 
-            metrics.casWriteMetrics.executionTimeMetrics.addNano(latency);
-            metrics.writeMetricsForLevel(consistencyForConsensus).executionTimeMetrics.addNano(latency);
+            Tracing.trace("CAS precondition does not match current values {}; proposing empty update", current);
+            return CasProposalAttempt.propose(Proposal.empty(begin.ballot, partitionKey, metadata), false);
         }
+
+        if (begin.isPromised)
+        {
+            // finish the paxos round w/ the desired updates
+            // TODO "turn null updates into delete?" - what does this TODO even mean?
+            PartitionUpdate updates = request.makeUpdates(current, clientState, begin.ballot);
+
+            // Update the metrics before triggers potentially add mutations.
+            ClientRequestSizeMetrics.recordRowAndColumnCountMetrics(updates);
+
+            // Apply triggers to cas updates. A consideration here is that
+            // triggers emit Mutations, and so a given trigger implementation
+            // may generate mutations for partitions other than the one this
+            // paxos round is scoped for. In this case, TriggerExecutor will
+            // validate that the generated mutations are targetted at the same
+            // partition as the initial updates and reject (via an
+            // InvalidRequestException) any which aren't.
+            updates = TriggerExecutor.instance.execute(updates);
+
+            Proposal proposal = Proposal.of(begin.ballot, updates);
+            Tracing.trace("CAS precondition is met; proposing client-requested updates for {}", begin.ballot);
+            return CasProposalAttempt.propose(proposal, true);
+        }
+
+        // must retry, as only achieved read success in begin
+        Tracing.trace("CAS precondition is met, but ballot stale for proposal; retrying", current);
+        return CasProposalAttempt.retry();
+    }
+
+    /**
+     * Surfaces a superseded proposal that may have produced side effects: we don't know if our update has
+     * been applied, as the competing ballot may have completed our proposal, so we yield our uncertainty to
+     * the caller via timeout exception. Returns normally when the proposal is known to have had no side
+     * effects, in which case the caller can safely retry.
+     */
+    // TODO: should return more useful result to client, and should also avoid this situation where possible
+    private static void throwIfMayHaveSideEffects(PaxosPropose.Superseded superseded,
+                                                  Participants participants,
+                                                  ConsistencyLevel consistencyForConsensus,
+                                                  int failedAttemptsDueToContention,
+                                                  ClientRequestsMetrics metrics)
+    {
+        switch (superseded.hadSideEffects)
+        {
+            default: throw new IllegalStateException();
+
+            case MAYBE:
+                throw new MaybeFailure(false, participants.sizeOfPoll(), participants.sizeOfConsensusQuorum, 0, emptyMap())
+                        .markAndThrowAsTimeoutOrFailure(true, consistencyForConsensus, failedAttemptsDueToContention, metrics);
+
+            case NO:
+                return;
+        }
+    }
+
+    /**
+     * Backs off after a contention-induced retry, or, if the contention strategy decided to give up (for
+     * instance because the operation deadline expired), marks the timeout metrics and throws.
+     */
+    private static void waitForContentionOrThrow(long deadline,
+                                                 int failedAttemptsDueToContention,
+                                                 TableMetadata metadata,
+                                                 DecoratedKey partitionKey,
+                                                 ConsistencyLevel consistencyForConsensus,
+                                                 ContentionStrategy.Type type,
+                                                 Participants participants,
+                                                 ClientRequestsMetrics metrics)
+    {
+        if (!waitForContention(deadline, failedAttemptsDueToContention, metadata, partitionKey, consistencyForConsensus, type))
+            throw MaybeFailure.noResponses(participants).markAndThrowAsTimeoutOrFailure(true, consistencyForConsensus, failedAttemptsDueToContention, metrics);
+    }
+
+    /**
+     * Announces an agreed CAS update to the installed {@link Mutator}, then dispatches its commit and awaits
+     * it, pairing the announcement with a terminal outcome. A no-op when {@code agreed} is null (nothing to
+     * commit: the operation proposed an empty update).
+     *
+     * <p>The announcement may veto the commit of the DECIDED value (see
+     * {@link MutatorProvider#notifyCasCommit}): the dispatch is skipped, UNCONFIRMED is reported (a later
+     * operation or repair will complete it) and the operation fails with the veto. Likewise, when the commit
+     * is dispatched but not acknowledged in time, the terminal is reported as UNCONFIRMED before the failure
+     * surfaces to the client; the value may still be completed by a later operation or repair.
+     *
+     * <p>Returning normally means the commit reached a consistencyForCommit quorum and the value is now
+     * readable at that consistency, reported as APPLIED. Note that, unlike the v1 path in StorageProxy, we do
+     * not need to special case commits at consistency ANY here: v1 does not block at all for ANY (it fires
+     * the commits off and returns), so it must suppress this notification; here we always await PaxosCommit,
+     * which requires one genuine replica acknowledgement for ANY (hints are not counted as accepts), so
+     * reaching the end means the commit really was applied on at least the replicas that consistencyForCommit
+     * requires.
+     */
+    private static void completeCasCommit(@Nullable Agreed agreed,
+                                          Participants participants,
+                                          ConsistencyLevel consistencyForConsensus,
+                                          ConsistencyLevel consistencyForCommit,
+                                          long commitDeadline,
+                                          int failedAttemptsDueToContention,
+                                          ClientRequestsMetrics metrics)
+    {
+        if (agreed == null)
+            return;
+
+        announceCasCommit(agreed, consistencyForCommit, Mutator.CasCommitOrigin.CLIENT_OPERATION, true, metrics);
+        PaxosCommit.Status result = commit(agreed, participants, consistencyForConsensus, consistencyForCommit, true)
+                                    .awaitUntil(commitDeadline);
+        if (!result.isSuccess())
+        {
+            MutatorProvider.notifyCasCommitCompleted(agreed, consistencyForCommit, Mutator.CasCommitOrigin.CLIENT_OPERATION, Mutator.CasCommitOutcome.UNCONFIRMED);
+            throw result.maybeFailure().markAndThrowAsTimeoutOrFailure(true, consistencyForCommit, failedAttemptsDueToContention, metrics);
+        }
+        MutatorProvider.notifyCasCommitCompleted(agreed, consistencyForCommit, Mutator.CasCommitOrigin.CLIENT_OPERATION, Mutator.CasCommitOutcome.APPLIED);
+    }
+
+    /**
+     * Announces a commit dispatch to the installed {@link Mutator}, handling a veto: a
+     * {@link RequestExecutionException} thrown by {@link Mutator#onCasCommit} (see
+     * {@link MutatorProvider#notifyCasCommit}) marks the client request metrics matching the exception
+     * family, pairs the announcement with an UNCONFIRMED terminal, and propagates, so that the caller skips
+     * the dispatch and the driving operation fails with the veto.
+     */
+    private static void announceCasCommit(Commit commit,
+                                          ConsistencyLevel consistency,
+                                          Mutator.CasCommitOrigin origin,
+                                          boolean isWrite,
+                                          ClientRequestsMetrics metrics)
+    {
+        try
+        {
+            MutatorProvider.notifyCasCommit(commit, consistency, origin);
+        }
+        catch (RequestExecutionException e)
+        {
+            markCasVeto(e, isWrite, consistency, metrics);
+            MutatorProvider.notifyCasCommitCompleted(commit, consistency, origin, Mutator.CasCommitOutcome.UNCONFIRMED);
+            throw e;
+        }
+    }
+
+    private static void recordCasWriteLatency(TableMetadata metadata,
+                                              DecoratedKey partitionKey,
+                                              ConsistencyLevel consistencyForConsensus,
+                                              ClientRequestsMetrics metrics,
+                                              long start,
+                                              int failedAttemptsDueToContention)
+    {
+        final long latency = nanoTime() - start;
+
+        if (failedAttemptsDueToContention > 0)
+        {
+            metrics.casWriteMetrics.contention.update(failedAttemptsDueToContention);
+            openAndGetStore(metadata).metric.topCasPartitionContention.addSample(partitionKey.getKey(), failedAttemptsDueToContention);
+        }
+
+        metrics.casWriteMetrics.executionTimeMetrics.addNano(latency);
+        metrics.writeMetricsForLevel(consistencyForConsensus).executionTimeMetrics.addNano(latency);
     }
 
     private static RowIterator conditionNotMet(FilteredPartition read)
@@ -1039,24 +1172,9 @@ public class Paxos
         {
             // prepare
             PaxosPrepare retry = null;
-            PaxosPrepare.Status prepare;
-            try
-            {
-                prepare = preparing.awaitUntil(deadline);
-            }
-            catch (Throwable t)
-            {
-                // the fused prepare (and its batched commit) did not resolve: report it as not confirmed
-                if (pendingFused != null)
-                    MutatorProvider.notifyCasCommitCompleted(pendingFused, consistencyForConsensus, pendingFusedOrigin, Mutator.CasCommitOutcome.UNCONFIRMED);
-                throw t;
-            }
-            if (pendingFused != null)
-            {
-                MutatorProvider.notifyCasCommitCompleted(pendingFused, consistencyForConsensus, pendingFusedOrigin, fusedCommitOutcome(prepare.outcome));
-                pendingFused = null;
-                pendingFusedOrigin = null;
-            }
+            PaxosPrepare.Status prepare = awaitPrepareWithFusedCommit(preparing, deadline, pendingFused, pendingFusedOrigin, consistencyForConsensus);
+            pendingFused = null;
+            pendingFusedOrigin = null;
             boolean isPromised = false;
             retry: switch (prepare.outcome)
             {
@@ -1065,21 +1183,7 @@ public class Paxos
                 case FOUND_INCOMPLETE_COMMITTED:
                 {
                     FoundIncompleteCommitted incomplete = prepare.incompleteCommitted();
-                    Tracing.trace("Repairing replicas that missed the most recent commit");
-                    try
-                    {
-                        MutatorProvider.notifyCasCommit(incomplete.committed, consistencyForConsensus, Mutator.CasCommitOrigin.REFRESH_COMMITTED);
-                    }
-                    catch (RequestExecutionException e)
-                    {
-                        // The installed Mutator vetoed the refresh (see MutatorProvider.notifyCasCommit): skip the
-                        // dispatch, report UNCONFIRMED, and abort the driving operation; the lagging replicas are
-                        // refreshed by a later operation or repair instead.
-                        markCasVeto(e, isWrite, consistencyForConsensus, metrics);
-                        MutatorProvider.notifyCasCommitCompleted(incomplete.committed, consistencyForConsensus, Mutator.CasCommitOrigin.REFRESH_COMMITTED, Mutator.CasCommitOutcome.UNCONFIRMED);
-                        throw e;
-                    }
-                    retry = commitAndPrepare(incomplete.committed, incomplete.participants, query, isWrite, acceptEarlyReadPermission);
+                    retry = refreshIncompleteCommit(incomplete, query, isWrite, acceptEarlyReadPermission, consistencyForConsensus, metrics);
                     pendingFused = incomplete.committed;           // terminal delivered when 'retry' resolves
                     pendingFusedOrigin = Mutator.CasCommitOrigin.REFRESH_COMMITTED;
                     break;
@@ -1088,10 +1192,7 @@ public class Paxos
                 {
                     FoundIncompleteAccepted inProgress = prepare.incompleteAccepted();
                     Tracing.trace("Finishing incomplete paxos round {}", inProgress.accepted);
-                    if (isWrite)
-                        metrics.casWriteMetrics.unfinishedCommit.inc();
-                    else
-                        metrics.casReadMetrics.unfinishedCommit.inc();
+                    casRequestMetrics(isWrite, metrics).unfinishedCommit.inc();
 
                     // we DO NOT need to change the timestamp of this commit - either we or somebody else will finish it
                     // and the original timestamp is correctly linearised. By not updatinig the timestamp we leave enough
@@ -1111,20 +1212,10 @@ public class Paxos
                         case SUCCESS:
                         {
                             Agreed reproposeAgreed = repropose.agreed();
-                            try
-                            {
-                                MutatorProvider.notifyCasCommit(reproposeAgreed, consistencyForConsensus, Mutator.CasCommitOrigin.REPAIR_IN_PROGRESS);
-                            }
-                            catch (RequestExecutionException e)
-                            {
-                                // The installed Mutator vetoed the repair commit of a DECIDED round (see
-                                // MutatorProvider.notifyCasCommit): skip the dispatch, report UNCONFIRMED, and abort
-                                // the driving operation; the round stays uncommitted and is re-attempted by a later
-                                // operation or by the paxos auto-repair machinery, re-firing the notification.
-                                markCasVeto(e, isWrite, consistencyForConsensus, metrics);
-                                MutatorProvider.notifyCasCommitCompleted(reproposeAgreed, consistencyForConsensus, Mutator.CasCommitOrigin.REPAIR_IN_PROGRESS, Mutator.CasCommitOutcome.UNCONFIRMED);
-                                throw e;
-                            }
+                            // A veto aborts the driving operation; the round stays uncommitted and is
+                            // re-attempted by a later operation or by the paxos auto-repair machinery,
+                            // re-firing the notification.
+                            announceCasCommit(reproposeAgreed, consistencyForConsensus, Mutator.CasCommitOrigin.REPAIR_IN_PROGRESS, isWrite, metrics);
                             retry = commitAndPrepare(reproposeAgreed, inProgress.participants, query, isWrite, acceptEarlyReadPermission);
                             pendingFused = reproposeAgreed;        // terminal delivered when 'retry' resolves
                             pendingFusedOrigin = Mutator.CasCommitOrigin.REPAIR_IN_PROGRESS;
@@ -1144,27 +1235,16 @@ public class Paxos
                 {
                     Tracing.trace("Some replicas have already promised a higher ballot than ours; aborting");
                     // sleep a random amount to give the other proposer a chance to finish
-                    if (!waitForContention(deadline, ++failedAttemptsDueToContention, query.metadata(), query.partitionKey(), consistencyForConsensus, isWrite ? WRITE : READ))
-                        throw MaybeFailure.noResponses(prepare.participants).markAndThrowAsTimeoutOrFailure(true, consistencyForConsensus, failedAttemptsDueToContention, metrics);
+                    waitForContentionOrThrow(deadline, ++failedAttemptsDueToContention, query.metadata(), query.partitionKey(),
+                                             consistencyForConsensus, isWrite ? WRITE : READ, prepare.participants, metrics);
                     retry = prepare(prepare.retryWithAtLeast(), prepare.participants, query, isWrite, acceptEarlyReadPermission);
                     break;
                 }
                 case PROMISED: isPromised = true;
                 case READ_PERMITTED:
                 {
-                    // We have received a quorum of promises (or read permissions) that have all witnessed the commit of the prior paxos
-                    // round's proposal (if any).
-                    PaxosPrepare.Success success = prepare.success();
-
-                    DataResolver<?, ?> resolver = new DataResolver(query, success.participants, NoopReadRepair.instance, new Dispatcher.RequestTime(query.creationTimeNanos()), QueryInfoTracker.ReadTracker.NOOP);
-                    for (int i = 0 ; i < success.responses.size() ; ++i)
-                        resolver.preprocess(success.responses.get(i));
-
-                    class WasRun implements Runnable { boolean v; public void run() { v = true; } }
-                    WasRun hadShortRead = new WasRun();
-                    PartitionIterator result = resolver.resolve(hadShortRead);
-
-                    if (!isPromised && hadShortRead.v)
+                    BeginResult result = resolveBeginRead(prepare.success(), query, isPromised, failedAttemptsDueToContention);
+                    if (result == null)
                     {
                         // we need to propose an empty update to linearize our short read, but only had read success
                         // since we may continue to perform short reads, we ask our prepare not to accept an early
@@ -1173,8 +1253,7 @@ public class Paxos
                         acceptEarlyReadPermission = false;
                         break;
                     }
-
-                    return new BeginResult(success.ballot, success.participants, failedAttemptsDueToContention, result, !hadShortRead.v && success.isReadSafe, isPromised, success.supersededBy);
+                    return result;
                 }
 
                 case MAYBE_FAILURE:
@@ -1192,13 +1271,95 @@ public class Paxos
             {
                 Tracing.trace("Some replicas have already promised a higher ballot than ours; retrying");
                 // sleep a random amount to give the other proposer a chance to finish
-                if (!waitForContention(deadline, ++failedAttemptsDueToContention, query.metadata(), query.partitionKey(), consistencyForConsensus, isWrite ? WRITE : READ))
-                    throw MaybeFailure.noResponses(prepare.participants).markAndThrowAsTimeoutOrFailure(true, consistencyForConsensus, failedAttemptsDueToContention, metrics);
+                waitForContentionOrThrow(deadline, ++failedAttemptsDueToContention, query.metadata(), query.partitionKey(),
+                                         consistencyForConsensus, isWrite ? WRITE : READ, prepare.participants, metrics);
                 retry = prepare(prepare.retryWithAtLeast(), prepare.participants, query, isWrite, acceptEarlyReadPermission);
             }
 
             preparing = retry;
         }
+    }
+
+    /**
+     * Awaits the resolution of a prepare, delivering the terminal {@link Mutator.CasCommitOutcome} for the
+     * commit fused into it, if any. A commit batched into a commit-and-prepare (used to finish another
+     * proposer's round) has no separable acknowledgement, so its fate is only known when that prepare
+     * resolves: a promise-quorum outcome confirms it, anything else leaves it unconfirmed (including a
+     * failure to resolve at all, reported before the failure propagates).
+     */
+    private static PaxosPrepare.Status awaitPrepareWithFusedCommit(PaxosPrepare preparing,
+                                                                   long deadline,
+                                                                   @Nullable Commit pendingFused,
+                                                                   Mutator.CasCommitOrigin pendingFusedOrigin,
+                                                                   ConsistencyLevel consistencyForConsensus)
+    {
+        PaxosPrepare.Status prepare;
+        try
+        {
+            prepare = preparing.awaitUntil(deadline);
+        }
+        catch (Throwable t)
+        {
+            if (pendingFused != null)
+                MutatorProvider.notifyCasCommitCompleted(pendingFused, consistencyForConsensus, pendingFusedOrigin, Mutator.CasCommitOutcome.UNCONFIRMED);
+            throw t;
+        }
+        if (pendingFused != null)
+            MutatorProvider.notifyCasCommitCompleted(pendingFused, consistencyForConsensus, pendingFusedOrigin, fusedCommitOutcome(prepare.outcome));
+        return prepare;
+    }
+
+    /**
+     * Repairs the replicas that missed the most recent commit witnessed by a prepare, batching the commit
+     * refresh with the next prepare attempt. The refresh is announced to the installed {@link Mutator}
+     * first, which may veto it (see {@link #announceCasCommit}): the driving operation is then aborted and
+     * the lagging replicas are refreshed by a later operation or repair instead.
+     *
+     * @return the batched commit-and-prepare for the caller to await
+     */
+    private static PaxosPrepare refreshIncompleteCommit(FoundIncompleteCommitted incomplete,
+                                                        SinglePartitionReadCommand query,
+                                                        boolean isWrite,
+                                                        boolean acceptEarlyReadPermission,
+                                                        ConsistencyLevel consistencyForConsensus,
+                                                        ClientRequestsMetrics metrics)
+    {
+        Tracing.trace("Repairing replicas that missed the most recent commit");
+        announceCasCommit(incomplete.committed, consistencyForConsensus, Mutator.CasCommitOrigin.REFRESH_COMMITTED, isWrite, metrics);
+        return commitAndPrepare(incomplete.committed, incomplete.participants, query, isWrite, acceptEarlyReadPermission);
+    }
+
+    private static CASClientRequestMetrics casRequestMetrics(boolean isWrite, ClientRequestsMetrics metrics)
+    {
+        return isWrite ? metrics.casWriteMetrics : metrics.casReadMetrics;
+    }
+
+    /**
+     * Resolves the read responses attached to a successful prepare into the {@link BeginResult}, or returns
+     * null when the read came up short and only a read permission (not a promise) was obtained: the caller
+     * must then retry the prepare without accepting an early read permission, so that the empty update
+     * linearizing the short read can be proposed.
+     */
+    @Nullable
+    private static BeginResult resolveBeginRead(PaxosPrepare.Success success,
+                                                SinglePartitionReadCommand query,
+                                                boolean isPromised,
+                                                int failedAttemptsDueToContention)
+    {
+        // We have received a quorum of promises (or read permissions) that have all witnessed the commit of the prior paxos
+        // round's proposal (if any).
+        DataResolver<?, ?> resolver = new DataResolver(query, success.participants, NoopReadRepair.instance, new Dispatcher.RequestTime(query.creationTimeNanos()), QueryInfoTracker.ReadTracker.NOOP);
+        for (int i = 0 ; i < success.responses.size() ; ++i)
+            resolver.preprocess(success.responses.get(i));
+
+        class WasRun implements Runnable { boolean v; public void run() { v = true; } }
+        WasRun hadShortRead = new WasRun();
+        PartitionIterator result = resolver.resolve(hadShortRead);
+
+        if (!isPromised && hadShortRead.v)
+            return null;
+
+        return new BeginResult(success.ballot, success.participants, failedAttemptsDueToContention, result, !hadShortRead.v && success.isReadSafe, isPromised, success.supersededBy);
     }
 
     public static boolean isInRangeAndShouldProcess(InetAddressAndPort from, DecoratedKey key, TableMetadata table, boolean includesRead)

--- a/src/java/org/apache/cassandra/service/paxos/PaxosRepair.java
+++ b/src/java/org/apache/cassandra/service/paxos/PaxosRepair.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -426,38 +427,47 @@ public class PaxosRepair extends AbstractPaxosRepair
     }
 
     /**
+     * An announced commit awaiting its terminal: the commit last passed to {@link Mutator#onCasCommit}
+     * whose terminal has not been delivered yet, with its origin.
+     */
+    private static final class AnnouncedCommit
+    {
+        final Commit commit;
+        final Mutator.CasCommitOrigin origin;
+
+        AnnouncedCommit(Commit commit, Mutator.CasCommitOrigin origin)
+        {
+            this.commit = commit;
+            this.origin = origin;
+        }
+    }
+
+    /**
      * The commit last announced via {@link Mutator#onCasCommit} whose terminal has not been
-     * delivered yet, with its origin. Set (before notifying, so a veto leaves it set) by
-     * {@link #announceCommit} and cleared by {@link #completeAnnounced}, so that every announce is
-     * paired with a terminal: {@link Mutator.CasCommitOutcome#APPLIED} on an acknowledged commit,
+     * delivered yet. Set (before notifying, so a veto leaves it set) by {@link #announceCommit}
+     * and consumed atomically by {@link #completeAnnounced}, so that every announce is paired with
+     * exactly one terminal: {@link Mutator.CasCommitOutcome#APPLIED} on an acknowledged commit,
      * else {@link Mutator.CasCommitOutcome#UNCONFIRMED} — delivered when a retry re-announces, or
      * by the completion listener installed in the constructor when the repair ends (failure,
-     * cancellation, veto or exhausted retry budget) with the announce still open. State
-     * transitions are serialized by {@link AbstractPaxosRepair#updateState}, and the listener only
-     * fires after the terminal state is reached, so plain volatile fields suffice.
+     * cancellation, veto or exhausted retry budget) with the announce still open.
      */
-    private volatile Commit announcedCommit;
-    private volatile Mutator.CasCommitOrigin announcedOrigin;
+    private final AtomicReference<AnnouncedCommit> announced = new AtomicReference<>();
 
     private void announceCommit(Commit commit, Mutator.CasCommitOrigin origin)
     {
         // a previous attempt's announce that was never confirmed (commit unacknowledged, retried):
         // close it out before opening the new one, keeping announces and terminals 1:1
         completeAnnounced(Mutator.CasCommitOutcome.UNCONFIRMED);
-        announcedCommit = commit;
-        announcedOrigin = origin;
+        announced.set(new AnnouncedCommit(commit, origin));
         MutatorProvider.notifyCasCommit(commit, commitConsistency(), origin);
     }
 
     private void completeAnnounced(Mutator.CasCommitOutcome outcome)
     {
-        Commit commit = announcedCommit;
-        Mutator.CasCommitOrigin origin = announcedOrigin;
-        if (commit == null)
+        AnnouncedCommit open = announced.getAndSet(null);
+        if (open == null)
             return;
-        announcedCommit = null;
-        announcedOrigin = null;
-        MutatorProvider.notifyCasCommitCompleted(commit, commitConsistency(), origin, outcome);
+        MutatorProvider.notifyCasCommitCompleted(open.commit, commitConsistency(), open.origin, outcome);
     }
 
     private PaxosRepair(DecoratedKey partitionKey, Ballot incompleteBallot, TableMetadata table, ConsistencyLevel paxosConsistency)

--- a/src/java/org/apache/cassandra/service/paxos/PaxosRepair.java
+++ b/src/java/org/apache/cassandra/service/paxos/PaxosRepair.java
@@ -247,6 +247,11 @@ public class PaxosRepair extends AbstractPaxosRepair
                 // note: we could send to only those we know haven't witnessed it, but this is a rare operation so a small amount of redundant work is fine
                 if (oldestCommitted.equals(latestCommitted.ballot))
                     return DONE;
+                // Here and at the two notify sites below: a veto (RequestExecutionException from
+                // Mutator.onCasCommit, rethrown by notifyCasCommit) escapes into
+                // AbstractPaxosRepair.updateState's failure handling, failing only this repair attempt;
+                // the round stays uncommitted and the paxos auto-repair machinery re-attempts it later,
+                // re-firing the notification.
                 MutatorProvider.notifyCasCommit(latestCommitted, commitConsistency(), Mutator.CasCommitOrigin.REFRESH_COMMITTED);
                 return PaxosCommit.commit(latestCommitted, participants, paxosConsistency, commitConsistency(), true,
                                           new CommittingRepair(latestCommitted, Mutator.CasCommitOrigin.REFRESH_COMMITTED));

--- a/src/java/org/apache/cassandra/service/paxos/PaxosRepair.java
+++ b/src/java/org/apache/cassandra/service/paxos/PaxosRepair.java
@@ -247,14 +247,15 @@ public class PaxosRepair extends AbstractPaxosRepair
                 // note: we could send to only those we know haven't witnessed it, but this is a rare operation so a small amount of redundant work is fine
                 if (oldestCommitted.equals(latestCommitted.ballot))
                     return DONE;
-                // Here and at the two notify sites below: a veto (RequestExecutionException from
-                // Mutator.onCasCommit, rethrown by notifyCasCommit) escapes into
-                // AbstractPaxosRepair.updateState's failure handling, failing only this repair attempt;
-                // the round stays uncommitted and the paxos auto-repair machinery re-attempts it later,
-                // re-firing the notification.
-                MutatorProvider.notifyCasCommit(latestCommitted, commitConsistency(), Mutator.CasCommitOrigin.REFRESH_COMMITTED);
+                // Here and at the two announce sites below: the announce is paired with a terminal even
+                // on failure. A veto (RequestExecutionException rethrown by notifyCasCommit) or any later
+                // failure ends this attempt via AbstractPaxosRepair.updateState's Failure handling, and
+                // the completion listener installed in the constructor closes the announce as
+                // UNCONFIRMED; the round stays uncommitted and the paxos auto-repair machinery
+                // re-attempts it later, re-firing the notification.
+                announceCommit(latestCommitted, Mutator.CasCommitOrigin.REFRESH_COMMITTED);
                 return PaxosCommit.commit(latestCommitted, participants, paxosConsistency, commitConsistency(), true,
-                                          new CommittingRepair(latestCommitted, Mutator.CasCommitOrigin.REFRESH_COMMITTED));
+                                          new CommittingRepair());
             }
             else if (isAcceptedButNotCommitted && !isPromisedButNotAccepted && !reproposalMayBeRejected)
             {
@@ -337,9 +338,9 @@ public class PaxosRepair extends AbstractPaxosRepair
                     // finish the in-progress commit
                     FoundIncompleteCommitted incomplete = input.incompleteCommitted();
                     logger.trace("PaxosRepair of {} found in progress {}", partitionKey(), incomplete.committed);
-                    MutatorProvider.notifyCasCommit(incomplete.committed, commitConsistency(), Mutator.CasCommitOrigin.REFRESH_COMMITTED);
+                    announceCommit(incomplete.committed, Mutator.CasCommitOrigin.REFRESH_COMMITTED);
                     return PaxosCommit.commit(incomplete.committed, participants, paxosConsistency, commitConsistency(), true,
-                                              new CommitAndRestart(incomplete.committed, Mutator.CasCommitOrigin.REFRESH_COMMITTED)); // we don't know if we're done, so we must restart
+                                              new CommitAndRestart()); // we don't know if we're done, so we must restart
                 }
 
                 case PROMISED:
@@ -387,9 +388,9 @@ public class PaxosRepair extends AbstractPaxosRepair
 
                     logger.trace("PaxosRepair of {} committing successful proposal {}", partitionKey(), proposal);
                     Agreed agreed = proposal.agreed();
-                    MutatorProvider.notifyCasCommit(agreed, commitConsistency(), Mutator.CasCommitOrigin.REPAIR_IN_PROGRESS);
+                    announceCommit(agreed, Mutator.CasCommitOrigin.REPAIR_IN_PROGRESS);
                     return PaxosCommit.commit(agreed, participants, paxosConsistency, commitConsistency(), true,
-                                              new CommittingRepair(agreed, Mutator.CasCommitOrigin.REPAIR_IN_PROGRESS));
+                                              new CommittingRepair());
 
                 default:
                     throw new IllegalStateException();
@@ -399,45 +400,64 @@ public class PaxosRepair extends AbstractPaxosRepair
 
     private class CommittingRepair extends ConsumerState<PaxosCommit.Status>
     {
-        private final Agreed committed;
-        private final Mutator.CasCommitOrigin origin;
-
-        private CommittingRepair(Agreed committed, Mutator.CasCommitOrigin origin)
-        {
-            this.committed = committed;
-            this.origin = origin;
-        }
-
         @Override
         public State execute(PaxosCommit.Status input)
         {
             logger.trace("PaxosRepair of {} {}", partitionKey(), input);
             if (!input.isSuccess())
+                // the announce stays open: a retry either re-announces (closing this one as
+                // UNCONFIRMED) or ends the repair with a Failure (same, via the completion listener)
                 return retry(this);
             // the commit reached a commitConsistency() quorum: the recovered value is now readable
-            MutatorProvider.notifyCasCommitCompleted(committed, commitConsistency(), origin, Mutator.CasCommitOutcome.APPLIED);
+            completeAnnounced(Mutator.CasCommitOutcome.APPLIED);
             return DONE;
         }
     }
 
     private class CommitAndRestart extends ConsumerState<PaxosCommit.Status>
     {
-        private final Agreed committed;
-        private final Mutator.CasCommitOrigin origin;
-
-        private CommitAndRestart(Agreed committed, Mutator.CasCommitOrigin origin)
-        {
-            this.committed = committed;
-            this.origin = origin;
-        }
-
         @Override
         public State execute(PaxosCommit.Status input)
         {
             if (input.isSuccess())
-                MutatorProvider.notifyCasCommitCompleted(committed, commitConsistency(), origin, Mutator.CasCommitOutcome.APPLIED);
+                completeAnnounced(Mutator.CasCommitOutcome.APPLIED);
             return restart(this);
         }
+    }
+
+    /**
+     * The commit last announced via {@link Mutator#onCasCommit} whose terminal has not been
+     * delivered yet, with its origin. Set (before notifying, so a veto leaves it set) by
+     * {@link #announceCommit} and cleared by {@link #completeAnnounced}, so that every announce is
+     * paired with a terminal: {@link Mutator.CasCommitOutcome#APPLIED} on an acknowledged commit,
+     * else {@link Mutator.CasCommitOutcome#UNCONFIRMED} — delivered when a retry re-announces, or
+     * by the completion listener installed in the constructor when the repair ends (failure,
+     * cancellation, veto or exhausted retry budget) with the announce still open. State
+     * transitions are serialized by {@link AbstractPaxosRepair#updateState}, and the listener only
+     * fires after the terminal state is reached, so plain volatile fields suffice.
+     */
+    private volatile Commit announcedCommit;
+    private volatile Mutator.CasCommitOrigin announcedOrigin;
+
+    private void announceCommit(Commit commit, Mutator.CasCommitOrigin origin)
+    {
+        // a previous attempt's announce that was never confirmed (commit unacknowledged, retried):
+        // close it out before opening the new one, keeping announces and terminals 1:1
+        completeAnnounced(Mutator.CasCommitOutcome.UNCONFIRMED);
+        announcedCommit = commit;
+        announcedOrigin = origin;
+        MutatorProvider.notifyCasCommit(commit, commitConsistency(), origin);
+    }
+
+    private void completeAnnounced(Mutator.CasCommitOutcome outcome)
+    {
+        Commit commit = announcedCommit;
+        Mutator.CasCommitOrigin origin = announcedOrigin;
+        if (commit == null)
+            return;
+        announcedCommit = null;
+        announcedOrigin = null;
+        MutatorProvider.notifyCasCommitCompleted(commit, commitConsistency(), origin, outcome);
     }
 
     private PaxosRepair(DecoratedKey partitionKey, Ballot incompleteBallot, TableMetadata table, ConsistencyLevel paxosConsistency)
@@ -448,6 +468,10 @@ public class PaxosRepair extends AbstractPaxosRepair
         this.table = table;
         this.paxosConsistency = paxosConsistency;
         this.successCriteria = incompleteBallot;
+        // Pair any announce still open when the repair completes: on success paths the APPLIED
+        // terminal has already closed it (no-op here); on failure, cancellation or a veto this
+        // closes it as UNCONFIRMED, so tracking Mutators never leak in-flight state.
+        addListener((repair, result) -> completeAnnounced(Mutator.CasCommitOutcome.UNCONFIRMED));
     }
 
     public static PaxosRepair create(ConsistencyLevel consistency, DecoratedKey partitionKey, Ballot incompleteBallot, TableMetadata table)

--- a/test/distributed/org/apache/cassandra/distributed/test/MutatorVetoTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/MutatorVetoTest.java
@@ -19,9 +19,12 @@ package org.apache.cassandra.distributed.test;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nullable;
 
+import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionTimeoutException;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -87,7 +90,7 @@ public class MutatorVetoTest extends CASTestBase
     private static final String REQUEST_TIMEOUT = "2000ms";
     private static final String CONTENTION_TIMEOUT = "2000ms";
 
-    private static Cluster FOUR_NODES;
+    private static Cluster cluster;
 
     @BeforeClass
     public static void beforeClass() throws Throwable
@@ -97,23 +100,23 @@ public class MutatorVetoTest extends CASTestBase
         // properties are JVM-global), exactly how a real deployment installs a custom Mutator.
         CassandraRelevantProperties.CUSTOM_MUTATOR_CLASS.setString(VetoMutator.class.getName());
         TestBaseImpl.beforeClass();
-        FOUR_NODES = init(Cluster.build(4)
-                                 .withConfig(config -> config.set("paxos_variant", "v2")
-                                                             .set("write_request_timeout", REQUEST_TIMEOUT)
-                                                             .set("cas_contention_timeout", CONTENTION_TIMEOUT)
-                                                             .set("request_timeout", REQUEST_TIMEOUT))
-                                 .withoutVNodes()
-                                 .start(), 3);
+        cluster = init(Cluster.build(4)
+                              .withConfig(config -> config.set("paxos_variant", "v2")
+                                                          .set("write_request_timeout", REQUEST_TIMEOUT)
+                                                          .set("cas_contention_timeout", CONTENTION_TIMEOUT)
+                                                          .set("request_timeout", REQUEST_TIMEOUT))
+                              .withoutVNodes()
+                              .start(), 3);
         // Warm the paxos paths on every coordinator: the first CAS of a cold cluster can burn its
         // whole operation deadline before reaching the commit phase, leaving the scenarios below
         // with nothing to repair.
-        FOUR_NODES.schemaChange("CREATE TABLE " + KEYSPACE + ".warmup (pk int, ck int, v int, PRIMARY KEY (pk, ck))");
+        cluster.schemaChange("CREATE TABLE " + KEYSPACE + ".warmup (pk int, ck int, v int, PRIMARY KEY (pk, ck))");
         for (int i = 1; i <= 3; i++)
-            FOUR_NODES.coordinator(i).execute("INSERT INTO " + KEYSPACE + ".warmup (pk, ck, v) VALUES (?, 1, 1) IF NOT EXISTS", QUORUM, i);
+            cluster.coordinator(i).execute("INSERT INTO " + KEYSPACE + ".warmup (pk, ck, v) VALUES (?, 1, 1) IF NOT EXISTS", QUORUM, i);
         // Schema changes need every instance reachable: create all scenario tables while the ring
         // is whole.
         for (String table : new String[]{ "veto_repair", "veto_poison", "veto_begin" })
-            FOUR_NODES.schemaChange("CREATE TABLE " + KEYSPACE + '.' + table + " (pk int, ck int, v int, PRIMARY KEY (pk, ck))");
+            cluster.schemaChange("CREATE TABLE " + KEYSPACE + '.' + table + " (pk int, ck int, v int, PRIMARY KEY (pk, ck))");
         // Class invariant: {4} stays out of the ring, so every scenario runs on the stable
         // {1, 2, 3} topology; only beginIncompleteCommittedVetoAbortsOperation promotes {4} to
         // bootstrapping and puts it back afterwards.
@@ -123,8 +126,8 @@ public class MutatorVetoTest extends CASTestBase
     @AfterClass
     public static void afterClass()
     {
-        if (FOUR_NODES != null)
-            FOUR_NODES.close();
+        if (cluster != null)
+            cluster.close();
     }
 
     /**
@@ -227,52 +230,59 @@ public class MutatorVetoTest extends CASTestBase
 
     private static void resetMutator(int node)
     {
-        FOUR_NODES.get(node).runOnInstance(VetoMutator::reset);
+        cluster.get(node).runOnInstance(VetoMutator::reset);
     }
 
     private static String announces(int node)
     {
-        return FOUR_NODES.get(node).callOnInstance(() -> String.join(",", VetoMutator.announces));
+        return cluster.get(node).callOnInstance(() -> String.join(",", VetoMutator.announces));
     }
 
     private static void armRefreshVeto(int node, boolean armed)
     {
-        FOUR_NODES.get(node).runOnInstance(() -> VetoMutator.vetoRefresh = armed);
+        cluster.get(node).runOnInstance(() -> VetoMutator.vetoRefresh = armed);
     }
 
     private static int refreshAnnounced(int node)
     {
         // NOTE: must be a lambda, not a bound method reference — the latter would capture this
         // classloader's static AtomicInteger instead of the instance's.
-        return FOUR_NODES.get(node).callOnInstance(() -> VetoMutator.refreshAnnounced.get());
+        return cluster.get(node).callOnInstance(() -> VetoMutator.refreshAnnounced.get());
     }
 
-    private static List<String> awaitTerminals(int node, int expected) throws InterruptedException
+    private static List<String> awaitTerminals(int node, int expected)
     {
-        long deadline = System.currentTimeMillis() + 20_000;
-        List<String> result;
-        while ((result = terminals(node)).size() < expected && System.currentTimeMillis() < deadline)
-            Thread.sleep(50);
-        return result;
+        try
+        {
+            Awaitility.await()
+                      .atMost(20, TimeUnit.SECONDS)
+                      .pollInterval(50, TimeUnit.MILLISECONDS)
+                      .until(() -> terminals(node).size() >= expected);
+        }
+        catch (ConditionTimeoutException e)
+        {
+            // fall through: the caller's assertion reports the terminals actually delivered
+        }
+        return terminals(node);
     }
 
     private static List<String> terminals(int node)
     {
-        String joined = FOUR_NODES.get(node).callOnInstance(() -> String.join(",", VetoMutator.terminals));
+        String joined = cluster.get(node).callOnInstance(() -> String.join(",", VetoMutator.terminals));
         return joined.isEmpty() ? List.of() : List.of(joined.split(","));
     }
 
     private static void takeNodeFourOutOfRing()
     {
         for (int i = 1; i <= 4; ++i)
-            FOUR_NODES.get(i).acceptsOnInstance(CASTestBase::removeFromRing).accept(FOUR_NODES.get(4));
+            cluster.get(i).acceptsOnInstance(CASTestBase::removeFromRing).accept(cluster.get(4));
     }
 
 
     /** Runs a PaxosRepair for {@code pk} on {@code node}; returns "OK", or the failure cause prefixed with "FAILURE: ". */
     private static String repairOnNode(int node, String tableName, int pk)
     {
-        return FOUR_NODES.get(node).callOnInstance(() -> {
+        return cluster.get(node).callOnInstance(() -> {
             TableMetadata schema = Keyspace.open(KEYSPACE).getColumnFamilyStore(tableName).metadata.get();
             DecoratedKey key = schema.partitioner.decorateKey(Int32Type.instance.decompose(pk));
             try
@@ -292,9 +302,9 @@ public class MutatorVetoTest extends CASTestBase
 
     private static boolean hasRowInternally(int node, String tableName, int pk)
     {
-        return FOUR_NODES.get(node)
-                         .executeInternal("SELECT ck FROM " + KEYSPACE + '.' + tableName + " WHERE pk = ? AND ck = 1", pk)
-                         .length > 0;
+        return cluster.get(node)
+                      .executeInternal("SELECT ck FROM " + KEYSPACE + '.' + tableName + " WHERE pk = ? AND ck = 1", pk)
+                      .length > 0;
     }
 
     /**
@@ -306,11 +316,11 @@ public class MutatorVetoTest extends CASTestBase
     private static void commitOnlyOn(int coordinator, int holder, String tableName, int pk, int[] dropTo, int[] mustLack)
     {
         IMessageFilters.Filter dropCommits =
-            FOUR_NODES.filters().verbs(PAXOS_COMMIT_REQ.id).from(coordinator).to(dropTo).drop();
+            cluster.filters().verbs(PAXOS_COMMIT_REQ.id).from(coordinator).to(dropTo).drop();
         try
         {
-            FOUR_NODES.coordinator(coordinator)
-                      .execute("INSERT INTO " + KEYSPACE + '.' + tableName + " (pk, ck, v) VALUES (?, 1, 1) IF NOT EXISTS", QUORUM, pk);
+            cluster.coordinator(coordinator)
+                   .execute("INSERT INTO " + KEYSPACE + '.' + tableName + " (pk, ck, v) VALUES (?, 1, 1) IF NOT EXISTS", QUORUM, pk);
             Assert.fail("the CAS commit cannot reach a quorum and must time out");
         }
         catch (RuntimeException expected)
@@ -338,7 +348,7 @@ public class MutatorVetoTest extends CASTestBase
     {
         // schema changes need the whole ring: create the table before taking {4} out
         String tableName = "veto_repair";
-        int pk = pk(FOUR_NODES, 1, 2);
+        int pk = pk(cluster, 1, 2);
 
         commitOnlyOn(1, 3, tableName, pk, to(1, 2), to(1, 2));
 
@@ -359,8 +369,8 @@ public class MutatorVetoTest extends CASTestBase
         resetMutator(2);
         AtomicInteger dropped = new AtomicInteger();
         IMessageFilters.Filter dropFirstAttempt =
-            FOUR_NODES.filters().verbs(PAXOS_COMMIT_REQ.id).from(2).to(1, 2, 3)
-                      .messagesMatching((from, to, message) -> dropped.incrementAndGet() <= 3).drop();
+            cluster.filters().verbs(PAXOS_COMMIT_REQ.id).from(2).to(1, 2, 3)
+                   .messagesMatching((from, to, message) -> dropped.incrementAndGet() <= 3).drop();
         try
         {
             Assert.assertEquals("the retried repair must complete", "OK", repairOnNode(2, tableName, pk));
@@ -374,8 +384,8 @@ public class MutatorVetoTest extends CASTestBase
                             List.of("REFRESH_COMMITTED:UNCONFIRMED", "REFRESH_COMMITTED:APPLIED"), terminals);
         Assert.assertEquals(2, refreshAnnounced(2));
 
-        assertRows(FOUR_NODES.coordinator(3).execute("SELECT pk, ck, v FROM " + KEYSPACE + '.' + tableName + " WHERE pk = ?",
-                                                     org.apache.cassandra.distributed.api.ConsistencyLevel.SERIAL, pk),
+        assertRows(cluster.coordinator(3).execute("SELECT pk, ck, v FROM " + KEYSPACE + '.' + tableName + " WHERE pk = ?",
+                                                  org.apache.cassandra.distributed.api.ConsistencyLevel.SERIAL, pk),
                    row(pk, 1, 1));
     }
 
@@ -389,7 +399,7 @@ public class MutatorVetoTest extends CASTestBase
     public void paxosRepairPoisonRefreshDeliversApplied() throws Throwable
     {
         String tableName = "veto_poison";
-        int pk = pk(FOUR_NODES, 1, 2);
+        int pk = pk(cluster, 1, 2);
 
         commitOnlyOn(1, 3, tableName, pk, to(1, 2), to(1, 2));
 
@@ -397,16 +407,17 @@ public class MutatorVetoTest extends CASTestBase
         // commit-and-prepare (which would refresh the lagging commit) and the prepare-refresh
         // never leave the coordinator.
         IMessageFilters.Filter dropProgress =
-            FOUR_NODES.filters().verbs(PAXOS2_PROPOSE_REQ.id, PAXOS_PROPOSE_REQ.id, PAXOS2_COMMIT_AND_PREPARE_REQ.id, PAXOS2_PREPARE_REFRESH_REQ.id)
-                      .from(1).to(1, 2, 3).drop();
+            cluster.filters().verbs(PAXOS2_PROPOSE_REQ.id, PAXOS_PROPOSE_REQ.id, PAXOS2_COMMIT_AND_PREPARE_REQ.id, PAXOS2_PREPARE_REFRESH_REQ.id)
+                   .from(1).to(1, 2, 3).drop();
         try
         {
-            FOUR_NODES.coordinator(1)
-                      .execute("INSERT INTO " + KEYSPACE + '.' + tableName + " (pk, ck, v) VALUES (?, 2, 2) IF NOT EXISTS", QUORUM, pk);
+            cluster.coordinator(1)
+                   .execute("INSERT INTO " + KEYSPACE + '.' + tableName + " (pk, ck, v) VALUES (?, 2, 2) IF NOT EXISTS", QUORUM, pk);
             Assert.fail("the promised-but-never-proposed CAS must time out");
         }
         catch (RuntimeException expected)
         {
+            // CasWriteTimeout: the prepare succeeded but nothing was proposed, leaving the bare promise
         }
         finally
         {
@@ -419,8 +430,8 @@ public class MutatorVetoTest extends CASTestBase
         Assert.assertTrue("the poison-path refresh must deliver an APPLIED terminal: " + terminals,
                           terminals.contains("REFRESH_COMMITTED:APPLIED"));
 
-        assertRows(FOUR_NODES.coordinator(1).execute("SELECT pk, ck, v FROM " + KEYSPACE + '.' + tableName + " WHERE pk = ?",
-                                                     org.apache.cassandra.distributed.api.ConsistencyLevel.SERIAL, pk),
+        assertRows(cluster.coordinator(1).execute("SELECT pk, ck, v FROM " + KEYSPACE + '.' + tableName + " WHERE pk = ?",
+                                                  org.apache.cassandra.distributed.api.ConsistencyLevel.SERIAL, pk),
                    row(pk, 1, 1));
     }
 
@@ -439,12 +450,12 @@ public class MutatorVetoTest extends CASTestBase
         takeNodeFourOutOfRing();
         for (int i = 1; i <= 4; ++i)
         {
-            FOUR_NODES.get(i).acceptsOnInstance(CASTestBase::addToRingBootstrapping).accept(FOUR_NODES.get(4));
-            FOUR_NODES.get(i).acceptsOnInstance(CASTestBase::assertVisibleInRing).accept(FOUR_NODES.get(4));
+            cluster.get(i).acceptsOnInstance(CASTestBase::addToRingBootstrapping).accept(cluster.get(4));
+            cluster.get(i).acceptsOnInstance(CASTestBase::assertVisibleInRing).accept(cluster.get(4));
         }
         try
         {
-            int pk = pk(FOUR_NODES, 3, 4);
+            int pk = pk(cluster, 3, 4);
 
             // commit lands only on the pending {4}: dropped towards the natural replicas
             commitOnlyOn(2, 4, tableName, pk, to(1, 2, 3), to(1, 2, 3));
@@ -455,11 +466,11 @@ public class MutatorVetoTest extends CASTestBase
             // pending {4}: without this, {1, 2, 3} can answer first and the round is completed as
             // an in-progress repair instead. Excluding {1} from the prepare forces {2, 3, 4}.
             IMessageFilters.Filter excludeNodeOne =
-                FOUR_NODES.filters().verbs(org.apache.cassandra.net.Verb.PAXOS2_PREPARE_REQ.id).from(3).to(1).drop();
+                cluster.filters().verbs(org.apache.cassandra.net.Verb.PAXOS2_PREPARE_REQ.id).from(3).to(1).drop();
             try
             {
-                FOUR_NODES.coordinator(3)
-                          .execute("INSERT INTO " + KEYSPACE + '.' + tableName + " (pk, ck, v) VALUES (?, 3, 3) IF NOT EXISTS", QUORUM, pk);
+                cluster.coordinator(3)
+                       .execute("INSERT INTO " + KEYSPACE + '.' + tableName + " (pk, ck, v) VALUES (?, 3, 3) IF NOT EXISTS", QUORUM, pk);
                 Assert.fail("the refresh veto must abort the driving operation; announces=" + announces(3) + " terminals=" + terminals(3));
             }
             catch (RuntimeException e)
@@ -476,8 +487,8 @@ public class MutatorVetoTest extends CASTestBase
             armRefreshVeto(3, false);
             try
             {
-                FOUR_NODES.coordinator(3)
-                          .execute("INSERT INTO " + KEYSPACE + '.' + tableName + " (pk, ck, v) VALUES (?, 3, 3) IF NOT EXISTS", QUORUM, pk);
+                cluster.coordinator(3)
+                       .execute("INSERT INTO " + KEYSPACE + '.' + tableName + " (pk, ck, v) VALUES (?, 3, 3) IF NOT EXISTS", QUORUM, pk);
             }
             finally
             {

--- a/test/distributed/org/apache/cassandra/distributed/test/MutatorVetoTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/MutatorVetoTest.java
@@ -269,7 +269,7 @@ public class MutatorVetoTest extends CASTestBase
     }
 
 
-    /** Runs a PaxosRepair for {@code pk} on {@code node}; returns "OK" or "FAILURE: <cause>". */
+    /** Runs a PaxosRepair for {@code pk} on {@code node}; returns "OK", or the failure cause prefixed with "FAILURE: ". */
     private static String repairOnNode(int node, String tableName, int pk)
     {
         return FOUR_NODES.get(node).callOnInstance(() -> {

--- a/test/distributed/org/apache/cassandra/distributed/test/MutatorVetoTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/MutatorVetoTest.java
@@ -1,0 +1,492 @@
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.Nullable;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.db.ConsistencyLevel;
+import org.apache.cassandra.db.CounterMutation;
+import org.apache.cassandra.db.DecoratedKey;
+import org.apache.cassandra.db.IMutation;
+import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.db.Mutation;
+import org.apache.cassandra.db.WriteType;
+import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.db.rows.RowIterator;
+import org.apache.cassandra.distributed.Cluster;
+import org.apache.cassandra.distributed.api.IMessageFilters;
+import org.apache.cassandra.exceptions.OverloadedException;
+import org.apache.cassandra.locator.ReplicaPlan;
+import org.apache.cassandra.metrics.ClientRequestsMetrics;
+import org.apache.cassandra.schema.TableMetadata;
+import org.apache.cassandra.service.AbstractWriteResponseHandler;
+import org.apache.cassandra.service.CASRequest;
+import org.apache.cassandra.service.ClientState;
+import org.apache.cassandra.service.Mutator;
+import org.apache.cassandra.service.StorageProxy;
+import org.apache.cassandra.service.paxos.AbstractPaxosRepair;
+import org.apache.cassandra.service.paxos.Commit;
+import org.apache.cassandra.service.paxos.PaxosRepair;
+import org.apache.cassandra.transport.Dispatcher;
+import org.apache.cassandra.utils.TimeUUID;
+
+import static org.apache.cassandra.config.CassandraRelevantProperties.PAXOS_USE_SELF_EXECUTION;
+import static org.apache.cassandra.db.ConsistencyLevel.SERIAL;
+import static org.apache.cassandra.distributed.api.ConsistencyLevel.QUORUM;
+import static org.apache.cassandra.distributed.shared.AssertUtils.assertRows;
+import static org.apache.cassandra.distributed.shared.AssertUtils.row;
+import static org.apache.cassandra.net.Verb.PAXOS2_COMMIT_AND_PREPARE_REQ;
+import static org.apache.cassandra.net.Verb.PAXOS2_PREPARE_REFRESH_REQ;
+import static org.apache.cassandra.net.Verb.PAXOS2_PROPOSE_REQ;
+import static org.apache.cassandra.net.Verb.PAXOS_COMMIT_REQ;
+import static org.apache.cassandra.net.Verb.PAXOS_PROPOSE_REQ;
+
+/**
+ * Multi-node coverage for the {@link Mutator#onCasCommit} veto paths that a single-node unit test
+ * cannot reach — they all require a replica that missed a commit:
+ * <ul>
+ *   <li>{@code Paxos.begin}'s FOUND_INCOMPLETE_COMMITTED (REFRESH_COMMITTED) veto catch: only
+ *       taken when no promise carries a read response with the latest commit, i.e. when the only
+ *       up-to-date replica is a pending (bootstrapping) one, which is sent its prepare without a
+ *       read;</li>
+ *   <li>{@code PaxosRepair}'s query-phase REFRESH_COMMITTED announce, its veto/UNCONFIRMED
+ *       pairing, and the re-announce-closes-previous-announce branch (a failed commit attempt
+ *       retried);</li>
+ *   <li>{@code PaxosRepair.CommitAndRestart}'s APPLIED terminal (poison prepare finding an
+ *       incomplete commit).</li>
+ * </ul>
+ * Uses the {@link CASTestBase} choreography (paxos v2, self-execution via messaging so that
+ * commit messages — self included — can be dropped with filters).
+ */
+public class MutatorVetoTest extends CASTestBase
+{
+    private static final String REQUEST_TIMEOUT = "2000ms";
+    private static final String CONTENTION_TIMEOUT = "2000ms";
+
+    private static Cluster FOUR_NODES;
+
+    @BeforeClass
+    public static void beforeClass() throws Throwable
+    {
+        PAXOS_USE_SELF_EXECUTION.setBoolean(false);
+        // Read once at MutatorProvider class-init inside every instance classloader (system
+        // properties are JVM-global), exactly how a real deployment installs a custom Mutator.
+        CassandraRelevantProperties.CUSTOM_MUTATOR_CLASS.setString(VetoMutator.class.getName());
+        TestBaseImpl.beforeClass();
+        FOUR_NODES = init(Cluster.build(4)
+                                 .withConfig(config -> config.set("paxos_variant", "v2")
+                                                             .set("write_request_timeout", REQUEST_TIMEOUT)
+                                                             .set("cas_contention_timeout", CONTENTION_TIMEOUT)
+                                                             .set("request_timeout", REQUEST_TIMEOUT))
+                                 .withoutVNodes()
+                                 .start(), 3);
+        // Warm the paxos paths on every coordinator: the first CAS of a cold cluster can burn its
+        // whole operation deadline before reaching the commit phase, leaving the scenarios below
+        // with nothing to repair.
+        FOUR_NODES.schemaChange("CREATE TABLE " + KEYSPACE + ".warmup (pk int, ck int, v int, PRIMARY KEY (pk, ck))");
+        for (int i = 1; i <= 3; i++)
+            FOUR_NODES.coordinator(i).execute("INSERT INTO " + KEYSPACE + ".warmup (pk, ck, v) VALUES (?, 1, 1) IF NOT EXISTS", QUORUM, i);
+        // Schema changes need every instance reachable: create all scenario tables while the ring
+        // is whole.
+        for (String table : new String[]{ "veto_repair", "veto_poison", "veto_begin" })
+            FOUR_NODES.schemaChange("CREATE TABLE " + KEYSPACE + '.' + table + " (pk int, ck int, v int, PRIMARY KEY (pk, ck))");
+        // Class invariant: {4} stays out of the ring, so every scenario runs on the stable
+        // {1, 2, 3} topology; only beginIncompleteCommittedVetoAbortsOperation promotes {4} to
+        // bootstrapping and puts it back afterwards.
+        takeNodeFourOutOfRing();
+    }
+
+    @AfterClass
+    public static void afterClass()
+    {
+        if (FOUR_NODES != null)
+            FOUR_NODES.close();
+    }
+
+    /**
+     * Runs inside each instance; delegates the engine work and records/vetoes commit callbacks.
+     * Mirrors the deployment pattern of MutatorCasTest.RecordingMutator.
+     */
+    public static class VetoMutator implements Mutator
+    {
+        /** When true, {@link #onCasCommit} vetoes REFRESH_COMMITTED dispatches with an OverloadedException. */
+        public static volatile boolean vetoRefresh;
+        public static final AtomicInteger refreshAnnounced = new AtomicInteger();
+        /** Every announce, as "ORIGIN" (diagnostics). */
+        public static final List<String> announces = new CopyOnWriteArrayList<>();
+        /** One "ORIGIN:OUTCOME" entry per {@link #onCasCommitCompleted}. */
+        public static final List<String> terminals = new CopyOnWriteArrayList<>();
+
+        private final Mutator delegate = new StorageProxy.DefaultMutator();
+
+        public static void reset()
+        {
+            vetoRefresh = false;
+            refreshAnnounced.set(0);
+            announces.clear();
+            terminals.clear();
+        }
+
+        @Override
+        public void onCasCommit(Commit committed, ConsistencyLevel consistencyLevel, CasCommitOrigin origin)
+        {
+            announces.add(origin.toString());
+            if (origin == CasCommitOrigin.REFRESH_COMMITTED)
+            {
+                refreshAnnounced.incrementAndGet();
+                if (vetoRefresh)
+                    throw new OverloadedException("dtest mutator veto");
+            }
+        }
+
+        @Override
+        public void onCasCommitCompleted(Commit committed, ConsistencyLevel consistencyLevel, CasCommitOrigin origin, CasCommitOutcome outcome)
+        {
+            terminals.add(origin + ":" + outcome);
+        }
+
+        @Override
+        public AbstractWriteResponseHandler<IMutation> mutateStandard(Mutation mutation, ConsistencyLevel consistencyLevel, String localDataCenter,
+                                                                      StorageProxy.WritePerformer writePerformer, Runnable callback,
+                                                                      WriteType writeType, Dispatcher.RequestTime requestTime)
+        {
+            return delegate.mutateStandard(mutation, consistencyLevel, localDataCenter, writePerformer, callback, writeType, requestTime);
+        }
+
+        @Override
+        public void mutateAtomically(Collection<Mutation> mutations, ConsistencyLevel consistencyLevel, boolean requireQuorumForRemove,
+                                     Dispatcher.RequestTime requestTime, ClientRequestsMetrics metrics, ClientState clientState)
+        {
+            delegate.mutateAtomically(mutations, consistencyLevel, requireQuorumForRemove, requestTime, metrics, clientState);
+        }
+
+        @Override
+        public AbstractWriteResponseHandler<IMutation> mutateCounter(CounterMutation cm, String localDataCenter, Dispatcher.RequestTime requestTime)
+        {
+            return delegate.mutateCounter(cm, localDataCenter, requestTime);
+        }
+
+        @Override
+        public AbstractWriteResponseHandler<IMutation> mutateCounterOnLeader(CounterMutation mutation, String localDataCenter,
+                                                                             StorageProxy.WritePerformer performer, Runnable callback,
+                                                                             Dispatcher.RequestTime requestTime)
+        {
+            return delegate.mutateCounterOnLeader(mutation, localDataCenter, performer, callback, requestTime);
+        }
+
+        @Nullable
+        @Override
+        public AbstractWriteResponseHandler<Commit> mutatePaxos(Commit proposal, ConsistencyLevel consistencyLevel, boolean allowHints, Dispatcher.RequestTime requestTime)
+        {
+            return delegate.mutatePaxos(proposal, consistencyLevel, allowHints, requestTime);
+        }
+
+        @Override
+        public RowIterator mutateCas(TableMetadata metadata, DecoratedKey key, CASRequest request, ConsistencyLevel consistencyForPaxos,
+                                     ConsistencyLevel consistencyForCommit, ClientState clientState, long nowInSeconds, Dispatcher.RequestTime requestTime)
+        {
+            return Mutator.super.mutateCas(metadata, key, request, consistencyForPaxos, consistencyForCommit, clientState, nowInSeconds, requestTime);
+        }
+
+        @Override
+        public void persistBatchlog(Collection<Mutation> mutations, Dispatcher.RequestTime requestTime, ReplicaPlan.ForWrite replicaPlan, TimeUUID batchUUID)
+        {
+            delegate.persistBatchlog(mutations, requestTime, replicaPlan, batchUUID);
+        }
+
+        @Override
+        public void clearBatchlog(String keyspace, Dispatcher.RequestTime requestTime, ReplicaPlan.ForWrite replicaPlan, TimeUUID batchUUID)
+        {
+            delegate.clearBatchlog(keyspace, requestTime, replicaPlan, batchUUID);
+        }
+    }
+
+    private static void resetMutator(int node)
+    {
+        FOUR_NODES.get(node).runOnInstance(VetoMutator::reset);
+    }
+
+    private static String announces(int node)
+    {
+        return FOUR_NODES.get(node).callOnInstance(() -> String.join(",", VetoMutator.announces));
+    }
+
+    private static void armRefreshVeto(int node, boolean armed)
+    {
+        FOUR_NODES.get(node).runOnInstance(() -> VetoMutator.vetoRefresh = armed);
+    }
+
+    private static int refreshAnnounced(int node)
+    {
+        // NOTE: must be a lambda, not a bound method reference — the latter would capture this
+        // classloader's static AtomicInteger instead of the instance's.
+        return FOUR_NODES.get(node).callOnInstance(() -> VetoMutator.refreshAnnounced.get());
+    }
+
+    private static List<String> awaitTerminals(int node, int expected) throws InterruptedException
+    {
+        long deadline = System.currentTimeMillis() + 20_000;
+        List<String> result;
+        while ((result = terminals(node)).size() < expected && System.currentTimeMillis() < deadline)
+            Thread.sleep(50);
+        return result;
+    }
+
+    private static List<String> terminals(int node)
+    {
+        String joined = FOUR_NODES.get(node).callOnInstance(() -> String.join(",", VetoMutator.terminals));
+        return joined.isEmpty() ? List.of() : List.of(joined.split(","));
+    }
+
+    private static void takeNodeFourOutOfRing()
+    {
+        for (int i = 1; i <= 4; ++i)
+            FOUR_NODES.get(i).acceptsOnInstance(CASTestBase::removeFromRing).accept(FOUR_NODES.get(4));
+    }
+
+
+    /** Runs a PaxosRepair for {@code pk} on {@code node}; returns "OK" or "FAILURE: <cause>". */
+    private static String repairOnNode(int node, String tableName, int pk)
+    {
+        return FOUR_NODES.get(node).callOnInstance(() -> {
+            TableMetadata schema = Keyspace.open(KEYSPACE).getColumnFamilyStore(tableName).metadata.get();
+            DecoratedKey key = schema.partitioner.decorateKey(Int32Type.instance.decompose(pk));
+            try
+            {
+                AbstractPaxosRepair.Result result = PaxosRepair.create(SERIAL, key, null, schema).start().await();
+                if (!(result instanceof AbstractPaxosRepair.Failure))
+                    return "OK";
+                Throwable cause = ((AbstractPaxosRepair.Failure) result).failure;
+                return "FAILURE: " + cause;
+            }
+            catch (InterruptedException e)
+            {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    private static boolean hasRowInternally(int node, String tableName, int pk)
+    {
+        return FOUR_NODES.get(node)
+                         .executeInternal("SELECT ck FROM " + KEYSPACE + '.' + tableName + " WHERE pk = ? AND ck = 1", pk)
+                         .length > 0;
+    }
+
+    /**
+     * Leaves {@code pk} decided (accepted by a quorum) but committed only on {@code holder}: the
+     * coordinator's commit messages to every replica in {@code dropTo} are dropped, and the CAS
+     * times out awaiting its commit quorum. Self-verifying: asserts the commit landed exactly on
+     * the holder.
+     */
+    private static void commitOnlyOn(int coordinator, int holder, String tableName, int pk, int[] dropTo, int[] mustLack)
+    {
+        IMessageFilters.Filter dropCommits =
+            FOUR_NODES.filters().verbs(PAXOS_COMMIT_REQ.id).from(coordinator).to(dropTo).drop();
+        try
+        {
+            FOUR_NODES.coordinator(coordinator)
+                      .execute("INSERT INTO " + KEYSPACE + '.' + tableName + " (pk, ck, v) VALUES (?, 1, 1) IF NOT EXISTS", QUORUM, pk);
+            Assert.fail("the CAS commit cannot reach a quorum and must time out");
+        }
+        catch (RuntimeException expected)
+        {
+            // CasWriteTimeout: decided, but the commit reached only the holder
+        }
+        finally
+        {
+            dropCommits.off();
+        }
+        Assert.assertTrue("scenario setup: the commit must have landed on node " + holder,
+                          hasRowInternally(holder, tableName, pk));
+        for (int node : mustLack)
+            Assert.assertFalse("scenario setup: node " + node + " must have missed the commit",
+                               hasRowInternally(node, tableName, pk));
+    }
+
+    /**
+     * PaxosRepair announce/terminal pairing: a REFRESH_COMMITTED veto fails the repair attempt AND
+     * closes the announce with UNCONFIRMED; a commit attempt that fails re-announces on retry
+     * (closing the previous announce as UNCONFIRMED) before completing with APPLIED.
+     */
+    @Test
+    public void paxosRepairRefreshVetoAndReannouncePairing() throws Throwable
+    {
+        // schema changes need the whole ring: create the table before taking {4} out
+        String tableName = "veto_repair";
+        int pk = pk(FOUR_NODES, 1, 2);
+
+        commitOnlyOn(1, 3, tableName, pk, to(1, 2), to(1, 2));
+
+        // Vetoed refresh: the repair fails, the announce is paired with UNCONFIRMED
+        resetMutator(2);
+        armRefreshVeto(2, true);
+        String vetoedResult = repairOnNode(2, tableName, pk);
+        Assert.assertTrue("the vetoed repair attempt must fail with the veto; got " + vetoedResult
+                          + "; announces=" + announces(2) + " terminals=" + terminals(2),
+                          vetoedResult.contains("dtest mutator veto"));
+        List<String> terminals = awaitTerminals(2, 1);
+        Assert.assertEquals(1, refreshAnnounced(2));
+        Assert.assertEquals(List.of("REFRESH_COMMITTED:UNCONFIRMED"), terminals);
+
+        // Disarmed, but the first commit attempt is dropped towards the other replicas: the retry
+        // re-announces (closing the previous announce as UNCONFIRMED) and then completes APPLIED
+        armRefreshVeto(2, false);
+        resetMutator(2);
+        AtomicInteger dropped = new AtomicInteger();
+        IMessageFilters.Filter dropFirstAttempt =
+            FOUR_NODES.filters().verbs(PAXOS_COMMIT_REQ.id).from(2).to(1, 2, 3)
+                      .messagesMatching((from, to, message) -> dropped.incrementAndGet() <= 3).drop();
+        try
+        {
+            Assert.assertEquals("the retried repair must complete", "OK", repairOnNode(2, tableName, pk));
+        }
+        finally
+        {
+            dropFirstAttempt.off();
+        }
+        terminals = awaitTerminals(2, 2);
+        Assert.assertEquals("the failed attempt's announce is closed by the retry's re-announce",
+                            List.of("REFRESH_COMMITTED:UNCONFIRMED", "REFRESH_COMMITTED:APPLIED"), terminals);
+        Assert.assertEquals(2, refreshAnnounced(2));
+
+        assertRows(FOUR_NODES.coordinator(3).execute("SELECT pk, ck, v FROM " + KEYSPACE + '.' + tableName + " WHERE pk = ?",
+                                                     org.apache.cassandra.distributed.api.ConsistencyLevel.SERIAL, pk),
+                   row(pk, 1, 1));
+    }
+
+    /**
+     * CommitAndRestart: a poison prepare (no reads attached) that finds an incomplete commit
+     * refreshes it and delivers the APPLIED terminal. Setup: a commit held by one node only, plus
+     * a bare promise newer than the accepted round (a prepare whose operation never proposed), so
+     * the repair takes the poison path rather than the query-phase refresh.
+     */
+    @Test
+    public void paxosRepairPoisonRefreshDeliversApplied() throws Throwable
+    {
+        String tableName = "veto_poison";
+        int pk = pk(FOUR_NODES, 1, 2);
+
+        commitOnlyOn(1, 3, tableName, pk, to(1, 2), to(1, 2));
+
+        // Leave a bare newer promise: prepare succeeds everywhere, but the propose and the
+        // commit-and-prepare (which would refresh the lagging commit) and the prepare-refresh
+        // never leave the coordinator.
+        IMessageFilters.Filter dropProgress =
+            FOUR_NODES.filters().verbs(PAXOS2_PROPOSE_REQ.id, PAXOS_PROPOSE_REQ.id, PAXOS2_COMMIT_AND_PREPARE_REQ.id, PAXOS2_PREPARE_REFRESH_REQ.id)
+                      .from(1).to(1, 2, 3).drop();
+        try
+        {
+            FOUR_NODES.coordinator(1)
+                      .execute("INSERT INTO " + KEYSPACE + '.' + tableName + " (pk, ck, v) VALUES (?, 2, 2) IF NOT EXISTS", QUORUM, pk);
+            Assert.fail("the promised-but-never-proposed CAS must time out");
+        }
+        catch (RuntimeException expected)
+        {
+        }
+        finally
+        {
+            dropProgress.off();
+        }
+
+        resetMutator(2);
+        Assert.assertEquals("the repair must complete", "OK", repairOnNode(2, tableName, pk));
+        List<String> terminals = awaitTerminals(2, 1);
+        Assert.assertTrue("the poison-path refresh must deliver an APPLIED terminal: " + terminals,
+                          terminals.contains("REFRESH_COMMITTED:APPLIED"));
+
+        assertRows(FOUR_NODES.coordinator(1).execute("SELECT pk, ck, v FROM " + KEYSPACE + '.' + tableName + " WHERE pk = ?",
+                                                     org.apache.cassandra.distributed.api.ConsistencyLevel.SERIAL, pk),
+                   row(pk, 1, 1));
+    }
+
+    /**
+     * Paxos.begin FOUND_INCOMPLETE_COMMITTED veto: when the only replica having the latest commit
+     * is a pending (bootstrapping) one — which is sent its prepare without a read — the driving
+     * operation must refresh the commit before proceeding; a REFRESH_COMMITTED veto aborts it with
+     * the thrown exception and an UNCONFIRMED terminal, and once disarmed the operation succeeds.
+     */
+    @Test
+    public void beginIncompleteCommittedVetoAbortsOperation() throws Throwable
+    {
+        String tableName = "veto_begin";
+
+        // {4} is bootstrapping (pending), witnessed by every node
+        takeNodeFourOutOfRing();
+        for (int i = 1; i <= 4; ++i)
+        {
+            FOUR_NODES.get(i).acceptsOnInstance(CASTestBase::addToRingBootstrapping).accept(FOUR_NODES.get(4));
+            FOUR_NODES.get(i).acceptsOnInstance(CASTestBase::assertVisibleInRing).accept(FOUR_NODES.get(4));
+        }
+        try
+        {
+            int pk = pk(FOUR_NODES, 3, 4);
+
+            // commit lands only on the pending {4}: dropped towards the natural replicas
+            commitOnlyOn(2, 4, tableName, pk, to(1, 2, 3), to(1, 2, 3));
+
+            resetMutator(3);
+            armRefreshVeto(3, true);
+            // The consensus quorum (3 of the 3-natural + 1-pending electorate) must include the
+            // pending {4}: without this, {1, 2, 3} can answer first and the round is completed as
+            // an in-progress repair instead. Excluding {1} from the prepare forces {2, 3, 4}.
+            IMessageFilters.Filter excludeNodeOne =
+                FOUR_NODES.filters().verbs(org.apache.cassandra.net.Verb.PAXOS2_PREPARE_REQ.id).from(3).to(1).drop();
+            try
+            {
+                FOUR_NODES.coordinator(3)
+                          .execute("INSERT INTO " + KEYSPACE + '.' + tableName + " (pk, ck, v) VALUES (?, 3, 3) IF NOT EXISTS", QUORUM, pk);
+                Assert.fail("the refresh veto must abort the driving operation; announces=" + announces(3) + " terminals=" + terminals(3));
+            }
+            catch (RuntimeException e)
+            {
+                Assert.assertTrue("expected the veto to surface, got: " + e.getMessage(),
+                                  e.getMessage() != null && e.getMessage().contains("dtest mutator veto"));
+            }
+            Assert.assertTrue(refreshAnnounced(3) >= 1);
+            List<String> terminals = awaitTerminals(3, 1);
+            Assert.assertTrue("the vetoed refresh must be paired with UNCONFIRMED: " + terminals,
+                              terminals.contains("REFRESH_COMMITTED:UNCONFIRMED"));
+
+            // disarmed: the operation refreshes the commit and completes
+            armRefreshVeto(3, false);
+            try
+            {
+                FOUR_NODES.coordinator(3)
+                          .execute("INSERT INTO " + KEYSPACE + '.' + tableName + " (pk, ck, v) VALUES (?, 3, 3) IF NOT EXISTS", QUORUM, pk);
+            }
+            finally
+            {
+                excludeNodeOne.off();
+            }
+        }
+        finally
+        {
+            takeNodeFourOutOfRing();
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/service/MutatorCasTest.java
+++ b/test/unit/org/apache/cassandra/service/MutatorCasTest.java
@@ -39,14 +39,20 @@ import org.apache.cassandra.db.SinglePartitionReadCommand;
 import org.apache.cassandra.db.SystemKeyspace;
 import org.apache.cassandra.db.WriteType;
 import org.apache.cassandra.db.partitions.FilteredPartition;
+import org.apache.cassandra.db.partitions.PartitionIterator;
 import org.apache.cassandra.db.partitions.PartitionUpdate;
 import org.apache.cassandra.db.rows.RowIterator;
 import org.apache.cassandra.dht.ByteOrderedPartitioner;
 import org.apache.cassandra.dht.Token;
+import org.apache.cassandra.exceptions.ExceptionCode;
+import org.apache.cassandra.exceptions.InvalidRequestException;
+import org.apache.cassandra.exceptions.OverloadedException;
+import org.apache.cassandra.exceptions.RequestExecutionException;
 import org.apache.cassandra.exceptions.UnavailableException;
 import org.apache.cassandra.exceptions.WriteFailureException;
 import org.apache.cassandra.locator.ReplicaPlan;
 import org.apache.cassandra.metrics.ClientRequestsMetrics;
+import org.apache.cassandra.metrics.ClientRequestsMetricsProvider;
 import org.apache.cassandra.net.Message;
 import org.apache.cassandra.schema.KeyspaceParams;
 import org.apache.cassandra.schema.Schema;
@@ -138,6 +144,14 @@ public class MutatorCasTest
          */
         static volatile RuntimeException commitFailure;
 
+        /**
+         * When non-null, {@link #onCasCommit} throws this (after recording) for callbacks whose origin
+         * matches {@link #onCasCommitFailureOrigin} (all origins when that is null) -- lets a test
+         * drive the veto and containment paths of {@link MutatorProvider#notifyCasCommit}.
+         */
+        static volatile RuntimeException onCasCommitFailure;
+        static volatile Mutator.CasCommitOrigin onCasCommitFailureOrigin;
+
         private final Mutator delegate = new StorageProxy.DefaultMutator();
 
         static void reset()
@@ -148,6 +162,8 @@ public class MutatorCasTest
             commits.clear();
             completed.clear();
             commitFailure = null;
+            onCasCommitFailure = null;
+            onCasCommitFailureOrigin = null;
             sequence.set(0);
         }
 
@@ -196,6 +212,9 @@ public class MutatorCasTest
         public void onCasCommit(Commit committed, ConsistencyLevel consistencyLevel, CasCommitOrigin origin)
         {
             commits.add(new CommitRecord(committed, consistencyLevel, origin));
+            RuntimeException failure = onCasCommitFailure;
+            if (failure != null && (onCasCommitFailureOrigin == null || onCasCommitFailureOrigin == origin))
+                throw failure;
         }
 
         @Override
@@ -664,5 +683,426 @@ public class MutatorCasTest
     public void commitInterruptedCompletesUnconfirmedV1()
     {
         commitFailureCompletesUnconfirmed(new UncheckedInterruptedException(), "cas_commit_interrupt_v1");
+    }
+
+    /**
+     * The veto contract of {@link Mutator#onCasCommit}: a {@link OverloadedException} (any
+     * RequestExecutionException) thrown for a CLIENT_OPERATION commit propagates to the caller, the
+     * commit dispatch is skipped, and the announced commit is paired with an UNCONFIRMED terminal.
+     * The value is nonetheless DECIDED: the follow-up CAS on the same partition must find and
+     * complete it as a repair, and its condition must see the vetoed row.
+     */
+    private void vetoPropagatesAndValueCompletesLater(Config.PaxosVariant variant, String keyName)
+    {
+        setPaxosVariant(variant);
+        TableMetadata metadata = Schema.instance.getTableMetadata(KEYSPACE, TABLE);
+        DecoratedKey key = dk(keyName);
+
+        OverloadedException veto = new OverloadedException("mutator veto: downstream overloaded");
+        RecordingMutator.onCasCommitFailure = veto;
+        RecordingMutator.onCasCommitFailureOrigin = Mutator.CasCommitOrigin.CLIENT_OPERATION;
+
+        // The empty partition matches the condition, the proposal is accepted (DECIDED), then the
+        // commit announcement vetoes: the exact exception instance must surface to the caller.
+        assertThatThrownBy(() -> cas(KEYSPACE, key, ifEmptyInsert(metadata, key, "v-" + keyName)))
+            .isSameAs(veto);
+
+        assertThat(RecordingMutator.casBegun.get()).isEqualTo(1);
+        assertThat(RecordingMutator.casCompleted.get()).as("completion also fires on a veto").isEqualTo(1);
+        List<CommitRecord> clientCommits = RecordingMutator.commitsWithOrigin(Mutator.CasCommitOrigin.CLIENT_OPERATION);
+        assertThat(clientCommits).as("the veto still records the announced commit").hasSize(1);
+        assertThat(RecordingMutator.mutatePaxosCalls.get())
+            .as("a vetoed commit must never be dispatched (v1's commit transport is not invoked)")
+            .isZero();
+        List<CommitRecord> clientCompleted = RecordingMutator.completedWithOrigin(Mutator.CasCommitOrigin.CLIENT_OPERATION);
+        assertThat(clientCompleted).as("the vetoed commit is paired with exactly one terminal").hasSize(1);
+        CommitRecord terminal = clientCompleted.get(0);
+        assertThat(terminal.outcome)
+            .as("a vetoed commit is decided but not confirmed").isEqualTo(Mutator.CasCommitOutcome.UNCONFIRMED);
+        assertThat(terminal.commit.update.partitionKey()).isEqualTo(key);
+        assertThat(terminal.thread).isSameAs(Thread.currentThread());
+        assertThat(terminal.seq).isGreaterThan(clientCommits.get(0).seq);
+
+        // The vetoed value is decided: a later operation must complete it as a repair, and once the
+        // row is visible this second CAS must not apply.
+        RecordingMutator.reset();
+        try (RowIterator result = cas(KEYSPACE, key, ifEmptyInsert(metadata, key, "unused")))
+        {
+            assertThat(result)
+                .as("the vetoed-but-decided row must be visible to the follow-up CAS (condition not met)")
+                .isNotNull();
+        }
+        assertThat(RecordingMutator.commitsWithOrigin(Mutator.CasCommitOrigin.REPAIR_IN_PROGRESS))
+            .as("the vetoed round is completed by the follow-up operation as an in-progress repair")
+            .hasSize(1);
+        assertThat(RecordingMutator.commitsWithOrigin(Mutator.CasCommitOrigin.CLIENT_OPERATION))
+            .as("the non-applying follow-up must not commit anything of its own").isEmpty();
+    }
+
+    @Test
+    public void vetoPropagatesAndValueCompletesLaterV1()
+    {
+        vetoPropagatesAndValueCompletesLater(Config.PaxosVariant.v1, "cas_veto_v1");
+    }
+
+    @Test
+    public void vetoPropagatesAndValueCompletesLaterV2()
+    {
+        vetoPropagatesAndValueCompletesLater(Config.PaxosVariant.v2, "cas_veto_v2");
+    }
+
+    /**
+     * Only the RequestExecutionException family may veto: any other throwable from
+     * {@link Mutator#onCasCommit} — including RequestValidationExceptions like
+     * {@link InvalidRequestException} — keeps the historic containment (logged and ignored), so the
+     * operation applies normally and completes with an APPLIED terminal.
+     */
+    private void containedOnCasCommitFailure(Config.PaxosVariant variant, RuntimeException failure, String keyName)
+    {
+        setPaxosVariant(variant);
+        TableMetadata metadata = Schema.instance.getTableMetadata(KEYSPACE, TABLE);
+        DecoratedKey key = dk(keyName);
+
+        RecordingMutator.onCasCommitFailure = failure;
+        RecordingMutator.onCasCommitFailureOrigin = Mutator.CasCommitOrigin.CLIENT_OPERATION;
+
+        try (RowIterator result = cas(KEYSPACE, key, ifEmptyInsert(metadata, key, "v-" + keyName)))
+        {
+            assertThat(result).as("a contained onCasCommit failure must not affect the operation").isNull();
+        }
+        assertThat(RecordingMutator.commitsWithOrigin(Mutator.CasCommitOrigin.CLIENT_OPERATION)).hasSize(1);
+        List<CommitRecord> clientCompleted = RecordingMutator.completedWithOrigin(Mutator.CasCommitOrigin.CLIENT_OPERATION);
+        assertThat(clientCompleted).hasSize(1);
+        assertThat(clientCompleted.get(0).outcome)
+            .as("the commit proceeds and is acknowledged despite the contained callback failure")
+            .isEqualTo(Mutator.CasCommitOutcome.APPLIED);
+        assertThat(RecordingMutator.mutatePaxosCalls.get())
+            .as("the commit is dispatched normally")
+            .isEqualTo(variant == Config.PaxosVariant.v1 ? 1 : 0);
+    }
+
+    @Test
+    public void runtimeExceptionFromOnCasCommitIsContainedV1()
+    {
+        containedOnCasCommitFailure(Config.PaxosVariant.v1, new RuntimeException("boom"), "cas_contained_rte_v1");
+    }
+
+    @Test
+    public void runtimeExceptionFromOnCasCommitIsContainedV2()
+    {
+        containedOnCasCommitFailure(Config.PaxosVariant.v2, new RuntimeException("boom"), "cas_contained_rte_v2");
+    }
+
+    @Test
+    public void invalidRequestFromOnCasCommitIsContainedV1()
+    {
+        containedOnCasCommitFailure(Config.PaxosVariant.v1, new InvalidRequestException("not a veto"),
+                                    "cas_contained_ire_v1");
+    }
+
+    @Test
+    public void invalidRequestFromOnCasCommitIsContainedV2()
+    {
+        containedOnCasCommitFailure(Config.PaxosVariant.v2, new InvalidRequestException("not a veto"),
+                                    "cas_contained_ire_v2");
+    }
+
+    /**
+     * The veto applies to repair origins too — as a "defer, retry later" signal: throwing a
+     * RequestExecutionException while completing a foreign in-progress round skips the repair
+     * commit and fails the driving operation, but the DECIDED round is not lost — the next
+     * operation on the partition re-attempts the repair (re-firing the callback) and, once the
+     * implementation stops throwing, completes it.
+     */
+    private void repairOriginVetoDefersAndRetries(Config.PaxosVariant variant, String keyName)
+    {
+        setPaxosVariant(variant);
+        TableMetadata metadata = Schema.instance.getTableMetadata(KEYSPACE, TABLE);
+        DecoratedKey key = dk(keyName);
+
+        Ballot foreignBallot = BallotGenerator.Global.nextBallot(Ballot.Flag.GLOBAL);
+        PartitionUpdate foreignUpdate = insertRow(metadata, key, "foreign", foreignBallot.unixMicros());
+        SystemKeyspace.savePaxosProposal(Commit.newProposal(foreignBallot, foreignUpdate));
+        PaxosState.unsafeReset();
+
+        OverloadedException veto = new OverloadedException("mutator veto during repair");
+        RecordingMutator.onCasCommitFailure = veto;
+        RecordingMutator.onCasCommitFailureOrigin = null; // every origin
+
+        // The operation must complete the foreign round before proceeding, so the veto of that
+        // repair commit aborts the whole (innocent) driving operation with the thrown exception.
+        assertThatThrownBy(() -> cas(KEYSPACE, key, ifEmptyInsert(metadata, key, "unused")))
+            .isSameAs(veto);
+        assertThat(RecordingMutator.casCompleted.get()).as("completion also fires on a veto").isEqualTo(1);
+        List<CommitRecord> repairs = RecordingMutator.commitsWithOrigin(Mutator.CasCommitOrigin.REPAIR_IN_PROGRESS);
+        assertThat(repairs).as("the vetoed repair dispatch is still announced").isNotEmpty();
+        assertThat(RecordingMutator.completed)
+            .as("nothing may complete successfully: the vetoed repair commit was never dispatched")
+            .noneMatch(CommitRecord::isSuccess);
+        if (variant == Config.PaxosVariant.v1)
+        {
+            assertThat(RecordingMutator.mutatePaxosCalls.get())
+                .as("the vetoed repair commit must not reach the v1 commit transport").isZero();
+            List<CommitRecord> terminals = RecordingMutator.completedWithOrigin(Mutator.CasCommitOrigin.REPAIR_IN_PROGRESS);
+            assertThat(terminals).as("the v1 in-progress site pairs the veto with a terminal").hasSize(1);
+            assertThat(terminals.get(0).outcome).isEqualTo(Mutator.CasCommitOutcome.UNCONFIRMED);
+        }
+        else
+        {
+            // v2's begin()-path repair pairs the veto with an UNCONFIRMED terminal; a completion
+            // driven by the PaxosRepair machinery instead delivers none on failure — either way no
+            // success terminal may appear (asserted above), and any delivered one is UNCONFIRMED.
+            assertThat(RecordingMutator.completedWithOrigin(Mutator.CasCommitOrigin.REPAIR_IN_PROGRESS))
+                .allMatch(r -> r.outcome == Mutator.CasCommitOutcome.UNCONFIRMED);
+        }
+
+        // "Retried later, not lost": once the implementation stops throwing, the next operation
+        // finds the still-uncommitted round, re-fires the repair callback and completes it — the
+        // foreign row becomes visible, so this CAS does not apply.
+        RecordingMutator.reset();
+        try (RowIterator result = cas(KEYSPACE, key, ifEmptyInsert(metadata, key, "unused")))
+        {
+            assertThat(result)
+                .as("the retried repair must complete the vetoed round (foreign row visible)")
+                .isNotNull();
+        }
+        assertThat(RecordingMutator.commitsWithOrigin(Mutator.CasCommitOrigin.REPAIR_IN_PROGRESS))
+            .as("the retry re-fires the repair-origin callback").isNotEmpty();
+    }
+
+    @Test
+    public void repairOriginVetoDefersAndRetriesV1()
+    {
+        repairOriginVetoDefersAndRetries(Config.PaxosVariant.v1, "cas_repair_veto_v1");
+    }
+
+    @Test
+    public void repairOriginVetoDefersAndRetriesV2()
+    {
+        repairOriginVetoDefersAndRetries(Config.PaxosVariant.v2, "cas_repair_veto_v2");
+    }
+
+    /**
+     * Containment at repair origins is unchanged for anything that is not a
+     * RequestExecutionException: completing a foreign in-progress round succeeds despite the
+     * throwing callback.
+     */
+    private void nonVetoAtRepairOriginIsContained(Config.PaxosVariant variant, String keyName)
+    {
+        setPaxosVariant(variant);
+        TableMetadata metadata = Schema.instance.getTableMetadata(KEYSPACE, TABLE);
+        DecoratedKey key = dk(keyName);
+
+        Ballot foreignBallot = BallotGenerator.Global.nextBallot(Ballot.Flag.GLOBAL);
+        PartitionUpdate foreignUpdate = insertRow(metadata, key, "foreign", foreignBallot.unixMicros());
+        SystemKeyspace.savePaxosProposal(Commit.newProposal(foreignBallot, foreignUpdate));
+        PaxosState.unsafeReset();
+
+        RecordingMutator.onCasCommitFailure = new RuntimeException("contained at repair origins");
+        RecordingMutator.onCasCommitFailureOrigin = null; // every origin
+
+        try (RowIterator result = cas(KEYSPACE, key, ifEmptyInsert(metadata, key, "unused")))
+        {
+            assertThat(result).as("the repaired foreign round makes the CAS non-applying").isNotNull();
+        }
+        assertThat(RecordingMutator.casCompleted.get()).isEqualTo(1);
+        assertThat(RecordingMutator.commitsWithOrigin(Mutator.CasCommitOrigin.REPAIR_IN_PROGRESS))
+            .as("the foreign round was still repaired despite the throwing callback").hasSize(1);
+    }
+
+    @Test
+    public void nonVetoAtRepairOriginIsContainedV1()
+    {
+        nonVetoAtRepairOriginIsContained(Config.PaxosVariant.v1, "cas_repair_contained_v1");
+    }
+
+    @Test
+    public void nonVetoAtRepairOriginIsContainedV2()
+    {
+        nonVetoAtRepairOriginIsContained(Config.PaxosVariant.v2, "cas_repair_contained_v2");
+    }
+
+    /**
+     * The veto reaches SERIAL readers too: a read that must complete a foreign in-progress round
+     * before proceeding fails with the exact vetoed exception, marks the CAS-read unavailables
+     * meter, and — once the implementation stops throwing — the retried read completes the round
+     * and observes the foreign row.
+     */
+    private void serialReadVetoDefersAndRetries(Config.PaxosVariant variant, String keyName)
+    {
+        setPaxosVariant(variant);
+        TableMetadata metadata = Schema.instance.getTableMetadata(KEYSPACE, TABLE);
+        DecoratedKey key = dk(keyName);
+
+        Ballot foreignBallot = BallotGenerator.Global.nextBallot(Ballot.Flag.GLOBAL);
+        PartitionUpdate foreignUpdate = insertRow(metadata, key, "foreign", foreignBallot.unixMicros());
+        SystemKeyspace.savePaxosProposal(Commit.newProposal(foreignBallot, foreignUpdate));
+        PaxosState.unsafeReset();
+
+        OverloadedException veto = new OverloadedException("mutator veto during serial read");
+        RecordingMutator.onCasCommitFailure = veto;
+        RecordingMutator.onCasCommitFailureOrigin = null; // every origin
+
+        long unavailablesBefore = casReadUnavailables();
+        assertThatThrownBy(() -> serialRead(metadata, key)).isSameAs(veto);
+        assertThat(RecordingMutator.commitsWithOrigin(Mutator.CasCommitOrigin.REPAIR_IN_PROGRESS))
+            .as("the vetoed repair dispatch is still announced to the reader's mutator").isNotEmpty();
+        assertThat(casReadUnavailables())
+            .as("an Overloaded veto of a serial read marks the CAS-read unavailables meter (both engines)")
+            .isEqualTo(unavailablesBefore + 1);
+
+        // Deferred, not lost: the retried read completes the round and sees the foreign row.
+        RecordingMutator.reset();
+        try (PartitionIterator partitions = serialRead(metadata, key))
+        {
+            assertThat(partitions.hasNext()).as("the retried read returns the partition").isTrue();
+            try (RowIterator rows = partitions.next())
+            {
+                assertThat(rows.hasNext())
+                    .as("the retried read must observe the row of the previously vetoed round").isTrue();
+            }
+        }
+        assertThat(RecordingMutator.commitsWithOrigin(Mutator.CasCommitOrigin.REPAIR_IN_PROGRESS))
+            .as("the retried read re-fires the repair-origin callback").isNotEmpty();
+    }
+
+    private static PartitionIterator serialRead(TableMetadata metadata, DecoratedKey key)
+    {
+        SinglePartitionReadCommand command = SinglePartitionReadCommand.fullPartitionRead(metadata, FBUtilities.nowInSeconds(), key);
+        return StorageProxy.read(SinglePartitionReadCommand.Group.one(command),
+                                 ConsistencyLevel.SERIAL,
+                                 ClientState.forInternalCalls(),
+                                 Dispatcher.RequestTime.forImmediateExecution());
+    }
+
+    private static long casReadUnavailables()
+    {
+        return ClientRequestsMetricsProvider.instance.metrics(KEYSPACE).casReadMetrics.unavailables.getCount();
+    }
+
+    @Test
+    public void serialReadVetoDefersAndRetriesV1()
+    {
+        serialReadVetoDefersAndRetries(Config.PaxosVariant.v1, "cas_read_veto_v1");
+    }
+
+    @Test
+    public void serialReadVetoDefersAndRetriesV2()
+    {
+        serialReadVetoDefersAndRetries(Config.PaxosVariant.v2, "cas_read_veto_v2");
+    }
+
+    /** A RequestExecutionException subtype outside the concrete write/read exception families. */
+    static final class CustomVetoException extends RequestExecutionException
+    {
+        CustomVetoException(String message)
+        {
+            super(ExceptionCode.SERVER_ERROR, message);
+        }
+    }
+
+    /**
+     * A veto typed outside the concrete exception families still propagates on both engines — on
+     * v1 through the fallback catch in legacyCas that keeps the query tracker informed — skips the
+     * dispatch, and pairs the announcement with an UNCONFIRMED terminal.
+     */
+    private void customVetoTypePropagates(Config.PaxosVariant variant, String keyName)
+    {
+        setPaxosVariant(variant);
+        TableMetadata metadata = Schema.instance.getTableMetadata(KEYSPACE, TABLE);
+        DecoratedKey key = dk(keyName);
+
+        CustomVetoException veto = new CustomVetoException("custom veto type");
+        RecordingMutator.onCasCommitFailure = veto;
+        RecordingMutator.onCasCommitFailureOrigin = Mutator.CasCommitOrigin.CLIENT_OPERATION;
+
+        assertThatThrownBy(() -> cas(KEYSPACE, key, ifEmptyInsert(metadata, key, "v-" + keyName)))
+            .isSameAs(veto);
+        assertThat(RecordingMutator.mutatePaxosCalls.get())
+            .as("the vetoed commit must never be dispatched").isZero();
+        List<CommitRecord> terminals = RecordingMutator.completedWithOrigin(Mutator.CasCommitOrigin.CLIENT_OPERATION);
+        assertThat(terminals).as("the vetoed commit is paired with exactly one terminal").hasSize(1);
+        assertThat(terminals.get(0).outcome).isEqualTo(Mutator.CasCommitOutcome.UNCONFIRMED);
+    }
+
+    @Test
+    public void customVetoTypePropagatesV1()
+    {
+        customVetoTypePropagates(Config.PaxosVariant.v1, "cas_custom_veto_v1");
+    }
+
+    @Test
+    public void customVetoTypePropagatesV2()
+    {
+        customVetoTypePropagates(Config.PaxosVariant.v2, "cas_custom_veto_v2");
+    }
+
+    /**
+     * Custom-typed veto on the serial-read path: exercises the fallback catch in
+     * legacyReadWithPaxos (v1) and the raw v2 propagation — the exact instance surfaces to the
+     * reader even for a type outside the concrete exception families.
+     */
+    private void serialReadCustomVetoPropagates(Config.PaxosVariant variant, String keyName)
+    {
+        setPaxosVariant(variant);
+        TableMetadata metadata = Schema.instance.getTableMetadata(KEYSPACE, TABLE);
+        DecoratedKey key = dk(keyName);
+
+        Ballot foreignBallot = BallotGenerator.Global.nextBallot(Ballot.Flag.GLOBAL);
+        PartitionUpdate foreignUpdate = insertRow(metadata, key, "foreign", foreignBallot.unixMicros());
+        SystemKeyspace.savePaxosProposal(Commit.newProposal(foreignBallot, foreignUpdate));
+        PaxosState.unsafeReset();
+
+        CustomVetoException veto = new CustomVetoException("custom veto during serial read");
+        RecordingMutator.onCasCommitFailure = veto;
+        RecordingMutator.onCasCommitFailureOrigin = null; // every origin
+
+        assertThatThrownBy(() -> serialRead(metadata, key)).isSameAs(veto);
+        assertThat(RecordingMutator.commitsWithOrigin(Mutator.CasCommitOrigin.REPAIR_IN_PROGRESS))
+            .as("the vetoed repair dispatch is still announced").isNotEmpty();
+    }
+
+    @Test
+    public void serialReadCustomVetoPropagatesV1()
+    {
+        serialReadCustomVetoPropagates(Config.PaxosVariant.v1, "cas_read_custom_veto_v1");
+    }
+
+    @Test
+    public void serialReadCustomVetoPropagatesV2()
+    {
+        serialReadCustomVetoPropagates(Config.PaxosVariant.v2, "cas_read_custom_veto_v2");
+    }
+
+    /**
+     * v1, commit CL=ANY: normally ANY delivers no terminal (commitPaxos does not await an ack), but
+     * a veto always pairs the announcement with an UNCONFIRMED terminal — ANY included.
+     */
+    @Test
+    public void vetoAtConsistencyAnyDeliversUnconfirmedV1()
+    {
+        setPaxosVariant(Config.PaxosVariant.v1);
+        TableMetadata metadata = Schema.instance.getTableMetadata(KEYSPACE, TABLE);
+        DecoratedKey key = dk("cas_veto_any_v1");
+
+        OverloadedException veto = new OverloadedException("mutator veto at ANY");
+        RecordingMutator.onCasCommitFailure = veto;
+        RecordingMutator.onCasCommitFailureOrigin = Mutator.CasCommitOrigin.CLIENT_OPERATION;
+
+        assertThatThrownBy(() -> StorageProxy.cas(KEYSPACE,
+                                                  TABLE,
+                                                  key,
+                                                  ifEmptyInsert(metadata, key, "v-any"),
+                                                  ConsistencyLevel.SERIAL,
+                                                  ConsistencyLevel.ANY,
+                                                  ClientState.forInternalCalls(),
+                                                  FBUtilities.nowInSeconds(),
+                                                  Dispatcher.RequestTime.forImmediateExecution()))
+            .isSameAs(veto);
+
+        List<CommitRecord> clientCompleted = RecordingMutator.completedWithOrigin(Mutator.CasCommitOrigin.CLIENT_OPERATION);
+        assertThat(clientCompleted).as("a veto delivers the UNCONFIRMED terminal even at CL=ANY").hasSize(1);
+        assertThat(clientCompleted.get(0).outcome).isEqualTo(Mutator.CasCommitOutcome.UNCONFIRMED);
+        assertThat(RecordingMutator.mutatePaxosCalls.get()).isZero();
     }
 }

--- a/test/unit/org/apache/cassandra/service/MutatorCasTest.java
+++ b/test/unit/org/apache/cassandra/service/MutatorCasTest.java
@@ -44,10 +44,13 @@ import org.apache.cassandra.db.partitions.PartitionUpdate;
 import org.apache.cassandra.db.rows.RowIterator;
 import org.apache.cassandra.dht.ByteOrderedPartitioner;
 import org.apache.cassandra.dht.Token;
+import org.apache.cassandra.exceptions.CasWriteTimeoutException;
 import org.apache.cassandra.exceptions.ExceptionCode;
 import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.exceptions.OverloadedException;
 import org.apache.cassandra.exceptions.RequestExecutionException;
+import org.apache.cassandra.exceptions.RequestFailureException;
+import org.apache.cassandra.exceptions.RequestTimeoutException;
 import org.apache.cassandra.exceptions.UnavailableException;
 import org.apache.cassandra.exceptions.WriteFailureException;
 import org.apache.cassandra.locator.ReplicaPlan;
@@ -1005,6 +1008,128 @@ public class MutatorCasTest
         {
             super(ExceptionCode.SERVER_ERROR, message);
         }
+    }
+
+    /** A timeout-family subtype outside the concrete write/read timeout classes. */
+    static final class CustomTimeoutVetoException extends RequestTimeoutException
+    {
+        CustomTimeoutVetoException(String message)
+        {
+            super(ExceptionCode.WRITE_TIMEOUT, ConsistencyLevel.QUORUM, 0, 1, message);
+        }
+    }
+
+    /** A failure-family subtype outside the concrete write/read failure classes. */
+    static final class CustomFailureVetoException extends RequestFailureException
+    {
+        CustomFailureVetoException(String message)
+        {
+            super(ExceptionCode.WRITE_FAILURE, message, ConsistencyLevel.QUORUM, 0, 1, Collections.emptyMap());
+        }
+    }
+
+    private static ClientRequestsMetrics requestMetrics()
+    {
+        return ClientRequestsMetricsProvider.instance.metrics(KEYSPACE);
+    }
+
+    /** Arms {@code veto} for CLIENT_OPERATION, runs an applying CAS and asserts the exact instance surfaces. */
+    private void clientVeto(RuntimeException veto, String keyName)
+    {
+        TableMetadata metadata = Schema.instance.getTableMetadata(KEYSPACE, TABLE);
+        DecoratedKey key = dk(keyName);
+        RecordingMutator.reset();
+        RecordingMutator.onCasCommitFailure = veto;
+        RecordingMutator.onCasCommitFailureOrigin = Mutator.CasCommitOrigin.CLIENT_OPERATION;
+        assertThatThrownBy(() -> cas(KEYSPACE, key, ifEmptyInsert(metadata, key, "v-" + keyName))).isSameAs(veto);
+    }
+
+    /**
+     * Arms {@code veto} for every origin, injects a foreign in-progress round for {@code keyName}
+     * and asserts a SERIAL read fails with the exact instance while completing it.
+     */
+    private void serialReadVeto(RuntimeException veto, String keyName)
+    {
+        TableMetadata metadata = Schema.instance.getTableMetadata(KEYSPACE, TABLE);
+        DecoratedKey key = dk(keyName);
+        Ballot foreignBallot = BallotGenerator.Global.nextBallot(Ballot.Flag.GLOBAL);
+        SystemKeyspace.savePaxosProposal(Commit.newProposal(foreignBallot, insertRow(metadata, key, "foreign", foreignBallot.unixMicros())));
+        PaxosState.unsafeReset();
+        RecordingMutator.reset();
+        RecordingMutator.onCasCommitFailure = veto;
+        RecordingMutator.onCasCommitFailureOrigin = null;
+        assertThatThrownBy(() -> serialRead(metadata, key)).isSameAs(veto);
+    }
+
+    /**
+     * Every veto exception family marks its matching client-request meter on the v2 engine
+     * ({@code Paxos.markCasVeto}): Unavailable → unavailables, timeout family → timeouts, failure
+     * family → failures. (The Overloaded → unavailables branch is covered by the veto tests above.)
+     */
+    @Test
+    public void vetoFamilyMarksMatchingMeterV2()
+    {
+        setPaxosVariant(Config.PaxosVariant.v2);
+        ClientRequestsMetrics metrics = requestMetrics();
+
+        long unavailables = metrics.casWriteMetrics.unavailables.getCount();
+        clientVeto(UnavailableException.create(ConsistencyLevel.QUORUM, 1, 0), "cas_veto_meter_ua_v2");
+        assertThat(metrics.casWriteMetrics.unavailables.getCount()).isEqualTo(unavailables + 1);
+
+        long timeouts = metrics.casWriteMetrics.timeouts.getCount();
+        clientVeto(new CasWriteTimeoutException(WriteType.CAS, ConsistencyLevel.QUORUM, 0, 1, 0), "cas_veto_meter_to_v2");
+        assertThat(metrics.casWriteMetrics.timeouts.getCount()).isEqualTo(timeouts + 1);
+
+        long failures = metrics.casWriteMetrics.failures.getCount();
+        clientVeto(new WriteFailureException(ConsistencyLevel.QUORUM, 0, 1, WriteType.CAS, Collections.emptyMap()), "cas_veto_meter_fl_v2");
+        assertThat(metrics.casWriteMetrics.failures.getCount()).isEqualTo(failures + 1);
+    }
+
+    /**
+     * The v1 fallback catch in legacyCas routes veto types outside the concrete classes to the
+     * closest family meter, and the exact instance still surfaces.
+     */
+    @Test
+    public void customFamilyVetoMarksMatchingMeterV1()
+    {
+        setPaxosVariant(Config.PaxosVariant.v1);
+        ClientRequestsMetrics metrics = requestMetrics();
+
+        long timeouts = metrics.casWriteMetrics.timeouts.getCount();
+        clientVeto(new CustomTimeoutVetoException("custom timeout veto"), "cas_veto_meter_to_v1");
+        assertThat(metrics.casWriteMetrics.timeouts.getCount()).isEqualTo(timeouts + 1);
+
+        long failures = metrics.casWriteMetrics.failures.getCount();
+        clientVeto(new CustomFailureVetoException("custom failure veto"), "cas_veto_meter_fl_v1");
+        assertThat(metrics.casWriteMetrics.failures.getCount()).isEqualTo(failures + 1);
+    }
+
+    /** Same family routing through the v1 fallback catch in legacyReadWithPaxos (serial-read path). */
+    @Test
+    public void serialReadCustomFamilyVetoMarksMatchingMeterV1()
+    {
+        setPaxosVariant(Config.PaxosVariant.v1);
+        ClientRequestsMetrics metrics = requestMetrics();
+
+        long timeouts = metrics.casReadMetrics.timeouts.getCount();
+        serialReadVeto(new CustomTimeoutVetoException("custom timeout veto"), "cas_read_veto_meter_to_v1");
+        assertThat(metrics.casReadMetrics.timeouts.getCount()).isEqualTo(timeouts + 1);
+
+        long failures = metrics.casReadMetrics.failures.getCount();
+        serialReadVeto(new CustomFailureVetoException("custom failure veto"), "cas_read_veto_meter_fl_v1");
+        assertThat(metrics.casReadMetrics.failures.getCount()).isEqualTo(failures + 1);
+    }
+
+    /** The v2 read-side veto marks the CAS-read meters ({@code markCasVeto} with isWrite=false). */
+    @Test
+    public void serialReadTimeoutFamilyVetoMarksTimeoutsV2()
+    {
+        setPaxosVariant(Config.PaxosVariant.v2);
+        ClientRequestsMetrics metrics = requestMetrics();
+
+        long timeouts = metrics.casReadMetrics.timeouts.getCount();
+        serialReadVeto(new CustomTimeoutVetoException("custom timeout veto"), "cas_read_veto_meter_to_v2");
+        assertThat(metrics.casReadMetrics.timeouts.getCount()).isEqualTo(timeouts + 1);
     }
 
     /**

--- a/test/unit/org/apache/cassandra/service/MutatorCasTest.java
+++ b/test/unit/org/apache/cassandra/service/MutatorCasTest.java
@@ -54,12 +54,15 @@ import org.apache.cassandra.locator.ReplicaPlan;
 import org.apache.cassandra.metrics.ClientRequestsMetrics;
 import org.apache.cassandra.metrics.ClientRequestsMetricsProvider;
 import org.apache.cassandra.net.Message;
+import org.apache.cassandra.net.MessagingService;
 import org.apache.cassandra.schema.KeyspaceParams;
 import org.apache.cassandra.schema.Schema;
 import org.apache.cassandra.schema.TableMetadata;
+import org.apache.cassandra.service.paxos.AbstractPaxosRepair;
 import org.apache.cassandra.service.paxos.Ballot;
 import org.apache.cassandra.service.paxos.BallotGenerator;
 import org.apache.cassandra.service.paxos.Commit;
+import org.apache.cassandra.service.paxos.PaxosRepair;
 import org.apache.cassandra.service.paxos.PaxosState;
 import org.apache.cassandra.transport.Dispatcher;
 import org.apache.cassandra.utils.ByteBufferUtil;
@@ -327,6 +330,9 @@ public class MutatorCasTest
     public static void defineSchema()
     {
         SchemaLoader.prepareServer();
+        // PaxosRepair's query phase has no execute-on-self shortcut (unlike the prepare/propose/commit
+        // paths): it always goes through messaging, so loopback delivery needs a live listener.
+        MessagingService.instance().listen();
         SchemaLoader.createKeyspace(KEYSPACE,
                                     KeyspaceParams.simple(1),
                                     SchemaLoader.standardCFMD(KEYSPACE, TABLE));
@@ -1072,6 +1078,69 @@ public class MutatorCasTest
     public void serialReadCustomVetoPropagatesV2()
     {
         serialReadCustomVetoPropagates(Config.PaxosVariant.v2, "cas_read_custom_veto_v2");
+    }
+
+    /**
+     * Background {@code PaxosRepair} pairs every announce with a terminal even on failure: a veto
+     * thrown from {@link Mutator#onCasCommit} fails the repair attempt AND closes the announce
+     * with an UNCONFIRMED terminal (previously the failure was swallowed with no terminal, leaking
+     * any in-flight state a tracking implementation opened on the announce). Once the
+     * implementation stops throwing, a re-run repair completes the round with an APPLIED terminal.
+     */
+    @Test
+    public void paxosRepairVetoDeliversUnconfirmed() throws Exception
+    {
+        setPaxosVariant(Config.PaxosVariant.v2);
+        TableMetadata metadata = Schema.instance.getTableMetadata(KEYSPACE, TABLE);
+        DecoratedKey key = dk("cas_paxos_repair_veto");
+
+        Ballot foreignBallot = BallotGenerator.Global.nextBallot(Ballot.Flag.GLOBAL);
+        PartitionUpdate foreignUpdate = insertRow(metadata, key, "foreign", foreignBallot.unixMicros());
+        SystemKeyspace.savePaxosProposal(Commit.newProposal(foreignBallot, foreignUpdate));
+        PaxosState.unsafeReset();
+
+        OverloadedException veto = new OverloadedException("mutator veto during background repair");
+        RecordingMutator.onCasCommitFailure = veto;
+        RecordingMutator.onCasCommitFailureOrigin = null; // every origin
+
+        // null success criteria: passing the foreign ballot itself would clash with the witnessed
+        // ballot (reproposalMayBeRejected) and poison-loop to the retry timeout instead of
+        // completing the accepted proposal
+        AbstractPaxosRepair.Result result =
+            PaxosRepair.create(ConsistencyLevel.SERIAL, key, null, metadata).start().await();
+        assertThat(result).as("the vetoed repair attempt fails").isInstanceOf(AbstractPaxosRepair.Failure.class);
+        List<CommitRecord> announces = RecordingMutator.commitsWithOrigin(Mutator.CasCommitOrigin.REPAIR_IN_PROGRESS);
+        assertThat(announces).as("the vetoed repair commit is still announced").hasSize(1);
+        // the completion listener runs just after await() unblocks, on the repair's thread
+        List<CommitRecord> terminals = awaitCompleted(Mutator.CasCommitOrigin.REPAIR_IN_PROGRESS, 1);
+        assertThat(terminals).as("the failed repair pairs the announce with a terminal").hasSize(1);
+        assertThat(terminals.get(0).outcome).isEqualTo(Mutator.CasCommitOutcome.UNCONFIRMED);
+        assertThat(terminals.get(0).commit.update.partitionKey()).isEqualTo(key);
+
+        // Deferred, not lost: with the veto disarmed a re-run repair completes the round.
+        RecordingMutator.reset();
+        result = PaxosRepair.create(ConsistencyLevel.SERIAL, key, null, metadata).start().await();
+        assertThat(result).as("the retried repair succeeds").isNotInstanceOf(AbstractPaxosRepair.Failure.class);
+        assertThat(RecordingMutator.commitsWithOrigin(Mutator.CasCommitOrigin.REPAIR_IN_PROGRESS))
+            .as("the retried repair re-announces the commit").hasSize(1);
+        List<CommitRecord> applied = awaitCompleted(Mutator.CasCommitOrigin.REPAIR_IN_PROGRESS, 1);
+        assertThat(applied).hasSize(1);
+        assertThat(applied.get(0).outcome)
+            .as("an acknowledged repair commit completes as APPLIED")
+            .isEqualTo(Mutator.CasCommitOutcome.APPLIED);
+    }
+
+    /** The repair state machine delivers terminals on its own threads, just after await() unblocks. */
+    private static List<CommitRecord> awaitCompleted(Mutator.CasCommitOrigin origin, int expected) throws InterruptedException
+    {
+        long deadlineMillis = System.currentTimeMillis() + 10_000;
+        List<CommitRecord> records = RecordingMutator.completedWithOrigin(origin);
+        while (records.size() < expected && System.currentTimeMillis() < deadlineMillis)
+        {
+            Thread.sleep(10);
+            records = RecordingMutator.completedWithOrigin(origin);
+        }
+        return records;
     }
 
     /**

--- a/test/unit/org/apache/cassandra/service/MutatorCasTest.java
+++ b/test/unit/org/apache/cassandra/service/MutatorCasTest.java
@@ -20,9 +20,12 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nullable;
 
+import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionTimeoutException;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -1256,16 +1259,20 @@ public class MutatorCasTest
     }
 
     /** The repair state machine delivers terminals on its own threads, just after await() unblocks. */
-    private static List<CommitRecord> awaitCompleted(Mutator.CasCommitOrigin origin, int expected) throws InterruptedException
+    private static List<CommitRecord> awaitCompleted(Mutator.CasCommitOrigin origin, int expected)
     {
-        long deadlineMillis = System.currentTimeMillis() + 10_000;
-        List<CommitRecord> records = RecordingMutator.completedWithOrigin(origin);
-        while (records.size() < expected && System.currentTimeMillis() < deadlineMillis)
+        try
         {
-            Thread.sleep(10);
-            records = RecordingMutator.completedWithOrigin(origin);
+            Awaitility.await()
+                      .atMost(10, TimeUnit.SECONDS)
+                      .pollInterval(10, TimeUnit.MILLISECONDS)
+                      .until(() -> RecordingMutator.completedWithOrigin(origin).size() >= expected);
         }
-        return records;
+        catch (ConditionTimeoutException e)
+        {
+            // fall through: the caller's assertion reports the terminals actually delivered
+        }
+        return RecordingMutator.completedWithOrigin(origin);
     }
 
     /**


### PR DESCRIPTION
Follow-up to HCD-439 (Operation-level LWT tracking in the Mutator SPI).

HCD patch: https://github.com/riptano/hcd/pull/309

## Problem

`Mutator.onCasCommit` was fully contained by `MutatorProvider.notifyCasCommit` (`catch (Throwable)` -> no-spam WARN), so an implementation could not push back on the coordinator - e.g. throw `OverloadedException` when its downstream tracking system is overloaded. Any exception was logged and had no effect: the client never saw it, and the implementation's only alternative was to block the calling thread until its downstream recovered.

## Change

An implementation may now **veto** a commit dispatch by throwing a `RequestExecutionException` from `onCasCommit` - for **any** origin. The commit (or refresh) is not sent and the exception propagates to whatever drives the dispatch. Crucially, a veto **defers** the commit, it never loses it: when `onCasCommit` fires the value is already agreed by a quorum (decided), so the still-uncommitted round is re-attempted later - re-firing the callback each time - by:

- the next operation touching the partition (both engines), and
- the periodic paxos auto-repair machinery under v2 (`PaxosUncommittedTracker` maintenance loop, `cassandra.auto_repair_frequency_seconds`, default 5 minutes), which guarantees a retry even with no traffic. (v1 has no auto-repair: its retry is traffic-driven.)

The uncommitted round itself is the durable "not yet recorded" marker, so an implementation can apply backpressure without holding the thread and without keeping local retry state.

Per-origin consequences:

- **`CLIENT_OPERATION`**: the client CAS fails with the thrown exception. Every `RequestExecutionException` subclass (`OverloadedException`, `UnavailableException`, ...) maps to a real native-protocol error code (`OVERLOADED` 0x1001 is valid in all protocol versions and never downgraded) and is treated by the transport layer as an expected client error - no ERROR-log noise. `onCasCommitCompleted` fires with `UNCONFIRMED` (including at commit CL=ANY, which normally delivers no terminal).
- **`REPAIR_IN_PROGRESS` / `REFRESH_COMMITTED` from an operation** (v1 `beginAndRepairPaxos`, v2 `Paxos.begin`): the driving operation - possibly another client's CAS or SERIAL read - fails with the exception (it cannot safely proceed without completing the round, so skip-and-continue is not an option: its quorum read might miss a decided value). The v2 sites and the v1 in-progress site deliver an `UNCONFIRMED` terminal; the v1 fire-and-forget refresh site delivers none (unchanged).
- **Background `PaxosRepair`**: only that repair attempt fails (arbitrary thread, no client, no terminal - the veto lands in `AbstractPaxosRepair.updateState`'s failure handling); the auto-repair loop re-attempts it on its next tick. The same sites also run under operator-driven paxos cleanup (anti-entropy repair, topology operations), where a veto fails that cleanup session.

The exception surfaces as thrown, with one caveat: the v1 engine rewraps timeout-typed vetoes into its standard CAS/read timeout conversions - prefer non-timeout types such as `OverloadedException`.

Containment is unchanged for everything else: any non-`RequestExecutionException` throwable - including `RequestValidationException` (e.g. `InvalidRequestException`), which would falsely tell a client the request was invalid and non-retriable - is still logged and ignored, for every origin. `onCasCommitCompleted` remains unconditionally contained (it fires after the outcome is decided). The javadoc also warns that sustained vetoing has operational cost (uncommitted rounds accumulate; serial operations on those partitions keep failing; v2 paxos repairs, a topology-change prerequisite, cannot complete) - it is a transient overload response, not a steady state.

Instrumentation (also fixes pre-existing gaps where `checkHintOverload` throwing during the v1 commit phase escaped unrecorded):

- `legacyCas` and `legacyReadWithPaxos` gain an `OverloadedException` catch marking the CAS unavailables meters and notifying the LWT/read tracker (`lwtTracker.onError` / `readTracker.onError`), mirroring `StorageProxy.mutate`;
- the v2 veto catch sites mark the client request metrics by exception family (`Paxos.markCasVeto`: Overloaded/Unavailable -> unavailables, timeouts -> timeouts, failures -> failures), so a veto is visible in CAS metrics on both engines, for writes and serial reads alike;
- `legacyCas` and `legacyReadWithPaxos` also gain a fallback `catch (RequestExecutionException)` so a veto typed outside the concrete families (base-typed or custom subtypes) still reaches the LWT/read tracker and marks the closest family meter on v1, matching v2's `markCasVeto`.

## Implementation

- `MutatorProvider.notifyCasCommit`: rethrows `RequestExecutionException` (any origin); contains everything else as before.
- v1 `StorageProxy.doPaxos` (CLIENT_OPERATION) and `beginAndRepairPaxos` (REPAIR_IN_PROGRESS): the notify moved inside the existing `try` around `commitPaxos`, whose catch (broadened to `RuntimeException` at the repair site, matching the client site) delivers the `UNCONFIRMED` terminal and rethrows.
- v2 `Paxos.cas` (CLIENT_OPERATION) and both `Paxos.begin` repair/refresh sites: explicit `catch (RequestExecutionException)` delivering `UNCONFIRMED` before rethrowing.
- `PaxosRepair`: no code change needed - the rethrown veto is absorbed by the existing `Failure` state handling; a comment documents this.
- `Mutator` javadoc rewritten with the veto contract (`onCasCommit`, `onCasCommitCompleted` coverage, `mutateCas` outcome list).

## Tests

`MutatorCasTest` extended (25 tests, all passing under both `paxos_variant` v1 and v2):

- client veto propagates the exact exception instance, skips the commit dispatch (`mutatePaxos` not invoked on v1), delivers exactly one `UNCONFIRMED` terminal - and a follow-up CAS completes the decided value as `REPAIR_IN_PROGRESS`, observing the vetoed row;
- repair-origin veto defers and retries: vetoing while completing a foreign in-progress round aborts the driving operation with the exception, dispatches nothing, delivers no success terminal (v1: exactly one `UNCONFIRMED`) - then, once the implementation stops throwing, the next operation re-fires the repair callback and completes the round;
- serial-read veto: a SERIAL read that must complete a foreign round fails with the exact vetoed exception and marks the CAS-read unavailables meter (both engines); the retried read completes the round and observes the foreign row;
- plain `RuntimeException` and `InvalidRequestException` stay contained at the client origin (operation applies, `APPLIED` terminal), and a non-veto throwable stays contained at repair origins (foreign round still repaired);
- a custom `RequestExecutionException` subtype outside the concrete families still propagates (exercising the v1 fallback catches on both the write and serial-read paths), skips the dispatch, and pairs with an `UNCONFIRMED` terminal;
- veto at commit CL=ANY still delivers the `UNCONFIRMED` terminal.

`MutatorTest` and `MutatorProviderTest` also pass.
