### PR TITLE
HCD-541: Upgrading micrometer-core from 1.5.5 to 1.17.1(main)

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -754,7 +754,7 @@
             <exclusion groupId="junit" artifactId="junit"/>
           </dependency>
 
-          <dependency groupId="io.micrometer" artifactId="micrometer-core" version="1.5.5"/>
+          <dependency groupId="io.micrometer" artifactId="micrometer-core" version="1.17.1"/>
           <dependency groupId="org.latencyutils" artifactId="LatencyUtils" version="2.0.3"/>
         </dependencyManagement>
         <developer id="adelapena" name="Andres de la Peña"/>

--- a/src/java/org/apache/cassandra/index/sai/disk/v2/sortedterms/SortedTermsWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v2/sortedterms/SortedTermsWriter.java
@@ -25,7 +25,6 @@ import javax.annotation.concurrent.NotThreadSafe;
 
 import com.google.common.base.Preconditions;
 
-import io.micrometer.core.lang.NonNull;
 import org.apache.cassandra.index.sai.disk.format.IndexComponent;
 import org.apache.cassandra.index.sai.disk.io.IndexOutputWriter;
 import org.apache.cassandra.index.sai.disk.v1.MetadataWriter;
@@ -99,8 +98,8 @@ public class SortedTermsWriter implements Closeable
      * @param termsDataBlockOffsets  where to write the offsets of each block of terms data
      * @param trieComponent component where to write the trie that maps the terms to point ids
      */
-    public SortedTermsWriter(@NonNull IndexComponent.ForWrite termsDataComponent,
-                             @NonNull MetadataWriter metadataWriter,
+    public SortedTermsWriter(@Nonnull IndexComponent.ForWrite termsDataComponent,
+                             @Nonnull MetadataWriter metadataWriter,
                              @Nonnull NumericValuesWriter termsDataBlockOffsets,
                              @Nonnull IndexComponent.ForWrite trieComponent) throws IOException
     {

--- a/src/java/org/apache/cassandra/index/sai/disk/v9/keystore/KeyStoreWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v9/keystore/KeyStoreWriter.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.NotThreadSafe;
 
-import io.micrometer.core.lang.NonNull;
 import org.apache.cassandra.index.sai.disk.format.IndexComponent;
 import org.apache.cassandra.index.sai.disk.io.IndexOutput;
 import org.apache.cassandra.index.sai.disk.v1.MetadataWriter;
@@ -86,9 +85,9 @@ public class KeyStoreWriter implements Closeable
      * @param blockShift        the block shift that is used to determine the block size
      * @param clustering        determines whether the keys will be written as ordered partitions
      */
-    public KeyStoreWriter(@NonNull IndexComponent.ForWrite keysDataComponent,
-                          @NonNull MetadataWriter metadataWriter,
-                          @NonNull NumericValuesWriter keysBlockOffsets,
+    public KeyStoreWriter(@Nonnull IndexComponent.ForWrite keysDataComponent,
+                          @Nonnull MetadataWriter metadataWriter,
+                          @Nonnull NumericValuesWriter keysBlockOffsets,
                           int blockShift,
                           boolean clustering) throws IOException
     {


### PR DESCRIPTION

### What is the issue
It has been identified that CVE-2026-59295 and CVE-2026-40984 applies to all versions of micrometer-core up to 1.15.11. The library has thus been upgraded to 1.17.1 the most recent available version with the issue resolved.

### What does this PR fix and why was it fixed

This PR updates the micrometer-core 1.5.5 to 1.17.1
