### PR TITLE
CNDB-16011: Fix ColumnFamilyStoreTest fork timeout caused by a lock leak in testRWCDLocking

### DIFF
--- a/test/unit/org/apache/cassandra/db/ColumnFamilyStoreTest.java
+++ b/test/unit/org/apache/cassandra/db/ColumnFamilyStoreTest.java
@@ -167,6 +167,10 @@ public class ColumnFamilyStoreTest
         });
         task1.start();
 
+        // Wait until task1 is inside the critical section before starting task2, otherwise task2
+        // could acquire the lock first
+        assertTrue(task1StaredtLatch.await(30, TimeUnit.SECONDS));
+
         Thread task2 = new Thread(() -> {
             cfs.runWithCompactionsDisabled(() -> {
                                                task2StaredtLatch.countDown();
@@ -179,16 +183,25 @@ public class ColumnFamilyStoreTest
         });
         task2.start();
 
-        // Check that task1 started but task2 is waiting
-        assertTrue(task1StaredtLatch.await(30, TimeUnit.SECONDS));
-        assertEquals(1, task2StaredtLatch.getCount());
+        try
+        {
+            // Check that task2 stays blocked while task1 holds the lock
+            assertFalse(task2StaredtLatch.await(1, TimeUnit.SECONDS));
+        }
+        finally
+        {
+            // Release task1 even if an assertion fails: leaving it blocked would keep the lock held
+            // forever, hanging the truncation in the next test's setup until the fork times out
+            task1FinishLatch.countDown();
+        }
 
         // Allow task1 to complete and check task2 completed next
-        task1FinishLatch.countDown();
         assertTrue(task2StaredtLatch.await(30, TimeUnit.SECONDS));
 
-        task1.join();
-        task2.join();
+        task1.join(TimeUnit.SECONDS.toMillis(30));
+        task2.join(TimeUnit.SECONDS.toMillis(30));
+        assertFalse(task1.isAlive());
+        assertFalse(task2.isAlive());
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/db/ColumnFamilyStoreTest.java
+++ b/test/unit/org/apache/cassandra/db/ColumnFamilyStoreTest.java
@@ -143,13 +143,13 @@ public class ColumnFamilyStoreTest
     public void testRWCDLocking() throws InterruptedException
     {
         ColumnFamilyStore cfs = Keyspace.open(KEYSPACE1).getColumnFamilyStore(CF_STANDARD1);
-        CountDownLatch task1StaredtLatch = new CountDownLatch(1);
+        CountDownLatch task1StartedtLatch = new CountDownLatch(1);
         CountDownLatch task1FinishLatch = new CountDownLatch(1);
-        CountDownLatch task2StaredtLatch = new CountDownLatch(1);
+        CountDownLatch task2StartedtLatch = new CountDownLatch(1);
 
         Thread task1 = new Thread(() -> {
             cfs.runWithCompactionsDisabled(() -> {
-                                               task1StaredtLatch.countDown();
+                                               task1StartedtLatch.countDown();
                                                try
                                                {
                                                    task1FinishLatch.await();
@@ -169,11 +169,11 @@ public class ColumnFamilyStoreTest
 
         // Wait until task1 is inside the critical section before starting task2, otherwise task2
         // could acquire the lock first
-        assertTrue(task1StaredtLatch.await(30, TimeUnit.SECONDS));
+        assertTrue(task1StartedtLatch.await(30, TimeUnit.SECONDS));
 
         Thread task2 = new Thread(() -> {
             cfs.runWithCompactionsDisabled(() -> {
-                                               task2StaredtLatch.countDown();
+                                               task2StartedtLatch.countDown();
                                                return null;
                                            },
                                            OperationType.P0,
@@ -186,7 +186,7 @@ public class ColumnFamilyStoreTest
         try
         {
             // Check that task2 stays blocked while task1 holds the lock
-            assertFalse(task2StaredtLatch.await(1, TimeUnit.SECONDS));
+            assertFalse(task2StartedtLatch.await(1, TimeUnit.SECONDS));
         }
         finally
         {
@@ -196,7 +196,7 @@ public class ColumnFamilyStoreTest
         }
 
         // Allow task1 to complete and check task2 completed next
-        assertTrue(task2StaredtLatch.await(30, TimeUnit.SECONDS));
+        assertTrue(task2StartedtLatch.await(30, TimeUnit.SECONDS));
 
         task1.join(TimeUnit.SECONDS.toMillis(30));
         task2.join(TimeUnit.SECONDS.toMillis(30));


### PR DESCRIPTION
Fixes riptano/cndb#16011 

### Problem

`ColumnFamilyStoreTest` shows up as flaky in CI with:

```
testSnapshotCreationAndDeleteEmptyTable ... Timeout occurred.
```

This is a fork timeout (`test.timeout` = 480s), not a failure of the snapshot test itself: the whole class normally runs in a few seconds.

### Root cause

`testRWCDLocking` runs immediately before `testSnapshotCreationAndDeleteEmptyTable` in the JUnit method order. It starts `task1` and `task2` at the same time, both racing for the CFS `longRunningSerializedOperationsLock` inside `runWithCompactionsDisabled()`. When `task2` happens to acquire the lock first:

1. the `assertEquals(1, task2StaredtLatch.getCount())` assertion fails **before** `task1FinishLatch.countDown()` is ever executed;
2. `task1` stays parked forever inside the critical section, holding the lock;
3. the next test's `@Before` (`truncateCFS` → `truncateBlocking()`, which also needs that lock) blocks forever;
4. ant kills the fork at 480s and attributes the timeout to `testSnapshotCreationAndDeleteEmptyTable`; the buffered assertion failure from `testRWCDLocking` is lost with the killed fork.

### Fix

* Start `task2` only after `task1` is confirmed inside the critical section, so the acquisition order is deterministic.
* Assert that `task2` stays blocked using a bounded wait instead of an instantaneous latch-count check.
* Release `task1` in a `finally` block, so no assertion failure can leak the held lock into subsequent tests.
* Join both threads with a timeout and assert they terminated.

### Testing

Ran the full `ColumnFamilyStoreTest` class 3× locally (plus 15× the single snapshot test): all green, 19 tests each run.