### PR TITLE
HCD-534: Fix "Negative released" crash in MemtablePool when existing (5.0)

### DIFF
--- a/src/java/org/apache/cassandra/db/rows/BTreeRow.java
+++ b/src/java/org/apache/cassandra/db/rows/BTreeRow.java
@@ -650,10 +650,16 @@ public class BTreeRow extends AbstractRow
             {
                 if (deletion == existingDeletion)
                 {
-                    updateBtree = BTree.transformAndFilter(updateBtree, reconciler::retain);
+                    // The existing row's deletion shadows part of the update. Filter those cells out of
+                    // the UPDATE (incoming) side, but do NOT record their removal: that data was never
+                    // owned by the memtable, so accounting its removal would drive the allocator's
+                    // ownership negative and crash the next flush (CASSANDRA-21469).
+                    updateBtree = BTree.transformAndFilter(updateBtree, reconciler::removeShadowed);
                 }
                 else
                 {
+                    // The update's deletion shadows part of the existing row. Those cells ARE owned by
+                    // the memtable, so record their removal via retain().
                     existingBtree = BTree.transformAndFilter(existingBtree, reconciler::retain);
                 }
             }

--- a/src/java/org/apache/cassandra/db/rows/ColumnData.java
+++ b/src/java/org/apache/cassandra/db/rows/ColumnData.java
@@ -179,7 +179,15 @@ public abstract class ColumnData implements IMeasurableMemory
             return removeShadowed(existing, postReconcile);
         }
 
-        private ColumnData removeShadowed(ColumnData existing)
+        /**
+         * Like {@link #retain} but does NOT notify the {@link PostReconciliationFunction} of removed
+         * data. Use this e.g. when filtering shadowed cells out of the UPDATE (incoming) side of a merge:
+         * that data was never allocated to / owned by the memtable, so recording its removal would
+         * make the memtable allocator under-count what it owns and eventually report a negative
+         * release at flush (CASSANDRA-21469). Recording removals (via {@link #retain}) is only correct
+         * for the EXISTING side, whose data the memtable already owns.
+         */
+        public ColumnData removeShadowed(ColumnData existing)
         {
             return removeShadowed(existing, ColumnData.noOp);
         }

--- a/test/unit/org/apache/cassandra/db/partitions/MemtableNegativeReleasedCQLReproTest.java
+++ b/test/unit/org/apache/cassandra/db/partitions/MemtableNegativeReleasedCQLReproTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.db.partitions;
+
+import org.junit.Test;
+
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.memtable.Memtable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * CQL-driven regression test for CASSANDRA-21469 / HCD-534
+ * ("MemtableReclaimMemory AssertionError: Negative released in MemtablePool$SubPool").
+ * <p>
+ * Root cause: {@link org.apache.cassandra.db.rows.BTreeRow}{@code .mergeRowBTrees} used
+ * {@code Reconciler.retain} (instead of {@code removeShadowed}) on the UPDATE side when the existing
+ * row's deletion shadowed incoming cells. {@code retain} calls {@code PostReconciliationFunction.delete}
+ * which subtracts heap size from {@code owns}, but those incoming cells were never allocated to the
+ * memtable (they only exist transiently during the write). Under overwrite/delete churn (e.g. repair
+ * re-streaming old cells covered by newer deletions), {@code owns} drifted negative and the next flush
+ * hit {@code AssertionError: Negative released}.
+ * <p>
+ * Test: Writes a row with a high-timestamp row deletion, then writes older-timestamp cells to trigger
+ * the {@code deletion == existingDeletion} path in mergeRowBTrees. Checks all shard allocators' {@code
+ * owns >= 0} via {@code Memtable.getMemoryUsage()} (NOT via {@code getAllocator().onHeap().owns()},
+ * which only reads the top-level allocator that TrieMemtable never uses for writes). Forces TrieMemtable
+ * explicitly because SkipListMemtable has a completely different merge path and is unaffected.
+ */
+public class MemtableNegativeReleasedCQLReproTest extends CQLTester
+{
+    /**
+     * The buggy path fires when an incoming write carries cells with older timestamps than an existing
+     * row deletion ({@code deletion == existingDeletion} in mergeRowBTrees). Write a row tombstone at
+     * ts=5000, then repeatedly write cells at ts &lt; 5000. On buggy code each write subtracts the
+     * incoming cells' heap size from {@code owns} even though that memory was never allocated to the
+     * memtable, drifting {@code owns} negative. Flushing then crashes with "Negative released".
+     */
+    @Test
+    public void oldCellsShadowedByRowDeletionKeepOwnsNonNegative() throws Throwable
+    {
+        // Force TrieMemtable — only it uses TriePartitionUpdater / BTreeRow.mergeRowBTrees.
+        // SkipListMemtable does not hit this bug.
+        createTable("CREATE TABLE %s (pk int, ck int, v int, PRIMARY KEY (pk, ck)) " +
+                    "WITH memtable = 'trie'");
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        // Establish a row tombstone at ts=5000.
+        execute("DELETE FROM %s USING TIMESTAMP 5000 WHERE pk = 0 AND ck = 0");
+
+        // Write cells at timestamps < 5000. Each write hits the mergeRowBTrees path where
+        // deletion == existingDeletion (the existing row's deletion shadows the incoming cells).
+        // On buggy code, retain() is called on the update side, subtracting the incoming cell's
+        // heap size even though it was never owned by the memtable.
+        for (int i = 0; i < 100; i++)
+        {
+            long ts = 1000 + (i * 30L); // always < 5000, always shadowed
+            execute("UPDATE %s USING TIMESTAMP " + ts + " SET v = " + i + " WHERE pk = 0 AND ck = 0");
+
+            // getMemoryUsage sums shard.allocator.onHeap().owns() across all shards, which is the
+            // correct total for TrieMemtable. The top-level allocator (getAllocator()) is always 0
+            // for TrieMemtable and must NOT be used here.
+            long ownsOnHeap = Memtable.getMemoryUsage(cfs.getTracker().getView().getCurrentMemtable()).ownsOnHeap;
+            assertThat(ownsOnHeap)
+                .as("memtable on-heap owns went NEGATIVE (iteration %d) — the memtable reported " +
+                    "releasing more on-heap memory than it allocated (CASSANDRA-21469 / HCD-534)", i)
+                .isGreaterThanOrEqualTo(0L);
+        }
+
+        // The real crash path: flush runs discard() -> releaseAll() -> SubPool.released(owns).
+        // If owns < 0, SubPool.released asserts "Negative released: <value>".
+        flush();
+    }
+}


### PR DESCRIPTION
### What is the issue

When BTreeRow.mergeRowBTrees reconciles an incoming update against an existing row whose deletion supersedes the update's deletion (deletion == existingDeletion), the incoming cells are shadowed and must be filtered out of the update BTree. The buggy code filtered them with Reconciler.retain(), which notifies PostReconciliationFunction. delete() for each removed cell. On the TrieMemtable write path that callback reaches BasePartitionUpdater.delete(), which subtracts the cell's on-heap size from heapSize; that value is then fed into SubAllocator.adjust() and decrements the shard allocator's owns counter.

The problem is that those cells were never allocated to the memtable: they exist only transiently inside the incoming PartitionUpdate. Each write that hits this path over-decrements owns by the incoming cells' heap size. Under workloads that repeatedly re-stream cells already covered by a newer row tombstone (e.g. repair or counter mutation churn), owns drifts below zero. The next flush then calls releaseAll() -> SubPool.released(owns) with a negative argument and crashes with:

  AssertionError: Negative released: -34187
  at MemtablePool$SubPool.released
  at MemtableAllocator$SubAllocator.releaseAll
  at MemtableAllocator$SubAllocator.setDiscarded
  at NativeAllocator.setDiscarded
  at TrieMemtable.discard

### What does this PR fix and why was it fixed

Fix: use Reconciler.removeShadowed() (which silently discards the shadowed cells without any accounting callback) instead of retain() for the UPDATE side. The existing-side branch is unchanged; those cells ARE owned by the memtable and their removal must be tracked. Reconciler.removeShadowed() is made public so it can be referenced via method reference from BTreeRow.

Regression test: MemtableNegativeReleasedCQLReproTest writes a row tombstone at ts=5000 then drives 100 writes of older-timestamp cells (always shadowed). Forces TrieMemtable explicitly via WITH memtable = 'trie' (the default TestMemtable in the test config is SkipListMemtable, which has a different merge path and is unaffected). Checks Memtable.getMemoryUsage().ownsOnHeap >= 0 after every write (reading the shard allocators via addMemoryUsageTo, not the top-level allocator which is always zero in TrieMemtable). Flushes at the end to exercise the exact production crash path.

Backport of CASSANDRA-21469.
