### PR TITLE
Add adaptive BM25 search fallback

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -446,8 +446,11 @@ public enum CassandraRelevantProperties
     SAI_QUERY_OPTIMIZATION_USE_TERM_STATISTICS("cassandra.sai.query_optimization.use_term_statistics", "false"),
 
     /**
-     * Maximum number of candidate-to-index-source probes allowed before a filtered BM25 query switches from
-     * search-then-sort to ordered index scan with post-filtering. Set to 0 to disable the adaptive fallback.
+     * Target maximum number of candidate-to-index-source probes before a filtered BM25 query switches from
+     * search-then-sort to ordered index scan with post-filtering. The candidate cap is never lower than the query
+     * soft limit, so the actual number of probes can exceed this target when many index sources are active. Crossing
+     * the cap discards the buffered candidates and starts a full BM25 posting scan, trading that extra scan work for
+     * bounded filter-first work. Set to 0 to disable the adaptive fallback.
      */
     SAI_BM25_SEARCH_THEN_SORT_MAX_CANDIDATE_SOURCE_PROBES("cassandra.sai.bm25.search_then_sort.max_candidate_source_probes", "10000"),
 

--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -445,6 +445,12 @@ public enum CassandraRelevantProperties
      */
     SAI_QUERY_OPTIMIZATION_USE_TERM_STATISTICS("cassandra.sai.query_optimization.use_term_statistics", "false"),
 
+    /**
+     * Maximum number of candidate-to-index-source probes allowed before a filtered BM25 query switches from
+     * search-then-sort to ordered index scan with post-filtering. Set to 0 to disable the adaptive fallback.
+     */
+    SAI_BM25_SEARCH_THEN_SORT_MAX_CANDIDATE_SOURCE_PROBES("cassandra.sai.bm25.search_then_sort.max_candidate_source_probes", "10000"),
+
     /** Controls the number of rows read in a single batch when fetching rows for a partition key */
     SAI_PARTITION_ROW_BATCH_SIZE("cassandra.sai.partition_row_batch_size", "100"),
 

--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -450,7 +450,7 @@ public enum CassandraRelevantProperties
      * search-then-sort to ordered index scan with post-filtering. The candidate cap is never lower than the query
      * soft limit, so the actual number of probes can exceed this target when many index sources are active. Crossing
      * the cap discards the buffered candidates and starts a full BM25 posting scan, trading that extra scan work for
-     * bounded filter-first work. Set to 0 to disable the adaptive fallback.
+     * bounded filter-first work. Set to a non-positive value to disable the adaptive fallback.
      */
     SAI_BM25_SEARCH_THEN_SORT_MAX_CANDIDATE_SOURCE_PROBES("cassandra.sai.bm25.search_then_sort.max_candidate_source_probes", "10000"),
 

--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -445,15 +445,6 @@ public enum CassandraRelevantProperties
      */
     SAI_QUERY_OPTIMIZATION_USE_TERM_STATISTICS("cassandra.sai.query_optimization.use_term_statistics", "false"),
 
-    /**
-     * Target maximum number of candidate-to-index-source probes before a filtered BM25 query switches from
-     * search-then-sort to ordered index scan with post-filtering. The candidate cap is never lower than the query
-     * soft limit, so the actual number of probes can exceed this target when many index sources are active. Crossing
-     * the cap discards the buffered candidates and starts a full BM25 posting scan, trading that extra scan work for
-     * bounded filter-first work. Set to a non-positive value to disable the adaptive fallback.
-     */
-    SAI_BM25_SEARCH_THEN_SORT_MAX_CANDIDATE_SOURCE_PROBES("cassandra.sai.bm25.search_then_sort.max_candidate_source_probes", "10000"),
-
     /** Controls the number of rows read in a single batch when fetching rows for a partition key */
     SAI_PARTITION_ROW_BATCH_SIZE("cassandra.sai.partition_row_batch_size", "100"),
 

--- a/src/java/org/apache/cassandra/index/sai/QueryContext.java
+++ b/src/java/org/apache/cassandra/index/sai/QueryContext.java
@@ -289,6 +289,13 @@ public class QueryContext
             this.queryPlanInfo = new PlanInfo(originalPlan, optimizedPlan);
     }
 
+    public void recordBm25SearchThenSortFallback()
+    {
+        checkThreadOwnership();
+        if (queryPlanInfo != null)
+            queryPlanInfo = queryPlanInfo.withActualStrategy(false, true);
+    }
+
     /**
      * @return a {@link Snapshot} representing an immutable version of this query context.
      */
@@ -406,6 +413,27 @@ public class QueryContext
             this.indexReferencesInPlan = optimizedPlan.referencedIndexCount();
             this.searchExecutedBeforeOrder = optimizedPlan.isSearchThenOrderHybrid();
             this.filterExecutedAfterOrderedScan = optimizedPlan.isOrderedScanThenFilterHybrid();
+        }
+
+        private PlanInfo(PlanInfo original,
+                         boolean searchExecutedBeforeOrder,
+                         boolean filterExecutedAfterOrderedScan)
+        {
+            this.costEstimated = original.costEstimated;
+            this.rowsToReturnEstimated = original.rowsToReturnEstimated;
+            this.rowsToFetchEstimated = original.rowsToFetchEstimated;
+            this.keysToIterateEstimated = original.keysToIterateEstimated;
+            this.logSelectivityEstimated = original.logSelectivityEstimated;
+            this.indexReferencesInQuery = original.indexReferencesInQuery;
+            this.indexReferencesInPlan = original.indexReferencesInPlan;
+            this.searchExecutedBeforeOrder = searchExecutedBeforeOrder;
+            this.filterExecutedAfterOrderedScan = filterExecutedAfterOrderedScan;
+        }
+
+        private PlanInfo withActualStrategy(boolean searchExecutedBeforeOrder,
+                                            boolean filterExecutedAfterOrderedScan)
+        {
+            return new PlanInfo(this, searchExecutedBeforeOrder, filterExecutedAfterOrderedScan);
         }
     }
 }

--- a/src/java/org/apache/cassandra/index/sai/plan/Plan.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Plan.java
@@ -2202,9 +2202,9 @@ abstract public class Plan
         Iterator<? extends PrimaryKey> getTopKRows(KeyRangeIterator keys, int softLimit);
 
         default Iterator<? extends PrimaryKey> getTopKRows(KeyRangeIterator keys,
-                                                            int softLimit,
-                                                            int fallbackSoftLimit,
-                                                            boolean fallbackAllowed)
+                                                           int softLimit,
+                                                           int fallbackSoftLimit,
+                                                           boolean fallbackAllowed)
         {
             return getTopKRows(keys, softLimit);
         }

--- a/src/java/org/apache/cassandra/index/sai/plan/Plan.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Plan.java
@@ -1499,7 +1499,7 @@ abstract public class Plan
         {
             KeyRangeIterator sourceIterator = (KeyRangeIterator) source.execute(executor);
             int softLimit = max(1, round((float) access.expectedAccessCount(factory.tableMetrics.rows)));
-            if (!ordering.isBM25())
+            if (!ordering.isBM25() || source.usesIncludedIndex())
                 return executor.getTopKRows(sourceIterator, softLimit);
 
             Access fallbackAccess = access.scaleCount(1.0 / boundedSelectivity(source.selectivity()));
@@ -1507,8 +1507,7 @@ abstract public class Plan
                                         round((float) fallbackAccess.expectedAccessCount(factory.tableMetrics.rows)));
             return executor.getTopKRows(sourceIterator,
                                         softLimit,
-                                        fallbackSoftLimit,
-                                        !source.usesIncludedIndex());
+                                        fallbackSoftLimit);
         }
 
         @Override
@@ -2203,8 +2202,7 @@ abstract public class Plan
 
         default Iterator<? extends PrimaryKey> getTopKRows(KeyRangeIterator keys,
                                                            int softLimit,
-                                                           int fallbackSoftLimit,
-                                                           boolean fallbackAllowed)
+                                                           int fallbackSoftLimit)
         {
             return getTopKRows(keys, softLimit);
         }

--- a/src/java/org/apache/cassandra/index/sai/plan/Plan.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Plan.java
@@ -1499,7 +1499,16 @@ abstract public class Plan
         {
             KeyRangeIterator sourceIterator = (KeyRangeIterator) source.execute(executor);
             int softLimit = max(1, round((float) access.expectedAccessCount(factory.tableMetrics.rows)));
-            return executor.getTopKRows(sourceIterator, softLimit);
+            if (!ordering.isBM25())
+                return executor.getTopKRows(sourceIterator, softLimit);
+
+            Access fallbackAccess = access.scaleCount(1.0 / boundedSelectivity(source.selectivity()));
+            int fallbackSoftLimit = max(softLimit,
+                                        round((float) fallbackAccess.expectedAccessCount(factory.tableMetrics.rows)));
+            return executor.getTopKRows(sourceIterator,
+                                        softLimit,
+                                        fallbackSoftLimit,
+                                        !source.usesIncludedIndex());
         }
 
         @Override
@@ -2191,6 +2200,14 @@ abstract public class Plan
         Iterator<? extends PrimaryKey> getKeysFromIndex(Expression predicate);
         Iterator<? extends PrimaryKey> getTopKRows(Expression predicate, int softLimit);
         Iterator<? extends PrimaryKey> getTopKRows(KeyRangeIterator keys, int softLimit);
+
+        default Iterator<? extends PrimaryKey> getTopKRows(KeyRangeIterator keys,
+                                                            int softLimit,
+                                                            int fallbackSoftLimit,
+                                                            boolean fallbackAllowed)
+        {
+            return getTopKRows(keys, softLimit);
+        }
     }
 
     /**

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -128,6 +128,7 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
 
     private final PrimaryKey.Factory keyFactory;
     private final PrimaryKey firstPrimaryKey;
+    private boolean bm25StatsInitialized;
 
     private final NavigableSet<Clustering<?>> nextClusterings;
 
@@ -627,36 +628,29 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
      */
     public CloseableIterator<PrimaryKeyWithSortKey> getTopKRows(KeyRangeIterator source, int softLimit)
     {
-        return getTopKRows(source, softLimit, Long.MAX_VALUE, softLimit, 0, 0);
+        MaterializedKeys materializedKeys;
+        try
+        {
+            materializedKeys = materializeKeys(source, Long.MAX_VALUE);
+        }
+        catch (Throwable t)
+        {
+            FileUtils.closeQuietly(source);
+            throw t;
+        }
+        return scoreMaterializedKeys(source, materializedKeys.primaryKeys, softLimit);
     }
 
     @Override
     public CloseableIterator<PrimaryKeyWithSortKey> getTopKRows(KeyRangeIterator source,
                                                                 int softLimit,
-                                                                int fallbackSoftLimit,
-                                                                boolean fallbackAllowed)
+                                                                int fallbackSoftLimit)
     {
-        if (!fallbackAllowed)
-            return getTopKRows(source, softLimit);
-
-        long probeBudget;
-        try
-        {
-            probeBudget = CassandraRelevantProperties.SAI_BM25_SEARCH_THEN_SORT_MAX_CANDIDATE_SOURCE_PROBES.getLong();
-        }
-        catch (Throwable t)
-        {
-            FileUtils.closeQuietly(source);
-            throw t;
-        }
-
-        if (probeBudget <= 0)
-            return getTopKRows(source, softLimit);
-
         QueryView orderingView;
         try
         {
             orderingView = getQueryView(orderer.context);
+            initializeBm25Stats(orderingView);
         }
         catch (Throwable t)
         {
@@ -664,67 +658,62 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
             throw t;
         }
 
-        int sourceCount = max(1, orderingView.memtableIndexes.size() + orderingView.sstableIndexes.size());
-        long candidateLimit = calculateBm25CandidateLimit(softLimit, probeBudget, sourceCount);
-        return getTopKRows(source,
-                           softLimit,
-                           candidateLimit,
-                           fallbackSoftLimit,
-                           sourceCount,
-                           probeBudget);
-    }
+        if (orderer.bm25stats.getDocCount() == 0)
+        {
+            FileUtils.closeQuietly(source);
+            return CloseableIterator.emptyIterator();
+        }
 
-    private CloseableIterator<PrimaryKeyWithSortKey> getTopKRows(KeyRangeIterator source,
-                                                                 int softLimit,
-                                                                 long candidateLimit,
-                                                                 int fallbackSoftLimit,
-                                                                 int sourceCount,
-                                                                 long probeBudget)
-    {
-        boolean sourceOpen = true;
+        int sourceCount = max(1, orderingView.memtableIndexes.size() + orderingView.sstableIndexes.size());
+        long postingVisits = estimateBm25PostingVisits();
+        long candidateLimit = calculateBm25CandidateLimit(softLimit, postingVisits, sourceCount);
+
+        MaterializedKeys materializedKeys;
         try
         {
-            MaterializedKeys materializedKeys = materializeKeys(source, candidateLimit);
-            if (materializedKeys.limitExceeded)
-            {
-                Tracing.logAndTrace(logger,
-                                    "Switching filtered BM25 query to ordered index scan after materializing {} candidates across {} ordering index sources (probe budget {}, fallback soft limit {})",
-                                    materializedKeys.primaryKeys.size(),
-                                    sourceCount,
-                                    probeBudget,
-                                    fallbackSoftLimit);
-                queryContext.recordBm25SearchThenSortFallback();
-                FileUtils.closeQuietly(source);
-                sourceOpen = false;
-                return getTopKRows((Expression) null, fallbackSoftLimit);
-            }
-
-            if (materializedKeys.primaryKeys.isEmpty())
-            {
-                FileUtils.closeQuietly(source);
-                sourceOpen = false;
-                return CloseableIterator.emptyIterator();
-            }
-            var result = getTopKRows(materializedKeys.primaryKeys, softLimit);
-            // We cannot close the source iterator eagerly because it produces partially loaded PrimaryKeys
-            // that might not be needed until a deeper search into the ordering index, which happens after
-            // we exit this block.
-            var wrappedResult = CloseableIterator.withOnClose(result, source);
-            sourceOpen = false;
-            return wrappedResult;
+            materializedKeys = materializeKeys(source, candidateLimit);
         }
         catch (Throwable t)
         {
-            if (sourceOpen)
-                FileUtils.closeQuietly(source);
+            FileUtils.closeQuietly(source);
             throw t;
         }
+
+        if (materializedKeys.limitExceeded)
+        {
+            FileUtils.closeQuietly(source);
+            Tracing.logAndTrace(logger,
+                                "Switching filtered BM25 query to ordered index scan after materializing {} candidates across {} ordering index sources (estimated {} BM25 posting visits, fallback soft limit {})",
+                                materializedKeys.primaryKeys.size(),
+                                sourceCount,
+                                postingVisits,
+                                fallbackSoftLimit);
+            queryContext.recordBm25SearchThenSortFallback();
+            return getTopKRows((Expression) null, fallbackSoftLimit);
+        }
+
+        return scoreMaterializedKeys(source, materializedKeys.primaryKeys, softLimit);
     }
 
     @VisibleForTesting
-    static long calculateBm25CandidateLimit(int softLimit, long probeBudget, int sourceCount)
+    static long calculateBm25CandidateLimit(int softLimit, long postingVisits, int sourceCount)
     {
-        return max(softLimit, max(1L, probeBudget / sourceCount));
+        long candidatesPerSource = postingVisits / sourceCount;
+        if (postingVisits % sourceCount != 0)
+            candidatesPerSource++;
+        return max(softLimit, candidatesPerSource);
+    }
+
+    private long estimateBm25PostingVisits()
+    {
+        long postingVisits = 0;
+        for (long frequency : orderer.bm25stats.getFrequencies().values())
+        {
+            if (Long.MAX_VALUE - postingVisits < frequency)
+                return Long.MAX_VALUE;
+            postingVisits += frequency;
+        }
+        return postingVisits;
     }
 
     /**
@@ -770,6 +759,31 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
         }
     }
 
+    private CloseableIterator<PrimaryKeyWithSortKey> scoreMaterializedKeys(KeyRangeIterator source,
+                                                                           List<PrimaryKey> primaryKeys,
+                                                                           int softLimit)
+    {
+        if (primaryKeys.isEmpty())
+        {
+            FileUtils.closeQuietly(source);
+            return CloseableIterator.emptyIterator();
+        }
+
+        try
+        {
+            var result = getTopKRows(primaryKeys, softLimit);
+            // We cannot close the source iterator eagerly because it produces partially loaded PrimaryKeys
+            // that might not be needed until a deeper search into the ordering index, which happens after
+            // we exit this block.
+            return CloseableIterator.withOnClose(result, source);
+        }
+        catch (Throwable t)
+        {
+            FileUtils.closeQuietly(source);
+            throw t;
+        }
+    }
+
     private CloseableIterator<PrimaryKeyWithSortKey> getTopKRows(List<PrimaryKey> sourceKeys, int softLimit)
     {
         Tracing.logAndTrace(logger, "SAI predicates produced {} keys", sourceKeys.size());
@@ -792,31 +806,9 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
         try
         {
             QueryView view = getQueryView(orderer.context);
-            if (orderer.isBM25())
-            {
-                // Pre-calculate term expressions
-                List<Pair<ByteBuffer, Expression>> termAndExpressions = new ArrayList<>();
-                for (ByteBuffer term : orderer.getQueryTerms())
-                {
-                    Expression termExpression = new Expression(orderer.context)
-                                                .add(Operator.ANALYZER_MATCHES, term);
-                    termAndExpressions.add(Pair.create(term, termExpression));
-                }
-
-                for (MemtableIndex index : view.memtableIndexes)
-                    orderer.bm25stats.add(index.getRowCount(),
-                                          index.getApproximateTermCount(),
-                                          termAndExpressions,
-                                          termExpression -> index.estimateMatchingRowsCount(termExpression));
-                for (SSTableIndex index : view.sstableIndexes)
-                    orderer.bm25stats.add(index.getRowCount(),
-                                          index.getApproximateTermCount(),
-                                          termAndExpressions,
-                                          termExpression -> index.getMatchingRowsCount(termExpression, mergeRange, queryContext));
-                // No documents indexed, the iterator will be empty
-                if (orderer.bm25stats.getDocCount() == 0)
-                    return CloseableIterator.emptyIterator();
-            }
+            initializeBm25Stats(view);
+            if (orderer.isBM25() && orderer.bm25stats.getDocCount() == 0)
+                return CloseableIterator.emptyIterator();
 
             for (MemtableIndex index : view.memtableIndexes)
                 memtableResults.addAll(memtableSearcher.search(index));
@@ -837,6 +829,32 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
                 FileUtils.closeQuietly(memtableResults);
             throw t;
         }
+    }
+
+    private void initializeBm25Stats(QueryView view)
+    {
+        if (!orderer.isBM25() || bm25StatsInitialized)
+            return;
+
+        List<Pair<ByteBuffer, Expression>> termAndExpressions = new ArrayList<>();
+        for (ByteBuffer term : orderer.getQueryTerms())
+        {
+            Expression termExpression = new Expression(orderer.context)
+                                        .add(Operator.ANALYZER_MATCHES, term);
+            termAndExpressions.add(Pair.create(term, termExpression));
+        }
+
+        for (MemtableIndex index : view.memtableIndexes)
+            orderer.bm25stats.add(index.getRowCount(),
+                                  index.getApproximateTermCount(),
+                                  termAndExpressions,
+                                  termExpression -> index.estimateMatchingRowsCount(termExpression));
+        for (SSTableIndex index : view.sstableIndexes)
+            orderer.bm25stats.add(index.getRowCount(),
+                                  index.getApproximateTermCount(),
+                                  termAndExpressions,
+                                  termExpression -> index.getMatchingRowsCount(termExpression, mergeRange, queryContext));
+        bm25StatsInitialized = true;
     }
 
     /**

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -627,7 +627,15 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
      */
     public CloseableIterator<PrimaryKeyWithSortKey> getTopKRows(KeyRangeIterator source, int softLimit)
     {
-        return getTopKRows(source, softLimit, Long.MAX_VALUE, softLimit, 0, 0);
+        try
+        {
+            return getTopKRows(source, softLimit, Long.MAX_VALUE, softLimit, 0, 0);
+        }
+        catch (Throwable t)
+        {
+            FileUtils.closeQuietly(source);
+            throw t;
+        }
     }
 
     @Override
@@ -644,7 +652,7 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
         {
             QueryView orderingView = getQueryView(orderer.context);
             int sourceCount = max(1, orderingView.memtableIndexes.size() + orderingView.sstableIndexes.size());
-            long candidateLimit = max(1L, probeBudget / sourceCount);
+            long candidateLimit = calculateBm25CandidateLimit(softLimit, probeBudget, sourceCount);
             return getTopKRows(source,
                                softLimit,
                                candidateLimit,
@@ -660,44 +668,43 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
     }
 
     private CloseableIterator<PrimaryKeyWithSortKey> getTopKRows(KeyRangeIterator source,
-                                                                  int softLimit,
-                                                                  long candidateLimit,
-                                                                  int fallbackSoftLimit,
-                                                                  int sourceCount,
-                                                                  long probeBudget)
+                                                                 int softLimit,
+                                                                 long candidateLimit,
+                                                                 int fallbackSoftLimit,
+                                                                 int sourceCount,
+                                                                 long probeBudget)
     {
-        try
+        MaterializedKeys materializedKeys = materializeKeys(source, candidateLimit);
+        if (materializedKeys.limitExceeded)
         {
-            MaterializedKeys materializedKeys = materializeKeys(source, candidateLimit);
-            if (materializedKeys.limitExceeded)
-            {
-                FileUtils.closeQuietly(source);
-                Tracing.logAndTrace(logger,
-                                    "Switching filtered BM25 query to ordered index scan after materializing {} candidates across {} ordering index sources (probe budget {}, fallback soft limit {})",
-                                    materializedKeys.primaryKeys.size(),
-                                    sourceCount,
-                                    probeBudget,
-                                    fallbackSoftLimit);
-                queryContext.recordBm25SearchThenSortFallback();
-                return getTopKRows((Expression) null, fallbackSoftLimit);
-            }
-
-            if (materializedKeys.primaryKeys.isEmpty())
-            {
-                FileUtils.closeQuietly(source);
-                return CloseableIterator.emptyIterator();
-            }
-            var result = getTopKRows(materializedKeys.primaryKeys, softLimit);
-            // We cannot close the source iterator eagerly because it produces partially loaded PrimaryKeys
-            // that might not be needed until a deeper search into the ordering index, which happens after
-            // we exit this block.
-            return CloseableIterator.withOnClose(result, source);
+            Tracing.logAndTrace(logger,
+                                "Switching filtered BM25 query to ordered index scan after materializing {} candidates across {} ordering index sources (probe budget {}, fallback soft limit {})",
+                                materializedKeys.primaryKeys.size(),
+                                sourceCount,
+                                probeBudget,
+                                fallbackSoftLimit);
+            queryContext.recordBm25SearchThenSortFallback();
+            CloseableIterator<PrimaryKeyWithSortKey> result = getTopKRows((Expression) null, fallbackSoftLimit);
+            FileUtils.closeQuietly(source);
+            return result;
         }
-        catch (Throwable t)
+
+        if (materializedKeys.primaryKeys.isEmpty())
         {
             FileUtils.closeQuietly(source);
-            throw t;
+            return CloseableIterator.emptyIterator();
         }
+        var result = getTopKRows(materializedKeys.primaryKeys, softLimit);
+        // We cannot close the source iterator eagerly because it produces partially loaded PrimaryKeys
+        // that might not be needed until a deeper search into the ordering index, which happens after
+        // we exit this block.
+        return CloseableIterator.withOnClose(result, source);
+    }
+
+    @VisibleForTesting
+    static long calculateBm25CandidateLimit(int softLimit, long probeBudget, int sourceCount)
+    {
+        return max(softLimit, max(1L, probeBudget / sourceCount));
     }
 
     /**

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -664,6 +664,7 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
             return CloseableIterator.emptyIterator();
         }
 
+        // Filter-first reads every candidate from every ordering source; direct BM25 advances through term postings.
         int sourceCount = max(1, orderingView.memtableIndexes.size() + orderingView.sstableIndexes.size());
         long postingVisits = estimateBm25PostingVisits();
         long candidateLimit = calculateBm25CandidateLimit(softLimit, postingVisits, sourceCount);

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -627,15 +627,7 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
      */
     public CloseableIterator<PrimaryKeyWithSortKey> getTopKRows(KeyRangeIterator source, int softLimit)
     {
-        try
-        {
-            return getTopKRows(source, softLimit, Long.MAX_VALUE, softLimit, 0, 0);
-        }
-        catch (Throwable t)
-        {
-            FileUtils.closeQuietly(source);
-            throw t;
-        }
+        return getTopKRows(source, softLimit, Long.MAX_VALUE, softLimit, 0, 0);
     }
 
     @Override
@@ -644,27 +636,42 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
                                                                 int fallbackSoftLimit,
                                                                 boolean fallbackAllowed)
     {
-        long probeBudget = CassandraRelevantProperties.SAI_BM25_SEARCH_THEN_SORT_MAX_CANDIDATE_SOURCE_PROBES.getLong();
-        if (!fallbackAllowed || probeBudget <= 0)
+        if (!fallbackAllowed)
             return getTopKRows(source, softLimit);
 
+        long probeBudget;
         try
         {
-            QueryView orderingView = getQueryView(orderer.context);
-            int sourceCount = max(1, orderingView.memtableIndexes.size() + orderingView.sstableIndexes.size());
-            long candidateLimit = calculateBm25CandidateLimit(softLimit, probeBudget, sourceCount);
-            return getTopKRows(source,
-                               softLimit,
-                               candidateLimit,
-                               fallbackSoftLimit,
-                               sourceCount,
-                               probeBudget);
+            probeBudget = CassandraRelevantProperties.SAI_BM25_SEARCH_THEN_SORT_MAX_CANDIDATE_SOURCE_PROBES.getLong();
         }
         catch (Throwable t)
         {
             FileUtils.closeQuietly(source);
             throw t;
         }
+
+        if (probeBudget <= 0)
+            return getTopKRows(source, softLimit);
+
+        QueryView orderingView;
+        try
+        {
+            orderingView = getQueryView(orderer.context);
+        }
+        catch (Throwable t)
+        {
+            FileUtils.closeQuietly(source);
+            throw t;
+        }
+
+        int sourceCount = max(1, orderingView.memtableIndexes.size() + orderingView.sstableIndexes.size());
+        long candidateLimit = calculateBm25CandidateLimit(softLimit, probeBudget, sourceCount);
+        return getTopKRows(source,
+                           softLimit,
+                           candidateLimit,
+                           fallbackSoftLimit,
+                           sourceCount,
+                           probeBudget);
     }
 
     private CloseableIterator<PrimaryKeyWithSortKey> getTopKRows(KeyRangeIterator source,
@@ -674,31 +681,44 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
                                                                  int sourceCount,
                                                                  long probeBudget)
     {
-        MaterializedKeys materializedKeys = materializeKeys(source, candidateLimit);
-        if (materializedKeys.limitExceeded)
+        boolean sourceOpen = true;
+        try
         {
-            Tracing.logAndTrace(logger,
-                                "Switching filtered BM25 query to ordered index scan after materializing {} candidates across {} ordering index sources (probe budget {}, fallback soft limit {})",
-                                materializedKeys.primaryKeys.size(),
-                                sourceCount,
-                                probeBudget,
-                                fallbackSoftLimit);
-            queryContext.recordBm25SearchThenSortFallback();
-            CloseableIterator<PrimaryKeyWithSortKey> result = getTopKRows((Expression) null, fallbackSoftLimit);
-            FileUtils.closeQuietly(source);
-            return result;
-        }
+            MaterializedKeys materializedKeys = materializeKeys(source, candidateLimit);
+            if (materializedKeys.limitExceeded)
+            {
+                Tracing.logAndTrace(logger,
+                                    "Switching filtered BM25 query to ordered index scan after materializing {} candidates across {} ordering index sources (probe budget {}, fallback soft limit {})",
+                                    materializedKeys.primaryKeys.size(),
+                                    sourceCount,
+                                    probeBudget,
+                                    fallbackSoftLimit);
+                queryContext.recordBm25SearchThenSortFallback();
+                FileUtils.closeQuietly(source);
+                sourceOpen = false;
+                return getTopKRows((Expression) null, fallbackSoftLimit);
+            }
 
-        if (materializedKeys.primaryKeys.isEmpty())
-        {
-            FileUtils.closeQuietly(source);
-            return CloseableIterator.emptyIterator();
+            if (materializedKeys.primaryKeys.isEmpty())
+            {
+                FileUtils.closeQuietly(source);
+                sourceOpen = false;
+                return CloseableIterator.emptyIterator();
+            }
+            var result = getTopKRows(materializedKeys.primaryKeys, softLimit);
+            // We cannot close the source iterator eagerly because it produces partially loaded PrimaryKeys
+            // that might not be needed until a deeper search into the ordering index, which happens after
+            // we exit this block.
+            var wrappedResult = CloseableIterator.withOnClose(result, source);
+            sourceOpen = false;
+            return wrappedResult;
         }
-        var result = getTopKRows(materializedKeys.primaryKeys, softLimit);
-        // We cannot close the source iterator eagerly because it produces partially loaded PrimaryKeys
-        // that might not be needed until a deeper search into the ordering index, which happens after
-        // we exit this block.
-        return CloseableIterator.withOnClose(result, source);
+        catch (Throwable t)
+        {
+            if (sourceOpen)
+                FileUtils.closeQuietly(source);
+            throw t;
+        }
     }
 
     @VisibleForTesting

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -627,15 +627,67 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
      */
     public CloseableIterator<PrimaryKeyWithSortKey> getTopKRows(KeyRangeIterator source, int softLimit)
     {
+        return getTopKRows(source, softLimit, Long.MAX_VALUE, softLimit, 0, 0);
+    }
+
+    @Override
+    public CloseableIterator<PrimaryKeyWithSortKey> getTopKRows(KeyRangeIterator source,
+                                                                int softLimit,
+                                                                int fallbackSoftLimit,
+                                                                boolean fallbackAllowed)
+    {
+        long probeBudget = CassandraRelevantProperties.SAI_BM25_SEARCH_THEN_SORT_MAX_CANDIDATE_SOURCE_PROBES.getLong();
+        if (!fallbackAllowed || probeBudget <= 0)
+            return getTopKRows(source, softLimit);
+
         try
         {
-            var primaryKeys = materializeKeys(source);
-            if (primaryKeys.isEmpty())
+            QueryView orderingView = getQueryView(orderer.context);
+            int sourceCount = max(1, orderingView.memtableIndexes.size() + orderingView.sstableIndexes.size());
+            long candidateLimit = max(1L, probeBudget / sourceCount);
+            return getTopKRows(source,
+                               softLimit,
+                               candidateLimit,
+                               fallbackSoftLimit,
+                               sourceCount,
+                               probeBudget);
+        }
+        catch (Throwable t)
+        {
+            FileUtils.closeQuietly(source);
+            throw t;
+        }
+    }
+
+    private CloseableIterator<PrimaryKeyWithSortKey> getTopKRows(KeyRangeIterator source,
+                                                                  int softLimit,
+                                                                  long candidateLimit,
+                                                                  int fallbackSoftLimit,
+                                                                  int sourceCount,
+                                                                  long probeBudget)
+    {
+        try
+        {
+            MaterializedKeys materializedKeys = materializeKeys(source, candidateLimit);
+            if (materializedKeys.limitExceeded)
+            {
+                FileUtils.closeQuietly(source);
+                Tracing.logAndTrace(logger,
+                                    "Switching filtered BM25 query to ordered index scan after materializing {} candidates across {} ordering index sources (probe budget {}, fallback soft limit {})",
+                                    materializedKeys.primaryKeys.size(),
+                                    sourceCount,
+                                    probeBudget,
+                                    fallbackSoftLimit);
+                queryContext.recordBm25SearchThenSortFallback();
+                return getTopKRows((Expression) null, fallbackSoftLimit);
+            }
+
+            if (materializedKeys.primaryKeys.isEmpty())
             {
                 FileUtils.closeQuietly(source);
                 return CloseableIterator.emptyIterator();
             }
-            var result = getTopKRows(primaryKeys, softLimit);
+            var result = getTopKRows(materializedKeys.primaryKeys, softLimit);
             // We cannot close the source iterator eagerly because it produces partially loaded PrimaryKeys
             // that might not be needed until a deeper search into the ordering index, which happens after
             // we exit this block.
@@ -652,16 +704,17 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
      * Materialize the keys from the given source iterator. If there is a meaningful {@link #mergeRange}, the keys
      * are filtered to only include those within the range. Note: does not close the source iterator.
      * @param source The source iterator to materialize keys from.
-     * @return The list of materialized keys within the {@link #mergeRange}.
+     * @param candidateLimit Maximum number of keys to materialize without marking the result as over limit.
+     * @return The materialized keys within the {@link #mergeRange} and whether the limit was exceeded.
      */
-    private List<PrimaryKey> materializeKeys(KeyRangeIterator source)
+    private MaterializedKeys materializeKeys(KeyRangeIterator source, long candidateLimit)
     {
         // Skip to the first key (which is really just a token) in the range if it is not the minimum token
         if (!mergeRange.left.isMinimum())
             source.skipTo(firstPrimaryKey);
 
         if (!source.hasNext())
-            return List.of();
+            return new MaterializedKeys(List.of(), false);
 
         var maxToken = primaryKeyFactory().createTokenOnly(mergeRange.right.getToken());
         var hasLimitingMaxToken = !maxToken.token().isMinimum() && maxToken.compareTo(source.getMaximum()) < 0;
@@ -672,8 +725,22 @@ public class QueryController implements Plan.Executor, Plan.CostEstimator
             if (hasLimitingMaxToken && next.compareTo(maxToken) > 0)
                 break;
             primaryKeys.add(next);
+            if (primaryKeys.size() > candidateLimit)
+                return new MaterializedKeys(primaryKeys, true);
         }
-        return primaryKeys;
+        return new MaterializedKeys(primaryKeys, false);
+    }
+
+    private static final class MaterializedKeys
+    {
+        private final List<PrimaryKey> primaryKeys;
+        private final boolean limitExceeded;
+
+        private MaterializedKeys(List<PrimaryKey> primaryKeys, boolean limitExceeded)
+        {
+            this.primaryKeys = primaryKeys;
+            this.limitExceeded = limitExceeded;
+        }
     }
 
     private CloseableIterator<PrimaryKeyWithSortKey> getTopKRows(List<PrimaryKey> sourceKeys, int softLimit)

--- a/test/unit/org/apache/cassandra/index/sai/cql/BM25Test.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/BM25Test.java
@@ -677,20 +677,17 @@ public class BM25Test extends SAITester
         {
             CassandraRelevantProperties.SAI_QUERY_PLAN_METRICS_ENABLED.setBoolean(true);
             createTable("CREATE TABLE %s(id int PRIMARY KEY, site text, extension text, body text)");
-            String siteIndex = createIndex("CREATE CUSTOM INDEX ON %s(site) USING 'StorageAttachedIndex'");
-            String extensionIndex = createIndex("CREATE CUSTOM INDEX ON %s(extension) USING 'StorageAttachedIndex'");
+            createIndex("CREATE CUSTOM INDEX ON %s(site) USING 'StorageAttachedIndex'");
+            createIndex("CREATE CUSTOM INDEX ON %s(extension) USING 'StorageAttachedIndex'");
             createAnalyzedIndex("body");
 
             execute("INSERT INTO %s(id, site, extension, body) VALUES (1, 'pepsi', 'pdf', 'freight freight freight')");
             execute("INSERT INTO %s(id, site, extension, body) VALUES (2, 'pepsi', 'pdf', 'freight freight')");
             execute("INSERT INTO %s(id, site, extension, body) VALUES (3, 'pepsi', 'pdf', 'freight orders and notes')");
-            for (int id = 4; id <= 8; id++)
-                execute("INSERT INTO %s(id, site, extension, body) VALUES (?, 'pepsi', 'pdf', 'inventory notes')", id);
             execute("INSERT INTO %s(id, site, extension, body) VALUES (99, 'other', 'docx', 'freight freight freight freight')");
 
             String query = "SELECT id FROM %s WHERE site = 'pepsi' AND extension = 'pdf' " +
                            "ORDER BY body BM25 OF 'freight' LIMIT 2";
-            String hintedQuery = query + String.format(" WITH included_indexes = {%s, %s}", siteIndex, extensionIndex);
 
             var indexGroup = Objects.requireNonNull(StorageAttachedIndexGroup.getIndexGroup(getCurrentColumnFamilyStore()));
             var tableMetrics = indexGroup.queryMetrics().perTableMetrics.get(TableQueryMetrics.QueryKind.ALL);
@@ -698,13 +695,17 @@ public class BM25Test extends SAITester
             long sortThenFilterCount = queryPlanMetrics.sortThenFilterQueriesCompleted.getCount();
             long filterThenSortCount = queryPlanMetrics.filterThenSortQueriesCompleted.getCount();
 
-            // Included-index hints force the semantically equivalent filter-first control.
+            // Four posting visits cost more than scoring three filtered candidates, so filter-first is retained.
             QueryController.QUERY_OPT_LEVEL = 0;
-            assertRows(execute(hintedQuery), row(1), row(2));
+            assertRows(execute(query), row(1), row(2));
             assertEquals(sortThenFilterCount, queryPlanMetrics.sortThenFilterQueriesCompleted.getCount());
             assertEquals(filterThenSortCount + 1, queryPlanMetrics.filterThenSortQueriesCompleted.getCount());
 
-            // Eight filtered candidates exceed the four posting visits estimated for BM25-first execution.
+            // These additional candidates do not contain the query term, so they cannot change the expected top rows.
+            for (int id = 4; id <= 8; id++)
+                execute("INSERT INTO %s(id, site, extension, body) VALUES (?, 'pepsi', 'pdf', 'inventory notes')", id);
+
+            // Eight filtered candidates now exceed the same four posting visits and trigger BM25-first execution.
             QueryController.QUERY_OPT_LEVEL = 0;
             assertRows(execute(query), row(1), row(2));
             assertEquals(sortThenFilterCount + 1, queryPlanMetrics.sortThenFilterQueriesCompleted.getCount());

--- a/test/unit/org/apache/cassandra/index/sai/cql/BM25Test.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/BM25Test.java
@@ -699,12 +699,10 @@ public class BM25Test extends SAITester
             QueryController.QUERY_OPT_LEVEL = 1;
             assertRows(execute(query), row(1), row(2));
 
-            var queryPlanMetrics = Objects.requireNonNull(StorageAttachedIndexGroup.getIndexGroup(getCurrentColumnFamilyStore()))
-                                                 .queryMetrics()
-                                                 .perTableMetrics
-                                                 .get(TableQueryMetrics.QueryKind.ALL)
-                                                 .queryPlanMetrics;
-            long fallbackCount = Objects.requireNonNull(queryPlanMetrics).sortThenFilterQueriesCompleted.getCount();
+            var indexGroup = Objects.requireNonNull(StorageAttachedIndexGroup.getIndexGroup(getCurrentColumnFamilyStore()));
+            var tableMetrics = indexGroup.queryMetrics().perTableMetrics.get(TableQueryMetrics.QueryKind.ALL);
+            var queryPlanMetrics = Objects.requireNonNull(tableMetrics.queryPlanMetrics);
+            long fallbackCount = queryPlanMetrics.sortThenFilterQueriesCompleted.getCount();
 
             // Adaptive filter-first planning crosses the two-candidate cap and must match both controls.
             CassandraRelevantProperties.SAI_BM25_SEARCH_THEN_SORT_MAX_CANDIDATE_SOURCE_PROBES.setLong(2);

--- a/test/unit/org/apache/cassandra/index/sai/cql/BM25Test.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/BM25Test.java
@@ -690,25 +690,32 @@ public class BM25Test extends SAITester
             String query = "SELECT id FROM %s WHERE site = 'pepsi' AND extension = 'pdf' " +
                            "ORDER BY body BM25 OF 'freight' LIMIT 2";
 
+            var indexGroup = Objects.requireNonNull(StorageAttachedIndexGroup.getIndexGroup(getCurrentColumnFamilyStore()));
+            var tableMetrics = indexGroup.queryMetrics().perTableMetrics.get(TableQueryMetrics.QueryKind.ALL);
+            var queryPlanMetrics = Objects.requireNonNull(tableMetrics.queryPlanMetrics);
+            long sortThenFilterCount = queryPlanMetrics.sortThenFilterQueriesCompleted.getCount();
+            long filterThenSortCount = queryPlanMetrics.filterThenSortQueriesCompleted.getCount();
+
             // Forced filter-first control.
             CassandraRelevantProperties.SAI_BM25_SEARCH_THEN_SORT_MAX_CANDIDATE_SOURCE_PROBES.setLong(0);
             QueryController.QUERY_OPT_LEVEL = 0;
             assertRows(execute(query), row(1), row(2));
-
-            // Forced BM25-first control.
-            QueryController.QUERY_OPT_LEVEL = 1;
-            assertRows(execute(query), row(1), row(2));
-
-            var indexGroup = Objects.requireNonNull(StorageAttachedIndexGroup.getIndexGroup(getCurrentColumnFamilyStore()));
-            var tableMetrics = indexGroup.queryMetrics().perTableMetrics.get(TableQueryMetrics.QueryKind.ALL);
-            var queryPlanMetrics = Objects.requireNonNull(tableMetrics.queryPlanMetrics);
-            long fallbackCount = queryPlanMetrics.sortThenFilterQueriesCompleted.getCount();
+            assertEquals(sortThenFilterCount, queryPlanMetrics.sortThenFilterQueriesCompleted.getCount());
+            assertEquals(filterThenSortCount + 1, queryPlanMetrics.filterThenSortQueriesCompleted.getCount());
 
             // Adaptive filter-first planning crosses the two-candidate cap and must match both controls.
             CassandraRelevantProperties.SAI_BM25_SEARCH_THEN_SORT_MAX_CANDIDATE_SOURCE_PROBES.setLong(2);
             QueryController.QUERY_OPT_LEVEL = 0;
             assertRows(execute(query), row(1), row(2));
-            assertEquals(fallbackCount + 1, queryPlanMetrics.sortThenFilterQueriesCompleted.getCount());
+            assertEquals(sortThenFilterCount + 1, queryPlanMetrics.sortThenFilterQueriesCompleted.getCount());
+            assertEquals(filterThenSortCount + 1, queryPlanMetrics.filterThenSortQueriesCompleted.getCount());
+
+            // Disable adaptive fallback so the strategy counter proves the optimizer selected BM25-first directly.
+            CassandraRelevantProperties.SAI_BM25_SEARCH_THEN_SORT_MAX_CANDIDATE_SOURCE_PROBES.setLong(0);
+            QueryController.QUERY_OPT_LEVEL = 1;
+            assertRows(execute(query), row(1), row(2));
+            assertEquals(sortThenFilterCount + 2, queryPlanMetrics.sortThenFilterQueriesCompleted.getCount());
+            assertEquals(filterThenSortCount + 1, queryPlanMetrics.filterThenSortQueriesCompleted.getCount());
         }
         finally
         {

--- a/test/unit/org/apache/cassandra/index/sai/cql/BM25Test.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/BM25Test.java
@@ -671,24 +671,26 @@ public class BM25Test extends SAITester
     @Test
     public void testAdaptiveFallbackMatchesForcedStrategies()
     {
-        long defaultProbeBudget = CassandraRelevantProperties.SAI_BM25_SEARCH_THEN_SORT_MAX_CANDIDATE_SOURCE_PROBES.getLong();
         int defaultOptimizationLevel = QueryController.QUERY_OPT_LEVEL;
         boolean defaultQueryPlanMetrics = CassandraRelevantProperties.SAI_QUERY_PLAN_METRICS_ENABLED.getBoolean();
         try
         {
             CassandraRelevantProperties.SAI_QUERY_PLAN_METRICS_ENABLED.setBoolean(true);
             createTable("CREATE TABLE %s(id int PRIMARY KEY, site text, extension text, body text)");
-            createIndex("CREATE CUSTOM INDEX ON %s(site) USING 'StorageAttachedIndex'");
-            createIndex("CREATE CUSTOM INDEX ON %s(extension) USING 'StorageAttachedIndex'");
+            String siteIndex = createIndex("CREATE CUSTOM INDEX ON %s(site) USING 'StorageAttachedIndex'");
+            String extensionIndex = createIndex("CREATE CUSTOM INDEX ON %s(extension) USING 'StorageAttachedIndex'");
             createAnalyzedIndex("body");
 
             execute("INSERT INTO %s(id, site, extension, body) VALUES (1, 'pepsi', 'pdf', 'freight freight freight')");
             execute("INSERT INTO %s(id, site, extension, body) VALUES (2, 'pepsi', 'pdf', 'freight freight')");
             execute("INSERT INTO %s(id, site, extension, body) VALUES (3, 'pepsi', 'pdf', 'freight orders and notes')");
+            for (int id = 4; id <= 8; id++)
+                execute("INSERT INTO %s(id, site, extension, body) VALUES (?, 'pepsi', 'pdf', 'inventory notes')", id);
             execute("INSERT INTO %s(id, site, extension, body) VALUES (99, 'other', 'docx', 'freight freight freight freight')");
 
             String query = "SELECT id FROM %s WHERE site = 'pepsi' AND extension = 'pdf' " +
                            "ORDER BY body BM25 OF 'freight' LIMIT 2";
+            String hintedQuery = query + String.format(" WITH included_indexes = {%s, %s}", siteIndex, extensionIndex);
 
             var indexGroup = Objects.requireNonNull(StorageAttachedIndexGroup.getIndexGroup(getCurrentColumnFamilyStore()));
             var tableMetrics = indexGroup.queryMetrics().perTableMetrics.get(TableQueryMetrics.QueryKind.ALL);
@@ -696,22 +698,19 @@ public class BM25Test extends SAITester
             long sortThenFilterCount = queryPlanMetrics.sortThenFilterQueriesCompleted.getCount();
             long filterThenSortCount = queryPlanMetrics.filterThenSortQueriesCompleted.getCount();
 
-            // Forced filter-first control.
-            CassandraRelevantProperties.SAI_BM25_SEARCH_THEN_SORT_MAX_CANDIDATE_SOURCE_PROBES.setLong(0);
+            // Included-index hints force the semantically equivalent filter-first control.
             QueryController.QUERY_OPT_LEVEL = 0;
-            assertRows(execute(query), row(1), row(2));
+            assertRows(execute(hintedQuery), row(1), row(2));
             assertEquals(sortThenFilterCount, queryPlanMetrics.sortThenFilterQueriesCompleted.getCount());
             assertEquals(filterThenSortCount + 1, queryPlanMetrics.filterThenSortQueriesCompleted.getCount());
 
-            // Adaptive filter-first planning crosses the two-candidate cap and must match both controls.
-            CassandraRelevantProperties.SAI_BM25_SEARCH_THEN_SORT_MAX_CANDIDATE_SOURCE_PROBES.setLong(2);
+            // Eight filtered candidates exceed the four posting visits estimated for BM25-first execution.
             QueryController.QUERY_OPT_LEVEL = 0;
             assertRows(execute(query), row(1), row(2));
             assertEquals(sortThenFilterCount + 1, queryPlanMetrics.sortThenFilterQueriesCompleted.getCount());
             assertEquals(filterThenSortCount + 1, queryPlanMetrics.filterThenSortQueriesCompleted.getCount());
 
-            // Disable adaptive fallback so the strategy counter proves the optimizer selected BM25-first directly.
-            CassandraRelevantProperties.SAI_BM25_SEARCH_THEN_SORT_MAX_CANDIDATE_SOURCE_PROBES.setLong(0);
+            // The optimizer-selected BM25-first control must return the same rows in the same order.
             QueryController.QUERY_OPT_LEVEL = 1;
             assertRows(execute(query), row(1), row(2));
             assertEquals(sortThenFilterCount + 2, queryPlanMetrics.sortThenFilterQueriesCompleted.getCount());
@@ -719,7 +718,6 @@ public class BM25Test extends SAITester
         }
         finally
         {
-            CassandraRelevantProperties.SAI_BM25_SEARCH_THEN_SORT_MAX_CANDIDATE_SOURCE_PROBES.setLong(defaultProbeBudget);
             QueryController.QUERY_OPT_LEVEL = defaultOptimizationLevel;
             CassandraRelevantProperties.SAI_QUERY_PLAN_METRICS_ENABLED.setBoolean(defaultQueryPlanMetrics);
         }

--- a/test/unit/org/apache/cassandra/index/sai/cql/BM25Test.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/BM25Test.java
@@ -193,6 +193,7 @@ public class BM25Test extends SAITester
 
         // Re-inserting the deleted key in a third sstable must not fail either, and the row must come back exactly once
         execute("INSERT INTO %s (k, c, query_lexical_value, array_contains) VALUES (2, 1, 'apple juice', {'target'}) USING TIMESTAMP 4");
+        assertRows(execute(select, "target", "apple"), row(1, 1), row(2, 1));
         flush();
         assertRows(execute(select, "target", "apple"), row(1, 1), row(2, 1));
         compact();

--- a/test/unit/org/apache/cassandra/index/sai/cql/BM25Test.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/BM25Test.java
@@ -30,6 +30,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.cql3.UntypedResultSet;
 import org.apache.cassandra.cql3.statements.SelectStatement;
 import org.apache.cassandra.exceptions.InvalidRequestException;
@@ -662,6 +663,47 @@ public class BM25Test extends SAITester
     {
         QueryController.QUERY_OPT_LEVEL = 0;
         testWithPredicate();
+    }
+
+    @Test
+    public void testAdaptiveFallbackMatchesForcedStrategies()
+    {
+        long defaultProbeBudget = CassandraRelevantProperties.SAI_BM25_SEARCH_THEN_SORT_MAX_CANDIDATE_SOURCE_PROBES.getLong();
+        int defaultOptimizationLevel = QueryController.QUERY_OPT_LEVEL;
+        try
+        {
+            createTable("CREATE TABLE %s(id int PRIMARY KEY, site text, extension text, body text)");
+            createIndex("CREATE CUSTOM INDEX ON %s(site) USING 'StorageAttachedIndex'");
+            createIndex("CREATE CUSTOM INDEX ON %s(extension) USING 'StorageAttachedIndex'");
+            createAnalyzedIndex("body");
+
+            execute("INSERT INTO %s(id, site, extension, body) VALUES (1, 'pepsi', 'pdf', 'freight freight freight')");
+            execute("INSERT INTO %s(id, site, extension, body) VALUES (2, 'pepsi', 'pdf', 'freight freight')");
+            execute("INSERT INTO %s(id, site, extension, body) VALUES (3, 'pepsi', 'pdf', 'freight orders and notes')");
+            execute("INSERT INTO %s(id, site, extension, body) VALUES (99, 'other', 'docx', 'freight freight freight freight')");
+
+            String query = "SELECT id FROM %s WHERE site = 'pepsi' AND extension = 'pdf' " +
+                           "ORDER BY body BM25 OF 'freight' LIMIT 2";
+
+            // Forced filter-first control.
+            CassandraRelevantProperties.SAI_BM25_SEARCH_THEN_SORT_MAX_CANDIDATE_SOURCE_PROBES.setLong(0);
+            QueryController.QUERY_OPT_LEVEL = 0;
+            assertRows(execute(query), row(1), row(2));
+
+            // Forced BM25-first control.
+            QueryController.QUERY_OPT_LEVEL = 1;
+            assertRows(execute(query), row(1), row(2));
+
+            // Adaptive filter-first planning crosses the two-candidate cap and must match both controls.
+            CassandraRelevantProperties.SAI_BM25_SEARCH_THEN_SORT_MAX_CANDIDATE_SOURCE_PROBES.setLong(2);
+            QueryController.QUERY_OPT_LEVEL = 0;
+            assertRows(execute(query), row(1), row(2));
+        }
+        finally
+        {
+            CassandraRelevantProperties.SAI_BM25_SEARCH_THEN_SORT_MAX_CANDIDATE_SOURCE_PROBES.setLong(defaultProbeBudget);
+            QueryController.QUERY_OPT_LEVEL = defaultOptimizationLevel;
+        }
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/index/sai/cql/BM25Test.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/BM25Test.java
@@ -36,8 +36,10 @@ import org.apache.cassandra.cql3.statements.SelectStatement;
 import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.index.sai.SAITester;
 import org.apache.cassandra.index.sai.SAIUtil;
+import org.apache.cassandra.index.sai.StorageAttachedIndexGroup;
 import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.index.sai.disk.v1.SegmentBuilder;
+import org.apache.cassandra.index.sai.metrics.TableQueryMetrics;
 import org.apache.cassandra.index.sai.plan.QueryController;
 
 import org.junit.runner.RunWith;
@@ -671,8 +673,10 @@ public class BM25Test extends SAITester
     {
         long defaultProbeBudget = CassandraRelevantProperties.SAI_BM25_SEARCH_THEN_SORT_MAX_CANDIDATE_SOURCE_PROBES.getLong();
         int defaultOptimizationLevel = QueryController.QUERY_OPT_LEVEL;
+        boolean defaultQueryPlanMetrics = CassandraRelevantProperties.SAI_QUERY_PLAN_METRICS_ENABLED.getBoolean();
         try
         {
+            CassandraRelevantProperties.SAI_QUERY_PLAN_METRICS_ENABLED.setBoolean(true);
             createTable("CREATE TABLE %s(id int PRIMARY KEY, site text, extension text, body text)");
             createIndex("CREATE CUSTOM INDEX ON %s(site) USING 'StorageAttachedIndex'");
             createIndex("CREATE CUSTOM INDEX ON %s(extension) USING 'StorageAttachedIndex'");
@@ -695,15 +699,24 @@ public class BM25Test extends SAITester
             QueryController.QUERY_OPT_LEVEL = 1;
             assertRows(execute(query), row(1), row(2));
 
+            var queryPlanMetrics = Objects.requireNonNull(StorageAttachedIndexGroup.getIndexGroup(getCurrentColumnFamilyStore()))
+                                                 .queryMetrics()
+                                                 .perTableMetrics
+                                                 .get(TableQueryMetrics.QueryKind.ALL)
+                                                 .queryPlanMetrics;
+            long fallbackCount = Objects.requireNonNull(queryPlanMetrics).sortThenFilterQueriesCompleted.getCount();
+
             // Adaptive filter-first planning crosses the two-candidate cap and must match both controls.
             CassandraRelevantProperties.SAI_BM25_SEARCH_THEN_SORT_MAX_CANDIDATE_SOURCE_PROBES.setLong(2);
             QueryController.QUERY_OPT_LEVEL = 0;
             assertRows(execute(query), row(1), row(2));
+            assertEquals(fallbackCount + 1, queryPlanMetrics.sortThenFilterQueriesCompleted.getCount());
         }
         finally
         {
             CassandraRelevantProperties.SAI_BM25_SEARCH_THEN_SORT_MAX_CANDIDATE_SOURCE_PROBES.setLong(defaultProbeBudget);
             QueryController.QUERY_OPT_LEVEL = defaultOptimizationLevel;
+            CassandraRelevantProperties.SAI_QUERY_PLAN_METRICS_ENABLED.setBoolean(defaultQueryPlanMetrics);
         }
     }
 

--- a/test/unit/org/apache/cassandra/index/sai/cql/QueryTracingTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/QueryTracingTest.java
@@ -140,12 +140,12 @@ public class QueryTracingTest extends SAITester
 
             execute("INSERT INTO %s(id, site, extension, body) VALUES (4, 'pepsi', 'pdf', 'freight details')");
             assertRows(execute(query), row(1), row(2));
-            assertTraceContains("after materializing 2 candidates across 2 ordering index sources (probe budget 3, fallback soft limit ");
+            assertTraceContains("after materializing 3 candidates across 2 ordering index sources (probe budget 3, fallback soft limit ");
 
             flush();
-            // Two SSTables halve the candidate cap just as one SSTable plus a memtable does.
+            // Two SSTables produce the same soft-limit-floored cap as one SSTable plus a memtable.
             assertRows(execute(query), row(1), row(2));
-            assertTraceContains("after materializing 2 candidates across 2 ordering index sources (probe budget 3, fallback soft limit ");
+            assertTraceContains("after materializing 3 candidates across 2 ordering index sources (probe budget 3, fallback soft limit ");
 
             CassandraRelevantProperties.SAI_BM25_SEARCH_THEN_SORT_MAX_CANDIDATE_SOURCE_PROBES.setLong(0);
             assertRows(execute(query), row(1), row(2));

--- a/test/unit/org/apache/cassandra/index/sai/cql/QueryTracingTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/QueryTracingTest.java
@@ -22,6 +22,8 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.cassandra.index.sai.SAITester;
+import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.index.sai.plan.QueryController;
 import org.apache.cassandra.service.ClientState;
 import org.apache.cassandra.tracing.Tracing;
 import org.apache.cassandra.tracing.TracingTestImpl;
@@ -106,6 +108,49 @@ public class QueryTracingTest extends SAITester
                            "v ANN OF [1.2, 3.4] DESC");
     }
 
+    @Test
+    public void testAdaptiveBm25Fallback()
+    {
+        long defaultProbeBudget = CassandraRelevantProperties.SAI_BM25_SEARCH_THEN_SORT_MAX_CANDIDATE_SOURCE_PROBES.getLong();
+        int defaultOptimizationLevel = QueryController.QUERY_OPT_LEVEL;
+        try
+        {
+            QueryController.QUERY_OPT_LEVEL = 0;
+            CassandraRelevantProperties.SAI_BM25_SEARCH_THEN_SORT_MAX_CANDIDATE_SOURCE_PROBES.setLong(3);
+
+            createTable("CREATE TABLE %s(id int PRIMARY KEY, site text, extension text, body text)");
+            createIndex("CREATE CUSTOM INDEX ON %s(site) USING 'org.apache.cassandra.index.sai.StorageAttachedIndex'");
+            createIndex("CREATE CUSTOM INDEX ON %s(extension) USING 'org.apache.cassandra.index.sai.StorageAttachedIndex'");
+            createIndex("CREATE CUSTOM INDEX ON %s(body) USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' WITH OPTIONS = { 'index_analyzer': 'standard' }");
+
+            execute("INSERT INTO %s(id, site, extension, body) VALUES (1, 'pepsi', 'pdf', 'freight freight freight')");
+            execute("INSERT INTO %s(id, site, extension, body) VALUES (2, 'pepsi', 'pdf', 'freight freight')");
+            execute("INSERT INTO %s(id, site, extension, body) VALUES (3, 'pepsi', 'pdf', 'freight orders and notes')");
+            execute("INSERT INTO %s(id, site, extension, body) VALUES (99, 'other', 'docx', 'freight freight freight freight')");
+
+            String query = "SELECT id FROM %s WHERE site = 'pepsi' AND extension = 'pdf' ORDER BY body BM25 OF 'freight' LIMIT 2";
+            assertRowsIgnoringOrder(execute(query), row(1), row(2));
+            assertTraceDoesNotContain("Switching filtered BM25 query to ordered index scan");
+
+            flush();
+            assertRowsIgnoringOrder(execute(query), row(1), row(2));
+            assertTraceDoesNotContain("Switching filtered BM25 query to ordered index scan");
+
+            execute("INSERT INTO %s(id, site, extension, body) VALUES (4, 'pepsi', 'pdf', 'freight details')");
+            assertRowsIgnoringOrder(execute(query), row(1), row(2));
+            assertTraceContains("Switching filtered BM25 query to ordered index scan");
+
+            CassandraRelevantProperties.SAI_BM25_SEARCH_THEN_SORT_MAX_CANDIDATE_SOURCE_PROBES.setLong(0);
+            assertRowsIgnoringOrder(execute(query), row(1), row(2));
+            assertTraceDoesNotContain("Switching filtered BM25 query to ordered index scan");
+        }
+        finally
+        {
+            CassandraRelevantProperties.SAI_BM25_SEARCH_THEN_SORT_MAX_CANDIDATE_SOURCE_PROBES.setLong(defaultProbeBudget);
+            QueryController.QUERY_OPT_LEVEL = defaultOptimizationLevel;
+        }
+    }
+
     private void assertTraceHasPlan(String query, String... expected)
     {
         TracingTestImpl tracing = (TracingTestImpl) Tracing.instance;
@@ -125,5 +170,17 @@ public class QueryTracingTest extends SAITester
             return;
         }
         Assert.fail("Query plan not found in traces");
+    }
+
+    private void assertTraceContains(String expected)
+    {
+        Assertions.assertThat(tracing.getTraces()).anyMatch(trace -> trace.contains(expected));
+        tracing.getTraces().clear();
+    }
+
+    private void assertTraceDoesNotContain(String unexpected)
+    {
+        Assertions.assertThat(tracing.getTraces()).noneMatch(trace -> trace.contains(unexpected));
+        tracing.getTraces().clear();
     }
 }

--- a/test/unit/org/apache/cassandra/index/sai/cql/QueryTracingTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/QueryTracingTest.java
@@ -21,8 +21,8 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import org.apache.cassandra.index.sai.SAITester;
 import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.index.sai.SAITester;
 import org.apache.cassandra.index.sai.plan.QueryController;
 import org.apache.cassandra.service.ClientState;
 import org.apache.cassandra.tracing.Tracing;
@@ -129,19 +129,26 @@ public class QueryTracingTest extends SAITester
             execute("INSERT INTO %s(id, site, extension, body) VALUES (99, 'other', 'docx', 'freight freight freight freight')");
 
             String query = "SELECT id FROM %s WHERE site = 'pepsi' AND extension = 'pdf' ORDER BY body BM25 OF 'freight' LIMIT 2";
-            assertRowsIgnoringOrder(execute(query), row(1), row(2));
+            // Three candidates and one ordering source stay within the probe budget.
+            assertRows(execute(query), row(1), row(2));
             assertTraceDoesNotContain("Switching filtered BM25 query to ordered index scan");
 
             flush();
-            assertRowsIgnoringOrder(execute(query), row(1), row(2));
+            // The same candidate set in one SSTable also stays within the budget.
+            assertRows(execute(query), row(1), row(2));
             assertTraceDoesNotContain("Switching filtered BM25 query to ordered index scan");
 
             execute("INSERT INTO %s(id, site, extension, body) VALUES (4, 'pepsi', 'pdf', 'freight details')");
-            assertRowsIgnoringOrder(execute(query), row(1), row(2));
-            assertTraceContains("Switching filtered BM25 query to ordered index scan");
+            assertRows(execute(query), row(1), row(2));
+            assertTraceContains("after materializing 2 candidates across 2 ordering index sources (probe budget 3, fallback soft limit ");
+
+            flush();
+            // Two SSTables halve the candidate cap just as one SSTable plus a memtable does.
+            assertRows(execute(query), row(1), row(2));
+            assertTraceContains("after materializing 2 candidates across 2 ordering index sources (probe budget 3, fallback soft limit ");
 
             CassandraRelevantProperties.SAI_BM25_SEARCH_THEN_SORT_MAX_CANDIDATE_SOURCE_PROBES.setLong(0);
-            assertRowsIgnoringOrder(execute(query), row(1), row(2));
+            assertRows(execute(query), row(1), row(2));
             assertTraceDoesNotContain("Switching filtered BM25 query to ordered index scan");
         }
         finally

--- a/test/unit/org/apache/cassandra/index/sai/cql/QueryTracingTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/QueryTracingTest.java
@@ -116,8 +116,8 @@ public class QueryTracingTest extends SAITester
             QueryController.QUERY_OPT_LEVEL = 0;
 
             createTable("CREATE TABLE %s(id int PRIMARY KEY, site text, extension text, body text)");
-            String siteIndex = createIndex("CREATE CUSTOM INDEX ON %s(site) USING 'org.apache.cassandra.index.sai.StorageAttachedIndex'");
-            String extensionIndex = createIndex("CREATE CUSTOM INDEX ON %s(extension) USING 'org.apache.cassandra.index.sai.StorageAttachedIndex'");
+            createIndex("CREATE CUSTOM INDEX ON %s(site) USING 'org.apache.cassandra.index.sai.StorageAttachedIndex'");
+            createIndex("CREATE CUSTOM INDEX ON %s(extension) USING 'org.apache.cassandra.index.sai.StorageAttachedIndex'");
             createIndex("CREATE CUSTOM INDEX ON %s(body) USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' WITH OPTIONS = { 'index_analyzer': 'standard' }");
 
             execute("INSERT INTO %s(id, site, extension, body) VALUES (1, 'pepsi', 'pdf', 'freight freight freight')");
@@ -143,10 +143,6 @@ public class QueryTracingTest extends SAITester
             // Two SSTables produce the same derived cap as one SSTable plus a memtable.
             assertRows(execute(query), row(1), row(2));
             assertTraceContains("after materializing 4 candidates across 2 ordering index sources (estimated 5 BM25 posting visits, fallback soft limit ");
-
-            String hintedQuery = query + String.format(" WITH included_indexes = {%s, %s}", siteIndex, extensionIndex);
-            assertRows(execute(hintedQuery), row(1), row(2));
-            assertTraceDoesNotContain("Switching filtered BM25 query to ordered index scan");
         }
         finally
         {

--- a/test/unit/org/apache/cassandra/index/sai/cql/QueryTracingTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/QueryTracingTest.java
@@ -21,7 +21,6 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.index.sai.SAITester;
 import org.apache.cassandra.index.sai.plan.QueryController;
 import org.apache.cassandra.service.ClientState;
@@ -111,16 +110,14 @@ public class QueryTracingTest extends SAITester
     @Test
     public void testAdaptiveBm25Fallback()
     {
-        long defaultProbeBudget = CassandraRelevantProperties.SAI_BM25_SEARCH_THEN_SORT_MAX_CANDIDATE_SOURCE_PROBES.getLong();
         int defaultOptimizationLevel = QueryController.QUERY_OPT_LEVEL;
         try
         {
             QueryController.QUERY_OPT_LEVEL = 0;
-            CassandraRelevantProperties.SAI_BM25_SEARCH_THEN_SORT_MAX_CANDIDATE_SOURCE_PROBES.setLong(3);
 
             createTable("CREATE TABLE %s(id int PRIMARY KEY, site text, extension text, body text)");
-            createIndex("CREATE CUSTOM INDEX ON %s(site) USING 'org.apache.cassandra.index.sai.StorageAttachedIndex'");
-            createIndex("CREATE CUSTOM INDEX ON %s(extension) USING 'org.apache.cassandra.index.sai.StorageAttachedIndex'");
+            String siteIndex = createIndex("CREATE CUSTOM INDEX ON %s(site) USING 'org.apache.cassandra.index.sai.StorageAttachedIndex'");
+            String extensionIndex = createIndex("CREATE CUSTOM INDEX ON %s(extension) USING 'org.apache.cassandra.index.sai.StorageAttachedIndex'");
             createIndex("CREATE CUSTOM INDEX ON %s(body) USING 'org.apache.cassandra.index.sai.StorageAttachedIndex' WITH OPTIONS = { 'index_analyzer': 'standard' }");
 
             execute("INSERT INTO %s(id, site, extension, body) VALUES (1, 'pepsi', 'pdf', 'freight freight freight')");
@@ -129,31 +126,30 @@ public class QueryTracingTest extends SAITester
             execute("INSERT INTO %s(id, site, extension, body) VALUES (99, 'other', 'docx', 'freight freight freight freight')");
 
             String query = "SELECT id FROM %s WHERE site = 'pepsi' AND extension = 'pdf' ORDER BY body BM25 OF 'freight' LIMIT 2";
-            // Three candidates and one ordering source stay within the probe budget.
+            // Four BM25 postings are more work than scoring three candidates against one source.
             assertRows(execute(query), row(1), row(2));
             assertTraceDoesNotContain("Switching filtered BM25 query to ordered index scan");
 
             flush();
-            // The same candidate set in one SSTable also stays within the budget.
+            // The same work estimates in one SSTable retain filter-first execution.
             assertRows(execute(query), row(1), row(2));
             assertTraceDoesNotContain("Switching filtered BM25 query to ordered index scan");
 
             execute("INSERT INTO %s(id, site, extension, body) VALUES (4, 'pepsi', 'pdf', 'freight details')");
             assertRows(execute(query), row(1), row(2));
-            assertTraceContains("after materializing 3 candidates across 2 ordering index sources (probe budget 3, fallback soft limit ");
+            assertTraceContains("after materializing 4 candidates across 2 ordering index sources (estimated 5 BM25 posting visits, fallback soft limit ");
 
             flush();
-            // Two SSTables produce the same soft-limit-floored cap as one SSTable plus a memtable.
+            // Two SSTables produce the same derived cap as one SSTable plus a memtable.
             assertRows(execute(query), row(1), row(2));
-            assertTraceContains("after materializing 3 candidates across 2 ordering index sources (probe budget 3, fallback soft limit ");
+            assertTraceContains("after materializing 4 candidates across 2 ordering index sources (estimated 5 BM25 posting visits, fallback soft limit ");
 
-            CassandraRelevantProperties.SAI_BM25_SEARCH_THEN_SORT_MAX_CANDIDATE_SOURCE_PROBES.setLong(0);
-            assertRows(execute(query), row(1), row(2));
+            String hintedQuery = query + String.format(" WITH included_indexes = {%s, %s}", siteIndex, extensionIndex);
+            assertRows(execute(hintedQuery), row(1), row(2));
             assertTraceDoesNotContain("Switching filtered BM25 query to ordered index scan");
         }
         finally
         {
-            CassandraRelevantProperties.SAI_BM25_SEARCH_THEN_SORT_MAX_CANDIDATE_SOURCE_PROBES.setLong(defaultProbeBudget);
             QueryController.QUERY_OPT_LEVEL = defaultOptimizationLevel;
         }
     }

--- a/test/unit/org/apache/cassandra/index/sai/plan/PlanTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/plan/PlanTest.java
@@ -453,6 +453,13 @@ public class PlanTest
     }
 
     @Test
+    public void bm25CandidateLimitCoversSoftLimitAcrossManySources()
+    {
+        assertEquals(500, QueryController.calculateBm25CandidateLimit(400, 10_000, 20));
+        assertEquals(400, QueryController.calculateBm25CandidateLimit(400, 10_000, 30));
+    }
+
+    @Test
     public void annScan()
     {
         Plan.KeysIteration i = factory.sort(factory.everything, ordering);

--- a/test/unit/org/apache/cassandra/index/sai/plan/PlanTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/plan/PlanTest.java
@@ -35,9 +35,11 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.cassandra.cql3.Operator;
+import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.db.filter.IndexHints;
 import org.apache.cassandra.db.filter.RowFilter;
 import org.apache.cassandra.db.marshal.Redaction;
+import org.apache.cassandra.index.sai.QueryContext;
 import org.apache.cassandra.index.sai.disk.vector.VectorMemtableIndex;
 import org.apache.cassandra.index.sai.iterators.KeyRangeIterator;
 import org.apache.cassandra.index.sai.iterators.LongIterator;
@@ -422,6 +424,32 @@ public class PlanTest
                                              Mockito.eq(10),
                                              Mockito.eq(50),
                                              Mockito.eq(false));
+    }
+
+    @Test
+    public void bm25FallbackUpdatesActualPlanStrategy()
+    {
+        boolean defaultPlanMetricsEnabled = CassandraRelevantProperties.SAI_QUERY_PLAN_METRICS_ENABLED.getBoolean();
+        try
+        {
+            CassandraRelevantProperties.SAI_QUERY_PLAN_METRICS_ENABLED.setBoolean(true);
+            Plan.KeysIteration indexScan = factory.indexScan(saiPred1, (long) (0.2 * factory.tableMetrics.rows));
+            Plan.KeysIteration sort = factory.sort(indexScan, bm25Orderer());
+            Plan.RowsIteration plan = factory.limit(factory.recheckFilter(rowFilter1, factory.fetch(sort)), 10);
+
+            QueryContext context = new QueryContext();
+            context.recordQueryPlan(plan, plan);
+            assertTrue(context.snapshot().queryPlanInfo.searchExecutedBeforeOrder);
+            assertFalse(context.snapshot().queryPlanInfo.filterExecutedAfterOrderedScan);
+
+            context.recordBm25SearchThenSortFallback();
+            assertFalse(context.snapshot().queryPlanInfo.searchExecutedBeforeOrder);
+            assertTrue(context.snapshot().queryPlanInfo.filterExecutedAfterOrderedScan);
+        }
+        finally
+        {
+            CassandraRelevantProperties.SAI_QUERY_PLAN_METRICS_ENABLED.setBoolean(defaultPlanMetricsEnabled);
+        }
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/index/sai/plan/PlanTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/plan/PlanTest.java
@@ -382,7 +382,7 @@ public class PlanTest
     }
 
     @Test
-    public void bm25SortFilterLimitAllowsFallbackWithExpandedLimit()
+    public void bm25SortFilterLimitUsesExpandedFallbackLimit()
     {
         int limit = 10;
         double selectivity = 0.2;
@@ -399,8 +399,7 @@ public class PlanTest
 
         Mockito.verify(executor).getTopKRows(Mockito.any(KeyRangeIterator.class),
                                              Mockito.eq(limit),
-                                             Mockito.eq((int) round(limit / selectivity)),
-                                             Mockito.eq(true));
+                                             Mockito.eq((int) round(limit / selectivity)));
     }
 
     @Test
@@ -420,10 +419,10 @@ public class PlanTest
         Mockito.doReturn(new LongIterator(new long[] { 1L })).when(executor).getKeysFromIndex(saiPred1);
         Objects.requireNonNull(plan.firstNodeOfType(Plan.KeysIteration.class)).execute(executor);
 
-        Mockito.verify(executor).getTopKRows(Mockito.any(KeyRangeIterator.class),
-                                             Mockito.eq(10),
-                                             Mockito.eq(50),
-                                             Mockito.eq(false));
+        Mockito.verify(executor).getTopKRows(Mockito.any(KeyRangeIterator.class), Mockito.eq(10));
+        Mockito.verify(executor, Mockito.never()).getTopKRows(Mockito.any(KeyRangeIterator.class),
+                                                               Mockito.eq(10),
+                                                               Mockito.anyInt());
     }
 
     @Test
@@ -453,10 +452,11 @@ public class PlanTest
     }
 
     @Test
-    public void bm25CandidateLimitCoversSoftLimitAcrossManySources()
+    public void bm25CandidateLimitUsesPostingWorkPerSource()
     {
         assertEquals(500, QueryController.calculateBm25CandidateLimit(400, 10_000, 20));
         assertEquals(400, QueryController.calculateBm25CandidateLimit(400, 10_000, 30));
+        assertEquals(4, QueryController.calculateBm25CandidateLimit(1, 7, 2));
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/index/sai/plan/PlanTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/plan/PlanTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.google.common.base.Preconditions;
@@ -42,6 +43,7 @@ import org.apache.cassandra.index.sai.iterators.KeyRangeIterator;
 import org.apache.cassandra.index.sai.iterators.LongIterator;
 import org.apache.cassandra.index.sai.utils.PrimaryKey;
 import org.apache.cassandra.index.sai.utils.PrimaryKeyWithSortKey;
+import org.apache.cassandra.schema.IndexMetadata;
 import org.mockito.Mockito;
 
 import static java.lang.Math.ceil;
@@ -70,6 +72,14 @@ public class PlanTest
         Mockito.when(orderer.isANN()).thenReturn(true);
         Mockito.when(orderer.toString(Redaction.REDACT)).thenReturn("ORDER BY v ANN OF ?");
         Mockito.when(orderer.toString(Redaction.NONE)).thenReturn("ORDER BY v ANN OF X");
+        return orderer;
+    }
+
+    private static Orderer bm25Orderer()
+    {
+        Orderer orderer = Mockito.mock(Orderer.class);
+        Mockito.when(orderer.isBM25()).thenReturn(true);
+        Mockito.when(orderer.getIndexName()).thenReturn("body_idx");
         return orderer;
     }
 
@@ -367,6 +377,51 @@ public class PlanTest
         Plan.Executor executor = Mockito.mock(Plan.Executor.class);
         Objects.requireNonNull(plan.firstNodeOfType(Plan.KeysIteration.class)).execute(executor);
         Mockito.verify(executor, Mockito.times(1)).getTopKRows((KeyRangeIterator) Mockito.any(), Mockito.eq(limit));
+    }
+
+    @Test
+    public void bm25SortFilterLimitAllowsFallbackWithExpandedLimit()
+    {
+        int limit = 10;
+        double selectivity = 0.2;
+
+        Plan.KeysIteration indexScan = factory.indexScan(saiPred1, (long) (selectivity * factory.tableMetrics.rows));
+        Plan.KeysIteration sort = factory.sort(indexScan, bm25Orderer());
+        Plan.RowsIteration fetch = factory.fetch(sort);
+        Plan.RowsIteration filter = factory.filter(rowFilter1, fetch, selectivity);
+        Plan.RowsIteration plan = factory.limit(filter, limit);
+
+        Plan.Executor executor = Mockito.mock(Plan.Executor.class);
+        Mockito.doReturn(new LongIterator(new long[] { 1L })).when(executor).getKeysFromIndex(saiPred1);
+        Objects.requireNonNull(plan.firstNodeOfType(Plan.KeysIteration.class)).execute(executor);
+
+        Mockito.verify(executor).getTopKRows(Mockito.any(KeyRangeIterator.class),
+                                             Mockito.eq(limit),
+                                             Mockito.eq((int) round(limit / selectivity)),
+                                             Mockito.eq(true));
+    }
+
+    @Test
+    public void bm25SortWithIncludedIndexDisallowsFallback()
+    {
+        double selectivity = 0.2;
+        IndexMetadata included = IndexMetadata.fromSchemaMetadata("pred1_idx",
+                                                                  IndexMetadata.Kind.CUSTOM,
+                                                                  Collections.emptyMap());
+        IndexHints hints = IndexHints.create(Set.of(included), Collections.emptySet());
+        Plan.Factory hintedFactory = new Plan.Factory(KEYSPACE, table1M, new CostEstimator(table1M), hints);
+        Plan.KeysIteration indexScan = hintedFactory.indexScan(saiPred1, (long) (selectivity * table1M.rows));
+        Plan.KeysIteration sort = hintedFactory.sort(indexScan, bm25Orderer());
+        Plan.RowsIteration plan = hintedFactory.limit(hintedFactory.fetch(sort), 10);
+
+        Plan.Executor executor = Mockito.mock(Plan.Executor.class);
+        Mockito.doReturn(new LongIterator(new long[] { 1L })).when(executor).getKeysFromIndex(saiPred1);
+        Objects.requireNonNull(plan.firstNodeOfType(Plan.KeysIteration.class)).execute(executor);
+
+        Mockito.verify(executor).getTopKRows(Mockito.any(KeyRangeIterator.class),
+                                             Mockito.eq(10),
+                                             Mockito.eq(50),
+                                             Mockito.eq(false));
     }
 
     @Test


### PR DESCRIPTION
### What is the issue

Filtered BM25 search-then-sort can read a large candidate set from every active ordering-index source. With correlated predicates and multiple SSTables, that work can reach the server range timeout.

This is a follow-up to #2579.

### What does this PR fix and why was it fixed

- Derives the execution break-even from current query and index statistics: filtered candidate work versus BM25 term posting work per active source.
- Keeps filter-first scoring while it is cheaper, then switches to the existing exact BM25 scan plus engine-side row-filter recheck when candidate work becomes more expensive.
- Uses the query soft limit as the candidate floor and preserves the expanded fallback soft limit for post-filtering.
- Keeps included-index hints on the required filter-first path and leaves non-BM25 ordering unchanged.
- Traces the executed strategy and corrects the existing query-plan flags without adding a metric, configuration property, CQL, or Data API change.

Tests:

- PlanTest: 52 passed
- QueryTracingTest: 2 passed
- BM25Test: 255 passed
- PlanWithIndexHintsTest: 86 passed, 2 expected skips
