### PR TITLE
CNDB-18972: Fix search-then-sort BM25 failing on partition tombstones

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/v1/InvertedIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/InvertedIndexSearcher.java
@@ -39,6 +39,7 @@ import org.apache.cassandra.db.Slices;
 import org.apache.cassandra.db.memtable.Memtable;
 import org.apache.cassandra.db.rows.Cell;
 import org.apache.cassandra.db.rows.Row;
+import org.apache.cassandra.db.rows.Unfiltered;
 import org.apache.cassandra.dht.AbstractBounds;
 import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.index.FeatureNeedsIndexRebuildException;
@@ -169,13 +170,17 @@ public class InvertedIndexSearcher extends IndexSearcher
         var slices = Slices.with(indexContext.comparator(), Slice.make(primaryKey.clustering()));
         try (var rowIterator = sstable.iterator(dk, slices, columnFilter, false, SSTableReadsListener.NOOP_LISTENER))
         {
-            // primaryKey might not belong to this sstable, thus the iterator will be empty
-            if (rowIterator.isEmpty())
-                return null;
-            var unfiltered = rowIterator.next();
-            assert unfiltered.isRow() : unfiltered;
-            Row row = (Row) unfiltered;
-            return row.getCell(indexContext.getDefinition());
+            while (rowIterator.hasNext())
+            {
+                Unfiltered unfiltered = rowIterator.next();
+                // A range tombstone marker can precede the requested row, so skip non-row unfiltereds.
+                if (unfiltered.isRow())
+                {
+                    Row row = (Row) unfiltered;
+                    return row.getCell(indexContext.getDefinition());
+                }
+            }
+            return null;
         }
     }
 

--- a/src/java/org/apache/cassandra/index/sai/utils/PrimaryKeyWithSortKey.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/PrimaryKeyWithSortKey.java
@@ -73,7 +73,9 @@ public abstract class PrimaryKeyWithSortKey implements PrimaryKey
             return true;
 
         var cell = row.getCell(column);
-        if (!cell.isLive(nowInSecs))
+        // The live row might not have the indexed column at all (e.g. the partition was deleted and re-inserted
+        // without it, while an older sstable still scored the previous value), in which case the index data is stale.
+        if (cell == null || !cell.isLive(nowInSecs))
             return false;
 
         assert cell instanceof CellWithSourceTable : "Expected CellWithSource, got " + cell.getClass();

--- a/test/unit/org/apache/cassandra/index/sai/cql/BM25Test.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/BM25Test.java
@@ -164,6 +164,81 @@ public class BM25Test extends SAITester
     }
 
     @Test
+    public void testSearchThenSortWithPartitionTombstoneInSeparateSSTable()
+    {
+        // A search-then-sort BM25 query reads each candidate row straight from every sstable. A partition that is
+        // present in an sstable only as a partition-level tombstone (deleted after the sstable holding its row was
+        // flushed) must be skipped, not fail the query with NoSuchElementException.
+        createTable("CREATE TABLE %s (k int, c int, query_lexical_value text, array_contains set<text>, PRIMARY KEY (k, c))");
+        createIndex("CREATE CUSTOM INDEX ON %s(array_contains) USING 'org.apache.cassandra.index.sai.StorageAttachedIndex'");
+        createAnalyzedIndex("query_lexical_value");
+        execute("INSERT INTO %s (k, c, query_lexical_value, array_contains) VALUES (1, 1, 'apple', {'target'})");
+        execute("INSERT INTO %s (k, c, query_lexical_value, array_contains) VALUES (2, 1, 'apple juice', {'target'}) USING TIMESTAMP 1");
+        // Insert many unrelated rows so we do search-then-sort
+        for (int i = 3; i < 100; i++)
+            execute("INSERT INTO %s (k, c, query_lexical_value, array_contains) VALUES (?, 1, 'apple juice', {'other'})", i);
+        flush();
+
+        // The tombstone for k = 2 lands in a second sstable. Live rows on either side of c = 1 keep its lexical
+        // index segment spanning the deleted candidate, while the first sstable's collection index still emits (2, 1).
+        execute("DELETE FROM %s USING TIMESTAMP 2 WHERE k = 2");
+        execute("INSERT INTO %s (k, c, query_lexical_value, array_contains) VALUES (2, 0, 'pear', {'other'}) USING TIMESTAMP 3");
+        execute("INSERT INTO %s (k, c, query_lexical_value, array_contains) VALUES (2, 2, 'pear', {'other'}) USING TIMESTAMP 3");
+        flush();
+        String select = "SELECT k, c FROM %s WHERE array_contains CONTAINS ? " +
+                        "ORDER BY query_lexical_value BM25 OF ? LIMIT 3";
+        assertEmpty(execute(select, "target", "term-no-document-contains"));
+        assertRows(execute(select, "target", "apple"), row(1, 1));
+
+        // Re-inserting the deleted key in a third sstable must not fail either, and the row must come back exactly once
+        execute("INSERT INTO %s (k, c, query_lexical_value, array_contains) VALUES (2, 1, 'apple juice', {'target'}) USING TIMESTAMP 4");
+        flush();
+        assertRows(execute(select, "target", "apple"), row(1, 1), row(2, 1));
+        compact();
+        assertRows(execute(select, "target", "apple"), row(1, 1), row(2, 1));
+    }
+
+    @Test
+    public void testSearchThenSortWithRowReinsertedWithoutOrderedColumn() throws Throwable
+    {
+        // The live row has no value for the BM25 column (deleted and re-inserted without it) while an older sstable
+        // still holds and scores the previous value: the stale score must be discarded, not NPE during validation.
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v text, n int)");
+        createIndex("CREATE CUSTOM INDEX ON %s(n) USING 'org.apache.cassandra.index.sai.StorageAttachedIndex'");
+        createAnalyzedIndex();
+        execute("INSERT INTO %s (k, v, n) VALUES (1, 'apple', 0)");
+        execute("INSERT INTO %s (k, v, n) VALUES (2, 'apple juice', 0)");
+        // Insert many unrelated rows so we do search-then-sort
+        for (int i = 3; i < 100; i++)
+            execute("INSERT INTO %s (k, v, n) VALUES (?, 'apple juice', 1)", i);
+        flush();
+
+        execute("DELETE FROM %s WHERE k = 2");
+        execute("INSERT INTO %s (k, n) VALUES (2, 0)");
+        String select = "SELECT k FROM %s WHERE n = 0 ORDER BY v BM25 OF 'apple' LIMIT 3";
+        beforeAndAfterFlush(() -> assertRows(execute(select), row(1)));
+    }
+
+    @Test
+    public void testSearchThenSortWithRangeTombstoneBeforeLiveRow()
+    {
+        createTable("CREATE TABLE %s (k int, c int, v text, n int, PRIMARY KEY (k, c))");
+        createIndex("CREATE CUSTOM INDEX ON %s(n) USING 'org.apache.cassandra.index.sai.StorageAttachedIndex'");
+        createAnalyzedIndex();
+        execute("INSERT INTO %s (k, c, v, n) VALUES (1, 1, 'apple', 0)");
+        execute("INSERT INTO %s (k, c, v, n) VALUES (2, 1, 'apple juice', 0)");
+        for (int i = 3; i < 100; i++)
+            execute("INSERT INTO %s (k, c, v, n) VALUES (?, 1, 'apple juice', 1)", i);
+
+        // The range tombstone is older than the live row, so both are preserved in the sstable.
+        execute("DELETE FROM %s USING TIMESTAMP 1 WHERE k = 2 AND c >= 0 AND c <= 2");
+        flush();
+
+        String select = "SELECT k, c FROM %s WHERE n = 0 ORDER BY v BM25 OF 'apple' LIMIT 3";
+        assertRows(execute(select), row(1, 1), row(2, 1));
+    }
+
+    @Test
     public void testTwoIndexesAmbiguousPredicate() throws Throwable
     {
         createTable("CREATE TABLE %s (k int PRIMARY KEY, v text)");

--- a/test/unit/org/apache/cassandra/index/sai/utils/PrimaryKeyWithSortKeyTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/utils/PrimaryKeyWithSortKeyTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.utils;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.db.rows.Cell;
+import org.apache.cassandra.db.rows.Row;
+import org.apache.cassandra.index.sai.IndexContext;
+import org.apache.cassandra.io.sstable.SSTableId;
+import org.apache.cassandra.schema.ColumnMetadata;
+
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class PrimaryKeyWithSortKeyTest
+{
+    private static final int NOW_IN_SEC = 0;
+
+    private ColumnMetadata column;
+    private PrimaryKeyWithSortKey key;
+    private Row row;
+
+    @Before
+    public void setUp()
+    {
+        column = ColumnMetadata.regularColumn("ks", "table", "value", Int32Type.instance);
+        IndexContext context = mock(IndexContext.class);
+        when(context.getDefinition()).thenReturn(column);
+        SSTableId<?> source = mock(SSTableId.class);
+        key = new PrimaryKeyWithScore(context, source, mock(PrimaryKey.class), 1.0f, false);
+        row = mock(Row.class);
+    }
+
+    @Test
+    public void testMissingCellIsInvalid()
+    {
+        when(row.getCell(column)).thenReturn(null);
+
+        assertFalse(key.isIndexDataValid(row, NOW_IN_SEC));
+    }
+
+    @Test
+    public void testNonLiveCellIsInvalid()
+    {
+        Cell<?> cell = mock(Cell.class);
+        when(cell.isLive(NOW_IN_SEC)).thenReturn(false);
+        doReturn(cell).when(row).getCell(column);
+
+        assertFalse(key.isIndexDataValid(row, NOW_IN_SEC));
+    }
+}


### PR DESCRIPTION
CNDB ticket: https://github.com/riptano/cndb/issues/18972

### What is the issue
Search-then-sort BM25 (SAI predicate + ORDER BY … BM25 OF) reads each candidate row from every sstable in InvertedIndexSearcher.readColumn(), guarded by rowIterator.isEmpty(). That is false when the partition carries a partition-level deletion, so for a key that an sstable holds only as a tombstone (deleted after the sstable with its row was flushed, or deleted and re-inserted across a flush boundary) rowIterator.next() throws NoSuchElementException and the read fails with an unmapped failure reason. Candidate keys are not liveness-checked, so one such key fails the query for any BM25 term, and index rebuilds don't clear it. Follow-up to CNDB-13696.

PrimaryKeyWithSortKey.isIndexDataValid() NPEs when the live row has no cell for the ordered column (partition re-inserted without it) while an older sstable scored the previous value.
### What does this PR fix and why was it fixed
readColumn() guards on hasNext() and skips non-row unfiltereds; isIndexDataValid() null-checks the cell. Adds BM25Test cases for a tombstone-only partition in a separate sstable (with and without same-key re-insert) and for a re-insert without the ordered column.

CC @erichare 