### PR TITLE
CNDB-19129-on-demand: expose num of indexed rows via SegmentMetadata#totalRowCount without opening SAI searcher or vector graph

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/disk/v1/SegmentMetadata.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/SegmentMetadata.java
@@ -36,6 +36,7 @@ import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.index.sai.IndexContext;
 import org.apache.cassandra.index.sai.SSTableContext;
+import org.apache.cassandra.index.sai.disk.format.IndexComponents;
 import org.apache.cassandra.index.sai.disk.ModernResettableByteBuffersIndexOutput;
 import org.apache.cassandra.index.sai.disk.PostingList;
 import org.apache.cassandra.index.sai.disk.format.IndexComponentType;
@@ -231,7 +232,26 @@ public class SegmentMetadata implements Comparable<SegmentMetadata>
     @SuppressWarnings("resource")
     public static List<SegmentMetadata> loadForTesting(MetadataSource source, IndexContext context) throws IOException
     {
+        logger.warn("Loading segment metadata without full primary key boundary resolution. Some ORDER BY queries" +
+                    " may not work correctly.");
         return load(source, context, null, false);
+    }
+
+    /**
+     * Returns the number of rows the index of the provided components has indexed in its sstable, that is the sum of
+     * the rows of all its segments.
+     * <p>
+     * Only the (small) metadata component is read: no searcher, primary key map or graph is opened, so this can be
+     * used where the index is not, or cannot be, loaded for reads &mdash; on compactors, which do not open SAI
+     * searchers, or before the sstable index has made it into the index view. For the same reason the primary key
+     * boundaries of the returned segments are not fully resolved, which is why they are not exposed here.
+     */
+    public static long totalRowCount(IndexComponents.ForRead perIndexComponents, IndexContext context) throws IOException
+    {
+        long rows = 0;
+        for (SegmentMetadata metadata : load(MetadataSource.loadMetadata(perIndexComponents), context, null, false))
+            rows += metadata.numRows;
+        return rows;
     }
 
     /**

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/SegmentMetadata.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/SegmentMetadata.java
@@ -152,10 +152,6 @@ public class SegmentMetadata implements Comparable<SegmentMetadata>
     @SuppressWarnings("resource")
     private SegmentMetadata(IndexInput input, IndexContext context, Version version, SSTableContext sstableContext, boolean loadFullResolutionBounds) throws IOException
     {
-        if (!loadFullResolutionBounds)
-            logger.warn("Loading segment metadata without full primary key boundary resolution. Some ORDER BY queries" +
-                        " may not work correctly.");
-
         AbstractType<?> termsType = context.getValidator();
 
         this.version = version;
@@ -189,7 +185,7 @@ public class SegmentMetadata implements Comparable<SegmentMetadata>
         else
         {
             assert sstableContext == null;
-            // Only valid in some very specific tests.
+            // Only valid when the caller does not use the boundaries for query processing.
             PrimaryKey.Factory primaryKeyFactory = context.keyFactory();
             this.minKey = primaryKeyFactory.createPartitionKeyOnly(DatabaseDescriptor.getPartitioner().decorateKey(readBytes(input)));
             this.maxKey = primaryKeyFactory.createPartitionKeyOnly(DatabaseDescriptor.getPartitioner().decorateKey(readBytes(input)));
@@ -224,9 +220,21 @@ public class SegmentMetadata implements Comparable<SegmentMetadata>
     }
 
     /**
-     * This is only visible for testing because the SegmentFlushTest creates fake boundary scenarios that break
-     * normal assumptions about the min/max row ids mapping to specific positions in the per-sstable index components.
-     * Only set loadFullResolutionBounds to false in tests when you are sure that is the only possible solution.
+     * Loads segment metadata without fully resolving its primary key boundaries. This avoids opening the primary key
+     * map and is intended for callers that only need metadata unrelated to those boundaries, such as compactors.
+     * The returned primary key boundaries must not be used for query processing.
+     */
+    @SuppressWarnings("resource")
+    public static List<SegmentMetadata> loadWithoutFullResolutionBounds(MetadataSource source,
+                                                                         IndexContext context) throws IOException
+    {
+        return load(source, context, null, false);
+    }
+
+    /**
+     * Test-only variant that warns about unresolved primary key boundaries. SegmentFlushTest uses this because it
+     * creates fake boundary scenarios that break normal assumptions about the min/max row ids mapping to specific
+     * positions in the per-sstable index components.
      */
     @VisibleForTesting
     @SuppressWarnings("resource")
@@ -234,7 +242,7 @@ public class SegmentMetadata implements Comparable<SegmentMetadata>
     {
         logger.warn("Loading segment metadata without full primary key boundary resolution. Some ORDER BY queries" +
                     " may not work correctly.");
-        return load(source, context, null, false);
+        return loadWithoutFullResolutionBounds(source, context);
     }
 
     /**
@@ -249,13 +257,15 @@ public class SegmentMetadata implements Comparable<SegmentMetadata>
     public static long totalRowCount(IndexComponents.ForRead perIndexComponents, IndexContext context) throws IOException
     {
         long rows = 0;
-        for (SegmentMetadata metadata : load(MetadataSource.loadMetadata(perIndexComponents), context, null, false))
+        MetadataSource source = MetadataSource.loadMetadata(perIndexComponents);
+        for (SegmentMetadata metadata : loadWithoutFullResolutionBounds(source, context))
             rows += metadata.numRows;
         return rows;
     }
 
     /**
-     * Only set loadFullResolutionBounds to false in tests when you are sure that is exactly what you want.
+     * Internal implementation for the public loading modes above. Callers should select the overload that matches
+     * whether fully resolved primary key boundaries are required.
      */
     private static List<SegmentMetadata> load(MetadataSource source, IndexContext context, SSTableContext sstableContext, boolean loadFullResolutionBounds) throws IOException
     {

--- a/src/java/org/apache/cassandra/sensors/ExecutionTimeSensorAccumulator.java
+++ b/src/java/org/apache/cassandra/sensors/ExecutionTimeSensorAccumulator.java
@@ -16,9 +16,8 @@
 package org.apache.cassandra.sensors;
 
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.DoubleAccumulator;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import com.google.common.util.concurrent.AtomicDouble;
 
 /**
  * Per-request accumulator for execution-time sensors.
@@ -45,7 +44,7 @@ public class ExecutionTimeSensorAccumulator
     private final AtomicInteger responseCount = new AtomicInteger(0);
 
     /** Running max per (context, type) pair — populated by accumulate(). */
-    private final ConcurrentHashMap<ContextTypePair, AtomicDouble> maxByContextType = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<ContextTypePair, DoubleAccumulator> maxByContextType = new ConcurrentHashMap<>();
 
     /**
      * @param threshold number of {@link #onResponse} calls after which the accumulated maxes are
@@ -67,8 +66,8 @@ public class ExecutionTimeSensorAccumulator
      */
     public void accumulate(Context context, Type type, double value)
     {
-        maxByContextType.computeIfAbsent(new ContextTypePair(context, type), k -> new AtomicDouble(0))
-                        .updateAndGet(current -> Math.max(value, current));
+        maxByContextType.computeIfAbsent(new ContextTypePair(context, type), k -> new DoubleAccumulator(Math::max, 0))
+                        .accumulate(value);
     }
 
     /**
@@ -85,7 +84,7 @@ public class ExecutionTimeSensorAccumulator
 
         if (responseCount.incrementAndGet() == threshold)
         {
-            for (ConcurrentHashMap.Entry<ContextTypePair, AtomicDouble> entry : maxByContextType.entrySet())
+            for (ConcurrentHashMap.Entry<ContextTypePair, DoubleAccumulator> entry : maxByContextType.entrySet())
                 sensors.incrementSensor(entry.getKey().context, entry.getKey().type, entry.getValue().get());
         }
     }

--- a/test/unit/org/apache/cassandra/index/sai/disk/v1/SegmentFlushTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/disk/v1/SegmentFlushTest.java
@@ -181,6 +181,10 @@ public class SegmentFlushTest
         List<SegmentMetadata> segmentMetadatas = SegmentMetadata.loadForTesting(source, indexContext);
         assertEquals(segments, segmentMetadatas.size());
 
+        // the indexed rows of the sstable are counted across all its segments, without opening the index for reads
+        assertEquals(2, SegmentMetadata.totalRowCount(components, indexContext));
+        assertEquals(segmentMetadatas.stream().mapToLong(metadata -> metadata.numRows).sum(), SegmentMetadata.totalRowCount(components, indexContext));
+
         // verify segment metadata
         SegmentMetadata segmentMetadata = segmentMetadatas.get(0);
         segmentRowIdOffset = sstableRowId1;


### PR DESCRIPTION
### What is the issue
cndb-19129

