### PR TITLE
CNDB-18937: Upgrade to netty 4.1.137.Final (main-5.0)

### DIFF
--- a/.build/parent-pom-template.xml
+++ b/.build/parent-pom-template.xml
@@ -760,7 +760,7 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-all</artifactId>
-        <version>4.1.136.Final</version>
+        <version>4.1.137.Final</version>
         <exclusions>
           <exclusion>
             <groupId>io.netty</groupId>
@@ -850,18 +850,18 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-epoll</artifactId>
-        <version>4.1.136.Final</version>
+        <version>4.1.137.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-epoll</artifactId>
-        <version>4.1.136.Final</version>
+        <version>4.1.137.Final</version>
         <classifier>linux-x86_64</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-epoll</artifactId>
-        <version>4.1.136.Final</version>
+        <version>4.1.137.Final</version>
         <classifier>linux-aarch_64</classifier>
       </dependency>
 


### PR DESCRIPTION
### What is the issue
There are a few new CVEs that have been addressed in 4.1.137.Final (see https://netty.io/news/2026/08/06/4-1-137-Final.html). Of note:
- https://security.snyk.io/vuln/SNYK-JAVA-IONETTY-19005879
- https://security.snyk.io/vuln/SNYK-JAVA-IONETTY-18956131
- https://security.snyk.io/vuln/SNYK-JAVA-IONETTY-18956130


### What does this PR fix and why was it fixed
Upgrades Netty to 4.1.137.Final.
