### PR TITLE
CNDB-16069: Shard VectorCompaction100dTest by version to fit the test fork timeout

### DIFF
--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorCompaction100dEbEcTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorCompaction100dEbEcTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright DataStax, Inc.
+ * Copyright IBM Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,21 +22,15 @@ import org.junit.runners.Parameterized;
 
 import org.apache.cassandra.index.sai.disk.format.Version;
 
-public class VectorCompaction100dTest extends VectorCompactionTest
+/**
+ * Shard of {@link VectorCompaction100dTest} covering versions EB and EC: the full version matrix
+ * takes longer than the test fork timeout on slow CI hosts.
+ */
+public class VectorCompaction100dEbEcTest extends VectorCompaction100dTest
 {
-    // The full version matrix takes longer than the test fork timeout on slow CI hosts, so the
-    // 100d suite is sharded by version: this class covers FB and later, older versions are covered
-    // by VectorCompaction100dEdFaTest, VectorCompaction100dEbEcTest and
-    // VectorCompaction100dLegacyTest.
     @Parameterized.Parameters(name = "version={0} enableNVQ={1}")
     public static Collection<Object[]> data()
     {
-        return data(v -> v.onOrAfter(Version.FB));
-    }
-
-    @Override
-    public int dimension()
-    {
-        return 100;
+        return data(v -> v.onOrAfter(Version.EB) && !v.onOrAfter(Version.ED));
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorCompaction100dEdFaTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorCompaction100dEdFaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright DataStax, Inc.
+ * Copyright IBM Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,21 +22,15 @@ import org.junit.runners.Parameterized;
 
 import org.apache.cassandra.index.sai.disk.format.Version;
 
-public class VectorCompaction100dTest extends VectorCompactionTest
+/**
+ * Shard of {@link VectorCompaction100dTest} covering versions ED and FA: the full version matrix
+ * takes longer than the test fork timeout on slow CI hosts.
+ */
+public class VectorCompaction100dEdFaTest extends VectorCompaction100dTest
 {
-    // The full version matrix takes longer than the test fork timeout on slow CI hosts, so the
-    // 100d suite is sharded by version: this class covers FB and later, older versions are covered
-    // by VectorCompaction100dEdFaTest, VectorCompaction100dEbEcTest and
-    // VectorCompaction100dLegacyTest.
     @Parameterized.Parameters(name = "version={0} enableNVQ={1}")
     public static Collection<Object[]> data()
     {
-        return data(v -> v.onOrAfter(Version.FB));
-    }
-
-    @Override
-    public int dimension()
-    {
-        return 100;
+        return data(v -> v.onOrAfter(Version.ED) && !v.onOrAfter(Version.FB));
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorCompaction100dLegacyTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorCompaction100dLegacyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright DataStax, Inc.
+ * Copyright IBM Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,21 +22,15 @@ import org.junit.runners.Parameterized;
 
 import org.apache.cassandra.index.sai.disk.format.Version;
 
-public class VectorCompaction100dTest extends VectorCompactionTest
+/**
+ * Shard of {@link VectorCompaction100dTest} covering the versions before EB: the full version
+ * matrix takes longer than the test fork timeout on slow CI hosts.
+ */
+public class VectorCompaction100dLegacyTest extends VectorCompaction100dTest
 {
-    // The full version matrix takes longer than the test fork timeout on slow CI hosts, so the
-    // 100d suite is sharded by version: this class covers FB and later, older versions are covered
-    // by VectorCompaction100dEdFaTest, VectorCompaction100dEbEcTest and
-    // VectorCompaction100dLegacyTest.
     @Parameterized.Parameters(name = "version={0} enableNVQ={1}")
     public static Collection<Object[]> data()
     {
-        return data(v -> v.onOrAfter(Version.FB));
-    }
-
-    @Override
-    public int dimension()
-    {
-        return 100;
+        return data(v -> !v.onOrAfter(Version.EB));
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/VectorCompactionTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/VectorCompactionTest.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import org.junit.Before;
@@ -72,9 +73,15 @@ abstract public class VectorCompactionTest extends VectorTester
     @Parameterized.Parameters(name = "version={0} enableNVQ={1}")
     public static Collection<Object[]> data()
     {
+        return data(v -> true);
+    }
+
+    protected static Collection<Object[]> data(Predicate<Version> versionFilter)
+    {
         // See Version file for explanation of changes associated with each version
         return Version.ALL.stream()
                           .filter(v -> v.onOrAfter(Version.JVECTOR_EARLIEST))
+                          .filter(versionFilter)
                           .flatMap(vd -> {
                               // NVQ is only relevant some of the time
                               Boolean[] enableNVQ = JVectorVersionUtil.versionSupportsNVQ(vd)


### PR DESCRIPTION
Porting https://github.com/datastax/cassandra/pull/2582 to main

The class runs 14 version/NVQ combinations times 6 test methods in a single fork, ~460s locally with the time spread evenly across the combinations. On slower CI hosts the cumulative runtime crosses the 480s fork timeout partway through the matrix, so CI reports a timeout against whichever parameterization happens to be running at that point.

Split the 100d suite into four forks along version boundaries, following the existing dimension-based split between VectorCompaction2dTest and VectorCompaction100dTest:

- VectorCompaction100dTest: versions FB and later (4 combinations)
- VectorCompaction100dEdFaTest: versions ED and FA (4 combinations)
- VectorCompaction100dEbEcTest: versions EB and EC (3 combinations)
- VectorCompaction100dLegacyTest: versions before EB (3 combinations)

VectorCompactionTest.data() now takes an optional version filter; VectorCompaction2dTest keeps running the full matrix, which is much cheaper at dimension 2. Coverage is unchanged: the same 84 test cases now run across four forks (118s/116s/84s/77s locally).

### What is the issue
...

### What does this PR fix and why was it fixed
...
