### PR TITLE
CNDB-17527: Remove unneeded setting of messaging version in index hints tests

### DIFF
--- a/test/unit/org/apache/cassandra/db/filter/IndexHintsTest.java
+++ b/test/unit/org/apache/cassandra/db/filter/IndexHintsTest.java
@@ -33,7 +33,6 @@ import org.apache.cassandra.index.sai.analyzer.AnalyzerEqOperatorSupport;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.cql3.CQLTester;
 import org.apache.cassandra.cql3.Operator;
 import org.apache.cassandra.cql3.restrictions.StatementRestrictions;
@@ -74,8 +73,6 @@ public class IndexHintsTest extends CQLTester
     @BeforeClass
     public static void setUpClass()
     {
-        // Set the messaging version that adds support for the new index hints before starting the server
-        CassandraRelevantProperties.DS_CURRENT_MESSAGING_VERSION.setInt(MessagingService.VERSION_DS_12);
         CQLTester.setUpClass();
         CQLTester.enableCoordinatorExecution();
     }

--- a/test/unit/org/apache/cassandra/index/SkipIndexOnFullPrimaryKeysTester.java
+++ b/test/unit/org/apache/cassandra/index/SkipIndexOnFullPrimaryKeysTester.java
@@ -30,7 +30,6 @@ import org.apache.cassandra.cql3.restrictions.StatementRestrictions;
 import org.apache.cassandra.db.ReadCommand;
 import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.index.sai.SAITester;
-import org.apache.cassandra.net.MessagingService;
 import org.assertj.core.api.Assertions;
 
 /**
@@ -61,8 +60,6 @@ public abstract class SkipIndexOnFullPrimaryKeysTester extends SAITester
     @BeforeClass
     public static void setUpClass()
     {
-        // Set the messaging version that adds support for the new index hints before starting the server
-        CassandraRelevantProperties.DS_CURRENT_MESSAGING_VERSION.setInt(MessagingService.VERSION_DS_12);
         CQLTester.setUpClass();
         CQLTester.enableCoordinatorExecution();
     }

--- a/test/unit/org/apache/cassandra/index/sai/cql/PlanWithIndexHintsTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/PlanWithIndexHintsTest.java
@@ -18,9 +18,7 @@ package org.apache.cassandra.index.sai.cql;
 
 import java.util.Arrays;
 
-import org.apache.cassandra.net.MessagingService;
 import org.junit.Assume;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.cassandra.config.CassandraRelevantProperties;
@@ -52,13 +50,6 @@ import static java.lang.String.format;
  */
 public class PlanWithIndexHintsTest extends SAITester.Versioned
 {
-    @BeforeClass
-    public static void setUpClass()
-    {
-        CassandraRelevantProperties.DS_CURRENT_MESSAGING_VERSION.setInt(MessagingService.VERSION_DS_12);
-        SAITester.setUpClass();
-    }
-
     @Test
     public void testQueryPlanning() throws Throwable
     {


### PR DESCRIPTION
### What is the issue

Index hints test set the messaging version to `VERSION_DS_12` because it wasn't the default when index hints were introduced by https://github.com/riptano/cndb/issues/13129. However, `main-5.0` already uses `VERSION_DS_20` as the default, which already supports hints. We should get rid of that step in tests.

### What does this PR fix and why was it fixed

Remove manual setting of the messaging version in tests using index hints.