### PR TITLE
HCD-549: Expose the origin of a replica-side apply to secondary indexes

### DIFF
--- a/src/java/org/apache/cassandra/db/CassandraKeyspaceWriteHandler.java
+++ b/src/java/org/apache/cassandra/db/CassandraKeyspaceWriteHandler.java
@@ -52,7 +52,7 @@ public class CassandraKeyspaceWriteHandler implements KeyspaceWriteHandler
             {
                 position = addToCommitLog(mutation);
             }
-            return new CassandraWriteContext(group, position);
+            return new CassandraWriteContext(group, position, writeOptions, mutation.origin());
         }
         catch (Throwable t)
         {

--- a/src/java/org/apache/cassandra/db/CassandraKeyspaceWriteHandler.java
+++ b/src/java/org/apache/cassandra/db/CassandraKeyspaceWriteHandler.java
@@ -19,12 +19,15 @@
 package org.apache.cassandra.db;
 
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.cassandra.db.commitlog.CommitLog;
 import org.apache.cassandra.db.commitlog.CommitLogPosition;
 import org.apache.cassandra.db.partitions.PartitionUpdate;
 import org.apache.cassandra.exceptions.RequestExecutionException;
+import org.apache.cassandra.index.Index;
+import org.apache.cassandra.index.SecondaryIndexManager;
 import org.apache.cassandra.schema.TableId;
 import org.apache.cassandra.tracing.Tracing;
 import org.apache.cassandra.utils.concurrent.OpOrder;
@@ -42,9 +45,16 @@ public class CassandraKeyspaceWriteHandler implements KeyspaceWriteHandler
     public WriteContext beginWrite(Mutation mutation, WriteOptions writeOptions) throws RequestExecutionException
     {
         OpOrder.Group group = null;
+        Map<Index, Index.PreparedWrite> prepared = null;
         try
         {
             group = Keyspace.writeOrder.start();
+
+            // Let the indexes see the write BEFORE anything is persisted (Index#prepareWrite). This must
+            // precede the commit log append: it is the ordering that lets an index treat a replayed
+            // mutation as one it has already been told about.
+            if (writeOptions.updateIndexes)
+                prepared = prepareIndexWrites(mutation, writeOptions);
 
             // write the mutation to the commitlog and memtables
             CommitLogPosition position = null;
@@ -52,16 +62,41 @@ public class CassandraKeyspaceWriteHandler implements KeyspaceWriteHandler
             {
                 position = addToCommitLog(mutation);
             }
-            return new CassandraWriteContext(group, position, writeOptions, mutation.origin());
+            return new CassandraWriteContext(group, position, writeOptions, mutation.origin(), prepared);
         }
         catch (Throwable t)
         {
+            // The write is failing before anything was persisted: whatever the indexes prepared for it
+            // is undone. (A failure inside prepareIndexWrites itself has already aborted and emptied it.)
+            if (prepared != null && !prepared.isEmpty())
+                SecondaryIndexManager.abortPreparedWrites(prepared);
             if (group != null)
             {
                 group.close();
             }
             throw t;
         }
+    }
+
+    /**
+     * Offers each partition update to its table's indexes, mirroring the per-update loop of
+     * {@code Keyspace.applyInternal}: an update whose table has been dropped is skipped there, so it is skipped
+     * here too. Costs a volatile read per update for a table whose indexes do not prepare writes, which is
+     * the common case; the handle map is only created when an index actually returns a handle.
+     *
+     * @return the handles keyed by index, for the mutation's {@link CassandraWriteContext}; null if none
+     */
+    private Map<Index, Index.PreparedWrite> prepareIndexWrites(Mutation mutation, WriteOptions writeOptions)
+    {
+        Map<Index, Index.PreparedWrite> prepared = null;
+        for (PartitionUpdate update : mutation.getPartitionUpdates())
+        {
+            ColumnFamilyStore cfs = keyspace.getIfExists(update.metadata().id);
+            if (cfs == null || !cfs.indexManager.preparesWrites())
+                continue;
+            prepared = cfs.indexManager.prepareWrite(update, writeOptions, mutation.origin(), prepared);
+        }
+        return prepared;
     }
 
     private CommitLogPosition addToCommitLog(Mutation mutation)

--- a/src/java/org/apache/cassandra/db/CassandraWriteContext.java
+++ b/src/java/org/apache/cassandra/db/CassandraWriteContext.java
@@ -18,9 +18,14 @@
 
 package org.apache.cassandra.db;
 
+import java.util.Map;
+import javax.annotation.Nullable;
+
 import com.google.common.base.Preconditions;
 
 import org.apache.cassandra.db.commitlog.CommitLogPosition;
+import org.apache.cassandra.index.Index;
+import org.apache.cassandra.index.SecondaryIndexManager;
 import org.apache.cassandra.utils.concurrent.OpOrder;
 
 public class CassandraWriteContext implements WriteContext
@@ -29,10 +34,17 @@ public class CassandraWriteContext implements WriteContext
     private final CommitLogPosition position;
     private final WriteOptions writeOptions;
     private final WriteOrigin origin;
+    /**
+     * The handles the indexes returned from {@link Index#prepareWrite} for this mutation, keyed by index
+     * (identity), or null when none did. A mutation holds at most one update per table, so one handle per
+     * index is enough. Only the mutation thread touches it; a handle leaves it in {@link #takePreparedWrite}
+     * or is aborted in {@link #close()}, never both.
+     */
+    private final @Nullable Map<Index, Index.PreparedWrite> preparedWrites;
 
     public CassandraWriteContext(OpOrder.Group opGroup, CommitLogPosition position)
     {
-        this(opGroup, position, null, null);
+        this(opGroup, position, null, null, null);
     }
 
     public CassandraWriteContext(OpOrder.Group opGroup,
@@ -40,11 +52,21 @@ public class CassandraWriteContext implements WriteContext
                                  WriteOptions writeOptions,
                                  WriteOrigin origin)
     {
+        this(opGroup, position, writeOptions, origin, null);
+    }
+
+    public CassandraWriteContext(OpOrder.Group opGroup,
+                                 CommitLogPosition position,
+                                 WriteOptions writeOptions,
+                                 WriteOrigin origin,
+                                 @Nullable Map<Index, Index.PreparedWrite> preparedWrites)
+    {
         Preconditions.checkArgument(opGroup != null);
         this.opGroup = opGroup;
         this.position = position;
         this.writeOptions = writeOptions;
         this.origin = origin;
+        this.preparedWrites = preparedWrites;
     }
 
     public static CassandraWriteContext fromContext(WriteContext context)
@@ -93,9 +115,40 @@ public class CassandraWriteContext implements WriteContext
         return origin;
     }
 
+    /**
+     * Hands {@code index} the handle it returned from {@link Index#prepareWrite} for the enclosing mutation --
+     * captured by the keyspace write handler BEFORE the commit log append -- and forgets it: a second call
+     * returns null, and a handle taken here is not {@linkplain Index#abortWrite aborted} when the context is
+     * closed. Meant to be called from the index's own {@code indexerFor}, on the mutation thread.
+     *
+     * @return the handle, or null if the index returned none, was not asked (indexing skipped for this write,
+     * index not writable, context not opened for a mutation), or already took it
+     */
+    @Override
+    public @Nullable Index.PreparedWrite takePreparedWrite(Index index)
+    {
+        return preparedWrites == null ? null : preparedWrites.remove(index);
+    }
+
+    /**
+     * Ends the write: whatever handles the indexes did not {@linkplain #takePreparedWrite take back} -- the
+     * write failed after they were prepared, the table was dropped, the index was not asked for an indexer or
+     * did not take it -- are {@linkplain Index#abortWrite aborted}, then the write order group is closed.
+     */
     @Override
     public void close()
     {
-        opGroup.close();
+        try
+        {
+            if (preparedWrites != null && !preparedWrites.isEmpty())
+            {
+                SecondaryIndexManager.abortPreparedWrites(preparedWrites);
+                preparedWrites.clear();
+            }
+        }
+        finally
+        {
+            opGroup.close();
+        }
     }
 }

--- a/src/java/org/apache/cassandra/db/CassandraWriteContext.java
+++ b/src/java/org/apache/cassandra/db/CassandraWriteContext.java
@@ -27,12 +27,24 @@ public class CassandraWriteContext implements WriteContext
 {
     private final OpOrder.Group opGroup;
     private final CommitLogPosition position;
+    private final WriteOptions writeOptions;
+    private final WriteOrigin origin;
 
     public CassandraWriteContext(OpOrder.Group opGroup, CommitLogPosition position)
+    {
+        this(opGroup, position, null, null);
+    }
+
+    public CassandraWriteContext(OpOrder.Group opGroup,
+                                 CommitLogPosition position,
+                                 WriteOptions writeOptions,
+                                 WriteOrigin origin)
     {
         Preconditions.checkArgument(opGroup != null);
         this.opGroup = opGroup;
         this.position = position;
+        this.writeOptions = writeOptions;
+        this.origin = origin;
     }
 
     public static CassandraWriteContext fromContext(WriteContext context)
@@ -49,6 +61,34 @@ public class CassandraWriteContext implements WriteContext
     public CommitLogPosition getPosition()
     {
         return position;
+    }
+
+    /**
+     * The options the enclosing mutation is being applied with, or null when this context was not opened for
+     * a mutation (index build, compaction, cleanup, and the read path — see
+     * {@link KeyspaceWriteHandler#createContextForIndexing()} and
+     * {@link KeyspaceWriteHandler#createContextForRead()}).
+     * <p>
+     * Secondary indexes receive this context in {@code Index.Group#indexerFor} and can use it to tell an
+     * ordinary write from a hint replay, a read repair, a batchlog replay or a commit log replay, which
+     * {@code IndexTransaction.Type} alone does not distinguish.
+     */
+    public WriteOptions getWriteOptions()
+    {
+        return writeOptions;
+    }
+
+    /**
+     * Where the enclosing mutation came from, or null when this context was not opened for a mutation.
+     * <p>
+     * Null and {@link WriteOrigin#LOCAL} are different answers. Null means "there is no mutation here at
+     * all" -- an index build, a compaction, a cleanup, or the read path. {@code LOCAL} means "there is a
+     * mutation and it did not arrive over the wire", which is a real, common origin: a write this node
+     * coordinated, a commit log replay, a paxos commit applied where it was proposed.
+     */
+    public WriteOrigin getOrigin()
+    {
+        return origin;
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/CassandraWriteContext.java
+++ b/src/java/org/apache/cassandra/db/CassandraWriteContext.java
@@ -81,10 +81,12 @@ public class CassandraWriteContext implements WriteContext
     /**
      * Where the enclosing mutation came from, or null when this context was not opened for a mutation.
      * <p>
-     * Null and {@link WriteOrigin#LOCAL} are different answers. Null means "there is no mutation here at
-     * all" -- an index build, a compaction, a cleanup, or the read path. {@code LOCAL} means "there is a
-     * mutation and it did not arrive over the wire", which is a real, common origin: a write this node
-     * coordinated, a commit log replay, a paxos commit applied where it was proposed.
+     * Null, {@link WriteOrigin#LOCAL} and {@link WriteOrigin#UNKNOWN} are three different answers. Null
+     * means "there is no mutation here at all" -- an index build, a compaction, a cleanup, or the read
+     * path. {@code LOCAL} means "there is a mutation and it provably did not arrive over the wire", which
+     * is a real, common origin: a write this node coordinated, a commit log replay, a paxos commit applied
+     * where it was proposed. {@code UNKNOWN} means the origin could not be determined (snitch missing or
+     * failing, local datacenter unresolved) -- the write may have come from anywhere.
      */
     public WriteOrigin getOrigin()
     {

--- a/src/java/org/apache/cassandra/db/Mutation.java
+++ b/src/java/org/apache/cassandra/db/Mutation.java
@@ -82,6 +82,18 @@ public class Mutation implements IMutation, Supplier<Mutation>
     // keep track of when mutation has started waiting for a MV partition lock
     final AtomicLong viewLockAcquireStart = new AtomicLong(0);
 
+    // Where this mutation came from, when it arrived over the wire. Set by the verb handler before the
+    // apply -- and, in MutationVerbHandler, before the payload can be handed to the forwarding path -- then
+    // read by the keyspace write handler, which passes it to secondary indexes through the write context.
+    // Never serialized, and never part of the mutation's identity.
+    //
+    // The handler thread that writes it is also the one that reads it back through Keyspace.apply, and the
+    // one re-dispatch that changes threads (Keyspace.applyInternal deferring on MV lock contention) goes
+    // through an executor, which already publishes safely. Volatile anyway: this is one field written once
+    // per inbound message on a path that is otherwise easy to get subtly wrong, and it costs nothing next
+    // to the commit log append that follows.
+    private volatile WriteOrigin origin = WriteOrigin.LOCAL;
+
     private final boolean cdcEnabled;
     private final RequestTracker requestTracker;
 
@@ -136,12 +148,30 @@ public class Mutation implements IMutation, Supplier<Mutation>
             }
         }
 
-        return new Mutation(keyspaceName, key, builder.build(), approxCreatedAtNanos);
+        Mutation filtered = new Mutation(keyspaceName, key, builder.build(), approxCreatedAtNanos);
+        filtered.origin = origin;
+        return filtered;
     }
 
     public Mutation without(TableId tableId)
     {
         return without(Collections.singleton(tableId));
+    }
+
+    /**
+     * Records where this mutation came from, for the benefit of the replica-side apply path. Called by the
+     * verb handlers before the apply; {@link WriteOrigin#LOCAL} otherwise.
+     */
+    public Mutation withOrigin(WriteOrigin origin)
+    {
+        this.origin = origin == null ? WriteOrigin.LOCAL : origin;
+        return this;
+    }
+
+    /** Never null; {@link WriteOrigin#LOCAL} for a mutation that did not arrive over the wire. */
+    public WriteOrigin origin()
+    {
+        return origin;
     }
 
     public String getKeyspaceName()
@@ -255,7 +285,12 @@ public class Mutation implements IMutation, Supplier<Mutation>
             modifications.put(table, PartitionUpdate.merge(updates));
             updates.clear();
         }
-        return new Mutation(ks, key, modifications.build(), approxTime.now());
+
+        Mutation merged = new Mutation(ks, key, modifications.build(), approxTime.now());
+        // All inputs were checked to share a keyspace and a key above, so they came from one inbound
+        // message and share an origin; keep it rather than silently reverting the merged result to LOCAL.
+        merged.origin = mutations.get(0).origin;
+        return merged;
     }
 
     public Future<?> applyFuture(WriteOptions writeOptions)

--- a/src/java/org/apache/cassandra/db/MutationVerbHandler.java
+++ b/src/java/org/apache/cassandra/db/MutationVerbHandler.java
@@ -79,6 +79,18 @@ public class MutationVerbHandler extends AbstractMutationVerbHandler<Mutation>
             return;
         }
 
+        // Record where the write came from before anything else touches the payload: an inbound mutation is
+        // applied with the same WriteOptions as a locally coordinated one, so this is the only point at which
+        // the replica can still tell that the coordinator sits in another datacenter. See WriteOrigin.
+        //
+        // Stamped BEFORE forwarding on purpose. forwardToLocalNodes hands this very Mutation instance to the
+        // outbound connections, which serialize it on their own threads; writing to it after that would
+        // race with them and break the "never modify a mutation while it is being serialized" rule this
+        // class's payload lives under (see Mutation). Doing it here means the write happens-before the
+        // handoff. The origin itself is never serialized, so the forwarded copies carry nothing extra --
+        // each recipient stamps its own from its own message.
+        message.payload.withOrigin(WriteOrigin.fromMessage(message));
+
         // Check if there were any forwarding headers in this message
         ForwardingInfo forwardTo = message.forwardTo();
         if (forwardTo != null)
@@ -111,7 +123,9 @@ public class MutationVerbHandler extends AbstractMutationVerbHandler<Mutation>
             requestSensors.incrementSensor(context, Type.INTERNODE_BYTES, message.payloadSize(MessagingService.current_version) / tables.size());
         }
 
-        message.payload.applyFuture(WriteOptions.DEFAULT).addCallback(o -> respond(requestSensors, message, respondToAddress), wto -> failed());
+        // The origin was stamped in doVerb, before the payload could be handed to the forwarding path.
+        message.payload.applyFuture(WriteOptions.DEFAULT)
+                       .addCallback(o -> respond(requestSensors, message, respondToAddress), wto -> failed());
     }
 
     private static void forwardToLocalNodes(Message<Mutation> originalMessage, ForwardingInfo forwardTo)

--- a/src/java/org/apache/cassandra/db/ReadRepairVerbHandler.java
+++ b/src/java/org/apache/cassandra/db/ReadRepairVerbHandler.java
@@ -38,7 +38,7 @@ public class ReadRepairVerbHandler extends AbstractMutationVerbHandler<Mutation>
     @Override
     void applyMutation(Message<Mutation> message, InetAddressAndPort respondToAddress)
     {
-        message.payload.apply(WriteOptions.FOR_READ_REPAIR);
+        message.payload.withOrigin(WriteOrigin.fromMessage(message)).apply(WriteOptions.FOR_READ_REPAIR);
         MessagingService.instance().send(message.emptyResponse(), respondToAddress);
     }
 }

--- a/src/java/org/apache/cassandra/db/WriteContext.java
+++ b/src/java/org/apache/cassandra/db/WriteContext.java
@@ -18,6 +18,10 @@
 
 package org.apache.cassandra.db;
 
+import javax.annotation.Nullable;
+
+import org.apache.cassandra.index.Index;
+
 /**
  * Issued by the keyspace write handler and used in the write path (as expected), as well as the read path
  * and some async index building code. In the read and index paths, the write context is intended to be used
@@ -26,6 +30,16 @@ package org.apache.cassandra.db;
  */
 public interface WriteContext extends AutoCloseable
 {
+    /**
+     * Hands {@code index} the handle it returned from {@link Index#prepareWrite} for the enclosing mutation,
+     * once: see {@link CassandraWriteContext#takePreparedWrite}. A context that carries no mutation (index
+     * build, compaction, cleanup, the read path) returns null, which is the default.
+     */
+    default @Nullable Index.PreparedWrite takePreparedWrite(Index index)
+    {
+        return null;
+    }
+
     @Override
     void close();
 }

--- a/src/java/org/apache/cassandra/db/WriteOrigin.java
+++ b/src/java/org/apache/cassandra/db/WriteOrigin.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db;
+
+import java.util.function.Function;
+
+import javax.annotation.Nullable;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.locator.IEndpointSnitch;
+import org.apache.cassandra.locator.InetAddressAndPort;
+import org.apache.cassandra.net.Message;
+import org.apache.cassandra.utils.FBUtilities;
+import org.apache.cassandra.utils.JVMStabilityInspector;
+
+/**
+ * Where a replica-side apply came from.
+ * <p>
+ * A replica applying a mutation cannot otherwise tell whether the write was coordinated by a node in its
+ * own datacenter or in a remote one: every inbound {@code MUTATION_REQ} is applied with
+ * {@link WriteOptions#DEFAULT}, exactly like a write this node coordinates itself. That distinction is not
+ * derivable from the {@link Mutation} — it lives only in the {@link Message} — so it is captured here by the
+ * verb handlers and carried to {@link CassandraWriteContext}, which secondary indexes already receive in
+ * {@code Index.Group#indexerFor}.
+ * <p>
+ * Two different endpoints of the inbound message answer two different questions:
+ * <ul>
+ *   <li>{@link Message#respondTo()} is the <em>coordinator</em>. For a write relayed inside a remote
+ *       datacenter, {@code ForwardingInfo} handling in {@link MutationVerbHandler} puts the original
+ *       coordinator in {@code RESPOND_TO}, so this is the true origin on both the direct and the forwarded
+ *       leg. It drives {@link #isCrossDatacenter()}, which is true on <em>every</em> replica in the
+ *       receiving datacenter.</li>
+ *   <li>{@link Message#from()} is the <em>sender</em>. It is never serialized — the receiver stamps it with
+ *       the connection peer — so it is the relay node for a forwarded message and the remote coordinator for
+ *       a message delivered straight to this replica. It drives
+ *       {@link #isDirectFromRemoteDatacenter()}.</li>
+ * </ul>
+ * <b>Read {@link #isDirectFromRemoteDatacenter()}'s contract before inferring anything from it.</b> It is
+ * tempting to read it as "I am this datacenter's single entry point for the write", and for an ordinary
+ * write that is exactly what it means — but only because {@code MUTATION_REQ} is the one verb that fans out
+ * inside the receiving datacenter. Every other verb here is sent point-to-point to each replica, so all of
+ * them see it as true.
+ * <p>
+ * Instances are immutable and are created once per inbound message, not per partition update.
+ */
+public final class WriteOrigin
+{
+    private static final Logger logger = LoggerFactory.getLogger(WriteOrigin.class);
+
+    /**
+     * A write with no inbound message behind it: coordinated by this node on behalf of a client, or applied
+     * by an internal path such as commit log replay, batchlog replay of a locally owned mutation, or a
+     * paxos commit applied where it was proposed. Never cross-datacenter.
+     */
+    public static final WriteOrigin LOCAL = new WriteOrigin(null, null, false, false);
+
+    private final InetAddressAndPort coordinator;
+    private final String datacenter;
+    private final boolean crossDatacenter;
+    private final boolean directFromRemoteDatacenter;
+
+    private WriteOrigin(InetAddressAndPort coordinator,
+                        String datacenter,
+                        boolean crossDatacenter,
+                        boolean directFromRemoteDatacenter)
+    {
+        this.coordinator = coordinator;
+        this.datacenter = datacenter;
+        this.crossDatacenter = crossDatacenter;
+        this.directFromRemoteDatacenter = directFromRemoteDatacenter;
+    }
+
+    /**
+     * Derives the origin of an inbound mutation-carrying message.
+     * <p>
+     * Never throws: any failure yields {@link #LOCAL}.
+     * <p>
+     * Note that "the snitch cannot place this endpoint" is mostly <em>not</em> such a failure. Most snitches
+     * in this tree ({@code GossipingPropertyFileSnitch}, the cloud metadata snitches) answer an endpoint they
+     * do not know with a synthetic datacenter name rather than null, so an endpoint missing from the local
+     * topology reads as a real — and therefore remote — datacenter. Consumers must treat
+     * {@link #isCrossDatacenter()} as best-effort during a topology change, not as ground truth.
+     */
+    public static WriteOrigin fromMessage(Message<?> message)
+    {
+        try
+        {
+            // A message this node addressed to itself is not an inbound write in any meaningful sense:
+            // paths that reuse their verb handler for local execution (PaxosCommit#executeOnSelf) would
+            // otherwise report the node as its own coordinator instead of LOCAL.
+            if (FBUtilities.getBroadcastAddressAndPort().equals(message.respondTo()))
+                return LOCAL;
+
+            IEndpointSnitch snitch = DatabaseDescriptor.getEndpointSnitch();
+            if (snitch == null)
+                return LOCAL;
+
+            String localDatacenter = DatabaseDescriptor.getLocalDataCenter();
+            if (localDatacenter == null)
+                localDatacenter = snitch.getLocalDatacenter();
+
+            return create(message.respondTo(), message.from(), localDatacenter, snitch::getDatacenter);
+        }
+        catch (Throwable t)
+        {
+            JVMStabilityInspector.inspectThrowable(t);
+            // A snitch that throws for an endpoint (PropertyFileSnitch does, for one it has no entry for)
+            // must not fail the write. Degrade to "no origin" and say so once per problem endpoint rather
+            // than on every mutation -- this runs on the mutation stage.
+            logger.debug("Could not determine the origin of a {} from {}", message.verb(), message.from(), t);
+            return LOCAL;
+        }
+    }
+
+    /**
+     * Derives the origin of an apply learned from a single peer, for verb handlers whose payload is not
+     * a {@link Mutation} and whose verbs never carry {@code FORWARD_TO} -- the paxos commit family, where
+     * {@code respondTo() == from()} always, so the peer is both coordinator and sender. Same never-throws
+     * contract as {@link #fromMessage}.
+     */
+    public static WriteOrigin fromPeer(InetAddressAndPort peer)
+    {
+        try
+        {
+            // See fromMessage: a delivery from this node itself is a local apply, not an inbound one.
+            if (FBUtilities.getBroadcastAddressAndPort().equals(peer))
+                return LOCAL;
+
+            IEndpointSnitch snitch = DatabaseDescriptor.getEndpointSnitch();
+            if (snitch == null)
+                return LOCAL;
+
+            String localDatacenter = DatabaseDescriptor.getLocalDataCenter();
+            if (localDatacenter == null)
+                localDatacenter = snitch.getLocalDatacenter();
+
+            return create(peer, peer, localDatacenter, snitch::getDatacenter);
+        }
+        catch (Throwable t)
+        {
+            JVMStabilityInspector.inspectThrowable(t);
+            logger.debug("Could not determine the origin of an apply from {}", peer, t);
+            return LOCAL;
+        }
+    }
+
+    /**
+     * The datacenter-placement logic, free of any snitch or configuration lookup: the coordinator and
+     * the sender of the message, this node's datacenter, and the topology to place them with.
+     * <p>
+     * {@code datacenterOf} may return null for an endpoint it cannot place. Both unplaceable cases resolve
+     * <em>away</em> from claiming something we cannot support: an unplaceable coordinator yields
+     * {@link #LOCAL} rather than a guess at a remote datacenter, and an unplaceable sender leaves
+     * {@link #isDirectFromRemoteDatacenter()} false rather than asserting a delivery path we did not observe.
+     * (In practice most snitches here never return null — see {@link #fromMessage}.)
+     * <p>
+     * Public so that code reacting to an origin -- a secondary index, typically -- can build one
+     * deterministically in a unit test instead of standing up a cluster.
+     */
+    public static WriteOrigin create(@Nullable InetAddressAndPort coordinator,
+                                     @Nullable InetAddressAndPort sender,
+                                     @Nullable String localDatacenter,
+                                     Function<InetAddressAndPort, String> datacenterOf)
+    {
+        if (coordinator == null || localDatacenter == null)
+            return LOCAL;
+
+        String coordinatorDatacenter = datacenterOf.apply(coordinator);
+        if (coordinatorDatacenter == null)
+            return LOCAL;
+
+        if (localDatacenter.equals(coordinatorDatacenter))
+            return new WriteOrigin(coordinator, coordinatorDatacenter, false, false);
+
+        // The write crossed a datacenter boundary. It reached this node directly from that datacenter only
+        // if the sender is the one that sat on the far side of the boundary; a message relayed by a peer of
+        // this datacenter was sent by that peer. A sender we cannot place proves nothing, so say no.
+        String senderDatacenter = sender == null ? null : datacenterOf.apply(sender);
+        boolean direct = senderDatacenter != null && !localDatacenter.equals(senderDatacenter);
+
+        return new WriteOrigin(coordinator, coordinatorDatacenter, true, direct);
+    }
+
+    /**
+     * The node that coordinated the write, or null when it was initiated locally (see {@link #LOCAL}).
+     * For a hint this is the node that held the hint, and for a read repair the node that ran the read —
+     * that is, the node the apply came from, which is not necessarily the node the client talked to.
+     */
+    @Nullable
+    public InetAddressAndPort coordinator()
+    {
+        return coordinator;
+    }
+
+    /** The coordinator's datacenter, or null when the write was initiated locally. */
+    @Nullable
+    public String datacenter()
+    {
+        return datacenter;
+    }
+
+    /** Whether the write was coordinated in a datacenter other than this node's. */
+    public boolean isCrossDatacenter()
+    {
+        return crossDatacenter;
+    }
+
+    /**
+     * Whether the message reached this node <em>directly</em> from a node in the coordinator's remote
+     * datacenter, rather than being relayed to it by a peer of its own datacenter. False for every locally
+     * coordinated write.
+     * <p>
+     * This is a statement about the delivery path, not an election. Whether it also identifies a
+     * <em>unique</em> node per receiving datacenter depends entirely on how the verb fans out:
+     * <ul>
+     *   <li>{@code MUTATION_REQ} — <b>unique</b>. {@code StorageProxy.sendMessagesToNonlocalDC} sends one
+     *       message per remote datacenter and lets the receiver fan it out via {@code ForwardingInfo}, so
+     *       exactly one replica per receiving datacenter sees this true. (A datacenter with a single
+     *       contacted replica gets no {@code ForwardingInfo}, and that replica is still the only one.)</li>
+     *   <li>{@code READ_REPAIR_REQ}, {@code HINT_REQ}, {@code PAXOS2_COMMIT_REMOTE_REQ} — <b>not unique</b>.
+     *       {@code BlockingPartitionRepair}, {@code HintsDispatcher} and {@code PaxosCommit} each send
+     *       point-to-point to every destination, so <em>every</em> replica in the receiving datacenter sees
+     *       this true.</li>
+     * </ul>
+     * Do not use it to elect one node per datacenter unless you have restricted yourself to the standard
+     * write path and are willing to have that coupling break silently if the transport changes.
+     */
+    public boolean isDirectFromRemoteDatacenter()
+    {
+        return directFromRemoteDatacenter;
+    }
+
+    @Override
+    public String toString()
+    {
+        if (coordinator == null)
+            return "WriteOrigin{local}";
+
+        return "WriteOrigin{coordinator=" + coordinator
+               + ", dc=" + datacenter
+               + ", crossDc=" + crossDatacenter
+               + ", direct=" + directFromRemoteDatacenter
+               + '}';
+    }
+}

--- a/src/java/org/apache/cassandra/db/WriteOrigin.java
+++ b/src/java/org/apache/cassandra/db/WriteOrigin.java
@@ -67,9 +67,21 @@ public final class WriteOrigin
     /**
      * A write with no inbound message behind it: coordinated by this node on behalf of a client, or applied
      * by an internal path such as commit log replay, batchlog replay of a locally owned mutation, or a
-     * paxos commit applied where it was proposed. Never cross-datacenter.
+     * paxos commit applied where it was proposed. Never cross-datacenter -- this constant means the write
+     * genuinely originated here, not "we could not tell"; that is {@link #UNKNOWN}.
      */
     public static final WriteOrigin LOCAL = new WriteOrigin(null, null, false, false);
+
+    /**
+     * The origin could not be determined: the snitch is missing or misbehaving, this node's own datacenter
+     * is not configured, or placing an endpoint threw. The write may well have come from another
+     * datacenter -- there is just no way to tell -- so this is deliberately NOT {@link #LOCAL}, whose
+     * contract is "genuinely originated here".
+     * <p>
+     * Both boolean accessors answer false, because answering true to either would be a guess; a consumer
+     * that must distinguish "provably local" from "undetermined" checks {@link #isUnknown()}.
+     */
+    public static final WriteOrigin UNKNOWN = new WriteOrigin(null, null, false, false);
 
     private final InetAddressAndPort coordinator;
     private final String datacenter;
@@ -90,7 +102,8 @@ public final class WriteOrigin
     /**
      * Derives the origin of an inbound mutation-carrying message.
      * <p>
-     * Never throws: any failure yields {@link #LOCAL}.
+     * Never throws: any failure yields {@link #UNKNOWN} -- not {@link #LOCAL}, because a write we could
+     * not place may well be cross-datacenter, and LOCAL promises it is not.
      * <p>
      * Note that "the snitch cannot place this endpoint" is mostly <em>not</em> such a failure. Most snitches
      * in this tree ({@code GossipingPropertyFileSnitch}, the cloud metadata snitches) answer an endpoint they
@@ -110,22 +123,22 @@ public final class WriteOrigin
 
             IEndpointSnitch snitch = DatabaseDescriptor.getEndpointSnitch();
             if (snitch == null)
-                return LOCAL;
+                return UNKNOWN;
 
             String localDatacenter = DatabaseDescriptor.getLocalDataCenter();
             if (localDatacenter == null)
                 localDatacenter = snitch.getLocalDatacenter();
 
-            return create(message.respondTo(), message.from(), localDatacenter, snitch::getDatacenter);
+            return origin(message.respondTo(), message.from(), localDatacenter, snitch::getDatacenter);
         }
         catch (Throwable t)
         {
             JVMStabilityInspector.inspectThrowable(t);
             // A snitch that throws for an endpoint (PropertyFileSnitch does, for one it has no entry for)
-            // must not fail the write. Degrade to "no origin" and say so once per problem endpoint rather
-            // than on every mutation -- this runs on the mutation stage.
+            // must not fail the write. Degrade to "undetermined" and say so once per problem endpoint
+            // rather than on every mutation -- this runs on the mutation stage.
             logger.debug("Could not determine the origin of a {} from {}", message.verb(), message.from(), t);
-            return LOCAL;
+            return UNKNOWN;
         }
     }
 
@@ -145,19 +158,19 @@ public final class WriteOrigin
 
             IEndpointSnitch snitch = DatabaseDescriptor.getEndpointSnitch();
             if (snitch == null)
-                return LOCAL;
+                return UNKNOWN;
 
             String localDatacenter = DatabaseDescriptor.getLocalDataCenter();
             if (localDatacenter == null)
                 localDatacenter = snitch.getLocalDatacenter();
 
-            return create(peer, peer, localDatacenter, snitch::getDatacenter);
+            return origin(peer, peer, localDatacenter, snitch::getDatacenter);
         }
         catch (Throwable t)
         {
             JVMStabilityInspector.inspectThrowable(t);
             logger.debug("Could not determine the origin of an apply from {}", peer, t);
-            return LOCAL;
+            return UNKNOWN;
         }
     }
 
@@ -165,26 +178,31 @@ public final class WriteOrigin
      * The datacenter-placement logic, free of any snitch or configuration lookup: the coordinator and
      * the sender of the message, this node's datacenter, and the topology to place them with.
      * <p>
-     * {@code datacenterOf} may return null for an endpoint it cannot place. Both unplaceable cases resolve
-     * <em>away</em> from claiming something we cannot support: an unplaceable coordinator yields
-     * {@link #LOCAL} rather than a guess at a remote datacenter, and an unplaceable sender leaves
-     * {@link #isDirectFromRemoteDatacenter()} false rather than asserting a delivery path we did not observe.
+     * {@code datacenterOf} may return null for an endpoint it cannot place. Undetermined cases resolve
+     * <em>away</em> from claiming something we cannot support, and are honest about which kind of
+     * "cannot" they are: no coordinator at all means the write genuinely started here ({@link #LOCAL}),
+     * while a coordinator or a local datacenter we cannot place means we simply do not know
+     * ({@link #UNKNOWN}). An unplaceable sender leaves {@link #isDirectFromRemoteDatacenter()} false
+     * rather than asserting a delivery path we did not observe.
      * (In practice most snitches here never return null — see {@link #fromMessage}.)
      * <p>
      * Public so that code reacting to an origin -- a secondary index, typically -- can build one
      * deterministically in a unit test instead of standing up a cluster.
      */
-    public static WriteOrigin create(@Nullable InetAddressAndPort coordinator,
+    public static WriteOrigin origin(@Nullable InetAddressAndPort coordinator,
                                      @Nullable InetAddressAndPort sender,
                                      @Nullable String localDatacenter,
                                      Function<InetAddressAndPort, String> datacenterOf)
     {
-        if (coordinator == null || localDatacenter == null)
+        if (coordinator == null)
             return LOCAL;
+
+        if (localDatacenter == null)
+            return UNKNOWN;
 
         String coordinatorDatacenter = datacenterOf.apply(coordinator);
         if (coordinatorDatacenter == null)
-            return LOCAL;
+            return UNKNOWN;
 
         if (localDatacenter.equals(coordinatorDatacenter))
             return new WriteOrigin(coordinator, coordinatorDatacenter, false, false);
@@ -247,9 +265,17 @@ public final class WriteOrigin
         return directFromRemoteDatacenter;
     }
 
+    /** True only for {@link #UNKNOWN}: the origin could not be determined, as opposed to provably local. */
+    public boolean isUnknown()
+    {
+        return this == UNKNOWN;
+    }
+
     @Override
     public String toString()
     {
+        if (this == UNKNOWN)
+            return "WriteOrigin{unknown}";
         if (coordinator == null)
             return "WriteOrigin{local}";
 

--- a/src/java/org/apache/cassandra/hints/HintVerbHandler.java
+++ b/src/java/org/apache/cassandra/hints/HintVerbHandler.java
@@ -25,6 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.db.WriteOrigin;
 import org.apache.cassandra.db.partitions.PartitionUpdate;
 import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.net.IVerbHandler;
@@ -120,6 +121,10 @@ public final class HintVerbHandler implements IVerbHandler<HintMessage>
         else
         {
             // the common path - the node is both the destination and a valid replica for the hint.
+            // The origin of a replayed hint is the node that held it, which is where the write was
+            // coordinated from and so may well be another datacenter; Mutation.without preserves it across
+            // the truncation filtering Hint.applyFuture does.
+            hint.mutation.withOrigin(WriteOrigin.fromMessage(message));
             hint.applyFuture().addCallback(o -> respond(message), e -> logger.debug("Failed to apply hint", e));
         }
     }

--- a/src/java/org/apache/cassandra/index/Index.java
+++ b/src/java/org/apache/cassandra/index/Index.java
@@ -37,6 +37,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import org.apache.cassandra.cql3.Operator;
+import org.apache.cassandra.db.CassandraWriteContext;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.DeletionTime;
@@ -45,6 +46,8 @@ import org.apache.cassandra.db.ReadCommand;
 import org.apache.cassandra.db.ReadExecutionController;
 import org.apache.cassandra.db.RegularAndStaticColumns;
 import org.apache.cassandra.db.WriteContext;
+import org.apache.cassandra.db.WriteOptions;
+import org.apache.cassandra.db.WriteOrigin;
 import org.apache.cassandra.db.filter.RowFilter;
 import org.apache.cassandra.db.lifecycle.LifecycleNewTracker;
 import org.apache.cassandra.db.marshal.AbstractType;
@@ -653,6 +656,87 @@ public interface Index
      */
 
     /**
+     * An opaque handle returned by {@link #prepareWrite}, carried by the write context of the enclosing mutation
+     * and taken back by the index in {@link #indexerFor} ({@link CassandraWriteContext#takePreparedWrite}) for
+     * the same partition update, so an index can carry state from before the write is persisted to the moment
+     * its rows are applied. Cassandra never inspects it.
+     */
+    interface PreparedWrite
+    {
+    }
+
+    /**
+     * Whether this index wants {@link #prepareWrite} called. Off by default, and cached by the index manager
+     * when the index is registered, so that a table whose indexes do not use the hook pays nothing for it on
+     * the write path -- no call, no allocation. An index that overrides {@link #prepareWrite} must override
+     * this to return {@code true}, or it is never called.
+     */
+    default boolean preparesWrites()
+    {
+        return false;
+    }
+
+    /**
+     * Gives the index a look at a partition update BEFORE it is persisted anywhere on this replica: before the
+     * mutation is appended to the commit log, and before it reaches the memtable (where
+     * {@link #indexerFor} and the resulting {@link Indexer} callbacks observe it).
+     * <p>
+     * The one guarantee this ordering provides, and the reason the hook exists: if the process dies at any
+     * point after this method returns, either the write never made it to the commit log or, if it did and is
+     * replayed at the next startup, the index has already been told about it. An index that keeps its own
+     * write-ahead record of in-flight updates can therefore record the update here and treat the commit log
+     * replay as already covered, instead of having to detect and track replayed rows. Nothing has been fsync'd
+     * when this runs; an index that needs its own record durable before Cassandra's must arrange that itself,
+     * off the mutation thread.
+     * <p>
+     * Called, when {@link #preparesWrites} is true, for every update applied on the write path -- client writes,
+     * hints, read repair, batchlog replay, paxos commits, and the commit log replay itself -- with the
+     * {@link WriteOptions} the mutation is applied with, so an index can tell those apart (a replayed mutation,
+     * {@link WriteOptions#FOR_COMMITLOG_REPLAY}, was already prepared when it was first written). Not called for
+     * updates that skip indexing, nor while the index is not writable. The writability test is the one
+     * {@link #indexerFor} is later gated by, but it is evaluated twice, at each end of the write: an index that
+     * becomes writable in between is asked for an {@link Indexer} it was not prepared for, and its
+     * {@link CassandraWriteContext#takePreparedWrite} then returns null. An index must accept an Indexer with no
+     * handle; it can rely on every handle it did return reaching exactly one of the two outcomes below.
+     * <p>
+     * Runs on the mutation thread, before the write, while the keyspace's write order group is held: it must be
+     * fast, and it must not wait on anything the write path itself produces (a flush barrier, an fsync of this
+     * mutation). A thrown exception fails the write before anything is persisted; the handles other indexes
+     * returned for the same mutation are then {@linkplain #abortWrite aborted}. The default does nothing and
+     * returns {@code null}.
+     * <p>
+     * The handle returned here travels in the mutation's {@link CassandraWriteContext}, from which the index takes
+     * it back in {@link #indexerFor} with {@link CassandraWriteContext#takePreparedWrite}. It is handed to exactly
+     * one of those two outcomes: taken there, or {@linkplain #abortWrite aborted} because the update is never
+     * applied to this index -- never both, never neither.
+     *
+     * @param update the partition update about to be written
+     * @param options the options the enclosing mutation is applied with
+     * @param origin where the enclosing mutation came from (never null on this path)
+     * @return a handle the index will take back from the write context when the update is applied, or
+     * {@code null} if the index has nothing to carry over
+     */
+    default PreparedWrite prepareWrite(PartitionUpdate update, WriteOptions options, WriteOrigin origin)
+    {
+        return null;
+    }
+
+    /**
+     * Tells the index that a handle {@link #prepareWrite} returned was NOT taken back in {@link #indexerFor}:
+     * the write failed between the two (another index's {@code prepareWrite} threw, the commit log append
+     * failed, the memtable apply of an earlier update of the same mutation failed), the update was dropped
+     * because its table no longer exists, the index is no longer writable so it was not asked for an indexer,
+     * or the index's own {@code indexerFor} simply did not take it. Whatever {@code prepareWrite} recorded for
+     * the update should be undone: as far as this replica is concerned the write never happened. Runs on the
+     * mutation thread when the write context is closed. The default does nothing.
+     *
+     * @param prepared the handle {@link #prepareWrite} returned, never null
+     */
+    default void abortWrite(PreparedWrite prepared)
+    {
+    }
+
+    /**
      * Creates a new {@code Indexer} object for updates to a given partition.
      *
      * @param key key of the partition being modified
@@ -660,7 +744,10 @@ public interface Index
      * This can be empty as an update might only contain partition, range and row deletions, but
      * the indexer is guaranteed to not get any cells for a column that is not part of {@code columns}.
      * @param nowInSec current time of the update operation
-     * @param ctx WriteContext spanning the update operation
+     * @param ctx WriteContext spanning the update operation. On the write path it is the
+     *            {@link CassandraWriteContext} of the enclosing mutation, carrying what {@link #prepareWrite}
+     *            returned for this update: an index that prepares writes takes its handle back with
+     *            {@link CassandraWriteContext#takePreparedWrite}.
      * @param transactionType indicates what kind of update is being performed on the base data
      *                        i.e. a write time insert/update/delete or the result of compaction
      * @param memtable current memtable that the write goes into. It's to make sure memtable and index memtable

--- a/src/java/org/apache/cassandra/index/SecondaryIndexManager.java
+++ b/src/java/org/apache/cassandra/index/SecondaryIndexManager.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -68,6 +69,7 @@ import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.Operator;
 import org.apache.cassandra.cql3.PageSize;
 import org.apache.cassandra.cql3.statements.schema.IndexTarget;
+import org.apache.cassandra.db.CassandraWriteContext;
 import org.apache.cassandra.db.Clustering;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.DecoratedKey;
@@ -83,6 +85,8 @@ import org.apache.cassandra.db.SinglePartitionReadCommand;
 import org.apache.cassandra.db.Slices;
 import org.apache.cassandra.db.SystemKeyspace;
 import org.apache.cassandra.db.WriteContext;
+import org.apache.cassandra.db.WriteOptions;
+import org.apache.cassandra.db.WriteOrigin;
 import org.apache.cassandra.db.compaction.CompactionManager;
 import org.apache.cassandra.db.filter.ClusteringIndexSliceFilter;
 import org.apache.cassandra.db.filter.ColumnFilter;
@@ -209,6 +213,13 @@ public class SecondaryIndexManager implements IndexRegistry, INotificationConsum
      * The indexes that are available for writing.
      */
     private final Map<String, Index> writableIndexes = Maps.newConcurrentMap();
+
+    /**
+     * Whether any registered index answers true to {@link Index#preparesWrites()}. Recomputed when an index is
+     * registered or removed, so the write path can skip {@link #prepareWrite} -- no call, no allocation -- for
+     * the tables (nearly all of them) whose indexes do not use the hook.
+     */
+    private volatile boolean preparesWrites;
 
     /**
      * The groups of all the registered indexes
@@ -420,6 +431,7 @@ public class SecondaryIndexManager implements IndexRegistry, INotificationConsum
 
         if (null != removed)
         {
+            updatePreparesWrites();
             removed.unregister(this);
 
             markIndexRemoved(removed);
@@ -1470,6 +1482,7 @@ public class SecondaryIndexManager implements IndexRegistry, INotificationConsum
     {
         String name = index.getIndexMetadata().name;
         indexes.put(name, index);
+        updatePreparesWrites();
         logger.trace("Registered index {}", name);
 
         // instantiate and add the index group if it hasn't been already added
@@ -1571,6 +1584,94 @@ public class SecondaryIndexManager implements IndexRegistry, INotificationConsum
      * Implementations of the various IndexTransaction interfaces, for keeping indexes in sync with base data
      * during updates, compaction and cleanup. Plus factory methods for obtaining transaction instances.
      */
+
+    /**
+     * Whether {@link #prepareWrite} has anything to do for this table: true iff a registered index answers true
+     * to {@link Index#preparesWrites()}. A volatile read, nothing else -- the write path checks it for every
+     * partition update it applies.
+     */
+    public boolean preparesWrites()
+    {
+        return preparesWrites;
+    }
+
+    private void updatePreparesWrites()
+    {
+        boolean any = false;
+        for (Index index : indexes.values())
+            any |= index.preparesWrites();
+        preparesWrites = any;
+    }
+
+    /**
+     * Offers {@code update} to every writable index that {@linkplain Index#preparesWrites prepares writes},
+     * BEFORE the enclosing mutation is appended to the commit log (see {@link Index#prepareWrite}). Called by
+     * the keyspace write handler, and only when {@link #preparesWrites()} is true, with the same writability
+     * test {@link #newUpdateTransaction} will apply, so an index is prepared for exactly the updates it will
+     * later be asked an {@link Index.Indexer} for.
+     * <p>
+     * The handles the indexes return are added to {@code handles}, keyed by index (identity), which the caller
+     * puts in the {@link CassandraWriteContext} of the mutation for {@link CassandraWriteContext#takePreparedWrite}.
+     * The map is created lazily, when the first index actually returns a handle, and only then.
+     * <p>
+     * If an index throws, the handles already collected for this mutation -- including those of other tables,
+     * {@code handles} being per mutation -- are {@linkplain #abortPreparedWrites aborted} and the map emptied
+     * before the exception propagates: the write is failing before anything was persisted.
+     *
+     * @param handles the mutation's handles collected so far, or null if none yet
+     * @return {@code handles}, or the map created for the first handle; null if there is still none
+     */
+    public @Nullable Map<Index, Index.PreparedWrite> prepareWrite(PartitionUpdate update,
+                                                                   WriteOptions options,
+                                                                   WriteOrigin origin,
+                                                                   @Nullable Map<Index, Index.PreparedWrite> handles)
+    {
+        try
+        {
+            for (Index index : indexes.values())
+            {
+                if (!index.preparesWrites() || !writableIndexes.containsKey(index.getIndexMetadata().name))
+                    continue;
+                Index.PreparedWrite handle = index.prepareWrite(update, options, origin);
+                if (handle == null)
+                    continue;
+                if (handles == null)
+                    handles = new IdentityHashMap<>(2);
+                handles.put(index, handle);
+            }
+            return handles;
+        }
+        catch (Throwable t)
+        {
+            if (handles != null)
+            {
+                abortPreparedWrites(handles);
+                handles.clear();
+            }
+            throw t;
+        }
+    }
+
+    /**
+     * Tells each index that the handle it returned from {@link Index#prepareWrite} will not be taken back in
+     * {@link Index#indexerFor} (see {@link Index#abortWrite}). Never throws: an index failing to abort is
+     * logged, and the others are still told.
+     */
+    public static void abortPreparedWrites(Map<Index, Index.PreparedWrite> handles)
+    {
+        for (Map.Entry<Index, Index.PreparedWrite> entry : handles.entrySet())
+        {
+            try
+            {
+                entry.getKey().abortWrite(entry.getValue());
+            }
+            catch (Throwable t)
+            {
+                JVMStabilityInspector.inspectThrowable(t);
+                logger.error("Index {} failed to abort a prepared write", entry.getKey().getIndexMetadata().name, t);
+            }
+        }
+    }
 
     /**
      * Transaction for updates on the write path.

--- a/src/java/org/apache/cassandra/service/paxos/CommitVerbHandler.java
+++ b/src/java/org/apache/cassandra/service/paxos/CommitVerbHandler.java
@@ -20,6 +20,7 @@
  */
 package org.apache.cassandra.service.paxos;
 
+import org.apache.cassandra.db.WriteOrigin;
 import org.apache.cassandra.net.IVerbHandler;
 import org.apache.cassandra.net.Message;
 import org.apache.cassandra.net.MessagingService;
@@ -50,7 +51,7 @@ public class CommitVerbHandler implements IVerbHandler<Commit>
         sensors.incrementSensor(context, Type.INTERNODE_BYTES, message.payloadSize(MessagingService.current_version));
         RequestTracker.instance.set(sensors);
 
-        PaxosState.commitDirect(message.payload, p -> MutatorProvider.instance.onAppliedProposal(p));
+        PaxosState.commitDirect(message.payload, WriteOrigin.fromMessage(message), p -> MutatorProvider.instance.onAppliedProposal(p));
 
         Tracing.trace("Enqueuing acknowledge to {}", message.from());
         Message.Builder<NoPayload> reply = message.emptyResponseBuilder();

--- a/src/java/org/apache/cassandra/service/paxos/PaxosCommit.java
+++ b/src/java/org/apache/cassandra/service/paxos/PaxosCommit.java
@@ -29,6 +29,7 @@ import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.ConsistencyLevel;
 import org.apache.cassandra.db.Mutation;
+import org.apache.cassandra.db.WriteOrigin;
 import org.apache.cassandra.exceptions.RequestFailureReason;
 import org.apache.cassandra.locator.EndpointsForToken;
 import org.apache.cassandra.locator.InOurDc;
@@ -350,7 +351,10 @@ public class PaxosCommit<OnDone extends Consumer<? super PaxosCommit.Status>> ex
             if (!Paxos.isInRangeAndShouldProcess(from, agreed.update.partitionKey(), agreed.update.metadata(), false))
                 return null;
 
-            PaxosState.commitDirect(agreed);
+            // Attribute the base-table apply to the peer that delivered the commit, so a secondary index
+            // can tell a commit from another datacenter apart from one proposed here. This covers every
+            // inbound PAXOS_COMMIT_REQ regardless of paxos_variant; the executeOnSelf path stays LOCAL.
+            PaxosState.commitDirect(agreed, WriteOrigin.fromPeer(from), c -> {});
             Tracing.trace("Enqueuing acknowledge to {}", from);
             return NoPayload.noPayload;
         }

--- a/src/java/org/apache/cassandra/service/paxos/PaxosCommitAndPrepare.java
+++ b/src/java/org/apache/cassandra/service/paxos/PaxosCommitAndPrepare.java
@@ -20,6 +20,7 @@ package org.apache.cassandra.service.paxos;
 
 import java.io.IOException;
 
+import org.apache.cassandra.db.WriteOrigin;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.SinglePartitionReadCommand;
 import org.apache.cassandra.io.util.DataInputPlus;
@@ -136,7 +137,8 @@ public class PaxosCommitAndPrepare
 
             try (PaxosState state = PaxosState.get(commit))
             {
-                state.commit(commit);
+                // The next round's coordinator is where this apply came from -- possibly another datacenter.
+                state.commit(commit, WriteOrigin.fromPeer(from));
                 return PaxosPrepare.RequestHandler.execute(request, state);
             }
         }

--- a/src/java/org/apache/cassandra/service/paxos/PaxosPrepareRefresh.java
+++ b/src/java/org/apache/cassandra/service/paxos/PaxosPrepareRefresh.java
@@ -24,6 +24,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.cassandra.db.WriteOrigin;
 import org.apache.cassandra.exceptions.RequestFailureReason;
 import org.apache.cassandra.exceptions.WriteTimeoutException;
 import org.apache.cassandra.io.IVersionedSerializer;
@@ -181,7 +182,8 @@ public class PaxosPrepareRefresh implements RequestCallbackWithFailure<PaxosPrep
 
             try (PaxosState state = PaxosState.get(commit))
             {
-                state.commit(commit);
+                // The refreshing peer is where this apply came from -- possibly another datacenter.
+                state.commit(commit, WriteOrigin.fromPeer(from));
                 Ballot latest = state.current(request.promised).latestWitnessedOrLowBound();
                 if (isAfter(latest, request.promised))
                 {

--- a/src/java/org/apache/cassandra/service/paxos/PaxosState.java
+++ b/src/java/org/apache/cassandra/service/paxos/PaxosState.java
@@ -44,6 +44,7 @@ import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.db.Mutation;
 import org.apache.cassandra.db.SystemKeyspace;
 import org.apache.cassandra.db.WriteOptions;
+import org.apache.cassandra.db.WriteOrigin;
 import org.apache.cassandra.db.WriteType;
 import org.apache.cassandra.exceptions.ReadTimeoutException;
 import org.apache.cassandra.exceptions.RequestTimeoutException;
@@ -679,7 +680,18 @@ public class PaxosState implements PaxosOperationLock
 
     public void commit(Agreed commit)
     {
-        applyCommit(commit, this, c -> {}, (apply, to) ->
+        commit(commit, WriteOrigin.LOCAL);
+    }
+
+    /**
+     * As {@link #commit(Agreed)}, but recording where the commit came from. The verb handlers that learn
+     * a commit from a peer (a prepare-phase refresh, a commit-and-prepare) pass the origin so the base
+     * table mutation applied here is attributed to the node that delivered it -- the same contract as
+     * every other replica-side apply; see {@link WriteOrigin}.
+     */
+    public void commit(Agreed commit, WriteOrigin origin)
+    {
+        applyCommit(commit, origin, this, c -> {}, (apply, to) ->
             currentUpdater.accumulateAndGet(to, new UnsafeSnapshot(apply), Snapshot::merge)
         );
     }
@@ -688,10 +700,21 @@ public class PaxosState implements PaxosOperationLock
     {
         commitDirect(commit, c -> {});
     }
-    
+
     public static void commitDirect(Commit commit, Consumer<Commit> callback)
     {
-        applyCommit(commit, null, callback, (apply, ignore) -> {
+        commitDirect(commit, WriteOrigin.LOCAL, callback);
+    }
+
+    /**
+     * As {@link #commitDirect(Commit, Consumer)}, but recording where the commit came from.
+     * {@link WriteOrigin#LOCAL} remains correct for the paths with no message behind them -- a
+     * coordinator applying its own commit ({@code PaxosCommit#executeOnSelf},
+     * {@code StorageProxy#commitPaxosLocal}).
+     */
+    public static void commitDirect(Commit commit, WriteOrigin origin, Consumer<Commit> callback)
+    {
+        applyCommit(commit, origin, null, callback, (apply, ignore) -> {
             try (PaxosState state = tryGetUnsafe(apply.update.partitionKey(), apply.update.metadata()))
             {
                 if (state != null)
@@ -700,7 +723,7 @@ public class PaxosState implements PaxosOperationLock
         });
     }
 
-    private static void applyCommit(Commit commit, PaxosState state, Consumer<Commit> callback, BiConsumer<Commit, PaxosState> postCommit)
+    private static void applyCommit(Commit commit, WriteOrigin origin, PaxosState state, Consumer<Commit> callback, BiConsumer<Commit, PaxosState> postCommit)
     {
         if (paxosStatePurging() == legacy && !(commit instanceof CommittedWithTTL))
             commit = CommittedWithTTL.withDefaultTTL(commit);
@@ -714,7 +737,10 @@ public class PaxosState implements PaxosOperationLock
             if (commit.ballot.unixMicros() >= SystemKeyspace.getTruncatedAt(commit.update.metadata().id))
             {
                 Tracing.trace("Committing proposal {}", commit);
-                Mutation mutation = commit.makeMutation();
+                // The mutation is manufactured here, replica-side, from the commit -- it never travelled
+                // as a Mutation, so MutationVerbHandler's stamping cannot have covered it. The origin is
+                // threaded down from the verb handler instead (never serialized; see WriteOrigin).
+                Mutation mutation = commit.makeMutation().withOrigin(origin);
                 Keyspace.open(mutation.getKeyspaceName()).apply(mutation, WriteOptions.FOR_PAXOS_COMMIT);
                 callback.accept(commit);
             }

--- a/test/distributed/org/apache/cassandra/distributed/test/WriteOriginDistributedTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/WriteOriginDistributedTest.java
@@ -1,0 +1,520 @@
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
+import java.util.regex.Pattern;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.distributed.Cluster;
+import org.apache.cassandra.distributed.api.ConsistencyLevel;
+import org.apache.cassandra.distributed.api.Feature;
+import org.apache.cassandra.distributed.api.IInstanceConfig;
+import org.apache.cassandra.batchlog.BatchlogManager;
+import org.apache.cassandra.config.Config;
+import org.apache.cassandra.net.Verb;
+import org.apache.cassandra.service.paxos.Paxos;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * End-to-end proof that a secondary index can see where a replica-side apply came from.
+ *
+ * A custom index ({@link WriteOriginLoggingIndex}) logs the {@code WriteOptions} and {@code WriteOrigin}
+ * its Indexer is handed for every apply; the test drives writes from datacenter1 and reads each node's
+ * log to check what that node actually saw. Four nodes, two datacenters, NTS {dc1:2, dc2:2}, so every
+ * node is a replica of every key and the only thing that differs between them is provenance.
+ *
+ * What is being demonstrated, and why it could not be observed before:
+ *
+ *  - a write coordinated in datacenter1 reaches datacenter2 as ONE MUTATION_REQ carrying a
+ *    ForwardingInfo, which the receiving relay fans out locally. Every dc2 replica must nonetheless see
+ *    the ORIGINAL coordinator (RESPOND_TO survives the relay), while only the node the message actually
+ *    reached is marked direct;
+ *  - the coordinator's own replica applies with no inbound message at all, and must be distinguishable
+ *    from its same-datacenter peer, which applies one it received;
+ *  - a paxos commit applies with WriteOptions.FOR_PAXOS_COMMIT and a read repair with
+ *    FOR_READ_REPAIR, where an ordinary write applies with DEFAULT -- distinctions
+ *    IndexTransaction.Type cannot make, since all three are UPDATE;
+ *  - a read repair is stamped by a different verb handler than an ordinary write, and is attributed to
+ *    the node that ran the READ rather than to whoever originally wrote the row.
+ *
+ * Paxos is covered under BOTH variants, since their transports differ: under v1 every replica gets
+ * PAXOS_COMMIT_REQ (labelled FOR_PAXOS_COMMIT, attributed to the delivering peer via the threading in
+ * PaxosState), while under v2 a datacenter-local commit reaches the remote datacenter as
+ * PAXOS2_COMMIT_REMOTE_REQ -- an ordinary mutation, attributed by MutationVerbHandler but labelled
+ * DEFAULT rather than as a paxos commit.
+ *
+ * Run with: ant test-jvm-dtest-some -Dtest.name=org.apache.cassandra.distributed.test.WriteOriginDistributedTest
+ */
+public class WriteOriginDistributedTest extends TestBaseImpl
+{
+    private static final String KS = "write_origin_ks";
+    private static final String TBL = "tbl";
+    private static final String KS_TBL = KS + '.' + TBL;
+    private static final String IDX = "write_origin_idx";
+
+    private static final String DC1 = "datacenter1";
+    private static final String DC2 = "datacenter2";
+
+    /** What Config ships with; restored after any test that flips it, so test order does not matter. */
+    private static final String DEFAULT_PAXOS_VARIANT = "v1";
+
+    private static Cluster cluster;
+
+    @BeforeClass
+    public static void setUp() throws Throwable
+    {
+        Consumer<IInstanceConfig> conf = config -> config.with(Feature.GOSSIP, Feature.NETWORK)
+                                                         .set("dynamic_snitch", false);
+
+        cluster = new Cluster.Builder().withNodes(4).withDCs(2).withConfig(conf).start();
+
+        // Guard the node -> datacenter assumption every assertion below relies on, so a change in the
+        // framework's DC naming surfaces here rather than as a mysterious failure later.
+        assertEquals(DC1, cluster.get(1).config().localDatacenter());
+        assertEquals(DC1, cluster.get(2).config().localDatacenter());
+        assertEquals(DC2, cluster.get(3).config().localDatacenter());
+        assertEquals(DC2, cluster.get(4).config().localDatacenter());
+
+        cluster.schemaChange("CREATE KEYSPACE " + KS + " WITH replication = "
+                             + "{'class': 'NetworkTopologyStrategy', 'datacenter1': 2, 'datacenter2': 2}");
+        cluster.schemaChange("CREATE TABLE " + KS_TBL + " (k int PRIMARY KEY, v int)");
+        cluster.schemaChange("CREATE CUSTOM INDEX " + IDX + " ON " + KS_TBL + " (v) USING '"
+                             + WriteOriginLoggingIndex.class.getName() + '\'');
+    }
+
+    @AfterClass
+    public static void tearDown()
+    {
+        if (cluster != null)
+            cluster.close();
+    }
+
+    /**
+     * An ordinary write coordinated on node1, in datacenter1.
+     *
+     * Before this change every one of these four applies looked identical to the index: same
+     * IndexTransaction.Type, same WriteOptions.DEFAULT, nothing naming the coordinator.
+     */
+    @Test
+    public void ordinaryWriteIsLabelledPerReplica()
+    {
+        long[] marks = mark();
+
+        cluster.coordinator(1).execute("INSERT INTO " + KS_TBL + " (k, v) VALUES (?, ?)",
+                                       ConsistencyLevel.LOCAL_QUORUM, 1, 1);
+
+        // The coordinator's own replica: applied with no inbound message behind it, so there is no
+        // coordinator to name. This is WriteOrigin.LOCAL, and it is NOT the same as "no origin".
+        assertOneLine(1, marks, "key=1", "options=DEFAULT", "coordinator=null", "crossDc=false", "direct=false");
+
+        // Its datacenter peer received the write from node1: a coordinator, but a local one.
+        assertOneLine(2, marks, "key=1", "options=DEFAULT", "coordinatorDc=" + DC1, "crossDc=false", "direct=false");
+
+        // Both datacenter2 replicas name the ORIGINAL datacenter1 coordinator, even though only one of
+        // them heard from it directly -- ForwardingInfo puts it in RESPOND_TO, which survives the relay.
+        for (int node : new int[]{ 3, 4 })
+            assertOneLine(node, marks, "key=1", "options=DEFAULT", "coordinatorDc=" + DC1, "crossDc=true");
+
+        // ... and exactly one of them is the node the cross-DC message actually reached. That uniqueness
+        // is a property of MUTATION_REQ's fan-out, not of the signal: see WriteOrigin's javadoc for the
+        // verbs where every receiving replica is direct.
+        long direct = count(3, marks, "key=1.*direct=true") + count(4, marks, "key=1.*direct=true");
+        assertEquals("exactly one datacenter2 replica should have received the cross-DC message directly",
+                     1, direct);
+    }
+
+    /**
+     * A paxos commit under paxos_variant v1: labelled by WriteOptions AND attributed to the peer that
+     * delivered it.
+     *
+     * A commit's Mutation never travels as one -- PAXOS_COMMIT_REQ carries an Agreed, and each replica
+     * manufactures the mutation in PaxosState.applyCommit -- so MutationVerbHandler's stamping cannot
+     * cover it. The origin is threaded from PaxosCommit.RequestHandler instead, built from the message's
+     * sender, which is never serialized: no wire format is involved.
+     *
+     * The commit is sent point-to-point to every replica, so the datacenter2 replicas are BOTH direct --
+     * the documented non-uniqueness of that bit, visible here. And the "coordinator" is the peer the
+     * commit came FROM, which for the coordinator's own replica is nobody: it applies via executeOnSelf
+     * with no message behind it, and stays LOCAL.
+     *
+     * Compare {@link #dcLocalPaxosCommitUnderV2StampsTheRemoteLeg}: same statement, same consistency
+     * levels, only the variant differs.
+     */
+    @Test
+    public void paxosCommitUnderV1IsAttributedToThePeerThatDeliveredIt()
+    {
+        setPaxosVariant("v1");
+        try
+        {
+            long[] marks = mark();
+
+            cluster.coordinator(1).execute("INSERT INTO " + KS_TBL + " (k, v) VALUES (?, ?) IF NOT EXISTS",
+                                           ConsistencyLevel.LOCAL_SERIAL, ConsistencyLevel.LOCAL_QUORUM, 2, 2);
+
+            // The proposing node applies its own commit: no message, LOCAL.
+            assertOneLine(1, marks, "key=2",
+                          "options=FOR_PAXOS_COMMIT", "coordinator=null", "crossDc=false");
+
+            // Its datacenter peer received the commit from node1: a coordinator, but a local one.
+            assertOneLine(2, marks, "key=2",
+                          "options=FOR_PAXOS_COMMIT", "coordinatorDc=" + DC1, "crossDc=false", "direct=false");
+
+            // The datacenter2 replicas know the commit came from datacenter1 -- previously these read
+            // "coordinator=null, crossDc=false", indistinguishable from a locally proposed commit.
+            for (int node : new int[]{ 3, 4 })
+                assertOneLine(node, marks, "key=2",
+                              "options=FOR_PAXOS_COMMIT", "coordinatorDc=" + DC1, "crossDc=true", "direct=true");
+        }
+        finally
+        {
+            setPaxosVariant(DEFAULT_PAXOS_VARIANT);
+        }
+    }
+
+    /**
+     * v2's datacenter-local commit, whose remote leg takes a different transport than v1's.
+     *
+     * With paxos_variant v2 and a datacenter-local serial consistency, PaxosCommit sends the remote
+     * datacenter a PAXOS2_COMMIT_REMOTE_REQ instead of a PAXOS_COMMIT_REQ -- and that verb is handled by
+     * the ordinary MutationVerbHandler, so it is stamped there like a client write and labelled DEFAULT
+     * rather than FOR_PAXOS_COMMIT. The local-datacenter legs still go through PaxosState.applyCommit
+     * and keep the paxos label. Either way, every replica now knows where the commit came from.
+     */
+    @Test
+    public void dcLocalPaxosCommitUnderV2StampsTheRemoteLeg()
+    {
+        setPaxosVariant("v2");
+        try
+        {
+            long[] marks = mark();
+
+            cluster.coordinator(1).execute("INSERT INTO " + KS_TBL + " (k, v) VALUES (?, ?) IF NOT EXISTS",
+                                           ConsistencyLevel.LOCAL_SERIAL, ConsistencyLevel.LOCAL_QUORUM, 4, 4);
+
+            // The proposing node applies its own commit with no message behind it...
+            assertOneLine(1, marks, "key=4",
+                          "options=FOR_PAXOS_COMMIT", "coordinator=null", "crossDc=false");
+
+            // ... while its datacenter peer is delivered one, and attributes it.
+            assertOneLine(2, marks, "key=4",
+                          "options=FOR_PAXOS_COMMIT", "coordinatorDc=" + DC1, "crossDc=false");
+
+            // datacenter2 receives it as a plain mutation: attributed, but labelled DEFAULT -- the one
+            // paxos leg where the ORIGIN survives and the KIND does not.
+            for (int node : new int[]{ 3, 4 })
+                assertOneLine(node, marks, "key=4",
+                              "options=DEFAULT", "coordinatorDc=" + DC1, "crossDc=true");
+        }
+        finally
+        {
+            setPaxosVariant(DEFAULT_PAXOS_VARIANT);
+        }
+    }
+
+    /**
+     * A blocking read repair, which reaches the stale replica through ReadRepairVerbHandler rather than
+     * MutationVerbHandler -- a separate stamping site, and one whose origin is the node that ran the
+     * READ, not the node that ran the original write.
+     *
+     * node4 is kept from ever receiving the write (the filter covers the relayed leg as well as the
+     * direct one, so ForwardingInfo cannot sneak it in), then a read at ALL from datacenter1 finds the
+     * digest mismatch and repairs it. The MUTATION_REQ filter stays up throughout, so read repair is
+     * provably the only path the row can take to node4.
+     */
+    @Test
+    public void readRepairIsLabelledAndAttributedToTheReadCoordinator()
+    {
+        long[] marks = mark();
+
+        cluster.filters().verbs(Verb.MUTATION_REQ.id).to(4).drop();
+        try
+        {
+            cluster.coordinator(1).execute("INSERT INTO " + KS_TBL + " (k, v) VALUES (?, ?)",
+                                           ConsistencyLevel.LOCAL_QUORUM, 3, 3);
+
+            assertEquals("node4 must not have seen the write", 0, count(4, marks, "key=3"));
+
+            // Reading at ALL forces node4 into the quorum, mismatching, and repairs it.
+            cluster.coordinator(1).execute("SELECT * FROM " + KS_TBL + " WHERE k = ?",
+                                           ConsistencyLevel.ALL, 3);
+
+            assertOneLine(4, marks, "key=3",
+                          "options=FOR_READ_REPAIR", "coordinatorDc=" + DC1, "crossDc=true");
+        }
+        finally
+        {
+            cluster.filters().reset();
+        }
+    }
+
+    /**
+     * The happy path of a multi-datacenter LOGGED batch.
+     *
+     * A logged batch is two mechanisms glued together, and only one of them is datacenter-aware:
+     *
+     *  - the BATCHLOG is strictly local to the coordinator's datacenter. ReplicaPlans.forBatchlogWrite
+     *    picks min(2, candidates) nodes from the local DC only, excluding the coordinator itself unless
+     *    it is a single-node DC -- so here, with datacenter1 = {node1, node2} and node1 coordinating,
+     *    the batch is stored on node2 alone. The remote datacenter never learns a batch existed;
+     *  - the MUTATIONS then take the ordinary write path (asyncWriteBatchedMutations ->
+     *    sendToHintedReplicas), including the per-remote-DC ForwardingInfo relay. So each partition of
+     *    the batch looks to every replica exactly like an independent ordinary write.
+     *
+     * The test pins both halves: a counting filter proves not one BATCH_STORE_REQ crossed into
+     * datacenter2 (while at least one reached node2, so the batch demonstrably used the batchlog --
+     * single-partition logged batches skip it), and the per-replica origins of both partitions are
+     * identical to what an ordinary write produces, each with exactly one direct delivery into
+     * datacenter2.
+     */
+    @Test
+    public void loggedBatchHappyPathBehavesLikeOrdinaryWritesPerPartition()
+    {
+        long[] marks = mark();
+
+        AtomicInteger batchStoreCrossDc = new AtomicInteger();
+        AtomicInteger batchStoreToNode2 = new AtomicInteger();
+        cluster.filters().verbs(Verb.BATCH_STORE_REQ.id).from(1).to(3, 4)
+               .messagesMatching((from, to, message) -> { batchStoreCrossDc.incrementAndGet(); return false; })
+               .drop();
+        cluster.filters().verbs(Verb.BATCH_STORE_REQ.id).from(1).to(2)
+               .messagesMatching((from, to, message) -> { batchStoreToNode2.incrementAndGet(); return false; })
+               .drop();
+        try
+        {
+            // Two partitions: a single-partition logged batch bypasses the batchlog entirely.
+            cluster.coordinator(1).execute("BEGIN BATCH "
+                                           + "INSERT INTO " + KS_TBL + " (k, v) VALUES (10, 10); "
+                                           + "INSERT INTO " + KS_TBL + " (k, v) VALUES (11, 11); "
+                                           + "APPLY BATCH",
+                                           ConsistencyLevel.LOCAL_QUORUM);
+
+            for (int key : new int[]{ 10, 11 })
+            {
+                String keyFragment = "key=" + key;
+
+                // Indistinguishable from two ordinary writes, per replica:
+                assertOneLine(1, marks, keyFragment, "options=DEFAULT", "coordinator=null", "crossDc=false");
+                assertOneLine(2, marks, keyFragment, "options=DEFAULT", "coordinatorDc=" + DC1, "crossDc=false");
+                for (int node : new int[]{ 3, 4 })
+                    assertOneLine(node, marks, keyFragment, "options=DEFAULT", "coordinatorDc=" + DC1, "crossDc=true");
+
+                // ... and each partition's cross-DC message went through the ForwardingInfo relay:
+                // exactly one direct delivery into datacenter2 per partition.
+                long direct = count(3, marks, keyFragment + ".*direct=true")
+                            + count(4, marks, keyFragment + ".*direct=true");
+                assertEquals("exactly one datacenter2 replica should be direct for " + keyFragment, 1, direct);
+            }
+
+            // The batchlog half: written in the coordinator's DC, never sent across.
+            assertTrue("the batch should have been stored on node2 (single local-DC batchlog candidate)",
+                       batchStoreToNode2.get() >= 1);
+            assertEquals("the batchlog must never leave the coordinator's datacenter", 0, batchStoreCrossDc.get());
+        }
+        finally
+        {
+            cluster.filters().reset();
+        }
+    }
+
+    /**
+     * The recovery path of a multi-datacenter LOGGED batch: the coordinator crashes after storing the
+     * batch, before the mutations complete.
+     *
+     * Recovery is NOT per-datacenter, and this is the part worth seeing end to end. The batchlog lives
+     * only in the originating coordinator's datacenter (on node2 here, see the happy-path test), so
+     * that lone datacenter1 node is what drives recovery for the whole cluster: its BatchlogManager
+     * replays batches older than the replay timeout by applying each mutation locally with
+     * WriteOptions.FOR_BATCH_REPLAY and sending ONE plain MUTATION_REQ per live remote replica --
+     * point-to-point, no ForwardingInfo, no per-DC relay (BatchlogManager.sendSingleReplayMutation).
+     *
+     * Consequences the test pins, replica by replica:
+     *  - datacenter2 first learns of the rows from the REPLAY: origin = node2 (the batchlog node, in
+     *    datacenter1), NOT the dead coordinator -- consistent with the origin contract everywhere else:
+     *    "who delivered this apply", not "who the client talked to";
+     *  - both datacenter2 replicas are direct=true: the point-to-point fan-out again, same as read
+     *    repair and hints;
+     *  - the replayed applies arrive as ordinary DEFAULT mutations; only the batchlog node's own
+     *    re-apply carries FOR_BATCH_REPLAY (with no coordinator -- there is no message behind it).
+     *
+     * Scenario: datacenter2 is partitioned away, so a QUORUM batch (3 of 4) times out after the batch
+     * was durably stored on node2; node1 then crashes, taking with it both the client's only
+     * acknowledgement path and the hints it stored for datacenter2. The partition heals, node2's
+     * batchlog replay is forced until datacenter2 holds both rows -- provably via replay, since node1
+     * (and its hints) stay down until the assertions are done.
+     */
+    @Test
+    public void loggedBatchRecoveryIsDrivenByTheBatchlogNodeAcrossDatacenters() throws Throwable
+    {
+        long[] marks = mark();
+
+        cluster.filters().verbs(Verb.MUTATION_REQ.id).from(1).to(3, 4).drop();
+        try
+        {
+            try
+            {
+                cluster.coordinator(1).execute("BEGIN BATCH "
+                                               + "INSERT INTO " + KS_TBL + " (k, v) VALUES (20, 20); "
+                                               + "INSERT INTO " + KS_TBL + " (k, v) VALUES (21, 21); "
+                                               + "APPLY BATCH",
+                                               ConsistencyLevel.QUORUM);
+                fail("the batch should have timed out with datacenter2 unreachable");
+            }
+            catch (RuntimeException expected)
+            {
+                // WriteTimeoutException (writeType=BATCH) surfaced through the dtest coordinator: the
+                // batchlog write succeeded, the mutation phase could not reach QUORUM.
+            }
+
+            // datacenter2 saw nothing...
+            for (int node : new int[]{ 3, 4 })
+                for (int key : new int[]{ 20, 21 })
+                    assertEquals("node" + node + " must not have applied key=" + key + " while partitioned",
+                                 0, count(node, marks, "key=" + key));
+
+            // ... and node2 applied its ordinary write-path legs (proof the batch got as far as the
+            // mutation phase before dying).
+            for (int key : new int[]{ 20, 21 })
+                assertOneLine(2, marks, "key=" + key, "options=DEFAULT", "coordinatorDc=" + DC1, "crossDc=false");
+
+            // The coordinator "crashes". This also strands the hints node1 wrote for datacenter2 when
+            // the mutation phase timed out, so nothing but node2's batchlog can deliver these rows.
+            cluster.get(1).shutdown().get();
+        }
+        finally
+        {
+            cluster.filters().reset();
+        }
+
+        try
+        {
+            // Heal and force replay on node2 until datacenter2 holds both rows. The replay only picks
+            // up batches older than the replay window (2x the write timeout by default), hence the loop.
+            long deadline = System.currentTimeMillis() + 120_000;
+            while (System.currentTimeMillis() < deadline
+                   && (cluster.get(3).executeInternal("SELECT k FROM " + KS_TBL + " WHERE k = 20").length == 0
+                       || cluster.get(3).executeInternal("SELECT k FROM " + KS_TBL + " WHERE k = 21").length == 0
+                       || cluster.get(4).executeInternal("SELECT k FROM " + KS_TBL + " WHERE k = 20").length == 0
+                       || cluster.get(4).executeInternal("SELECT k FROM " + KS_TBL + " WHERE k = 21").length == 0))
+            {
+                cluster.get(2).runOnInstance(() -> {
+                    try
+                    {
+                        BatchlogManager.instance.forceBatchlogReplay();
+                    }
+                    catch (Exception e)
+                    {
+                        throw new RuntimeException(e);
+                    }
+                });
+                Thread.sleep(2000);
+            }
+
+            for (int key : new int[]{ 20, 21 })
+            {
+                String keyFragment = "key=" + key;
+
+                // The batchlog node re-applied its own copy: the one leg labelled as a replay, and the
+                // one with no message behind it.
+                assertEquals("node2 should have re-applied " + keyFragment + " exactly once as a replay",
+                             1, count(2, marks, keyFragment + ".*options=FOR_BATCH_REPLAY"));
+                assertEquals("node2's replay self-apply has no message behind it",
+                             1, count(2, marks, keyFragment + ".*options=FOR_BATCH_REPLAY, coordinator=null"));
+
+                // datacenter2's first and only applies: delivered by node2 -- the batchlog node, not
+                // the dead coordinator -- as plain mutations, point-to-point, so both are direct.
+                for (int node : new int[]{ 3, 4 })
+                    assertOneLine(node, marks, keyFragment,
+                                  "options=DEFAULT",
+                                  "coordinator=/127.0.0.2",
+                                  "coordinatorDc=" + DC1,
+                                  "crossDc=true",
+                                  "direct=true");
+            }
+        }
+        finally
+        {
+            cluster.get(1).startup();
+        }
+    }
+
+    /**
+     * Flips the paxos variant on every node. Passed as a String rather than as a Config.PaxosVariant so
+     * that no enum constant has to cross the boundary between the test's classloader and the isolated
+     * per-instance ones; the constant is resolved inside the node.
+     */
+    private static void setPaxosVariant(String variant)
+    {
+        cluster.forEach(i -> i.runOnInstance(() -> Paxos.setPaxosVariant(Config.PaxosVariant.valueOf(variant))));
+    }
+
+    private static long[] mark()
+    {
+        long[] marks = new long[5];
+        for (int n = 1; n <= 4; n++)
+            marks[n] = cluster.get(n).logs().mark();
+        return marks;
+    }
+
+    private static long count(int node, long[] marks, String regex)
+    {
+        return cluster.get(node).logs().grep(marks[node], WriteOriginLoggingIndex.MARKER + ".*" + regex)
+                      .getResult().size();
+    }
+
+    /**
+     * Waits for the node to log an apply for this key, then asserts it logged exactly one and that the
+     * line contains every given fragment.
+     *
+     * The wait is not optional politeness: the legs of a write that do not block the coordinator -- the
+     * cross-datacenter delivery of a LOCAL_QUORUM write, the remote commit of a LOCAL_SERIAL LWT -- land
+     * asynchronously, so grepping immediately after execute() races the apply. Requiring exactly one
+     * line afterwards is what stops a second, differently labelled apply of the same row (a read
+     * repair, say) from satisfying the assertion silently.
+     */
+    private static void assertOneLine(int node, long[] marks, String keyFragment, String... fragments)
+    {
+        String pattern = WriteOriginLoggingIndex.MARKER + ".*" + keyFragment + ",";
+        try
+        {
+            cluster.get(node).logs().watchFor(marks[node], Duration.ofSeconds(30), Pattern.compile(pattern));
+        }
+        catch (TimeoutException e)
+        {
+            throw new AssertionError("node" + node + " never logged an apply for " + keyFragment, e);
+        }
+
+        List<String> lines = cluster.get(node).logs().grep(marks[node], pattern).getResult();
+        assertEquals("node" + node + " should have logged exactly one apply for " + keyFragment
+                     + ", got: " + lines, 1, lines.size());
+
+        String line = lines.get(0);
+        for (String fragment : fragments)
+            assertTrue("node" + node + " line should contain '" + fragment + "', got: " + line,
+                       line.contains(fragment));
+    }
+}

--- a/test/distributed/org/apache/cassandra/distributed/test/WriteOriginLoggingIndex.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/WriteOriginLoggingIndex.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.cassandra.db.CassandraWriteContext;
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.DecoratedKey;
+import org.apache.cassandra.db.RegularAndStaticColumns;
+import org.apache.cassandra.db.WriteContext;
+import org.apache.cassandra.db.WriteOptions;
+import org.apache.cassandra.db.WriteOrigin;
+import org.apache.cassandra.db.memtable.Memtable;
+import org.apache.cassandra.index.StubIndex;
+import org.apache.cassandra.index.transactions.IndexTransaction;
+import org.apache.cassandra.schema.IndexMetadata;
+
+/**
+ * A custom secondary index that logs what {@link WriteOrigin} and {@link WriteOptions} its Indexer is
+ * handed for every apply, so a distributed test can assert what each replica actually saw.
+ * <p>
+ * This is the consumer the origin plumbing exists for: it observes the write path exactly where a real
+ * index does -- {@code Index.Group#indexerFor}, via {@code SecondaryIndexManager#newUpdateTransaction} --
+ * and reads the origin off the {@link WriteContext} it is already given. Nothing else is needed; there is
+ * no new SPI to implement.
+ * <p>
+ * Indexing behaviour is inherited from {@link StubIndex} (record and do nothing).
+ *
+ * @see WriteOriginDistributedTest
+ */
+public class WriteOriginLoggingIndex extends StubIndex
+{
+    private static final Logger logger = LoggerFactory.getLogger(WriteOriginLoggingIndex.class);
+
+    /** Every log line starts with this, so a test can grep for one index's applies. */
+    public static final String MARKER = "WriteOriginLoggingIndex apply";
+
+    private final ColumnFamilyStore baseCfs;
+
+    public WriteOriginLoggingIndex(ColumnFamilyStore baseCfs, IndexMetadata metadata)
+    {
+        super(baseCfs, metadata);
+        this.baseCfs = baseCfs;
+    }
+
+    @Override
+    public Indexer indexerFor(DecoratedKey key,
+                              RegularAndStaticColumns columns,
+                              long nowInSec,
+                              WriteContext ctx,
+                              IndexTransaction.Type transactionType,
+                              Memtable memtable)
+    {
+        logger.info("{}: key={}, txType={}, {}", MARKER, keyAsString(key), transactionType, describe(ctx));
+        return super.indexerFor(key, columns, nowInSec, ctx, transactionType, memtable);
+    }
+
+    private String keyAsString(DecoratedKey key)
+    {
+        try
+        {
+            return baseCfs.metadata().partitionKeyType.getString(key.getKey());
+        }
+        catch (Throwable t)
+        {
+            return key.toString();
+        }
+    }
+
+    /**
+     * Renders the two things the write context now carries. Both are null for a context opened outside a
+     * mutation (index build, compaction, cleanup), which is a distinct state from
+     * {@link WriteOrigin#LOCAL} -- "a mutation that did not arrive over the wire".
+     */
+    private static String describe(WriteContext ctx)
+    {
+        if (!(ctx instanceof CassandraWriteContext))
+            return "options=none, origin=none (foreign write context)";
+
+        CassandraWriteContext cassandraCtx = (CassandraWriteContext) ctx;
+        WriteOrigin origin = cassandraCtx.getOrigin();
+        if (origin == null)
+            return "options=" + cassandraCtx.getWriteOptions() + ", origin=none (no mutation)";
+
+        return "options=" + cassandraCtx.getWriteOptions()
+               + ", coordinator=" + origin.coordinator()
+               + ", coordinatorDc=" + origin.datacenter()
+               + ", crossDc=" + origin.isCrossDatacenter()
+               + ", direct=" + origin.isDirectFromRemoteDatacenter();
+    }
+}

--- a/test/unit/org/apache/cassandra/db/WriteOriginTest.java
+++ b/test/unit/org/apache/cassandra/db/WriteOriginTest.java
@@ -27,9 +27,15 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.locator.IEndpointSnitch;
 import org.apache.cassandra.locator.InetAddressAndPort;
+import org.apache.cassandra.locator.SimpleSnitch;
+import org.apache.cassandra.net.Message;
+import org.apache.cassandra.net.NoPayload;
+import org.apache.cassandra.net.Verb;
 import org.apache.cassandra.schema.TableId;
 import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.FBUtilities;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -66,7 +72,7 @@ public class WriteOriginTest
 
     private static WriteOrigin origin(InetAddressAndPort coordinator, InetAddressAndPort sender)
     {
-        return WriteOrigin.create(coordinator, sender, LOCAL_DC, TOPOLOGY::get);
+        return WriteOrigin.origin(coordinator, sender, LOCAL_DC, TOPOLOGY::get);
     }
 
     @Test
@@ -137,7 +143,8 @@ public class WriteOriginTest
     }
 
     /**
-     * An unplaceable coordinator degrades to "local" rather than to a guessed remote datacenter.
+     * An unplaceable coordinator degrades to UNKNOWN -- not to LOCAL, whose contract is "provably
+     * originated here", and not to a guessed remote datacenter.
      *
      * Note what this does NOT protect against: most snitches in this tree never return null, they return a
      * synthetic datacenter name ("UNKNOWN_DC") for an endpoint they cannot place, which compares unequal to
@@ -145,15 +152,146 @@ public class WriteOriginTest
      * return null. isCrossDatacenter() is best-effort during a topology change, and says so.
      */
     @Test
-    public void unplacedCoordinatorDegradesToLocal()
+    public void unplacedCoordinatorDegradesToUnknown()
     {
-        assertSame(WriteOrigin.LOCAL, origin(unplaced, unplaced));
+        WriteOrigin origin = origin(unplaced, unplaced);
+
+        assertSame(WriteOrigin.UNKNOWN, origin);
+        assertTrue(origin.isUnknown());
+        // Conservative on both questions -- but distinguishable from LOCAL, which answers the same.
+        assertFalse(origin.isCrossDatacenter());
+        assertFalse(origin.isDirectFromRemoteDatacenter());
+        assertFalse(WriteOrigin.LOCAL.isUnknown());
     }
 
     @Test
-    public void unknownLocalDatacenterDegradesToLocal()
+    public void unknownLocalDatacenterDegradesToUnknown()
     {
-        assertSame(WriteOrigin.LOCAL, WriteOrigin.create(remoteCoordinator, remoteCoordinator, null, TOPOLOGY::get));
+        assertSame(WriteOrigin.UNKNOWN, WriteOrigin.origin(remoteCoordinator, remoteCoordinator, null, TOPOLOGY::get));
+    }
+
+    /**
+     * A missing sender is a determinable case, not an UNKNOWN one: the coordinator places fine, so the
+     * cross-datacenter answer stands -- only the delivery path is unclaimed.
+     */
+    @Test
+    public void missingSenderLeavesTheDeliveryPathUnclaimed()
+    {
+        WriteOrigin origin = origin(remoteCoordinator, null);
+
+        assertTrue(origin.isCrossDatacenter());
+        assertFalse(origin.isDirectFromRemoteDatacenter());
+        assertFalse(origin.isUnknown());
+    }
+
+    /**
+     * The environment-reading entry points, on their happy paths: fromMessage places both endpoints
+     * through the installed snitch, and fromPeer is its single-endpoint equivalent for the paxos verbs.
+     */
+    @Test
+    public void fromMessageAndFromPeerPlaceEndpointsThroughTheInstalledSnitch()
+    {
+        withSnitchAndLocalDc(placingSnitch(), LOCAL_DC, () -> {
+            WriteOrigin fromMessage = WriteOrigin.fromMessage(Message.synthetic(remoteCoordinator, Verb.MUTATION_REQ, NoPayload.noPayload));
+            assertEquals(remoteCoordinator, fromMessage.coordinator());
+            assertTrue(fromMessage.isCrossDatacenter());
+            assertTrue(fromMessage.isDirectFromRemoteDatacenter());
+
+            WriteOrigin fromPeer = WriteOrigin.fromPeer(remoteCoordinator);
+            assertEquals(remoteCoordinator, fromPeer.coordinator());
+            assertTrue(fromPeer.isCrossDatacenter());
+            assertTrue(fromPeer.isDirectFromRemoteDatacenter());
+
+            // A delivery this node addressed to itself is a local apply, not an inbound one
+            // (PaxosCommit#executeOnSelf reuses its request handler with the node's own address).
+            InetAddressAndPort self = FBUtilities.getBroadcastAddressAndPort();
+            assertSame(WriteOrigin.LOCAL, WriteOrigin.fromMessage(Message.synthetic(self, Verb.MUTATION_REQ, NoPayload.noPayload)));
+            assertSame(WriteOrigin.LOCAL, WriteOrigin.fromPeer(self));
+        });
+    }
+
+    /** No snitch installed at all: nothing can be placed, so the answer is "undetermined", not "local". */
+    @Test
+    public void missingSnitchDegradesToUnknown()
+    {
+        withSnitchAndLocalDc(null, LOCAL_DC, () -> {
+            assertSame(WriteOrigin.UNKNOWN, WriteOrigin.fromMessage(Message.synthetic(remoteCoordinator, Verb.MUTATION_REQ, NoPayload.noPayload)));
+            assertSame(WriteOrigin.UNKNOWN, WriteOrigin.fromPeer(remoteCoordinator));
+        });
+    }
+
+    /**
+     * This node's own datacenter cannot be resolved: neither the config nor the snitch knows it, so the
+     * comparison that decides cross-datacenter has nothing to compare against.
+     */
+    @Test
+    public void unresolvableLocalDatacenterDegradesToUnknown()
+    {
+        IEndpointSnitch noLocalDc = new SimpleSnitch()
+        {
+            @Override
+            public String getLocalDatacenter()
+            {
+                return null;
+            }
+        };
+        withSnitchAndLocalDc(noLocalDc, null, () -> {
+            assertSame(WriteOrigin.UNKNOWN, WriteOrigin.fromMessage(Message.synthetic(remoteCoordinator, Verb.MUTATION_REQ, NoPayload.noPayload)));
+            assertSame(WriteOrigin.UNKNOWN, WriteOrigin.fromPeer(remoteCoordinator));
+        });
+    }
+
+    /**
+     * A snitch that throws while placing an endpoint (PropertyFileSnitch does, for one it has no entry
+     * for) must not fail the write -- and must not claim the write is local either.
+     */
+    @Test
+    public void throwingSnitchDegradesToUnknown()
+    {
+        IEndpointSnitch throwing = new SimpleSnitch()
+        {
+            @Override
+            public String getDatacenter(InetAddressAndPort endpoint)
+            {
+                throw new IllegalStateException("no topology entry for " + endpoint);
+            }
+        };
+        withSnitchAndLocalDc(throwing, LOCAL_DC, () -> {
+            assertSame(WriteOrigin.UNKNOWN, WriteOrigin.fromMessage(Message.synthetic(remoteCoordinator, Verb.MUTATION_REQ, NoPayload.noPayload)));
+            assertSame(WriteOrigin.UNKNOWN, WriteOrigin.fromPeer(remoteCoordinator));
+        });
+    }
+
+    /** Swaps the environment fromMessage/fromPeer read, restoring it whatever the body does. */
+    private static void withSnitchAndLocalDc(IEndpointSnitch snitch, String localDc, Runnable body)
+    {
+        IEndpointSnitch previousSnitch = DatabaseDescriptor.getEndpointSnitch();
+        String previousLocalDc = DatabaseDescriptor.getLocalDataCenter();
+        DatabaseDescriptor.setEndpointSnitch(snitch);
+        DatabaseDescriptor.setLocalDataCenter(localDc);
+        try
+        {
+            body.run();
+        }
+        finally
+        {
+            DatabaseDescriptor.setEndpointSnitch(previousSnitch);
+            DatabaseDescriptor.setLocalDataCenter(previousLocalDc);
+        }
+    }
+
+    /** A snitch backed by the same explicit topology map the pure-factory tests use. */
+    private static IEndpointSnitch placingSnitch()
+    {
+        return new SimpleSnitch()
+        {
+            @Override
+            public String getDatacenter(InetAddressAndPort endpoint)
+            {
+                String dc = TOPOLOGY.get(endpoint);
+                return dc != null ? dc : LOCAL_DC; // the local node itself is in LOCAL_DC
+            }
+        };
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/db/WriteOriginTest.java
+++ b/test/unit/org/apache/cassandra/db/WriteOriginTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db;
+
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.locator.InetAddressAndPort;
+import org.apache.cassandra.schema.TableId;
+import org.apache.cassandra.utils.ByteBufferUtil;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+public class WriteOriginTest
+{
+    private static final String LOCAL_DC = "dc1";
+    private static final String REMOTE_DC = "dc2";
+
+    private static InetAddressAndPort localCoordinator;
+    private static InetAddressAndPort localPeer;
+    private static InetAddressAndPort remoteCoordinator;
+    private static InetAddressAndPort unplaced;
+
+    private static final Map<InetAddressAndPort, String> TOPOLOGY = new HashMap<>();
+
+    @BeforeClass
+    public static void setUp() throws UnknownHostException
+    {
+        DatabaseDescriptor.daemonInitialization();
+
+        localCoordinator = InetAddressAndPort.getByName("127.0.0.1");
+        localPeer = InetAddressAndPort.getByName("127.0.0.2");
+        remoteCoordinator = InetAddressAndPort.getByName("127.0.0.3");
+        unplaced = InetAddressAndPort.getByName("127.0.0.4");
+
+        TOPOLOGY.put(localCoordinator, LOCAL_DC);
+        TOPOLOGY.put(localPeer, LOCAL_DC);
+        TOPOLOGY.put(remoteCoordinator, REMOTE_DC);
+    }
+
+    private static WriteOrigin origin(InetAddressAndPort coordinator, InetAddressAndPort sender)
+    {
+        return WriteOrigin.create(coordinator, sender, LOCAL_DC, TOPOLOGY::get);
+    }
+
+    @Test
+    public void locallyInitiatedWriteHasNoOrigin()
+    {
+        WriteOrigin origin = origin(null, null);
+
+        assertSame(WriteOrigin.LOCAL, origin);
+        assertNull(origin.coordinator());
+        assertNull(origin.datacenter());
+        assertFalse(origin.isCrossDatacenter());
+        assertFalse(origin.isDirectFromRemoteDatacenter());
+    }
+
+    @Test
+    public void writeCoordinatedInThisDatacenterIsNotCrossDatacenter()
+    {
+        WriteOrigin origin = origin(localCoordinator, localCoordinator);
+
+        assertEquals(localCoordinator, origin.coordinator());
+        assertEquals(LOCAL_DC, origin.datacenter());
+        assertFalse(origin.isCrossDatacenter());
+        assertFalse(origin.isDirectFromRemoteDatacenter());
+    }
+
+    /**
+     * The message that actually crossed the datacenter boundary: the remote coordinator is both the
+     * coordinator and the sender.
+     */
+    @Test
+    public void writeReceivedStraightFromARemoteCoordinatorIsDirect()
+    {
+        WriteOrigin origin = origin(remoteCoordinator, remoteCoordinator);
+
+        assertEquals(remoteCoordinator, origin.coordinator());
+        assertEquals(REMOTE_DC, origin.datacenter());
+        assertTrue(origin.isCrossDatacenter());
+        assertTrue(origin.isDirectFromRemoteDatacenter());
+    }
+
+    /**
+     * The same write as seen by the replicas the relay forwarded it to: RESPOND_TO still names the remote
+     * coordinator, but the sender is the local relay, so the message did not reach them directly.
+     */
+    @Test
+    public void forwardedWriteIsCrossDatacenterButNotDirect()
+    {
+        WriteOrigin origin = origin(remoteCoordinator, localPeer);
+
+        assertEquals(remoteCoordinator, origin.coordinator());
+        assertEquals(REMOTE_DC, origin.datacenter());
+        assertTrue(origin.isCrossDatacenter());
+        assertFalse(origin.isDirectFromRemoteDatacenter());
+    }
+
+    /**
+     * A sender the topology cannot place proves nothing about the delivery path, so we do not claim one.
+     * The alternative -- assuming the boundary -- would hand every relayed replica a false "direct" during
+     * the exact window (a node being replaced, an address just changed) when it is least verifiable.
+     */
+    @Test
+    public void crossDatacenterWriteFromAnUnplacedSenderIsNotClaimedDirect()
+    {
+        WriteOrigin origin = origin(remoteCoordinator, unplaced);
+
+        assertTrue(origin.isCrossDatacenter());
+        assertFalse(origin.isDirectFromRemoteDatacenter());
+    }
+
+    /**
+     * An unplaceable coordinator degrades to "local" rather than to a guessed remote datacenter.
+     *
+     * Note what this does NOT protect against: most snitches in this tree never return null, they return a
+     * synthetic datacenter name ("UNKNOWN_DC") for an endpoint they cannot place, which compares unequal to
+     * the local one and therefore reads as cross-datacenter. This branch only covers snitches that throw or
+     * return null. isCrossDatacenter() is best-effort during a topology change, and says so.
+     */
+    @Test
+    public void unplacedCoordinatorDegradesToLocal()
+    {
+        assertSame(WriteOrigin.LOCAL, origin(unplaced, unplaced));
+    }
+
+    @Test
+    public void unknownLocalDatacenterDegradesToLocal()
+    {
+        assertSame(WriteOrigin.LOCAL, WriteOrigin.create(remoteCoordinator, remoteCoordinator, null, TOPOLOGY::get));
+    }
+
+    @Test
+    public void mutationCarriesItsOriginAcrossFiltering()
+    {
+        WriteOrigin origin = origin(remoteCoordinator, remoteCoordinator);
+
+        Mutation mutation = new Mutation("ks",
+                                         DatabaseDescriptor.getPartitioner().decorateKey(ByteBufferUtil.bytes(1)),
+                                         ImmutableMap.of(),
+                                         0L);
+
+        assertSame(WriteOrigin.LOCAL, mutation.origin());
+
+        mutation.withOrigin(origin);
+        assertSame(origin, mutation.origin());
+
+        // Hint replay filters out truncated tables before applying; the origin must survive that copy.
+        TableId truncated = TableId.fromString("00000000-0000-0000-0000-000000000001");
+        assertSame(origin, mutation.without(Collections.singleton(truncated)).origin());
+
+        // As must the merge a trigger's augmented mutations go through.
+        assertSame(origin, Mutation.merge(Arrays.asList(mutation, mutation)).origin());
+
+        // And the setter never installs null: LOCAL is the "no inbound message" value, not null.
+        assertSame(WriteOrigin.LOCAL, mutation.withOrigin(null).origin());
+    }
+}

--- a/test/unit/org/apache/cassandra/index/PrepareWriteTest.java
+++ b/test/unit/org/apache/cassandra/index/PrepareWriteTest.java
@@ -1,0 +1,488 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.index;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.After;
+import org.junit.Test;
+
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.db.CassandraWriteContext;
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.DecoratedKey;
+import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.db.Mutation;
+import org.apache.cassandra.db.RegularAndStaticColumns;
+import org.apache.cassandra.db.RowUpdateBuilder;
+import org.apache.cassandra.db.WriteContext;
+import org.apache.cassandra.db.WriteOptions;
+import org.apache.cassandra.db.WriteOrigin;
+import org.apache.cassandra.db.commitlog.CommitLog;
+import org.apache.cassandra.db.commitlog.CommitLogPosition;
+import org.apache.cassandra.db.memtable.Memtable;
+import org.apache.cassandra.db.partitions.PartitionUpdate;
+import org.apache.cassandra.index.transactions.IndexTransaction;
+import org.apache.cassandra.schema.IndexMetadata;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * {@link Index#prepareWrite}: an index that {@linkplain Index#preparesWrites prepares writes} sees each partition
+ * update BEFORE the mutation is appended to the commit log, takes the handle it returned back from the
+ * {@link CassandraWriteContext} in {@code indexerFor} when the update reaches the memtable, and gets
+ * {@link Index#abortWrite} for every handle that is not taken.
+ */
+public class PrepareWriteTest extends CQLTester
+{
+    @After
+    public void resetIndexBehaviour()
+    {
+        PreparingIndex.failAfter.set(-1);
+        PreparingIndex.takeHandles = true;
+        PreparingIndex.prepareNothing = false;
+        ReadOnlyOnFailureIndex.failInitialization = false;
+    }
+
+    @Test
+    public void prepareWriteRunsBeforeTheCommitLogAppend() throws Throwable
+    {
+        createTable("CREATE TABLE %s (a int, b int, c int, PRIMARY KEY (a, b))");
+        PreparingIndex index = createPreparingIndex("prep_idx");
+        assertTrue(getCurrentColumnFamilyStore().indexManager.preparesWrites());
+
+        execute("INSERT INTO %s (a, b, c) VALUES (?, ?, ?)", 1, 2, 3);
+
+        assertEquals(1, index.prepared.size());
+        assertEquals(1, index.applied.size());
+        Prepared prepared = index.prepared.get(0);
+        Applied applied = index.applied.get(0);
+
+        // The handle returned by prepareWrite is the very object indexerFor takes back for the same update.
+        assertSame(prepared, applied.handle);
+        assertEquals(1, prepared.rows);
+        assertTrue("a taken handle is not aborted", index.aborted.isEmpty());
+
+        // The ordering proof: the commit log's allocation point observed in prepareWrite lies strictly
+        // before the position this mutation was appended at, which is only possible if prepareWrite ran
+        // before the append (a mutation's position is the END of its own allocation).
+        assertNotNull("the write went through the commit log", applied.position);
+        assertTrue("prepareWrite observed " + prepared.commitLogPositionBefore + ", the mutation landed at " + applied.position,
+                   prepared.commitLogPositionBefore.compareTo(applied.position) < 0);
+
+        // A client write this node coordinated, applied with the default options.
+        assertEquals(WriteOptions.DEFAULT, prepared.options);
+        assertSame(WriteOrigin.LOCAL, prepared.origin);
+    }
+
+    @Test
+    public void everyUpdateOfAMultiTableMutationIsPrepared() throws Throwable
+    {
+        String t1 = createTable("CREATE TABLE %s (a int, b int, PRIMARY KEY (a))");
+        PreparingIndex index1 = createPreparingIndex("prep_idx_t1");
+        String t2 = createTable("CREATE TABLE %s (a int, b int, PRIMARY KEY (a))");
+        PreparingIndex index2 = createPreparingIndex("prep_idx_t2");
+
+        // Same partition key in both tables: one Mutation, two PartitionUpdates.
+        execute(String.format("BEGIN UNLOGGED BATCH " +
+                              "INSERT INTO %s.%s (a, b) VALUES (7, 1); " +
+                              "INSERT INTO %s.%s (a, b) VALUES (7, 2); " +
+                              "APPLY BATCH", KEYSPACE, t1, KEYSPACE, t2));
+
+        assertEquals(1, index1.prepared.size());
+        assertEquals(1, index2.prepared.size());
+        assertSame(index1.prepared.get(0), index1.applied.get(0).handle);
+        assertSame(index2.prepared.get(0), index2.applied.get(0).handle);
+
+        // Both updates were prepared before the (single) commit log append of the mutation.
+        CommitLogPosition position = index1.applied.get(0).position;
+        assertEquals(position, index2.applied.get(0).position);
+        assertTrue(index1.prepared.get(0).commitLogPositionBefore.compareTo(position) < 0);
+        assertTrue(index2.prepared.get(0).commitLogPositionBefore.compareTo(position) < 0);
+    }
+
+    @Test
+    public void writesThatSkipIndexingAreNotPrepared() throws Throwable
+    {
+        createTable("CREATE TABLE %s (a int, b int, PRIMARY KEY (a))");
+        PreparingIndex index = createPreparingIndex("prep_idx_skip");
+
+        Keyspace.open(KEYSPACE).apply(mutation(1), WriteOptions.SKIP_INDEXES_AND_COMMITLOG);
+
+        assertTrue(index.prepared.isEmpty());
+        assertTrue(index.applied.isEmpty());
+        assertTrue(index.aborted.isEmpty());
+    }
+
+    @Test
+    public void commitLogReplayIsPreparedWithItsOwnOptions() throws Throwable
+    {
+        createTable("CREATE TABLE %s (a int, b int, PRIMARY KEY (a))");
+        PreparingIndex index = createPreparingIndex("prep_idx_replay");
+
+        // A fresh commit log, so that the replay below contains this test's write and nothing older.
+        CommitLog.instance.resetUnsafe(true);
+        execute("INSERT INTO %s (a, b) VALUES (?, ?)", 2, 2);
+        assertEquals(1, index.prepared.size());
+        CommitLogPosition appendedAt = index.applied.get(0).position;
+        assertNotNull(appendedAt);
+
+        // The real thing: stop the commit log without discarding its segments and start it again, which
+        // replays them the way a restart does (CommitLogReplayer, then a STARTUP flush of what it replayed).
+        // Nothing was flushed, so the mutation above is re-applied through the normal write path, and
+        // Cassandra does not second-guess which applies an index wants to know about: the replayed mutation
+        // is prepared like any other, labelled with the replay options so the index can recognise one it has
+        // already recorded when it was first written.
+        CommitLog.instance.resetUnsafe(false);
+
+        assertEquals(2, index.prepared.size());
+        assertEquals(2, index.applied.size());
+        Prepared replayed = index.prepared.get(1);
+        assertEquals(WriteOptions.FOR_COMMITLOG_REPLAY, replayed.options);
+        assertSame("a replayed mutation did not arrive over the wire", WriteOrigin.LOCAL, replayed.origin);
+        assertEquals(1, replayed.rows);
+        assertSame(replayed, index.applied.get(1).handle);
+        assertNull("no commit log append on replay", index.applied.get(1).position);
+        assertTrue("the replayed mutation was written before the replay started",
+                   appendedAt.compareTo(replayed.commitLogPositionBefore) < 0);
+        assertTrue(index.aborted.isEmpty());
+    }
+
+    @Test
+    public void aFailingPrepareAbortsTheOthersAndFailsTheWriteBeforeTheCommitLog() throws Throwable
+    {
+        String t1 = createTable("CREATE TABLE %s (a int, b int, PRIMARY KEY (a))");
+        PreparingIndex index1 = createPreparingIndex("prep_idx_fail_t1");
+        String t2 = createTable("CREATE TABLE %s (a int, b int, PRIMARY KEY (a))");
+        PreparingIndex index2 = createPreparingIndex("prep_idx_fail_t2");
+
+        // One mutation, two tables, two indexes: the first prepareWrite returns a handle, the second throws.
+        // Which index goes first is not specified, hence the shared countdown rather than a per-index switch.
+        PreparingIndex.failAfter.set(1);
+        Mutation mutation = Mutation.merge(Arrays.asList(mutation(t1, 1), mutation(t2, 1)));
+        CommitLogPosition before = CommitLog.instance.getCurrentPosition();
+        try
+        {
+            Keyspace.open(KEYSPACE).apply(mutation, WriteOptions.DEFAULT);
+            fail("the write should have failed");
+        }
+        catch (IllegalStateException expected)
+        {
+            assertEquals(PreparingIndex.FAILURE_MESSAGE, expected.getMessage());
+        }
+
+        // Exactly one handle was returned, and it was aborted: for the index that got it, the write never
+        // happened. Nobody was asked for an indexer.
+        List<Prepared> prepared = concat(index1.prepared, index2.prepared);
+        List<Prepared> aborted = concat(index1.aborted, index2.aborted);
+        assertEquals(1, prepared.size());
+        assertEquals(1, aborted.size());
+        assertSame(prepared.get(0), aborted.get(0));
+        assertTrue(index1.applied.isEmpty());
+        assertTrue(index2.applied.isEmpty());
+
+        // Nothing was persisted: no commit log append, no row in either memtable.
+        assertEquals(before, CommitLog.instance.getCurrentPosition());
+        assertEmpty(execute(String.format("SELECT * FROM %s.%s", KEYSPACE, t1)));
+        assertEmpty(execute(String.format("SELECT * FROM %s.%s", KEYSPACE, t2)));
+    }
+
+    @Test
+    public void aHandleTheIndexDoesNotTakeIsAbortedWhenTheWriteEnds() throws Throwable
+    {
+        createTable("CREATE TABLE %s (a int, b int, PRIMARY KEY (a))");
+        PreparingIndex index = createPreparingIndex("prep_idx_untaken");
+
+        PreparingIndex.takeHandles = false;
+        execute("INSERT INTO %s (a, b) VALUES (?, ?)", 1, 1);
+
+        // The write itself went through: the index got its indexer, just without taking the handle...
+        assertEquals(1, index.prepared.size());
+        assertEquals(1, index.applied.size());
+        assertNull(index.applied.get(0).handle);
+        assertRows(execute("SELECT a, b FROM %s"), row(1, 1));
+        // ... so the handle was aborted when the write context closed.
+        assertEquals(1, index.aborted.size());
+        assertSame(index.prepared.get(0), index.aborted.get(0));
+
+        // A handle is taken at most once: taking it again yields nothing, and does not abort it again.
+        PreparingIndex.takeHandles = true;
+        execute("INSERT INTO %s (a, b) VALUES (?, ?)", 2, 2);
+        assertEquals(2, index.applied.size());
+        assertSame(index.prepared.get(1), index.applied.get(1).handle);
+        assertNull(index.applied.get(1).secondTake);
+        assertEquals(1, index.aborted.size());
+    }
+
+    @Test
+    public void aPreparingIndexMayDeclineAWriteAndStillGetsItsIndexer() throws Throwable
+    {
+        createTable("CREATE TABLE %s (a int, b int, PRIMARY KEY (a))");
+        PreparingIndex index = createPreparingIndex("prep_idx_null");
+
+        // The index is asked and returns null: no handle to carry, nothing to abort, and the
+        // indexer is still asked for, taking null from the context, like every other write.
+        PreparingIndex.prepareNothing = true;
+        execute("INSERT INTO %s (a, b) VALUES (?, ?)", 1, 1);
+
+        assertEquals(1, index.declined.get());
+        assertTrue(index.prepared.isEmpty());
+        assertEquals(1, index.applied.size());
+        assertNull(index.applied.get(0).handle);
+        assertTrue(index.aborted.isEmpty());
+        assertRows(execute("SELECT a, b FROM %s"), row(1, 1));
+
+        // Deciding per write: the next one is prepared and its handle taken as usual.
+        PreparingIndex.prepareNothing = false;
+        execute("INSERT INTO %s (a, b) VALUES (?, ?)", 2, 2);
+        assertEquals(1, index.prepared.size());
+        assertSame(index.prepared.get(0), index.applied.get(1).handle);
+        assertTrue(index.aborted.isEmpty());
+    }
+
+    @Test
+    public void aNonWritableIndexIsNeitherPreparedNorAborted() throws Throwable
+    {
+        createTable("CREATE TABLE %s (a int, b int, PRIMARY KEY (a))");
+        ReadOnlyOnFailureIndex.failInitialization = true;
+        String name = createIndexAsync(String.format("CREATE CUSTOM INDEX prep_idx_ro ON %%s(b) USING '%s'",
+                                                     ReadOnlyOnFailureIndex.class.getName()));
+        waitForIndexBuilds(name);
+        SecondaryIndexManager manager = getCurrentColumnFamilyStore().indexManager;
+        ReadOnlyOnFailureIndex index = (ReadOnlyOnFailureIndex) manager.getIndexByName(name);
+        assertFalse("premise: the failed initialization left the index non-writable", manager.isIndexWritable(index));
+        assertTrue("registered, so the table still checks its indexes", manager.preparesWrites());
+
+        execute("INSERT INTO %s (a, b) VALUES (?, ?)", 1, 1);
+
+        // Not writable means not asked for an indexer, hence not prepared either -- and nothing to abort.
+        assertTrue(index.prepared.isEmpty());
+        assertTrue(index.applied.isEmpty());
+        assertTrue(index.aborted.isEmpty());
+    }
+
+    @Test
+    public void anIndexThatDoesNotPrepareCostsNothingAndTakesNull() throws Throwable
+    {
+        createTable("CREATE TABLE %s (a int, b int, PRIMARY KEY (a))");
+        String name = "plain_idx";
+        createIndex(String.format("CREATE CUSTOM INDEX %s ON %%s(b) USING '%s'", name, PlainIndex.class.getName()));
+        SecondaryIndexManager manager = getCurrentColumnFamilyStore().indexManager;
+        PlainIndex index = (PlainIndex) manager.getIndexByName(name);
+        assertFalse("no index of this table prepares writes: the write path skips the hook", manager.preparesWrites());
+
+        execute("INSERT INTO %s (a, b) VALUES (?, ?)", 1, 1);
+
+        assertEquals(1, index.taken.size());
+        assertNull(index.taken.get(0));
+
+        // Adding a preparing index flips the switch; dropping it flips it back.
+        createPreparingIndex("prep_idx_plain");
+        assertTrue(manager.preparesWrites());
+        dropIndex("DROP INDEX %s.prep_idx_plain");
+        assertFalse(manager.preparesWrites());
+    }
+
+    private PreparingIndex createPreparingIndex(String name)
+    {
+        createIndex(String.format("CREATE CUSTOM INDEX %s ON %%s(b) USING '%s'", name, PreparingIndex.class.getName()));
+        return (PreparingIndex) getCurrentColumnFamilyStore().indexManager.getIndexByName(name);
+    }
+
+    private Mutation mutation(int key)
+    {
+        return mutation(currentTable(), key);
+    }
+
+    private Mutation mutation(String table, int key)
+    {
+        ColumnFamilyStore cfs = Keyspace.open(KEYSPACE).getColumnFamilyStore(table);
+        return new RowUpdateBuilder(cfs.metadata(), 0, key).add("b", 1).build();
+    }
+
+    private static List<Prepared> concat(List<Prepared> a, List<Prepared> b)
+    {
+        List<Prepared> all = new CopyOnWriteArrayList<>(a);
+        all.addAll(b);
+        return all;
+    }
+
+    /** What one prepareWrite call saw; doubles as the handle taken back in indexerFor. */
+    static final class Prepared implements Index.PreparedWrite
+    {
+        final CommitLogPosition commitLogPositionBefore;
+        final WriteOptions options;
+        final WriteOrigin origin;
+        final int rows;
+
+        Prepared(CommitLogPosition commitLogPositionBefore, WriteOptions options, WriteOrigin origin, int rows)
+        {
+            this.commitLogPositionBefore = commitLogPositionBefore;
+            this.options = options;
+            this.origin = origin;
+            this.rows = rows;
+        }
+    }
+
+    /** What one indexerFor call took from the write context on the write path. */
+    static final class Applied
+    {
+        final Index.PreparedWrite handle;
+        final Index.PreparedWrite secondTake;
+        final CommitLogPosition position;
+
+        Applied(Index.PreparedWrite handle, Index.PreparedWrite secondTake, CommitLogPosition position)
+        {
+            this.handle = handle;
+            this.secondTake = secondTake;
+            this.position = position;
+        }
+    }
+
+    public static class PreparingIndex extends StubIndex
+    {
+        static final String FAILURE_MESSAGE = "prepareWrite is configured to fail";
+        /** Shared by all instances: when non-negative, the prepareWrite call that reaches zero throws. */
+        static final AtomicInteger failAfter = new AtomicInteger(-1);
+        /** Whether indexerFor takes the handle back from the write context. */
+        static volatile boolean takeHandles = true;
+        /** When set, prepareWrite declines every write (returns null) instead of preparing it. */
+        static volatile boolean prepareNothing = false;
+
+        final List<Prepared> prepared = new CopyOnWriteArrayList<>();
+        final List<Applied> applied = new CopyOnWriteArrayList<>();
+        final List<Prepared> aborted = new CopyOnWriteArrayList<>();
+        /** Writes prepareWrite was asked about and declined. */
+        final AtomicInteger declined = new AtomicInteger();
+
+        public PreparingIndex(ColumnFamilyStore baseCfs, IndexMetadata metadata)
+        {
+            super(baseCfs, metadata);
+        }
+
+        @Override
+        public boolean preparesWrites()
+        {
+            return true;
+        }
+
+        @Override
+        public PreparedWrite prepareWrite(PartitionUpdate update, WriteOptions options, WriteOrigin origin)
+        {
+            if (failAfter.get() >= 0 && failAfter.getAndDecrement() == 0)
+                throw new IllegalStateException(FAILURE_MESSAGE);
+            if (prepareNothing)
+            {
+                declined.incrementAndGet();
+                return null;
+            }
+            int rows = 0;
+            for (@SuppressWarnings("unused") Object row : update.rows())
+                rows++;
+            Prepared p = new Prepared(CommitLog.instance.getCurrentPosition(), options, origin, rows);
+            prepared.add(p);
+            return p;
+        }
+
+        @Override
+        public void abortWrite(PreparedWrite prepared)
+        {
+            aborted.add((Prepared) prepared);
+        }
+
+        @Override
+        public Indexer indexerFor(DecoratedKey key,
+                                  RegularAndStaticColumns columns,
+                                  long nowInSec,
+                                  WriteContext ctx,
+                                  IndexTransaction.Type transactionType,
+                                  Memtable memtable)
+        {
+            if (memtable != null) // the write path; the build/compaction/cleanup paths carry no handle
+            {
+                PreparedWrite handle = takeHandles ? ctx.takePreparedWrite(this) : null;
+                PreparedWrite secondTake = takeHandles ? ctx.takePreparedWrite(this) : null;
+                applied.add(new Applied(handle, secondTake, CassandraWriteContext.fromContext(ctx).getPosition()));
+            }
+            return super.indexerFor(key, columns, nowInSec, ctx, transactionType, memtable);
+        }
+    }
+
+    /** A preparing index whose initialization can be made to fail, leaving it readable but not writable. */
+    public static class ReadOnlyOnFailureIndex extends PreparingIndex
+    {
+        static volatile boolean failInitialization = false;
+
+        public ReadOnlyOnFailureIndex(ColumnFamilyStore baseCfs, IndexMetadata metadata)
+        {
+            super(baseCfs, metadata);
+        }
+
+        @Override
+        public Callable<?> getInitializationTask()
+        {
+            return () ->
+            {
+                if (failInitialization)
+                    throw new IllegalStateException("initialization is configured to fail");
+                return null;
+            };
+        }
+
+        @Override
+        public LoadType getSupportedLoadTypeOnFailure(boolean isInitialBuild)
+        {
+            return LoadType.READ;
+        }
+    }
+
+    /** Does not prepare writes; only records what taking a handle yields on the write path. */
+    public static class PlainIndex extends StubIndex
+    {
+        final List<Index.PreparedWrite> taken = new CopyOnWriteArrayList<>();
+
+        public PlainIndex(ColumnFamilyStore baseCfs, IndexMetadata metadata)
+        {
+            super(baseCfs, metadata);
+        }
+
+        @Override
+        public Indexer indexerFor(DecoratedKey key,
+                                  RegularAndStaticColumns columns,
+                                  long nowInSec,
+                                  WriteContext ctx,
+                                  IndexTransaction.Type transactionType,
+                                  Memtable memtable)
+        {
+            if (memtable != null)
+                taken.add(ctx.takePreparedWrite(this));
+            return super.indexerFor(key, columns, nowInSec, ctx, transactionType, memtable);
+        }
+    }
+}


### PR DESCRIPTION
### What is the issue

Context : https://datastax.jira.com/browse/HCD-549

A replica applying a mutation cannot tell whether the write was coordinated in its own datacenter or in a remote one. Every inbound MUTATION_REQ is applied with WriteOptions.DEFAULT, exactly like a write the node coordinates itself, and the distinction is not derivable from the Mutation at all -- it lives only in the Message, which never reaches Keyspace.applyInternal. Secondary indexes are the only in-process hook that observes every applied mutation (hints, read repair, batchlog replay, paxos commits, commit log replay, and writes relayed inside a remote datacenter all bypass the coordinator-side Mutator), so an index that wants to react per datacenter -- reading a row back at LOCAL_QUORUM before publishing it, say -- has no way to scope that reaction.

Therefore we need a way of intercepting any write to the CommitLog.
This is because on CommitLog replay there is no notion of the origin of the Mutation (WriteOrigin is 'commitlog-replay') and a custom Secondary Index cannot decide whether to replay it or not (in our HCD-549 we are interested only in Mutations coming from a remote datacenter).
The idea is to track the event on another "commit-log" (or equivalent persistent storage) handled custom external Secondary Index (this is already implemented on HCD on the H2O replicator)

### What does this PR fix and why was it fixed

Three commits, two additions to what a secondary index can learn about a write on a replica:

1. **`WriteOrigin`** — *where* an apply came from: the coordinator, its datacenter, and whether the message crossed a datacenter boundary (commits 1–2).
2. **`Index#prepareWrite`** — *when* an index first hears about it: before the commit log append, with a handle carried to its `Indexer` (commit 3).

Both are additive. Every new SPI method has a default; an existing index or index group is unaffected and pays nothing.

---

## Part 1 — `WriteOrigin`: where a replica-side apply came from

### Problem

A replica applying a mutation cannot tell whether the write was coordinated in its own datacenter or in a remote one. Every inbound `MUTATION_REQ` is applied with `WriteOptions.DEFAULT` (`MutationVerbHandler.applyMutation`), exactly like a write the node coordinates itself — and the distinction is not derivable from the `Mutation` at all. It lives only in the `Message`, which never reaches `Keyspace.applyInternal`.

That matters because secondary indexes are the only in-process hook that observes *every* applied mutation. Hints, read repair, batchlog replay, paxos commits, commit log replay, and writes relayed inside a remote datacenter all bypass the coordinator-side `Mutator`. An index that wants to react per datacenter — reading a row back at `LOCAL_QUORUM` before publishing it downstream, say — has no way to scope that reaction to the applies that need it.

Two things were already within reach and simply dropped: `WriteOptions` is in scope at `CassandraKeyspaceWriteHandler#beginWrite`, and `WriteContext` is threaded all the way into `Index.Group#indexerFor`. No index-SPI change is needed for this part.

### What an index sees now

`WriteOriginLoggingIndex` (test tree) logs the `WriteOptions` and `WriteOrigin` its Indexer is handed. `WriteOriginDistributedTest` runs it on four nodes across two datacenters (NTS `{dc1:2, dc2:2}`, every node replicates every key). One ordinary `LOCAL_QUORUM` write coordinated on node1:

```
node1  key=1 options=DEFAULT coordinator=null              coordinatorDc=null        crossDc=false direct=false
node2  key=1 options=DEFAULT coordinator=/127.0.0.1:7012   coordinatorDc=datacenter1 crossDc=false direct=false
node3  key=1 options=DEFAULT coordinator=/127.0.0.1:7012   coordinatorDc=datacenter1 crossDc=true  direct=true
node4  key=1 options=DEFAULT coordinator=/127.0.0.1:7012   coordinatorDc=datacenter1 crossDc=true  direct=false
```

Four applies of one write, previously indistinguishable. node4 heard the write from node3's relay yet still names the **original** datacenter1 coordinator, because `ForwardingInfo` puts it in `RESPOND_TO`; exactly one datacenter2 replica is `direct`.

A read repair — a different verb handler, attributed to the node that ran the *read*:

```
node4  key=3 options=FOR_READ_REPAIR coordinatorDc=datacenter1 crossDc=true direct=true
```

**Paxos commits are stamped on every variant, with no wire change.** A commit's `Mutation` never travels as one: `PAXOS_COMMIT_REQ` carries an `Agreed` and each replica manufactures the mutation inside `PaxosState.applyCommit`. The origin is threaded down as a parameter (`commitDirect` / `commit` / `applyCommit` gain a `WriteOrigin`; `makeMutation().withOrigin(origin)`) from every path with a peer behind it: `PaxosCommit.RequestHandler`, `PaxosPrepareRefresh`, `PaxosCommitAndPrepare`, and the unwired `CommitVerbHandler`. The message-free paths (`executeOnSelf`, `StorageProxy.commitPaxosLocal`) keep `LOCAL`, which `fromPeer`/`fromMessage` also return for a self-addressed delivery.

```
v1  LOCAL_SERIAL  node1 (proposer)  FOR_PAXOS_COMMIT  coordinator=null
                  node2 (dc1 peer)  FOR_PAXOS_COMMIT  coordinatorDc=datacenter1  crossDc=false
                  datacenter2       FOR_PAXOS_COMMIT  coordinatorDc=datacenter1  crossDc=true direct=true
v2  LOCAL_SERIAL  node1 (proposer)  FOR_PAXOS_COMMIT  coordinator=null
                  node2 (dc1 peer)  FOR_PAXOS_COMMIT  coordinatorDc=datacenter1  crossDc=false
                  datacenter2       DEFAULT           coordinatorDc=datacenter1  crossDc=true direct=true
```

v2's remote leg arrives as a plain mutation and is labelled `DEFAULT`; being attributed cross-DC, a consumer handles it under its client-write rules.

**LOGGED batches**, both paths:

- *Happy path* — the batchlog is local to the coordinator's datacenter (`ReplicaPlans.forBatchlogWrite`); a counting filter proves zero `BATCH_STORE_REQ` cross the boundary. The mutations take the ordinary write path, relay included, and label like independent writes.
- *Recovery (coordinator crash)* — the lone batchlog node drives replay for the whole cluster (`BatchlogManager.sendSingleReplayMutation`): locally with `FOR_BATCH_REPLAY` and no coordinator, and one plain `MUTATION_REQ` per remote replica, point-to-point:

```
node2 (batchlog)   key=20 options=FOR_BATCH_REPLAY coordinator=null
datacenter2  ×2    key=20 options=DEFAULT          coordinator=/127.0.0.2:7012 dc1 crossDc=true direct=true
```

dc2's applies are attributed to the batchlog node, not the dead coordinator — consistent with the contract everywhere else: "who delivered this apply".

### Change

**`WriteOrigin`** (new) records the coordinator, its datacenter, and two bits derived from two *different* endpoints of the inbound message:

| Bit | Derived from | Means |
|---|---|---|
| `isCrossDatacenter()` | `Message#respondTo()` — the coordinator; `ForwardingInfo` keeps the original one in `RESPOND_TO` | true on **every** replica in the receiving datacenter |
| `isDirectFromRemoteDatacenter()` | `Message#from()` — the sender | the message arrived straight from the remote datacenter rather than through a local relay |

The second bit is named for what it observes, not what it is tempting to infer: it is unique per receiving datacenter for an ordinary write (`MUTATION_REQ` is sent once per remote DC and fanned out by the receiver), but `READ_REPAIR_REQ`, `HINT_REQ` and `PAXOS2_COMMIT_REMOTE_REQ` are sent point-to-point, so on those every replica sees it true. The javadoc spells this out per verb.

**`Mutation`** carries the origin in a transient, non-serialized field alongside `viewLockAcquireStart`, preserved by `Mutation#without` and `Mutation#merge`. `MutationVerbHandler` stamps it **before** `forwardToLocalNodes`: forwarding hands the same instance to the outbound connections, which serialize it on their own threads, so the write must happen-before the handoff.

**`CassandraWriteContext`** also carries the `WriteOptions` the mutation is applied with. Both fields are null for a context opened outside a mutation (index build, compaction, cleanup, the read path). Null and `WriteOrigin.LOCAL` are different answers — "no mutation here" versus "a mutation that did not arrive over the wire".

**Degradation** (commit 2): the could-not-determine cases return **`WriteOrigin.UNKNOWN`** rather than `LOCAL`, whose contract is now strictly "provably originated here". `UNKNOWN` answers both booleans false (a true would be a guess) and is distinguishable via `isUnknown()`, so a consumer can treat "cannot tell" differently from "provably local". A missing snitch, an unresolvable local datacenter, a snitch that throws, and an unplaceable coordinator all yield `UNKNOWN`; a missing coordinator stays `LOCAL`; an unplaceable sender only clears `isDirectFromRemoteDatacenter()`. Most snitches answer an unknown endpoint with a synthetic datacenter (`UNKNOWN_DC`), which reads as remote; one that throws (`PropertyFileSnitch`) is caught, run through `JVMStabilityInspector` and logged at debug. Best-effort, and documented as such.

**Not covered**: `CounterMutationVerbHandler`; MV view replica writes (`ViewManager.pushViewReplicaUpdates` builds fresh mutations).

**Cost**: one small immutable object per inbound mutation message — not per partition update — plus the snitch lookups behind it, on the mutation stage.

---

## Part 2 — `Index#prepareWrite`: see the mutation before the commit log append

### Problem

An index that keeps its own durable record of in-flight writes — to emit them to an external system and confirm each one — can so far only learn about a mutation from `Indexer.insertRow`/`updateRow`, which run after the mutation is in the commit log. A crash in between leaves a mutation the commit log will replay but the index never saw. With Part 1 the index can now tell a replayed apply apart (`FOR_COMMITLOG_REPLAY`), but it still cannot tell *which* replayed rows it already recorded, and the replayed mutation carries no coordinator, so the per-datacenter decision is gone too. The result is replay-specific machinery on the index side that can only ever be approximate.

The fix is ordering. If the index is told about the update *before* the commit log append, then after a crash either the write never reached the commit log, or it is replayed and the index already holds its record. Replay becomes a case the index's own record covers, not one it has to detect.

### Change (commit 3)

- **`Index#prepareWrite(PartitionUpdate, WriteOptions, WriteOrigin)`** — called from `CassandraKeyspaceWriteHandler.beginWrite`, after the OpOrder group is opened and before `CommitLog.add`, once per partition update whose table has preparing indexes. Returns an opaque **`Index.PreparedWrite`** handle, or null. Runs on the mutation thread while the write order group is held: it must be fast, and must not wait on anything the write path itself produces. A thrown exception fails the write before anything is persisted. Nothing has been fsync'd when it runs; an index that needs its own record durable before Cassandra's arranges that itself, off the mutation thread.
- **`Index#preparesWrites()`** (default false) opts an index in. `SecondaryIndexManager` caches the answer per table when indexes are registered and removed, and the write handler checks that volatile flag per partition update: a table whose indexes do not use the hook pays no call and no allocation. The handle map is created lazily, when an index actually returns a handle.
- **The handle travels in the mutation's `CassandraWriteContext`** and the index takes it back in its existing six-argument `indexerFor` with **`WriteContext#takePreparedWrite(index)`** (default null on other contexts). One entry point for indexers, no group-level indirection, no change to the `Index.Group` contract.
- **`Index#abortWrite(PreparedWrite)`** (default no-op) is the other outcome. A handle reaches **exactly one** of `takePreparedWrite` or `abortWrite` — never both, never neither. It is aborted when the update is never applied to the index: another index's `prepareWrite` threw, the commit log append failed, the table was dropped between prepare and apply, the index is not writable, or its `indexerFor` simply did not take it. The write handler aborts on failure before the context exists; the context aborts whatever is left when it is closed.
- **Selection matches `indexerFor`.** `SecondaryIndexManager.prepareWrite` fans the update out with the same writable-index selector `newUpdateTransaction` uses, so an index is prepared for exactly the updates it is later given an Indexer for. Writes applied with `updateIndexes=false` are not prepared. The writability test is evaluated at each end of the write, so an index that becomes writable in between is handed an Indexer it was not prepared for and `takePreparedWrite` returns null — the contract says an index must accept that, and what it can still rely on (the exactly-one rule above). A preparing index may also decline a write by returning null; it still gets its Indexer, and nothing is aborted for that write.
- **Commit log replay is not special-cased**: a replayed mutation is prepared like any other, with `FOR_COMMITLOG_REPLAY`, so the index can recognise a write it has already recorded and skip it.

### Cost

For a table without preparing indexes: one volatile read per partition update. Otherwise one `prepareWrite` call per (update, writable preparing index) and one small map per mutation that returned a handle.

---

## Testing

- `WriteOriginDistributedTest` — 6/6 (ordinary write, paxos v1, paxos v2, read repair, logged batch happy path, logged batch coordinator-crash recovery). `ant test-jvm-dtest-some -Dtest.name=org.apache.cassandra.distributed.test.WriteOriginDistributedTest`.
- `WriteOriginTest` — 13/13, including every degradation branch (no snitch, a snitch that cannot name the local DC, a snitch that throws, a null sender, the self-addressed shortcut) through the real `fromMessage`/`fromPeer` entry points, plus the pure placement logic (`WriteOrigin.origin` is free of any snitch or configuration lookup and public, so downstream code can build one deterministically) and origin survival across `Mutation#without`, `Mutation#merge` and `withOrigin(null)`.
- `PrepareWriteTest` — 9/9: `prepareWrite` runs before the commit log append (the commit log position observed in the hook compared with the one the mutation is appended at); every update of a multi-table mutation is prepared; `SKIP_INDEXES` writes are not; a replay through the real `CommitLogReplayer` (`CommitLog#resetUnsafe(false)`) is prepared with `FOR_COMMITLOG_REPLAY`; a failing `prepareWrite` aborts the handles already collected and fails the write before the commit log; an untaken handle is aborted when the write ends; a preparing index may decline a write and still gets its Indexer; a non-writable index is neither prepared nor aborted; a table without preparing indexes skips the hook and its Indexer takes null.
- Paxos-path regression: `CASMultiDCTest` (5/5) and `PaxosRepairTest` (6, 1 pre-existing skip) green.
- Also green: `WriteOptionsTest`, `HintTest`, `MutationVerbHandlerOutOfRangeTest`, and both `SecondaryIndexTest`s (`db` and `cql3.validation.entities`).

**No behavior change for existing indexes** — nothing in the server reads the new accessors, and no index in the tree overrides `preparesWrites`.


**No behavior change: nothing in the server reads the new accessors.**

