### PR TITLE
CNDB-16069: Shard VectorCompaction100dTest by version to fit the test fork timeout

### DIFF
--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorCompaction100dEbEcTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorCompaction100dEbEcTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright DataStax, Inc.
+ * Copyright IBM Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,20 +22,15 @@ import org.junit.runners.Parameterized;
 
 import org.apache.cassandra.index.sai.disk.format.Version;
 
-public class VectorCompaction100dTest extends VectorCompactionTest
+/**
+ * Shard of {@link VectorCompaction100dTest} covering versions EB and EC: the full version matrix
+ * takes longer than the test fork timeout on slow CI hosts.
+ */
+public class VectorCompaction100dEbEcTest extends VectorCompaction100dTest
 {
-    // The full version matrix takes longer than the test fork timeout on slow CI hosts, so the
-    // 100d suite is sharded by version: this class covers ED and later, older versions are covered
-    // by VectorCompaction100dEbEcTest and VectorCompaction100dLegacyTest.
     @Parameterized.Parameters(name = "version={0} enableNVQ={1}")
     public static Collection<Object[]> data()
     {
-        return data(v -> v.onOrAfter(Version.ED));
-    }
-
-    @Override
-    public int dimension()
-    {
-        return 100;
+        return data(v -> v.onOrAfter(Version.EB) && !v.onOrAfter(Version.ED));
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorCompaction100dLegacyTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorCompaction100dLegacyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright DataStax, Inc.
+ * Copyright IBM Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,20 +22,15 @@ import org.junit.runners.Parameterized;
 
 import org.apache.cassandra.index.sai.disk.format.Version;
 
-public class VectorCompaction100dTest extends VectorCompactionTest
+/**
+ * Shard of {@link VectorCompaction100dTest} covering the versions before EB: the full version
+ * matrix takes longer than the test fork timeout on slow CI hosts.
+ */
+public class VectorCompaction100dLegacyTest extends VectorCompaction100dTest
 {
-    // The full version matrix takes longer than the test fork timeout on slow CI hosts, so the
-    // 100d suite is sharded by version: this class covers ED and later, older versions are covered
-    // by VectorCompaction100dEbEcTest and VectorCompaction100dLegacyTest.
     @Parameterized.Parameters(name = "version={0} enableNVQ={1}")
     public static Collection<Object[]> data()
     {
-        return data(v -> v.onOrAfter(Version.ED));
-    }
-
-    @Override
-    public int dimension()
-    {
-        return 100;
+        return data(v -> !v.onOrAfter(Version.EB));
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorCompactionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorCompactionTest.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import org.junit.Before;
@@ -72,9 +73,15 @@ abstract public class VectorCompactionTest extends VectorTester
     @Parameterized.Parameters(name = "version={0} enableNVQ={1}")
     public static Collection<Object[]> data()
     {
+        return data(v -> true);
+    }
+
+    protected static Collection<Object[]> data(Predicate<Version> versionFilter)
+    {
         // See Version file for explanation of changes associated with each version
         return Version.ALL.stream()
                           .filter(v -> v.onOrAfter(Version.JVECTOR_EARLIEST))
+                          .filter(versionFilter)
                           .flatMap(vd -> {
                               // NVQ is only relevant some of the time
                               Boolean[] enableNVQ = JVectorVersionUtil.versionSupportsNVQ(vd)


### PR DESCRIPTION
Fixes riptano/cndb#16069

### Problem

`VectorCompaction100dTest` fails in CI with:

```
testOneToOneCompaction[version=eb enableNVQ=false] ... Timeout occurred.
```

This is a fork timeout (`test.timeout` = 480s), not a failure of that parameterization: the class runs 10 version/NVQ combinations (fa×2, ed×2, ec×2, eb, dc, db, ca) × 6 test methods in a single fork. Locally that totals ~330s with the time spread evenly (~33s per combination); on slower CI hosts the cumulative runtime crosses 480s right around the 7th combination (`eb enableNVQ=false`), which is exactly where CI reports the timeout.

### Fix

Shard the 100d suite by version so each fork stays well under the timeout, following the existing precedent of sharding by dimension (`VectorCompaction2dTest` / `VectorCompaction100dTest`):

* `VectorCompaction100dTest` — versions ED and later (fa, ed → 4 combinations)
* `VectorCompaction100dEbEcTest` — versions EB and EC (3 combinations)
* `VectorCompaction100dLegacyTest` — versions before EB (dc, db, ca → 3 combinations)

`VectorCompactionTest.data()` now accepts an optional version filter; `VectorCompaction2dTest` still runs the full matrix (it is much cheaper at dimension 2). No coverage is removed — the same 10 combinations now run across three forks.

### Testing

Local runs after the split (the original single fork took ~340s):

| class | tests | wall clock |
|---|---|---|
| VectorCompaction100dTest | 24 (4 combos × 6 methods) | 140s |
| VectorCompaction100dEbEcTest | 18 (3 × 6) | 108s |
| VectorCompaction100dLegacyTest | 18 (3 × 6) | 112s |
| VectorCompaction2dTest (unchanged matrix) | 60 | 118s |

All pass; 24+18+18 = 60 tests, identical coverage to the pre-split class.