### PR TITLE
Shard VectorCompaction100dTest by version to fit the test fork timeout

### DIFF
--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorSiftSmallEbEcTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorSiftSmallEbEcTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.cql;
+
+import java.util.Collection;
+
+import org.junit.runners.Parameterized;
+
+import org.apache.cassandra.index.sai.disk.format.Version;
+
+/**
+ * Shard of {@link VectorSiftSmallTest} covering versions EB and EC: the full version matrix takes
+ * longer than the test fork timeout on slow CI hosts.
+ */
+public class VectorSiftSmallEbEcTest extends VectorSiftSmallTest
+{
+    @Parameterized.Parameters(name = "{0} {1}")
+    public static Collection<Object[]> data()
+    {
+        return data(v -> v.onOrAfter(Version.EB) && !v.onOrAfter(Version.ED));
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorSiftSmallLegacyTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorSiftSmallLegacyTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index.sai.cql;
+
+import java.util.Collection;
+
+import org.junit.runners.Parameterized;
+
+import org.apache.cassandra.index.sai.disk.format.Version;
+
+/**
+ * Shard of {@link VectorSiftSmallTest} covering the versions before EB: the full version matrix
+ * takes longer than the test fork timeout on slow CI hosts.
+ */
+public class VectorSiftSmallLegacyTest extends VectorSiftSmallTest
+{
+    @Parameterized.Parameters(name = "{0} {1}")
+    public static Collection<Object[]> data()
+    {
+        return data(v -> !v.onOrAfter(Version.EB));
+    }
+}

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorSiftSmallTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorSiftSmallTest.java
@@ -26,6 +26,7 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -33,9 +34,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 
 import org.junit.Test;
+import org.junit.runners.Parameterized;
 
 import org.apache.cassandra.cql3.UntypedResultSet;
 import org.apache.cassandra.index.sai.StorageAttachedIndex;
+import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.index.sai.disk.v1.SegmentBuilder;
 import org.apache.cassandra.index.sai.disk.v2.V2VectorIndexSearcher;
 import org.apache.cassandra.index.sai.disk.vector.JVectorVersionUtil;
@@ -47,6 +50,15 @@ import static org.junit.Assert.assertTrue;
 public class VectorSiftSmallTest extends VectorTester.Versioned
 {
     private static final String DATASET = "siftsmall"; // change to "sift" for larger dataset. requires manual download
+
+    // The full version matrix takes longer than the test fork timeout on slow CI hosts, so the
+    // suite is sharded by version: this class covers ED and later, older versions are covered by
+    // VectorSiftSmallEbEcTest and VectorSiftSmallLegacyTest.
+    @Parameterized.Parameters(name = "{0} {1}")
+    public static Collection<Object[]> data()
+    {
+        return data(v -> v.onOrAfter(Version.ED));
+    }
 
     @Override
     public void setup() throws Throwable
@@ -214,8 +226,10 @@ public class VectorSiftSmallTest extends VectorTester.Versioned
             assertTrue("Pre-compaction recall is " + recall, recall > 0.975);
         }
 
-        // When NVQ is enabled, we expect worse recall
-        float postCompactionRecall = JVectorVersionUtil.ENABLE_NVQ ? 0.9499f : 0.975f;
+        // When quantized scoring is used (NVQ, or the fused PQ that is always enabled for version
+        // FA and later), we expect worse recall
+        float postCompactionRecall = JVectorVersionUtil.ENABLE_NVQ || JVectorVersionUtil.shouldWriteFused(version)
+                                     ? 0.9499f : 0.975f;
 
         // Take the CassandraOnHeapGraph code path.
         compact();

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorTester.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorTester.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang.reflect.FieldUtils;
@@ -197,9 +198,15 @@ public class VectorTester extends SAITester
         @Parameterized.Parameters(name = "version={0} enableNVQ={1} enableFused={2}")
         public static Collection<Object[]> data()
         {
+            return data(v -> true);
+        }
+
+        protected static Collection<Object[]> data(Predicate<Version> versionFilter)
+        {
             // See Version file for explanation of changes associated with each version
             return Version.ALL.stream()
                               .filter(v -> v.onOrAfter(Version.JVECTOR_EARLIEST))
+                              .filter(versionFilter)
                               .flatMap(v -> {
                                   var enableNVQ = JVectorVersionUtil.versionSupportsNVQ(v)
                                                   ? new Boolean[]{ true, false }


### PR DESCRIPTION
Port of the `main-5.0` fix to `main`.

The class runs 14 version/NVQ combinations times 6 test methods in a single fork, ~460s locally with the time spread evenly across the combinations. On slower CI hosts the cumulative runtime crosses the 480s fork timeout partway through the matrix, so CI reports a timeout against whichever parameterization happens to be running at that point.

Split the 100d suite into four forks along version boundaries, following the existing dimension-based split between `VectorCompaction2dTest` and `VectorCompaction100dTest`:

- `VectorCompaction100dTest`: versions FB and later (4 combinations)
- `VectorCompaction100dEdFaTest`: versions ED and FA (4 combinations)
- `VectorCompaction100dEbEcTest`: versions EB and EC (3 combinations)
- `VectorCompaction100dLegacyTest`: versions before EB (3 combinations)

`VectorCompactionTest.data()` now takes an optional version filter; `VectorCompaction2dTest` keeps running the full matrix, which is much cheaper at dimension 2. Coverage is unchanged: the same 84 test cases now run across four forks (118s/116s/84s/77s locally).

Note: `main` needs one more shard than `main-5.0` because more index versions support NVQ here, so the version matrix is larger (14 combinations vs 10).