### PR TITLE
CNDB-18876: Add cells fetched/returned Codahale counters to TableQueryMetrics

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/metrics/TableQueryMetrics.java
+++ b/src/java/org/apache/cassandra/index/sai/metrics/TableQueryMetrics.java
@@ -224,6 +224,12 @@ public class TableQueryMetrics
         /** Total number of deleted individual rows or ranges of rows that are fetched. */
         public final Counter totalRowTombstonesFetched;
 
+        /** Total number of cells fetched from the storage engine, regardless of liveness, before post-filtering. */
+        public final Counter totalCellsFetched;
+
+        /** Total number of cells returned to the coordinator, regardless of liveness, after post-filtering. */
+        public final Counter totalCellsReturned;
+
         /** Total number of completed queries. */
         public final Counter totalQueriesCompleted;
 
@@ -250,6 +256,8 @@ public class TableQueryMetrics
             totalRowsFetched = Metrics.counter(createMetricName("TotalRowsFetched"));
             totalRowsReturned = Metrics.counter(createMetricName("TotalRowsReturned"));
             totalRowTombstonesFetched = Metrics.counter(createMetricName("TotalRowTombstonesFetched"));
+            totalCellsFetched = Metrics.counter(createMetricName("TotalCellsFetched"));
+            totalCellsReturned = Metrics.counter(createMetricName("TotalCellsReturned"));
             totalQueriesCompleted = Metrics.counter(createMetricName("TotalQueriesCompleted"));
             totalQueryTimeouts = Metrics.counter(createMetricName("TotalQueryTimeouts"));
             queryPlanMetrics = (CassandraRelevantProperties.SAI_QUERY_PLAN_METRICS_ENABLED.getBoolean())
@@ -273,6 +281,8 @@ public class TableQueryMetrics
             totalRowsFetched.inc(snapshot.rowsFetched);
             totalRowsReturned.inc(snapshot.rowsReturned);
             totalRowTombstonesFetched.inc(snapshot.rowTombstonesFetched);
+            totalCellsFetched.inc(snapshot.cellsFetched);
+            totalCellsReturned.inc(snapshot.cellsReturned);
 
             QueryContext.PlanInfo queryPlanInfo = snapshot.queryPlanInfo;
             if (queryPlanInfo != null && queryPlanMetrics != null)

--- a/test/unit/org/apache/cassandra/index/sai/QueryContextTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/QueryContextTest.java
@@ -70,6 +70,8 @@ public class QueryContextTest extends SAITester.Versioned
         assertEquals(4, snapshot.rowsFetched);
         assertEquals(4, snapshot.rowsReturned);
         assertEquals(0, snapshot.rowTombstonesFetched);
+        assertEquals(8, snapshot.cellsFetched);
+        assertEquals(8, snapshot.cellsReturned);
 
         // index filtering that accepts no rows
         snapshot = queryContext("SELECT * FROM %s WHERE a < 0 ALLOW FILTERING");
@@ -80,6 +82,8 @@ public class QueryContextTest extends SAITester.Versioned
         assertEquals(0, snapshot.rowsFetched);
         assertEquals(0, snapshot.rowsReturned);
         assertEquals(0, snapshot.rowTombstonesFetched);
+        assertEquals(0, snapshot.cellsFetched);
+        assertEquals(0, snapshot.cellsReturned);
 
         // index filtering that accepts some rows
         snapshot = queryContext("SELECT * FROM %s WHERE a = 0 ALLOW FILTERING",
@@ -92,6 +96,8 @@ public class QueryContextTest extends SAITester.Versioned
         assertEquals(2, snapshot.rowsFetched);
         assertEquals(2, snapshot.rowsReturned);
         assertEquals(0, snapshot.rowTombstonesFetched);
+        assertEquals(4, snapshot.cellsFetched);
+        assertEquals(4, snapshot.cellsReturned);
 
         // index filtering that accepts some rows, different value
         snapshot = queryContext("SELECT * FROM %s WHERE a = 1 ALLOW FILTERING",
@@ -104,6 +110,8 @@ public class QueryContextTest extends SAITester.Versioned
         assertEquals(2, snapshot.rowsFetched);
         assertEquals(2, snapshot.rowsReturned);
         assertEquals(0, snapshot.rowTombstonesFetched);
+        assertEquals(4, snapshot.cellsFetched);
+        assertEquals(4, snapshot.cellsReturned);
 
         // not-indexed column filtering that accepts all rows
         snapshot = queryContext("SELECT * FROM %s WHERE a = 0 AND b = 0 ALLOW FILTERING",
@@ -116,6 +124,8 @@ public class QueryContextTest extends SAITester.Versioned
         assertEquals(2, snapshot.rowsFetched);
         assertEquals(2, snapshot.rowsReturned);
         assertEquals(0, snapshot.rowTombstonesFetched);
+        assertEquals(4, snapshot.cellsFetched);
+        assertEquals(4, snapshot.cellsReturned);
 
         // not-indexed column filtering that accepts no rows
         snapshot = queryContext("SELECT * FROM %s WHERE a = 0 AND b = 1 ALLOW FILTERING");
@@ -126,6 +136,8 @@ public class QueryContextTest extends SAITester.Versioned
         assertEquals(2, snapshot.rowsFetched);
         assertEquals(0, snapshot.rowsReturned);
         assertEquals(0, snapshot.rowTombstonesFetched);
+        assertEquals(4, snapshot.cellsFetched);
+        assertEquals(0, snapshot.cellsReturned);
 
         // not-indexed column filtering that accepts some rows
         snapshot = queryContext("SELECT * FROM %s WHERE a >= 0 AND b = 0 ALLOW FILTERING",
@@ -138,6 +150,8 @@ public class QueryContextTest extends SAITester.Versioned
         assertEquals(4, snapshot.rowsFetched);
         assertEquals(2, snapshot.rowsReturned);
         assertEquals(0, snapshot.rowTombstonesFetched);
+        assertEquals(8, snapshot.cellsFetched);
+        assertEquals(4, snapshot.cellsReturned);
 
         // partition/primary key query
         snapshot = queryContext("SELECT * FROM %s WHERE a >= 0 AND k = 0 ALLOW FILTERING",
@@ -149,6 +163,8 @@ public class QueryContextTest extends SAITester.Versioned
         assertEquals(1, snapshot.rowsFetched);
         assertEquals(1, snapshot.rowsReturned);
         assertEquals(0, snapshot.rowTombstonesFetched);
+        assertEquals(2, snapshot.cellsFetched);
+        assertEquals(2, snapshot.cellsReturned);
 
         // partition/primary key filtering
         snapshot = queryContext("SELECT * FROM %s WHERE a >= 0 AND k != 1 ALLOW FILTERING",
@@ -162,6 +178,8 @@ public class QueryContextTest extends SAITester.Versioned
         assertEquals(4, snapshot.rowsFetched);
         assertEquals(3, snapshot.rowsReturned);
         assertEquals(0, snapshot.rowTombstonesFetched);
+        assertEquals(8, snapshot.cellsFetched);
+        assertEquals(6, snapshot.cellsReturned);
 
         // delete a partition/row
         execute("DELETE FROM %s WHERE k = 1");
@@ -176,6 +194,8 @@ public class QueryContextTest extends SAITester.Versioned
         assertEquals(3, snapshot.rowsFetched);
         assertEquals(3, snapshot.rowsReturned);
         assertEquals(0, snapshot.rowTombstonesFetched);
+        assertEquals(6, snapshot.cellsFetched);
+        assertEquals(6, snapshot.cellsReturned);
 
         // delete an indexed cell
         execute("DELETE a FROM %s WHERE k = 2");
@@ -189,6 +209,8 @@ public class QueryContextTest extends SAITester.Versioned
         assertEquals(3, snapshot.rowsFetched);
         assertEquals(2, snapshot.rowsReturned);
         assertEquals(0, snapshot.rowTombstonesFetched);
+        assertEquals(1 + 2 + 2, snapshot.cellsFetched);
+        assertEquals(4, snapshot.cellsReturned);
 
         // compact to rebuild the index, and verify that tombstones are gone
         flush();
@@ -203,6 +225,8 @@ public class QueryContextTest extends SAITester.Versioned
         assertEquals(2, snapshot.rowsFetched);
         assertEquals(2, snapshot.rowsReturned);
         assertEquals(0, snapshot.rowTombstonesFetched);
+        assertEquals(4, snapshot.cellsFetched);
+        assertEquals(4, snapshot.cellsReturned);
 
         // truncate the table
         truncate(false);
@@ -214,6 +238,8 @@ public class QueryContextTest extends SAITester.Versioned
         assertEquals(0, snapshot.rowsFetched);
         assertEquals(0, snapshot.rowsReturned);
         assertEquals(0, snapshot.rowTombstonesFetched);
+        assertEquals(0, snapshot.cellsFetched);
+        assertEquals(0, snapshot.cellsReturned);
 
         // insert some data using TTLs
         execute("INSERT INTO %s (k, a, b) VALUES (0, 0, 0)");
@@ -232,6 +258,8 @@ public class QueryContextTest extends SAITester.Versioned
         assertEquals(2, snapshot.rowsFetched);
         assertEquals(2, snapshot.rowsReturned);
         assertEquals(2, snapshot.rowTombstonesFetched);
+        assertEquals(8, snapshot.cellsFetched);
+        assertEquals(4, snapshot.cellsReturned);
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/index/sai/QueryContextTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/QueryContextTest.java
@@ -209,7 +209,7 @@ public class QueryContextTest extends SAITester.Versioned
         assertEquals(3, snapshot.rowsFetched);
         assertEquals(2, snapshot.rowsReturned);
         assertEquals(0, snapshot.rowTombstonesFetched);
-        assertEquals(1 + 2 + 2, snapshot.cellsFetched);
+        assertEquals(6, snapshot.cellsFetched);
         assertEquals(4, snapshot.cellsReturned);
 
         // compact to rebuild the index, and verify that tombstones are gone

--- a/test/unit/org/apache/cassandra/index/sai/metrics/QueryMetricsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/metrics/QueryMetricsTest.java
@@ -644,6 +644,28 @@ public class QueryMetricsTest extends AbstractMetricsTest
         waitForEqualsIfExists(perTable, objectName(name, TABLE_SP_HYBRID_QUERY_METRIC_TYPE), 0);
         waitForEqualsIfExists(perTable, objectName(name, TABLE_MP_HYBRID_QUERY_METRIC_TYPE), 2);
 
+        // Verify counters for total cells fetched.
+        // The table schema has 2 non-PK columns (n, v), so each live row contributes 2 cells.
+        // Tombstone rows (partition/range tombstones) contribute 0 cells.
+        name = "TotalCellsFetched";
+        waitForEquals(objectName(name, TABLE_QUERY_METRIC_TYPE), 2 * (numRowsPerPartition + numRows + numRowsPerPartition + numRows + numRowsPerPartition + numRows));
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_SP_FILTER_QUERY_METRIC_TYPE), 2 * numRowsPerPartition);
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_MP_FILTER_QUERY_METRIC_TYPE), 2 * numRows);
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_SP_TOPK_QUERY_METRIC_TYPE), 2 * numRowsPerPartition);
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_MP_TOPK_QUERY_METRIC_TYPE), 2 * numRows);
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_SP_HYBRID_QUERY_METRIC_TYPE), 2 * numRowsPerPartition);
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_MP_HYBRID_QUERY_METRIC_TYPE), 2 * numRows);
+
+        // Verify counters for total cells returned.
+        name = "TotalCellsReturned";
+        waitForEquals(objectName(name, TABLE_QUERY_METRIC_TYPE), 2 * (numRowsPerPartition + numRows + numRowsPerPartition + numRows + numRowsPerPartition + numRows));
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_SP_FILTER_QUERY_METRIC_TYPE), 2 * numRowsPerPartition);
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_MP_FILTER_QUERY_METRIC_TYPE), 2 * numRows);
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_SP_TOPK_QUERY_METRIC_TYPE), 2 * numRowsPerPartition);
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_MP_TOPK_QUERY_METRIC_TYPE), 2 * numRows);
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_SP_HYBRID_QUERY_METRIC_TYPE), 2 * numRowsPerPartition);
+        waitForEqualsIfExists(perTable, objectName(name, TABLE_MP_HYBRID_QUERY_METRIC_TYPE), 2 * numRows);
+
         // Verify counters for timeouts.
         name = "TotalQueryTimeouts";
         waitForEquals(objectName(name, TABLE_QUERY_METRIC_TYPE), 0);


### PR DESCRIPTION
## Summary

Adds two new Codahale `Counter` fields to `TableQueryMetrics.PerTable`:

- `totalCellsFetched` — total cells read from the storage engine, regardless of liveness, before post-filtering
- `totalCellsReturned` — total cells returned to the coordinator, regardless of liveness, after post-filtering

These counters mirror the existing `totalRowsFetched` / `totalRowsReturned` / `totalRowTombstonesFetched` pattern in both declaration, constructor initialisation, and `record()` increment order.

## Context

`QueryContext.Snapshot` already exposes `cellsFetched` and `cellsReturned` fields (added in PR #2564). This PR wires those snapshot fields into the per-table metrics layer so they are visible via JMX / Prometheus.

## Changes

**`TableQueryMetrics.java`** (`PerTable` only):

1. **Field declarations** — two new `public final Counter` fields added after `totalRowTombstonesFetched`.
2. **Constructor** — both counters initialised (via `Metrics.counter(createMetricName(...))`) after `totalRowTombstonesFetched`.
3. **`record(QueryContext.Snapshot)`** — both counters incremented after `totalRowTombstonesFetched.inc(...)`.

No other files are modified in this sub-task.

## Jira

CNDB-18876
