### PR TITLE
CNDB-18732: Add wildcard support in excluded_indexes index hints

### DIFF
--- a/pylib/cqlshlib/cql3handling.py
+++ b/pylib/cqlshlib/cql3handling.py
@@ -750,13 +750,15 @@ syntax_rules += r'''
                   ;
 <groupByClause> ::= [groupcol]=<cident>
                   ;
-<identifiers> ::= "{" <identifier> ( "," <identifier> )* "}" 
+<identifiers> ::= "{" <identifier> ( "," <identifier> )* "}"
+                  ;
+<identifiersOrStars> ::= "{" ( <identifier> | <star> ) ( "," ( <identifier> | <star> ) )* "}"
                   ;
 <options> ::= <option> ( "AND" <option> )*
                   ;
-<option> ::= "ann_options" "=" <mapLiteral> 
-           | "included_indexes" "=" <identifiers> 
-           | "excluded_indexes" "=" <identifiers> 
+<option> ::= "ann_options" "=" <mapLiteral>
+           | "included_indexes" "=" <identifiers>
+           | "excluded_indexes" "=" <identifiersOrStars>
            ;
 '''
 

--- a/src/antlr/Parser.g
+++ b/src/antlr/Parser.g
@@ -1414,9 +1414,14 @@ indexName returns [QualifiedName name]
     : (ksName[name] '.')? idxName[name]
     ;
 
+indexNameOrWildcard returns [QualifiedName name]
+    : n=indexName    { $name = n; }
+    | '\*'           { $name = QualifiedName.WILDCARD; }
+    ;
+
 indexNames returns [Set<QualifiedName> names]
     @init { $names = new HashSet<QualifiedName>(); }
-    : '{' ( t1=indexName { names.add(t1); } ( ',' tn=indexName { names.add(tn); } )* )? '}'
+    : '{' ( t1=indexNameOrWildcard { names.add(t1); } ( ',' tn=indexNameOrWildcard { names.add(tn); } )* )? '}'
     ;
 
 columnFamilyName returns [QualifiedName name]

--- a/src/java/org/apache/cassandra/cql3/QualifiedName.java
+++ b/src/java/org/apache/cassandra/cql3/QualifiedName.java
@@ -26,6 +26,13 @@ import java.util.Objects;
 public class QualifiedName
 {
     /**
+     * A sentinel {@link QualifiedName} used to represent the {@code *} wildcard in index hints
+     * (e.g. {@code WITH excluded_indexes = {*}}). It's not a valid identifier, so it can never collide with
+     * an actual index name.
+     */
+    public static final QualifiedName WILDCARD = new QualifiedName(null, "*");
+
+    /**
      * The keyspace name as stored internally.
      */
     private String keyspace;
@@ -39,6 +46,14 @@ public class QualifiedName
     {
         this.keyspace = keyspace;
         this.name = name;
+    }
+
+    /**
+     * @return {@code true} if this name represents the {@code *} wildcard, {@code false} otherwise
+     */
+    public boolean isWildcard()
+    {
+        return !hasKeyspace() && "*".equals(name);
     }
 
     /**

--- a/src/java/org/apache/cassandra/db/filter/IndexHints.java
+++ b/src/java/org/apache/cassandra/db/filter/IndexHints.java
@@ -57,6 +57,7 @@ public class IndexHints
     public static final String MISSING_INDEX_ERROR = "Table %s doesn't have an index named %s";
     public static final String NON_INCLUDABLE_INDEXES_ERROR = "It's not possible to use all the specified included indexes with this query.";
     public static final String TOO_MANY_INDEXES_ERROR = format("Cannot have more than %d included/excluded indexes, found ", Short.MAX_VALUE);
+    public static final String WILDCARD_INCLUDED_INDEXES_ERROR = "The wildcard '*' is not allowed in included_indexes.";
 
     public static final IndexHints NONE = new IndexHints(Collections.emptySet(), Collections.emptySet())
     {
@@ -366,13 +367,20 @@ public class IndexHints
      * </p>
      * All the mentioned indexes should exist in the index registry of the queried table,
      * or an {@link InvalidRequestException} will be thrown.
+     * </p>
+     * The {@code excluded} set can contain the {@code *} wildcard, represented by {@link QualifiedName#WILDCARD},
+     * which is expanded to all the indexes currently registered for the table. The wildcard is not allowed in the
+     * {@code included} set, since there is no defined use case for "include all indexes", and doing so will throw
+     * an {@link InvalidRequestException}.
      *
      * @param included the names of the indexes to include when executing the query
-     * @param excluded the names of the indexes to exclude when executing the query
+     * @param excluded the names of the indexes to exclude when executing the query, possibly containing the {@code *}
+     * wildcard to exclude all the indexes currently applicable to the table
      * @param table the queried table
      * @param indexRegistry the index registry of the queried table
      * @return the index hints represented by the specified sets of CQL names
-     * @throws InvalidRequestException if any of the specified indexes do not exist in the specified index registry
+     * @throws InvalidRequestException if any of the specified indexes do not exist in the specified index registry,
+     * or if the {@code *} wildcard is used in the {@code included} set
      */
     public static IndexHints fromCQLNames(Set<QualifiedName> included,
                                           Set<QualifiedName> excluded,
@@ -385,8 +393,18 @@ public class IndexHints
         if (excluded != null && excluded.size() > Short.MAX_VALUE)
             throw new InvalidRequestException(TOO_MANY_INDEXES_ERROR + excluded.size());
 
-        IndexHints hints = IndexHints.create(fetchIndexes(included, table, indexRegistry),
-                                             fetchIndexes(excluded, table, indexRegistry));
+        // The '*' wildcard is only supported for excluded_indexes: it's expanded here to the full set of indexes
+        // currently registered for the table, so it doesn't require a messaging version bump and replicas keep
+        // receiving an already-resolved, concrete set of excluded indexes exactly as before.
+        Set<IndexMetadata> includedIndexes = fetchIndexes(included, table, indexRegistry, false);
+        Set<IndexMetadata> excludedIndexes = fetchIndexes(excluded, table, indexRegistry, true);
+
+        // The wildcard expansion above can produce a larger set than what the user typed, so the size limit
+        // needs to be re-checked after expansion. The check above on the raw CQL names wouldn't catch this.
+        if (excludedIndexes.size() > Short.MAX_VALUE)
+            throw new InvalidRequestException(TOO_MANY_INDEXES_ERROR + excludedIndexes.size());
+
+        IndexHints hints = IndexHints.create(includedIndexes, excludedIndexes);
 
         if (hints == IndexHints.NONE)
             return hints;
@@ -408,15 +426,37 @@ public class IndexHints
         return hints;
     }
 
-    private static Set<IndexMetadata> fetchIndexes(Set<QualifiedName> indexNames, TableMetadata table, IndexRegistry indexRegistry)
+    /**
+     * Resolves the specified set of CQL index names into their {@link IndexMetadata}.
+     *
+     * @param indexNames the CQL names to resolve, possibly containing the {@code *} wildcard
+     * @param table the queried table
+     * @param indexRegistry the index registry of the queried table
+     * @param allowWildcard whether the {@code *} wildcard is allowed in {@code indexNames}. If it's present and
+     * allowed, it's expanded to all the indexes currently registered for the table.
+     * @return the resolved indexes
+     * @throws InvalidRequestException if the wildcard is present but not allowed, or if any of the named indexes
+     * do not exist in the specified index registry
+     */
+    private static Set<IndexMetadata> fetchIndexes(Set<QualifiedName> indexNames,
+                                                    TableMetadata table,
+                                                    IndexRegistry indexRegistry,
+                                                    boolean allowWildcard)
     {
         if (indexNames == null || indexNames.isEmpty())
             return Collections.emptySet();
 
-        Set<IndexMetadata> indexes = new HashSet<>(indexNames.size());
+        boolean wildcard = indexNames.stream().anyMatch(QualifiedName::isWildcard);
+        if (wildcard && !allowWildcard)
+            throw new InvalidRequestException(WILDCARD_INCLUDED_INDEXES_ERROR);
+
+        Set<IndexMetadata> indexes = wildcard ? metadata(indexRegistry.listIndexes()) : new HashSet<>(indexNames.size());
 
         for (QualifiedName indexName : indexNames)
         {
+            if (indexName.isWildcard())
+                continue;
+
             IndexMetadata index = fetchIndex(indexName, table, indexRegistry);
             indexes.add(index);
         }

--- a/src/java/org/apache/cassandra/db/filter/IndexHints.java
+++ b/src/java/org/apache/cassandra/db/filter/IndexHints.java
@@ -394,8 +394,8 @@ public class IndexHints
             throw new InvalidRequestException(TOO_MANY_INDEXES_ERROR + excluded.size());
 
         // The '*' wildcard is only supported for excluded_indexes: it's expanded here to the full set of indexes
-        // currently registered for the table, so it doesn't require a messaging version bump and replicas keep
-        // receiving an already-resolved, concrete set of excluded indexes exactly as before.
+        // currently registered for the table. This doesn't require explicit protocol support because replicas
+        // receive an already-resolved, concrete set of excluded indexes.
         Set<IndexMetadata> includedIndexes = fetchIndexes(included, table, indexRegistry, false);
         Set<IndexMetadata> excludedIndexes = fetchIndexes(excluded, table, indexRegistry, true);
 
@@ -439,26 +439,36 @@ public class IndexHints
      * do not exist in the specified index registry
      */
     private static Set<IndexMetadata> fetchIndexes(Set<QualifiedName> indexNames,
-                                                    TableMetadata table,
-                                                    IndexRegistry indexRegistry,
-                                                    boolean allowWildcard)
+                                                   TableMetadata table,
+                                                   IndexRegistry indexRegistry,
+                                                   boolean allowWildcard)
     {
         if (indexNames == null || indexNames.isEmpty())
             return Collections.emptySet();
 
-        boolean wildcard = indexNames.stream().anyMatch(QualifiedName::isWildcard);
-        if (wildcard && !allowWildcard)
-            throw new InvalidRequestException(WILDCARD_INCLUDED_INDEXES_ERROR);
-
-        Set<IndexMetadata> indexes = wildcard ? metadata(indexRegistry.listIndexes()) : new HashSet<>(indexNames.size());
+        boolean wildcardFound = false;
+        Set<IndexMetadata> indexes = new HashSet<>(indexNames.size());
 
         for (QualifiedName indexName : indexNames)
         {
             if (indexName.isWildcard())
-                continue;
+            {
+                if (wildcardFound)
+                    continue;
 
-            IndexMetadata index = fetchIndex(indexName, table, indexRegistry);
-            indexes.add(index);
+                if (!allowWildcard)
+                    throw new InvalidRequestException(WILDCARD_INCLUDED_INDEXES_ERROR);
+
+                wildcardFound = true;
+                indexes = metadata(indexRegistry.listIndexes());
+            }
+            else
+            {
+                IndexMetadata index = fetchIndex(indexName, table, indexRegistry);
+
+                if (!wildcardFound)
+                    indexes.add(index);
+            }
         }
 
         return indexes;

--- a/src/java/org/apache/cassandra/db/filter/IndexHints.md
+++ b/src/java/org/apache/cassandra/db/filter/IndexHints.md
@@ -62,6 +62,28 @@ However, excluding indexes might make it necessary to add `ALLOW FILTERING` to t
 Indexes that are applicable to the query and that are not mentioned in these two sets of included and excluded indexes
 might or might not be used, depending on the index query planner.
 
+## Excluding all indexes with a wildcard
+
+Rather than enumerating every index by name, `excluded_indexes` accepts the `*` wildcard to exclude all the
+indexes currently applicable to the queried table:
+```
+SELECT * FROM users
+  WHERE birth_year = 1981 AND country = 'FR' ALLOW FILTERING
+  WITH excluded_indexes = {*};
+```
+This is equivalent to explicitly listing every index on the table (`birth_year_idx`, `country_idx` and
+`phone_idx` in the example schema above), and is resolved to that concrete list of indexes by the coordinator
+before the query is sent to the replicas.
+
+The wildcard is only supported in `excluded_indexes`. Using it in `included_indexes` (e.g.
+`included_indexes = {*}`) will be rejected, since there is no defined semantics for "include all indexes".
+
+The wildcard can be combined with explicit index names in the same `excluded_indexes` set (e.g.
+`excluded_indexes = {*, some_idx}`), which is redundant but not an error. However, if `included_indexes` names
+an index that also exists on the table, combining it with `excluded_indexes = {*}` will fail with the same
+"indexes cannot be both included and excluded" error as if that index had been explicitly excluded, since the
+wildcard is expanded before that check is performed.
+
 ## Disambiguating queries
 
 Index hints can also be used to disambiguate queries where a restricted column has multiple indexes that return 

--- a/test/distributed/org/apache/cassandra/distributed/test/sai/IndexHintsDistributedTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/sai/IndexHintsDistributedTest.java
@@ -124,6 +124,7 @@ public class IndexHintsDistributedTest extends TestBaseImpl
 
             // test excluded indexes
             assertSelect(cluster, expectedErrorMessage, select + " WITH excluded_indexes = {legacy_idx, non_analyzed_sai_idx}", matchRows);
+            assertSelect(cluster, expectedErrorMessage, select + " ALLOW FILTERING WITH excluded_indexes = {*}", eqRows);
         });
     }
 

--- a/test/unit/org/apache/cassandra/db/filter/IndexHintsTest.java
+++ b/test/unit/org/apache/cassandra/db/filter/IndexHintsTest.java
@@ -58,6 +58,7 @@ import static java.lang.String.format;
 import static org.apache.cassandra.db.filter.IndexHints.CONFLICTING_INDEXES_ERROR;
 import static org.apache.cassandra.db.filter.IndexHints.MISSING_INDEX_ERROR;
 import static org.apache.cassandra.db.filter.IndexHints.TOO_MANY_INDEXES_ERROR;
+import static org.apache.cassandra.db.filter.IndexHints.WILDCARD_INCLUDED_INDEXES_ERROR;
 import static org.apache.cassandra.db.filter.IndexHints.WRONG_KEYSPACE_ERROR;
 
 /**
@@ -433,6 +434,11 @@ public class IndexHintsTest extends CQLTester
         testTransport(query + "WITH included_indexes={idx1,idx2}", IndexHints.create(indexes(idx1, idx2), indexes()));
         testTransport(query + "WITH excluded_indexes={idx1,idx2}", IndexHints.create(indexes(), indexes(idx1, idx2)));
         testTransport(query + "WITH included_indexes={idx1,idx2} AND excluded_indexes={idx3,idx4}", IndexHints.create(indexes(idx1, idx2), indexes(idx3, idx4)));
+
+        // the wildcard is expanded to all the indexes on the table before it's sent over the wire, so the wire
+        // format itself is unaffected by the wildcard
+        testTransport(query + "WITH excluded_indexes={*}", IndexHints.create(indexes(), indexes(idx1, idx2, idx3, idx4)));
+        testTransport(query + "WITH excluded_indexes={*, idx1}", IndexHints.create(indexes(), indexes(idx1, idx2, idx3, idx4)));
     }
 
     private void testTransport(String query, IndexHints expectedHints)
@@ -1319,6 +1325,44 @@ public class IndexHintsTest extends CQLTester
 
         assertConflictingHints("SELECT * FROM %s WHERE v1=0 WITH included_indexes={idx1} AND excluded_indexes={idx1}", "idx1");
         assertConflictingHints("SELECT * FROM %s WHERE v2=0 WITH included_indexes={idx2} AND excluded_indexes={idx2}", "idx2");
+    }
+
+    /**
+     * Tests the {@code *} wildcard in {@code excluded_indexes}, which should be equivalent to explicitly excluding
+     * every index applicable to the table.
+     */
+    @Test
+    public void testWildcardExcludedIndexes()
+    {
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v1 int, v2 int, v3 int)");
+        String idx1 = createIndex("CREATE INDEX idx1 ON %s(v1)");
+        String idx2 = createIndex("CREATE CUSTOM INDEX idx2 ON %s(v2) USING 'StorageAttachedIndex'");
+        Object[] row = row(0, 0, 0, 0);
+        execute("INSERT INTO %s (k, v1, v2, v3) VALUES (0, 0, 0, 0)");
+
+        // the wildcard excludes every applicable index, same as explicitly excluding all of them
+        assertNeedsAllowFiltering("SELECT * FROM %s WHERE v1=0 WITH excluded_indexes={*}");
+        assertNeedsAllowFiltering("SELECT * FROM %s WHERE v2=0 WITH excluded_indexes={*}");
+        assertNeedsAllowFiltering("SELECT * FROM %s WHERE v1=0 AND v2=0 WITH excluded_indexes={*}");
+        assertThatIndexQueryPlanFor("SELECT * FROM %s WHERE v1=0 ALLOW FILTERING WITH excluded_indexes={*}", row).selectsNone();
+        assertThatIndexQueryPlanFor("SELECT * FROM %s WHERE v2=0 ALLOW FILTERING WITH excluded_indexes={*}", row).selectsNone();
+        assertThatIndexQueryPlanFor("SELECT * FROM %s WHERE v1=0 AND v2=0 ALLOW FILTERING WITH excluded_indexes={*}", row).selectsNone();
+
+        // an unrestricted column (v3) has no index anyway, so the wildcard exclusion doesn't change anything for it
+        execute("SELECT * FROM %s WHERE v3=0 ALLOW FILTERING WITH excluded_indexes={*}");
+
+        // the wildcard combined with explicit names in the same set is redundant, but not an error
+        assertThatIndexQueryPlanFor("SELECT * FROM %s WHERE v1=0 ALLOW FILTERING WITH excluded_indexes={*, idx1}", row).selectsNone();
+        assertThatIndexQueryPlanFor("SELECT * FROM %s WHERE v1=0 ALLOW FILTERING WITH excluded_indexes={*, idx2}", row).selectsNone();
+
+        // the wildcard is not allowed in included_indexes
+        assertInvalidThrowMessage(IndexHints.WILDCARD_INCLUDED_INDEXES_ERROR,
+                                  InvalidRequestException.class,
+                                  "SELECT * FROM %s WHERE v1=0 ALLOW FILTERING WITH included_indexes={*}");
+
+        // a wildcard exclusion conflicts with an included index that exists on the table
+        assertConflictingHints("SELECT * FROM %s WHERE v1=0 WITH included_indexes={idx1} AND excluded_indexes={*}", "idx1");
+        assertConflictingHints("SELECT * FROM %s WHERE v2=0 WITH included_indexes={idx2} AND excluded_indexes={*}", "idx2");
     }
 
     /**

--- a/test/unit/org/apache/cassandra/db/filter/IndexHintsTest.java
+++ b/test/unit/org/apache/cassandra/db/filter/IndexHintsTest.java
@@ -58,7 +58,6 @@ import static java.lang.String.format;
 import static org.apache.cassandra.db.filter.IndexHints.CONFLICTING_INDEXES_ERROR;
 import static org.apache.cassandra.db.filter.IndexHints.MISSING_INDEX_ERROR;
 import static org.apache.cassandra.db.filter.IndexHints.TOO_MANY_INDEXES_ERROR;
-import static org.apache.cassandra.db.filter.IndexHints.WILDCARD_INCLUDED_INDEXES_ERROR;
 import static org.apache.cassandra.db.filter.IndexHints.WRONG_KEYSPACE_ERROR;
 
 /**
@@ -1335,8 +1334,8 @@ public class IndexHintsTest extends CQLTester
     public void testWildcardExcludedIndexes()
     {
         createTable("CREATE TABLE %s (k int PRIMARY KEY, v1 int, v2 int, v3 int)");
-        String idx1 = createIndex("CREATE INDEX idx1 ON %s(v1)");
-        String idx2 = createIndex("CREATE CUSTOM INDEX idx2 ON %s(v2) USING 'StorageAttachedIndex'");
+        createIndex("CREATE INDEX idx1 ON %s(v1)");
+        createIndex("CREATE CUSTOM INDEX idx2 ON %s(v2) USING 'StorageAttachedIndex'");
         Object[] row = row(0, 0, 0, 0);
         execute("INSERT INTO %s (k, v1, v2, v3) VALUES (0, 0, 0, 0)");
 
@@ -1349,16 +1348,31 @@ public class IndexHintsTest extends CQLTester
         assertThatIndexQueryPlanFor("SELECT * FROM %s WHERE v1=0 AND v2=0 ALLOW FILTERING WITH excluded_indexes={*}", row).selectsNone();
 
         // an unrestricted column (v3) has no index anyway, so the wildcard exclusion doesn't change anything for it
-        execute("SELECT * FROM %s WHERE v3=0 ALLOW FILTERING WITH excluded_indexes={*}");
+        assertThatIndexQueryPlanFor("SELECT * FROM %s WHERE v3=0 ALLOW FILTERING WITH excluded_indexes={*}", row).selectsNone();
 
         // the wildcard combined with explicit names in the same set is redundant, but not an error
         assertThatIndexQueryPlanFor("SELECT * FROM %s WHERE v1=0 ALLOW FILTERING WITH excluded_indexes={*, idx1}", row).selectsNone();
         assertThatIndexQueryPlanFor("SELECT * FROM %s WHERE v1=0 ALLOW FILTERING WITH excluded_indexes={*, idx2}", row).selectsNone();
 
-        // the wildcard is not allowed in included_indexes
+        // combining wildcard with a non-existing index name is still an error
+        String missingIndexError = String.format(IndexHints.MISSING_INDEX_ERROR, currentTable(), "idx3");
+        assertInvalidThrowMessage(missingIndexError,
+                                  InvalidRequestException.class,
+                                  "SELECT * FROM %s WITH excluded_indexes={idx3, *}");
+        assertInvalidThrowMessage(missingIndexError,
+                                  InvalidRequestException.class,
+                                  "SELECT * FROM %s WITH excluded_indexes={*, idx3}");
+
+        // the wildcard is not allowed in included_indexes, alone or combined with explicit names
         assertInvalidThrowMessage(IndexHints.WILDCARD_INCLUDED_INDEXES_ERROR,
                                   InvalidRequestException.class,
                                   "SELECT * FROM %s WHERE v1=0 ALLOW FILTERING WITH included_indexes={*}");
+        assertInvalidThrowMessage(IndexHints.WILDCARD_INCLUDED_INDEXES_ERROR,
+                                  InvalidRequestException.class,
+                                  "SELECT * FROM %s WHERE v1=0 ALLOW FILTERING WITH included_indexes={*, idx1}");
+        assertInvalidThrowMessage(IndexHints.WILDCARD_INCLUDED_INDEXES_ERROR,
+                                  InvalidRequestException.class,
+                                  "SELECT * FROM %s WHERE v1=0 ALLOW FILTERING WITH included_indexes={idx1, *}");
 
         // a wildcard exclusion conflicts with an included index that exists on the table
         assertConflictingHints("SELECT * FROM %s WHERE v1=0 WITH included_indexes={idx1} AND excluded_indexes={*}", "idx1");

--- a/test/unit/org/apache/cassandra/index/sai/cql/PlanWithIndexHintsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/PlanWithIndexHintsTest.java
@@ -164,6 +164,20 @@ public class PlanWithIndexHintsTest extends SAITester.Versioned
             assertThatPlanFor("SELECT * FROM %s WHERE v1='common' OR v2='common' ALLOW FILTERING WITH excluded_indexes={idx1,idx2}", numRows - 1).usesNone();
             assertANNOrderingNeedsIndex("SELECT * FROM %s ORDER BY v1 LIMIT 10 WITH excluded_indexes={idx1,idx2}", "v1");
             assertANNOrderingNeedsIndex("SELECT * FROM %s ORDER BY v2 LIMIT 10 WITH excluded_indexes={idx1,idx2}", "v2");
+
+            // excluding all indexes with the wildcard should behave exactly like excluding idx1 and idx2 explicitly
+            assertThatPlanFor("SELECT * FROM %s WHERE v1='rare' ALLOW FILTERING WITH excluded_indexes = {*}", 2).usesNone();
+            assertThatPlanFor("SELECT * FROM %s WHERE v2='rare' ALLOW FILTERING WITH excluded_indexes = {*}", 2).usesNone();
+            assertThatPlanFor("SELECT * FROM %s WHERE v1='rare' AND v2='rare' ALLOW FILTERING WITH excluded_indexes={*}", 1).usesNone();
+            assertThatPlanFor("SELECT * FROM %s WHERE v1='common' AND v2='common' ALLOW FILTERING WITH excluded_indexes={*}", numRows - 3).usesNone();
+            assertANNOrderingNeedsIndex("SELECT * FROM %s ORDER BY v1 LIMIT 10 WITH excluded_indexes={*}", "v1");
+            assertANNOrderingNeedsIndex("SELECT * FROM %s ORDER BY v2 LIMIT 10 WITH excluded_indexes={*}", "v2");
+
+            // the wildcard is not allowed in included_indexes
+            assertWildcardIncludedIndexesError("SELECT * FROM %s WHERE v1='rare' WITH included_indexes = {*}");
+
+            // a wildcard exclusion conflicts with an included index that exists on the table
+            assertConflictingHints("SELECT * FROM %s WHERE v1='rare' WITH included_indexes={idx1} AND excluded_indexes={*}", "idx1");
         });
     }
 
@@ -818,6 +832,20 @@ public class PlanWithIndexHintsTest extends SAITester.Versioned
         Assertions.assertThatThrownBy(() -> execute(query))
                   .isInstanceOf(InvalidRequestException.class)
                   .hasMessage(IndexHints.NON_INCLUDABLE_INDEXES_ERROR);
+    }
+
+    private void assertWildcardIncludedIndexesError(String query)
+    {
+        Assertions.assertThatThrownBy(() -> execute(query))
+                  .isInstanceOf(InvalidRequestException.class)
+                  .hasMessage(IndexHints.WILDCARD_INCLUDED_INDEXES_ERROR);
+    }
+
+    private void assertConflictingHints(String query, String indexName)
+    {
+        Assertions.assertThatThrownBy(() -> execute(query))
+                  .isInstanceOf(InvalidRequestException.class)
+                  .hasMessageContaining(IndexHints.CONFLICTING_INDEXES_ERROR + indexName);
     }
 
     private void assertANNOrderingNeedsIndex(String query, String column)


### PR DESCRIPTION
### What is the issue

[riptano/cndb#18732](https://github.com/riptano/cndb/issues/18732) — the current `excluded_indexes` index hint requires listing every index by name, which is inconvenient for the common case of "run this query without using any indexes at all". There is no shorthand for blanket exclusion.

### What does this PR fix and why was it fixed

Adds support for a `*` wildcard inside `excluded_indexes`, so a query can exclude all applicable indexes without enumerating their names:

```sql
SELECT ... FROM ... WHERE ... WITH excluded_indexes = {*};
```

This implements **Approach 1** from the issue: the coordinator resolves the wildcard into the full concrete set of indexes on the table at parse/validation time (`IndexHints.fromCQLNames`), before the query is sent to replicas. No messaging version bump is required. Approach 2 (a boolean flag on `ReadCommand`) is a possible future follow-up if the expanded-list approach proves insufficient.

**Design decisions:**
- `*` is only valid in `excluded_indexes`. Using it in `included_indexes` throws a new `InvalidRequestException` (`WILDCARD_INCLUDED_INDEXES_ERROR`) — "include all indexes" has no defined semantics.
- Wildcard expansion happens before the existing included/excluded conflict check, so `included_indexes = {idx1}` combined with `excluded_indexes = {*}` is caught by the existing `CONFLICTING_INDEXES_ERROR` path naturally.
- `{*, idx1}` (wildcard + explicit names) is redundant but valid, consistent with normal set semantics.
- `TOO_MANY_INDEXES_ERROR` is explicitly re-checked after expansion — the pre-expansion check on raw CQL names wouldn't catch an over-large expanded set.
- No wire format changes — the wildcard is fully resolved to a concrete `IndexMetadata` set before serialization.

**Files changed:**
- `src/antlr/Parser.g` — new `indexNameOrWildcard` grammar rule accepting `*` alongside index names.
- `src/java/org/apache/cassandra/cql3/QualifiedName.java` — `WILDCARD` sentinel + `isWildcard()`.
- `src/java/org/apache/cassandra/db/filter/IndexHints.java` — wildcard detection/expansion/rejection in `fromCQLNames`/`fetchIndexes`.
- `src/java/org/apache/cassandra/db/filter/IndexHints.md` — documents the new wildcard syntax and semantics.
- `test/unit/org/apache/cassandra/db/filter/IndexHintsTest.java` — new `testWildcardExcludedIndexes`, wildcard cases in `testParseAndValidate`/`testTransport`.
- `test/unit/org/apache/cassandra/index/sai/cql/PlanWithIndexHintsTest.java` — wildcard plan-level assertions and helpers.