### PR TITLE
CNDB-18565 5.0: Separately enable generic histogram for SAI queries latency

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -760,12 +760,18 @@ public enum CassandraRelevantProperties
 
     // SAI specific properties
 
+    /**
+     * Whether to enable the SAI histogram for the latency of queries of any kind if {@link #SAI_HISTOGRAMS_ENABLED}
+     * is not true. Enabled by default.
+     */
+    SAI_ALL_QUERIES_LATENCY_HISTOGRAM_ENABLED("cassandra.sai.metrics.histograms.all_queries.enabled", "true"),
+
     /** Class used to discover/load the proper SAI index components file for a given sstable. */
     SAI_ANN_USE_SYNTHETIC_SCORE("cassandra.sai.ann_use_synthetic_score", "false"),
-    
+
     /** The current version of the SAI on-disk index format. */
     SAI_CURRENT_VERSION("cassandra.sai.latest.version", "ec"),
-    
+
     SAI_CUSTOM_COMPONENTS_DISCOVERY_CLASS("cassandra.sai.custom_components_discovery_class"),
     SAI_ENABLE_EDGES_CACHE("cassandra.sai.enable_edges_cache", "false"),
     SAI_ENABLE_GENERAL_ORDER_BY("cassandra.sai.general_order_by", "true"),
@@ -790,6 +796,9 @@ public enum CassandraRelevantProperties
      * {@link org.apache.cassandra.index.sai.metrics.ColumnQueryMetrics.BKDIndexMetrics#intersectionLatency}, and
      * {@link org.apache.cassandra.index.sai.metrics.TableQueryMetrics.PerQuery#queryLatency}.
      * Enabled by default.
+     *  </p>
+     * Even if this is false, {@link #SAI_ALL_QUERIES_LATENCY_HISTOGRAM_ENABLED} can still enable the generic histogram
+     * for the latency of queries of any kind.
      */
     SAI_HISTOGRAMS_ENABLED("cassandra.sai.metrics.histograms.enabled", "true"),
 

--- a/src/java/org/apache/cassandra/index/sai/metrics/TableQueryMetrics.java
+++ b/src/java/org/apache/cassandra/index/sai/metrics/TableQueryMetrics.java
@@ -416,7 +416,8 @@ public class TableQueryMetrics
         {
             super(table.keyspace, table.name, METRIC_TYPE, queryKind, filter);
 
-            queryLatency = CassandraRelevantProperties.SAI_HISTOGRAMS_ENABLED.getBoolean()
+            queryLatency = (CassandraRelevantProperties.SAI_HISTOGRAMS_ENABLED.getBoolean() ||
+                            (CassandraRelevantProperties.SAI_ALL_QUERIES_LATENCY_HISTOGRAM_ENABLED.getBoolean() && queryKind == QueryKind.ALL))
                            ? Optional.of(Metrics.timer(createMetricName("QueryLatency")))
                            : Optional.empty();
 

--- a/test/unit/org/apache/cassandra/index/sai/metrics/IndexMetricsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/metrics/IndexMetricsTest.java
@@ -17,6 +17,7 @@
  */
 package org.apache.cassandra.index.sai.metrics;
 
+import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.cassandra.config.CassandraRelevantProperties;
@@ -32,6 +33,8 @@ import org.assertj.core.api.Assertions;
 
 import javax.management.ObjectName;
 
+import static org.apache.cassandra.index.sai.metrics.TableQueryMetrics.AbstractQueryMetrics.makeName;
+import static org.apache.cassandra.index.sai.metrics.TableQueryMetrics.QueryKind;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.*;
 
@@ -221,7 +224,11 @@ public class IndexMetricsTest extends AbstractMetricsTest
     private void assertMetricExistsIfEnabled(boolean shouldExist, String metricName, String table, String index, String metricType)
     {
         ObjectName name = objectName(metricName, KEYSPACE, table, index, metricType);
+        assertMetricsExistsIfEnabled(shouldExist, name);
+    }
 
+    private void assertMetricsExistsIfEnabled(boolean shouldExist, ObjectName name)
+    {
         if (shouldExist)
             assertMetricExists(name);
         else
@@ -241,11 +248,14 @@ public class IndexMetricsTest extends AbstractMetricsTest
     private void assertTableQueryMetricsExistsIfEnabled(boolean shouldExist, String metricName, String table)
     {
         ObjectName name = objectNameNoIndex(metricName, KEYSPACE, table, "PerQuery");
+        assertMetricsExistsIfEnabled(shouldExist, name);
+    }
 
-        if (shouldExist)
-            assertMetricExists(name);
-        else
-            assertMetricDoesNotExist(name);
+    private void assertPerQueryKindMetricExistsIfEnabled(boolean shouldExist, String metricName, String table, TableQueryMetrics.QueryKind kind)
+    {
+        String type = makeName(TableQueryMetrics.PerQuery.METRIC_TYPE, kind);
+        ObjectName name = objectNameNoIndex(metricName, KEYSPACE, table, type);
+        assertMetricsExistsIfEnabled(shouldExist, name);
     }
 
     private void assertIndexQueryCount(String index, long expectedCount)
@@ -474,14 +484,29 @@ public class IndexMetricsTest extends AbstractMetricsTest
     @Test
     public void testHistogramMetricsEnabledAndDisabled()
     {
-        testHistogramMetrics(false);
-        testHistogramMetrics(true);
+        for (Boolean histogramsEnabled: Arrays.asList(true, false))
+        {
+            for (Boolean perQueryKindEnabled: Arrays.asList(true, false))
+            {
+                for (Boolean allQueriesLatencyEnabled : Arrays.asList(true, false))
+                {
+                    testHistogramMetrics(histogramsEnabled, perQueryKindEnabled, allQueriesLatencyEnabled);
+                }
+            }
+        }
     }
 
-    private void testHistogramMetrics(boolean histogramsEnabled)
+    private void testHistogramMetrics(boolean histogramsEnabled, boolean perQueryKindEnabled, boolean allQueriesLatencyEnabled)
     {
-        // Set the property before creating any indexes
+        logger.debug("Testing with {}={}, {}={}, {}={}",
+                     CassandraRelevantProperties.SAI_HISTOGRAMS_ENABLED.getKey(), histogramsEnabled,
+                     CassandraRelevantProperties.SAI_QUERY_KIND_PER_QUERY_METRICS_ENABLED.getKey(), perQueryKindEnabled,
+                     CassandraRelevantProperties.SAI_ALL_QUERIES_LATENCY_HISTOGRAM_ENABLED.getKey(), allQueriesLatencyEnabled);
+
+        // Set the properties before creating any indexes
         CassandraRelevantProperties.SAI_HISTOGRAMS_ENABLED.setBoolean(histogramsEnabled);
+        CassandraRelevantProperties.SAI_QUERY_KIND_PER_QUERY_METRICS_ENABLED.setBoolean(perQueryKindEnabled);
+        CassandraRelevantProperties.SAI_ALL_QUERIES_LATENCY_HISTOGRAM_ENABLED.setBoolean(allQueriesLatencyEnabled);
 
         try
         {
@@ -527,7 +552,12 @@ public class IndexMetricsTest extends AbstractMetricsTest
             assertColumnQueryMetricsExistsIfEnabled(histogramsEnabled, "TermsLookupLatency", table, indexV2);
 
             // Test QueryLatency timer (TableQueryMetrics.PerQuery - table-level metric, no index name)
-            assertTableQueryMetricsExistsIfEnabled(histogramsEnabled, "QueryLatency", table);
+            for (QueryKind kind : QueryKind.values())
+            {
+                boolean shouldExist = (histogramsEnabled && perQueryKindEnabled) ||
+                                      (kind == QueryKind.ALL && (histogramsEnabled || allQueriesLatencyEnabled));
+                assertPerQueryKindMetricExistsIfEnabled(shouldExist, "QueryLatency", table, kind);
+            }
 
             // Verify that other PerQuery histograms are always enabled (not affected by the flag)
             assertTableQueryMetricsExistsIfEnabled(true, "SSTableIndexesHit", table);


### PR DESCRIPTION
### What is the issue

Currently we have two histograms for query latency in CNDB, one for range queries and other for single-partition queries. 

We usually assume that range queries are SAI queries because before https://github.com/riptano/cndb/issues/16859 all index queries are translated into range queries. However, after that patch SAI queries can be single-partition. Also, regardless of https://github.com/riptano/cndb/issues/16859 we can have queries with `ALLOW FILTERING` that are difficult to distinguish from SAI queries.

Histograms in CNDB are expensive, but we should probably consider adding yet another CNDB histogram for the latency of SAI queries. 

### What does this PR fix and why was it fixed

Allow to enable the histogram for the latency of SAI queries of any kind, regardless of the `cassandra.sai.metrics.histograms.enabled` system property, with a new `cassandra.sai.metrics.histograms.all_queries.enabled`. The histogram will be enabled if any of those two properties is true.

All the other similar histograms still depend on the `cassandra.sai.metrics.histograms.enabled` system property alone.
