### PR TITLE
CNDB-18937: Upgrade to netty 4.1.137.Final (main)

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -172,7 +172,7 @@
     <property name="chronicle-threads.version" value="2.24ea14" />
     <property name="chronicle-map.version" value="3.24ea4" />
 
-    <property name="netty.version" value="4.1.136.Final" />
+    <property name="netty.version" value="4.1.137.Final" />
 
     <condition property="maven-ant-tasks.jar.exists">
       <available file="${build.dir}/maven-ant-tasks-${maven-ant-tasks.version}.jar" />


### PR DESCRIPTION
### What is the issue
There are a few new CVEs that have been addressed in 4.1.137.Final (see https://netty.io/news/2026/08/06/4-1-137-Final.html). Of note:
- https://security.snyk.io/vuln/SNYK-JAVA-IONETTY-19005879
- https://security.snyk.io/vuln/SNYK-JAVA-IONETTY-18956131
- https://security.snyk.io/vuln/SNYK-JAVA-IONETTY-18956130


### What does this PR fix and why was it fixed
Upgrades Netty to 4.1.137.Final.